### PR TITLE
Pause sketch immediately on menu bar navigation to free the main thread

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -15,6 +15,9 @@ import {
 import GenerateThumbnailsButton from "@/components/GenerateThumbnailsButton";
 import PushNotificationManager from "@/components/PushNotificationManager";
 import ThemeToggle from "@/components/ThemeToggle";
+import {
+  pauseSketchForNav
+} from "@/lib/navigationPauseSignal";
 
 type NavItem = {
   href: string;
@@ -127,6 +130,7 @@ function MenuBar( {
               key={ href }
               href={ href }
               target={ target }
+              onClick={ !target ? pauseSketchForNav : undefined }
               className={ clsx(
                 "group relative flex items-center gap-2 rounded-xl px-4 py-2 transition-all duration-300 text-sm font-medium",
                 active

--- a/src/components/TemplateSketchPage/EngineSketchRenderer.tsx
+++ b/src/components/TemplateSketchPage/EngineSketchRenderer.tsx
@@ -12,6 +12,9 @@ import type {
   SketchEngine
 } from "@/engines/types";
 import useSketch from "../ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+import {
+  registerNavigationPause
+} from "@/lib/navigationPauseSignal";
 
 /**
  * Engine-agnostic sketch renderer.
@@ -43,6 +46,10 @@ export default function EngineSketchRenderer() {
       const instance = registration.createEngine();
 
       engineRef.current = instance;
+
+      const unregisterPause = registerNavigationPause( () => {
+        engineRef.current?.pause();
+      } );
 
       // Listen for the engine's ready event to know when the first frame
       // has been rendered and the canvas is ready to be measured/centered.
@@ -85,6 +92,7 @@ export default function EngineSketchRenderer() {
         } );
 
       return () => {
+        unregisterPause();
         instance.off(
           "ready",
           handleReady

--- a/src/lib/navigationPauseSignal.ts
+++ b/src/lib/navigationPauseSignal.ts
@@ -1,0 +1,27 @@
+let _callback: ( () => void ) | null = null;
+
+/**
+ * Register a function to call when the user navigates away from the current
+ * page. Returns an unregister function.
+ *
+ * Only one callback is active at a time — the most recently registered one.
+ * This is intentional: there is at most one running sketch on screen.
+ */
+export function registerNavigationPause( cb: () => void ): () => void {
+  _callback = cb;
+
+  return () => {
+    if ( _callback === cb ) {
+      _callback = null;
+    }
+  };
+}
+
+/**
+ * Call from any navigation entry point (menu links, etc.) to pause the
+ * active sketch before the new route starts rendering. No-op when no
+ * sketch is registered.
+ */
+export function pauseSketchForNav(): void {
+  _callback?.();
+}


### PR DESCRIPTION
When navigating away via the menu bar, Next.js App Router prepares the new route while the old page is still mounted. A sketch running at full speed blocks the main thread during this transition, making navigation feel sluggish.

A lightweight module-level signal (navigationPauseSignal) bridges the gap: EngineSketchRenderer registers a pause callback when an engine mounts and unregisters on cleanup; MenuBar calls pauseSketchForNav() on every internal link click, stopping the draw loop before Next.js starts rendering the new route.

External links (target="_blank") are left untouched.

https://claude.ai/code/session_01AezhouufEHuwCack6MdN6P