### PR TITLE
Pause sketch during animated viewport transitions (zoom/fit buttons)

### DIFF
--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -48,7 +48,9 @@ export default function ScalableViewport( {
   } = useViewportAnimation(
     setTransform,
     transform,
-    contentRef
+    contentRef,
+    () => onInteractionStart?.( "zooming" ),
+    onInteractionEnd
   );
 
   useViewportGestures( {

--- a/src/components/ScalableViewport/hooks/useViewportAnimation.ts
+++ b/src/components/ScalableViewport/hooks/useViewportAnimation.ts
@@ -17,7 +17,9 @@ export function useViewportAnimation(
     contentElement: HTMLDivElement | null
   ) => void,
   transform: React.MutableRefObject<TransformState>,
-  contentRef: React.RefObject<HTMLDivElement | null>
+  contentRef: React.RefObject<HTMLDivElement | null>,
+  onAnimationStart?: () => void,
+  onAnimationEnd?: () => void
 ) {
   const animationFrameRef = useRef<number | null>( null );
 
@@ -26,9 +28,12 @@ export function useViewportAnimation(
       if ( animationFrameRef.current ) {
         cancelAnimationFrame( animationFrameRef.current );
         animationFrameRef.current = null;
+        onAnimationEnd?.();
       }
     },
-    []
+    [
+      onAnimationEnd
+    ]
   );
 
   const animateTo = useCallback(
@@ -36,6 +41,7 @@ export function useViewportAnimation(
       targetX: number, targetY: number, targetScale: number
     ) => {
       cancelAnimation();
+      onAnimationStart?.();
 
       const startX = transform.current.x;
       const startY = transform.current.y;
@@ -68,6 +74,7 @@ export function useViewportAnimation(
           animationFrameRef.current = requestAnimationFrame( animate );
         } else {
           animationFrameRef.current = null;
+          onAnimationEnd?.();
         }
       };
 
@@ -77,7 +84,9 @@ export function useViewportAnimation(
       setTransform,
       cancelAnimation,
       transform,
-      contentRef
+      contentRef,
+      onAnimationStart,
+      onAnimationEnd
     ]
   );
 


### PR DESCRIPTION
Button-triggered viewport animations (fit, zoom in/out, reset) use a 250ms eased rAF loop that competes with a slow sketch's draw loop on the main thread. By wiring onAnimationStart/onAnimationEnd callbacks into useViewportAnimation — fired at animation start, on natural completion, and on early cancel — the sketch is now paused for the duration of any button-triggered animation, just like it is during drag and pinch gestures.

cancelAnimation also fires onAnimationEnd so that if a gesture interrupts a running animation, the pause/resume state stays consistent.

https://claude.ai/code/session_01AezhouufEHuwCack6MdN6P