### PR TITLE
fix: prevent document scroll on mobile for app-shell layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,6 +63,11 @@
     html {
         /* Make native UI controls match the theme */
         color-scheme: light;
+        /* Prevent document-level scrolling on mobile: the app uses an
+           app-shell layout where only the <main> area scrolls, not the page. */
+        height: 100%;
+        overflow: hidden;
+        overscroll-behavior: none;
     }
 
     .dark,
@@ -72,6 +77,9 @@
 
     body {
         @apply bg-background text-foreground antialiased;
+        height: 100%;
+        overflow: hidden;
+        overscroll-behavior: none;
     }
 
     /* Optional: make plain `border` pick your token */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -143,7 +143,7 @@ export default function RootLayout( {
           disableTransitionOnChange
         >
           <div className="flex flex-col h-[100svh] bg-hover/50">
-            <main className="flex-1 overflow-auto relative">{children}</main>
+            <main className="flex-1 overflow-auto overscroll-contain relative">{children}</main>
 
             <Suspense>
               <MenuBar


### PR DESCRIPTION
html/body get overflow:hidden + overscroll-behavior:none so a touch
gesture that lands on the MenuBar (or anywhere outside <main>) can
never trigger a document-level scroll or pull-to-refresh.
<main> keeps overflow-auto for its own content and gains
overscroll-contain to stop scroll-chaining at its boundary.

https://claude.ai/code/session_01MNNEon4pKcTQm9xSA2enxZ