### PR TITLE
fix: restore p5 sketch functions and events after SPA navigation

### DIFF
--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -44,6 +44,16 @@ type P5SketchRuntime = {
 export class P5Engine implements SketchEngine {
   readonly engineId = "p5";
 
+  // ES modules are cached after first import — the module body won't
+  // re-execute on second visit, so _setupFn/_drawFn stay null after reset().
+  // We cache them here and restore on subsequent visits.
+  private static readonly _sketchModuleCache = new Set<string>();
+  private static readonly _sketchFnCache = new Map<string, {
+    setupFn: ( ( ...args: any[] ) => any ) | null;
+    drawFn: ( ( ...args: any[] ) => any ) | null;
+    sketchOptions: any;
+  }>();
+
   private _isReady = false;
   private container: HTMLElement | null = null;
   private sketchRuntime: P5SketchRuntime | null = null;
@@ -107,6 +117,28 @@ export class P5Engine implements SketchEngine {
         );
         throw error;
       } );
+
+    // ES modules are cached — on second visit the module doesn't re-run,
+    // leaving _setupFn/_drawFn null. Restore them from our static cache.
+    // (sketchPath is guaranteed non-null here: the import above would have thrown otherwise.)
+    const runtime = this.sketchRuntime as any;
+    if ( sketchPath && !P5Engine._sketchModuleCache.has( sketchPath ) ) {
+      P5Engine._sketchModuleCache.add( sketchPath );
+      P5Engine._sketchFnCache.set( sketchPath, {
+        setupFn: runtime._setupFn,
+        drawFn: runtime._drawFn,
+        sketchOptions: runtime.sketchOptions
+      } );
+    } else if ( sketchPath ) {
+      const cached = P5Engine._sketchFnCache.get( sketchPath );
+      if ( cached ) {
+        runtime._setupFn = cached.setupFn;
+        runtime._drawFn = cached.drawFn;
+        if ( !runtime.sketchOptions && cached.sketchOptions ) {
+          runtime.sketchOptions = cached.sketchOptions;
+        }
+      }
+    }
 
     await this.sketchRuntime.start( container );
 

--- a/src/templates/p5/utils/options.js
+++ b/src/templates/p5/utils/options.js
@@ -169,15 +169,6 @@ function markLoadedWhenExifReady() {
 /*  Event hooks                                                       */
 /* ------------------------------------------------------------------ */
 
-events.register(
-  "engine-window-preload",
-  refreshAssets
-);
-events.register(
-  "pre-draw",
-  markLoadedWhenExifReady
-);
-
 /* ------------------------------------------------------------------ */
 /*  Options change tracking                                           */
 /* ------------------------------------------------------------------ */
@@ -364,10 +355,22 @@ function initializeOptionsSubscription() {
   );
 }
 
-events.register(
-  "pre-setup",
-  initializeOptionsSubscription
-);
+// Called by sketch.start() on every sketch initialization so that these
+// handlers survive a reset() which clears events.registeredEvents.
+export function registerEvents() {
+  events.register(
+    "engine-window-preload",
+    refreshAssets
+  );
+  events.register(
+    "pre-draw",
+    markLoadedWhenExifReady
+  );
+  events.register(
+    "pre-setup",
+    initializeOptionsSubscription
+  );
+}
 
 /**
  * Update the previous-options baseline to match the given effective

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -2,7 +2,7 @@ import time from "./time.js";
 import debug from "./debug.js";
 import events from "./events.js";
 import slides from "./slides/index";
-import options from "./options";
+import options, { registerEvents as registerOptionsEvents } from "./options";
 import {
   registerAnimationBridge
 } from "@/lib/animationBridge";
@@ -149,6 +149,10 @@ const sketch = {
       "post-draw",
       debug.fps
     );
+
+    // Re-register options module handlers (they were module-level before,
+    // but reset() clears registeredEvents so they must be re-registered here).
+    registerOptionsEvents();
 
     // Create the p5 instance in instance mode
     new p5(
@@ -385,6 +389,9 @@ const sketch = {
 
     // Clear all registered events so the next sketch starts fresh
     events.registeredEvents = {};
+
+    // Reset animation time so the next sketch starts at t=0
+    time.reset();
   },
 
   // ---- engine methods (backward compat for time.js, debug.js, etc.) ---


### PR DESCRIPTION
ES modules are cached after first import, so navigating back to a
previously-visited sketch left _setupFn/_drawFn null (reset() had
cleared them and the module didn't re-execute on re-import).

Three fixes:
- P5Engine caches _setupFn/_drawFn/_sketchOptions per sketch path
  and restores them when the cached module doesn't re-register them
- options.js event registrations (refreshAssets, initializeOptionsSubscription…)
  moved from module-level into an exported registerEvents() so they
  survive the reset() that clears events.registeredEvents each time
- sketch.reset() now calls time.reset() so each new sketch starts at t=0

https://claude.ai/code/session_013dKf9TQQFG7Q5SHAkriEH2