### PR TITLE
Show contextual label in FPS counter during viewport interactions

### DIFF
--- a/src/components/AnimationProgressionBar.tsx
+++ b/src/components/AnimationProgressionBar.tsx
@@ -18,6 +18,8 @@ import {
 interface AnimationProgressionBarProps {
   className?: string;
   disabled?: boolean;
+  onSeekStart?: () => void;
+  onSeekEnd?: () => void;
 }
 
 type AnimationConfig = {
@@ -62,7 +64,9 @@ function getAnimationConfigFromSketchOptions(
 
 export default function AnimationProgressionBar( {
   className = "",
-  disabled = false
+  disabled = false,
+  onSeekStart,
+  onSeekEnd
 }: AnimationProgressionBarProps ) {
   const [
     {
@@ -318,6 +322,7 @@ export default function AnimationProgressionBar( {
 
       isDraggingRef.current = true;
       setIsDragging( true );
+      onSeekStart?.();
 
       pausedByDragRef.current = pauseLoopForScrubbing();
 
@@ -332,7 +337,8 @@ export default function AnimationProgressionBar( {
       disabled,
       calculateProgressionFromEvent,
       pauseLoopForScrubbing,
-      setAnimationProgression
+      setAnimationProgression,
+      onSeekStart
     ]
   );
 
@@ -346,6 +352,7 @@ export default function AnimationProgressionBar( {
 
       isDraggingRef.current = false;
       setIsDragging( false );
+      onSeekEnd?.();
 
       // Resume the loop only if we were the ones who paused it.
       if ( pausedByDragRef.current ) {
@@ -360,7 +367,8 @@ export default function AnimationProgressionBar( {
       }
     },
     [
-      resumeLoopAfterScrubbing
+      resumeLoopAfterScrubbing,
+      onSeekEnd
     ]
   );
 

--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -33,7 +33,7 @@ export default function ScalableViewport( {
   showZoomControls?: boolean;
   disable?: boolean;
   isReady?: boolean;
-  onInteractionStart?: () => void;
+  onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
 } ) {
   const containerRef = useRef<HTMLDivElement | null>( null );

--- a/src/components/ScalableViewport/hooks/useViewportGestures.ts
+++ b/src/components/ScalableViewport/hooks/useViewportGestures.ts
@@ -19,7 +19,7 @@ interface UseViewportGesturesProps {
     contentElement: HTMLDivElement | null
   ) => void;
   cancelAnimation: () => void;
-  onInteractionStart?: () => void;
+  onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
 }
 
@@ -43,17 +43,17 @@ export function useViewportGestures( {
         }
 
         cancelAnimation();
-        onInteractionStart?.();
+        onInteractionStart?.( "panning" );
       },
       onDragEnd: () => onInteractionEnd?.(),
       onPinchStart: () => {
         cancelAnimation();
-        onInteractionStart?.();
+        onInteractionStart?.( "zooming" );
       },
       onPinchEnd: () => onInteractionEnd?.(),
       onWheelStart: () => {
         cancelAnimation();
-        onInteractionStart?.();
+        onInteractionStart?.( "zooming" );
       },
       onWheelEnd: () => onInteractionEnd?.(),
 

--- a/src/components/TemplateSketchPage/SketchPerformanceLabel.tsx
+++ b/src/components/TemplateSketchPage/SketchPerformanceLabel.tsx
@@ -12,13 +12,15 @@ import useSketch from "@/components/ClientProcessingSketch/components/SketchProv
 
 type SketchPerformanceLabelProps = {
   targetFps: number;
+  interactionMode?: "panning" | "zooming" | "seeking" | null;
 };
 
 const RED_THRESHOLD = 0.55;
 const WARNING_THRESHOLD = 0.85;
 
 export default function SketchPerformanceLabel( {
-  targetFps
+  targetFps,
+  interactionMode
 }: SketchPerformanceLabelProps ) {
   const [
     {
@@ -89,6 +91,12 @@ export default function SketchPerformanceLabel( {
       : ratio < WARNING_THRESHOLD
         ? "#f97316"
         : undefined;
+
+  if ( interactionMode ) {
+    return (
+      <p className="opacity-50">{interactionMode}</p>
+    );
+  }
 
   return (
     <p style={ color ? {

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import type React from "react";
 import {
-  useCallback, useMemo, useRef
+  useCallback, useMemo, useRef, useState
 } from "react";
 import AnimationProgressionBar from "@/components/AnimationProgressionBar";
 import EngineSketchRenderer from "@/components/TemplateSketchPage/EngineSketchRenderer";
@@ -38,6 +38,11 @@ export default function TemplateSketchPage() {
     dispatch
   ] = useSketch();
 
+  const [
+    interactionMode,
+    setInteractionMode
+  ] = useState<"panning" | "zooming" | "seeking" | null>( null );
+
   // Capture whether the sketch was looping at the moment a viewport gesture
   // starts, so we can restore the exact state when the gesture ends.
   const wasLoopingRef = useRef( false );
@@ -49,7 +54,9 @@ export default function TemplateSketchPage() {
     engine, looping
   };
 
-  const handleInteractionStart = useCallback( () => {
+  const handleInteractionStart = useCallback( ( mode: "panning" | "zooming" ) => {
+    setInteractionMode( mode );
+
     const {
       engine: e, looping: l
     } = interactionStateRef.current;
@@ -61,6 +68,8 @@ export default function TemplateSketchPage() {
   }, [] );
 
   const handleInteractionEnd = useCallback( () => {
+    setInteractionMode( null );
+
     const {
       engine: e
     } = interactionStateRef.current;
@@ -69,6 +78,14 @@ export default function TemplateSketchPage() {
       wasLoopingRef.current = false;
       e.play();
     }
+  }, [] );
+
+  const handleSeekStart = useCallback( () => {
+    setInteractionMode( "seeking" );
+  }, [] );
+
+  const handleSeekEnd = useCallback( () => {
+    setInteractionMode( null );
   }, [] );
 
   const {
@@ -189,7 +206,10 @@ export default function TemplateSketchPage() {
                 </span>
               </p>
 
-              <SketchPerformanceLabel targetFps={ effectiveSettings.animation?.framerate ?? 60 } />
+              <SketchPerformanceLabel
+                targetFps={ effectiveSettings.animation?.framerate ?? 60 }
+                interactionMode={ interactionMode }
+              />
             </div>
           )}
 
@@ -208,7 +228,10 @@ export default function TemplateSketchPage() {
                 } as React.CSSProperties
               }
             >
-              <AnimationProgressionBar />
+              <AnimationProgressionBar
+                onSeekStart={ handleSeekStart }
+                onSeekEnd={ handleSeekEnd }
+              />
             </div>
           )}
         </ScalableViewport>


### PR DESCRIPTION
During viewport gestures and scrubbing, the FPS counter now shows a descriptive text instead of the stale last-known FPS value:
- drag/pan → "panning"
- pinch or wheel zoom → "zooming"
- scrubbing the progress bar → "seeking"

The interaction mode is propagated from ScalableViewport gesture callbacks (now typed with a mode parameter) and from AnimationProgressionBar's new onSeekStart/onSeekEnd props, all wired up in TemplateSketchPage via a single interactionMode state.

https://claude.ai/code/session_01AezhouufEHuwCack6MdN6P