### PR TITLE
Fix zoom buttons always triggering fitToViewport

### DIFF
--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {
-  ReactNode, useEffect, useRef
+  ReactNode, useCallback, useEffect, useRef
 } from "react";
 import ZoomControls from "@/components/ScalableViewport/components/ZoomControls";
 import {
@@ -43,13 +43,20 @@ export default function ScalableViewport( {
     transform, setTransform
   } = useTransformState( initialScale || 1 );
 
+  const handleAnimationStart = useCallback(
+    () => onInteractionStart?.( "zooming" ),
+    [
+      onInteractionStart
+    ]
+  );
+
   const {
     animateTo, cancelAnimation
   } = useViewportAnimation(
     setTransform,
     transform,
     contentRef,
-    () => onInteractionStart?.( "zooming" ),
+    handleAnimationStart,
     onInteractionEnd
   );
 


### PR DESCRIPTION
The anonymous arrow function () => onInteractionStart?.("zooming") passed to useViewportAnimation was recreated on every render, causing animateTo → fitToViewport → ResizeObserver useEffect to all invalidate on each render. When the observer reconnected it immediately called fitToViewport, overriding any zoom action.

Wrapping it in useCallback makes the reference stable and breaks the invalidation chain.

https://claude.ai/code/session_01AezhouufEHuwCack6MdN6P