### PR TITLE
Pause sketch during viewport gestures to keep UI fluid

### DIFF
--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -23,7 +23,9 @@ export default function ScalableViewport( {
   showZoomControls = true,
   resolutionKey,
   isReady = true,
-  disable = false
+  disable = false,
+  onInteractionStart,
+  onInteractionEnd
 }: {
   children: ReactNode;
   initialScale?: number;
@@ -31,6 +33,8 @@ export default function ScalableViewport( {
   showZoomControls?: boolean;
   disable?: boolean;
   isReady?: boolean;
+  onInteractionStart?: () => void;
+  onInteractionEnd?: () => void;
 } ) {
   const containerRef = useRef<HTMLDivElement | null>( null );
   const contentRef = useRef<HTMLDivElement | null>( null );
@@ -52,7 +56,9 @@ export default function ScalableViewport( {
     contentRef,
     transform,
     setTransform,
-    cancelAnimation
+    cancelAnimation,
+    onInteractionStart,
+    onInteractionEnd
   } );
 
   const {

--- a/src/components/ScalableViewport/hooks/useViewportGestures.ts
+++ b/src/components/ScalableViewport/hooks/useViewportGestures.ts
@@ -19,6 +19,8 @@ interface UseViewportGesturesProps {
     contentElement: HTMLDivElement | null
   ) => void;
   cancelAnimation: () => void;
+  onInteractionStart?: () => void;
+  onInteractionEnd?: () => void;
 }
 
 export function useViewportGestures( {
@@ -26,7 +28,9 @@ export function useViewportGestures( {
   contentRef,
   transform,
   setTransform,
-  cancelAnimation
+  cancelAnimation,
+  onInteractionStart,
+  onInteractionEnd
 }: UseViewportGesturesProps ) {
   useGesture(
     {
@@ -39,9 +43,19 @@ export function useViewportGestures( {
         }
 
         cancelAnimation();
+        onInteractionStart?.();
       },
-      onPinchStart: () => cancelAnimation(),
-      onWheelStart: () => cancelAnimation(),
+      onDragEnd: () => onInteractionEnd?.(),
+      onPinchStart: () => {
+        cancelAnimation();
+        onInteractionStart?.();
+      },
+      onPinchEnd: () => onInteractionEnd?.(),
+      onWheelStart: () => {
+        cancelAnimation();
+        onInteractionStart?.();
+      },
+      onWheelEnd: () => onInteractionEnd?.(),
 
       // One-finger Drag (Pan)
       onDrag: ( {

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import type React from "react";
 import {
-  useCallback, useMemo
+  useCallback, useMemo, useRef
 } from "react";
 import AnimationProgressionBar from "@/components/AnimationProgressionBar";
 import EngineSketchRenderer from "@/components/TemplateSketchPage/EngineSketchRenderer";
@@ -32,10 +32,44 @@ const TemplateOptions = dynamic( () =>
 export default function TemplateSketchPage() {
   const [
     {
-      name, capturing, options, persistedJob, engineId, sketchLoaded, activeSlideIndex
+      name, capturing, options, persistedJob, engineId, sketchLoaded, activeSlideIndex,
+      engine, looping
     },
     dispatch
   ] = useSketch();
+
+  // Capture whether the sketch was looping at the moment a viewport gesture
+  // starts, so we can restore the exact state when the gesture ends.
+  const wasLoopingRef = useRef( false );
+  // Keep a stable ref to the latest engine/looping values to avoid stale closures.
+  const interactionStateRef = useRef( {
+    engine, looping
+  } );
+  interactionStateRef.current = {
+    engine, looping
+  };
+
+  const handleInteractionStart = useCallback( () => {
+    const {
+      engine: e, looping: l
+    } = interactionStateRef.current;
+
+    if ( e && l ) {
+      wasLoopingRef.current = true;
+      e.pause();
+    }
+  }, [] );
+
+  const handleInteractionEnd = useCallback( () => {
+    const {
+      engine: e
+    } = interactionStateRef.current;
+
+    if ( e && wasLoopingRef.current ) {
+      wasLoopingRef.current = false;
+      e.play();
+    }
+  }, [] );
 
   const {
     thumbnailUrl
@@ -126,6 +160,8 @@ export default function TemplateSketchPage() {
           showZoomControls={ !capturing && sketchLoaded }
           resolutionKey={ `${ effectiveSettings.size.width }x${ effectiveSettings.size.height }` }
           isReady={ sketchLoaded }
+          onInteractionStart={ handleInteractionStart }
+          onInteractionEnd={ handleInteractionEnd }
         >
           {sketchLoaded && !capturing && (
             <div


### PR DESCRIPTION
When a sketch runs below 60 FPS, its draw() call can block the main
thread long enough to make viewport dragging feel janky. By pausing
the sketch loop at the start of any drag/pinch/wheel gesture and
resuming it on end, the main thread is free to process pointer events
and apply CSS transforms without competition.

The sketch's explicit pause state (user-initiated via play/pause
button) is respected: only sketches that were actively looping at
gesture start are resumed when the gesture ends.

https://claude.ai/code/session_01AezhouufEHuwCack6MdN6P