### PR TITLE
refactor(seo): centralize config, fix title duplication, add breadcrumbs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,9 +14,15 @@ import ServiceWorkerUpdateNotifier from "@/components/ServiceWorkerUpdateNotifie
 import {
   getBaseUrl,
   getWebApplicationJsonLd,
+  OG_IMAGE,
+  SITE_AUTHOR,
+  SITE_CATEGORY,
   SITE_DESCRIPTION,
   SITE_KEYWORDS,
-  SITE_NAME
+  SITE_LOCALE,
+  SITE_NAME,
+  THEME_COLOR_DARK,
+  THEME_COLOR_LIGHT
 } from "@/lib/seo";
 import {
   getDevThumbnailStatus
@@ -34,11 +40,11 @@ export const metadata: Metadata = {
   keywords: SITE_KEYWORDS,
   authors: [
     {
-      name: "Steeve Pommier"
+      name: SITE_AUTHOR
     }
   ],
-  creator: "Steeve Pommier",
-  publisher: "Steeve Pommier",
+  creator: SITE_AUTHOR,
+  publisher: SITE_AUTHOR,
   formatDetection: {
     email: false,
     address: false,
@@ -49,17 +55,17 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
-    locale: "en_US",
+    locale: SITE_LOCALE,
     url: baseUrl,
     siteName: SITE_NAME,
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
     images: [
       {
-        url: "/assets/images/icon-512x512.png",
-        width: 512,
-        height: 512,
-        alt: `${ SITE_NAME } - Create social media videos from code templates`
+        url: OG_IMAGE.path,
+        width: OG_IMAGE.width,
+        height: OG_IMAGE.height,
+        alt: OG_IMAGE.alt
       }
     ]
   },
@@ -67,9 +73,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
-    images: [
-      "/assets/images/icon-512x512.png"
-    ]
+    images: [ OG_IMAGE.path ]
   },
   robots: {
     index: true,
@@ -86,7 +90,7 @@ export const metadata: Metadata = {
     icon: "/favicon.ico",
     apple: "/apple-touch-icon.png"
   },
-  category: "technology"
+  category: SITE_CATEGORY
 };
 
 export const viewport: Viewport = {
@@ -97,11 +101,11 @@ export const viewport: Viewport = {
   themeColor: [
     {
       media: "(prefers-color-scheme: light)",
-      color: "#ffffff"
+      color: THEME_COLOR_LIGHT
     },
     {
       media: "(prefers-color-scheme: dark)",
-      color: "#000000"
+      color: THEME_COLOR_DARK
     }
   ]
 };

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -2,18 +2,22 @@ import type {
   MetadataRoute
 } from "next";
 import {
-  SITE_DESCRIPTION, SITE_NAME
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_SHORT_NAME,
+  THEME_COLOR_DARK,
+  THEME_COLOR_LIGHT
 } from "@/lib/seo";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
     name: SITE_NAME,
-    short_name: "Social Templates",
+    short_name: SITE_SHORT_NAME,
     description: SITE_DESCRIPTION,
     start_url: "/",
     display: "standalone",
-    background_color: "#ffffff",
-    theme_color: "#000000",
+    background_color: THEME_COLOR_LIGHT,
+    theme_color: THEME_COLOR_DARK,
     categories: [
       "multimedia",
       "design",

--- a/src/app/templates/[engine]/[...sketch]/page.tsx
+++ b/src/app/templates/[engine]/[...sketch]/page.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import "@/engines/index"; // register all engines
 
 import {
-  hasEngine
+  hasEngine, getEngine
 } from "@/engines/registry";
 import {
   findSketchMeta
@@ -17,11 +17,19 @@ import {
 import SketchContextProvider from "@/components/ClientProcessingSketch/components/SketchProvider/SketchContextProvider";
 import TemplateSketchPage from "@/components/TemplateSketchPage/TemplateSketchPage";
 import SketchJsonLd from "@/components/SketchJsonLd/SketchJsonLd";
+import BreadcrumbJsonLd from "@/components/BreadcrumbJsonLd/BreadcrumbJsonLd";
 import {
   getJobById
 } from "@/lib/jobStore";
 import {
-  getBaseUrl, SITE_NAME
+  buildCanonicalPath,
+  buildOgTitle,
+  buildSketchDescription,
+  buildSketchKeywords,
+  buildThumbnailUrl,
+  formatSketchTitle,
+  getBaseUrl,
+  SITE_NAME
 } from "@/lib/seo";
 import {
   OptionsSchema
@@ -52,47 +60,37 @@ export async function generateMetadata( {
     engine: engineId, sketch
   } = await params;
   const sketchName = sketch[ sketch.length - 1 ];
-  const sketchMeta = findSketchMeta(
-    sketchName,
-    engineId
-  );
+  const sketchMeta = findSketchMeta( sketchName, engineId );
   const baseUrl = getBaseUrl();
 
-  const title = sketchName
-    .split( "-" )
-    .map( ( w ) => w.charAt( 0 ).toUpperCase() + w.slice( 1 ) )
-    .join( " " );
-
-  const canonicalPath = sketchMeta?.category
-    ? `/templates/${ engineId }/${ sketchMeta.category }/${ sketchName }`
-    : `/templates/${ engineId }/${ sketchName }`;
-
+  const engineLabel = hasEngine( engineId )
+    ? getEngine( engineId ).label
+    : engineId;
+  const title = formatSketchTitle( sketchName );
+  const description = buildSketchDescription( title, engineLabel );
+  const canonicalPath = buildCanonicalPath(
+    engineId, sketchName, sketchMeta?.category
+  );
   const thumbnailUrl = sketchMeta?.hasThumbnail
-    ? `${ baseUrl }/assets/images/templates/${ engineId }/${ sketchName }/thumbnail.jpeg`
+    ? buildThumbnailUrl( engineId, sketchName, baseUrl )
     : undefined;
 
-  const description = `Create ${ title } content with ${ engineId }. A template for generating social media visuals.`;
-
   return {
-    title: `${ title } | ${ SITE_NAME }`,
+    // Let the root layout template handle "| SITE_NAME" — only pass the page title
+    title,
     description,
-    keywords: [
-      title,
-      engineId,
-      "social media template",
-      "video generator",
-      "creative coding",
-      ...sketchName.split( "-" )
-    ],
+    keywords: buildSketchKeywords( sketchName, engineLabel ),
     alternates: {
       canonical: canonicalPath
     },
-    ...( thumbnailUrl && {
-      openGraph: {
-        title: `${ title } | ${ SITE_NAME }`,
-        description,
-        url: `${ baseUrl }${ canonicalPath }`,
-        siteName: SITE_NAME,
+    openGraph: {
+      // Always set page-specific OG so bots get the right title/description
+      title: buildOgTitle( title ),
+      description,
+      url: canonicalPath,
+      siteName: SITE_NAME,
+      type: "website",
+      ...( thumbnailUrl && {
         images: [
           {
             url: thumbnailUrl,
@@ -100,18 +98,17 @@ export async function generateMetadata( {
             height: 630,
             alt: `${ title } template preview`
           }
-        ],
-        type: "website"
-      },
-      twitter: {
-        card: "summary_large_image",
-        title: `${ title } | ${ SITE_NAME }`,
-        description,
-        images: [
-          thumbnailUrl
         ]
-      }
-    } )
+      } )
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: buildOgTitle( title ),
+      description,
+      ...( thumbnailUrl && {
+        images: [ thumbnailUrl ]
+      } )
+    }
   };
 }
 
@@ -141,56 +138,41 @@ export default async function StudioPage( {
   }
 
   /* ---- resolve template name from catch-all segments ------------- */
-  // e.g. ["photo", "photo-balloons"] → name = "photo-balloons"
-  //      ["hello-world"]             → name = "hello-world"
   const sketchName = sketchSegments[ sketchSegments.length - 1 ];
 
   /* ---- validate sketch exists in metadata ------------------------ */
-  const sketchMeta = findSketchMeta(
-    sketchName,
-    engineId
-  );
+  const sketchMeta = findSketchMeta( sketchName, engineId );
 
   if ( !sketchMeta ) {
-    return notFound( );
+    return notFound();
   }
 
   /* ---- canonical URL redirect ----------------------------------- */
-  // If the sketch has a category but the URL is missing it,
-  // redirect to the canonical path: /templates/<engine>/<category>/<name>
   if ( sketchMeta.category && sketchSegments.length === 1 ) {
     redirect( `/templates/${ engineId }/${ sketchMeta.category }/${ sketchName }` );
   }
 
-  /* ---- load options & form meta (reuses existing p5 utils) ------- */
+  /* ---- engine label for structured data -------------------------- */
+  const engineLabel = getEngine( engineId ).label;
+  const baseUrl = getBaseUrl();
+
+  /* ---- load options & form meta ---------------------------------- */
   const sketchOptions = OptionsSchema.parse( {} );
 
   const {
     formValues, formConfiguration
-  } = await getSketchMeta(
-    sketchName,
-    engineId
-  );
+  } = await getSketchMeta( sketchName, engineId );
 
-  const jsonOptions = await getJSONSketchOptions(
-    sketchName,
-    engineId
-  );
+  const jsonOptions = await getJSONSketchOptions( sketchName, engineId );
 
   if ( jsonOptions ) {
-    Object.assign(
-      sketchOptions,
-      jsonOptions
-    );
+    Object.assign( sketchOptions, jsonOptions );
   }
 
   if ( formValues ) {
-    Object.assign(
-      sketchOptions,
-      {
-        sketch: structuredClone( formValues )
-      }
-    );
+    Object.assign( sketchOptions, {
+      sketch: structuredClone( formValues )
+    } );
   }
 
   /* ---- persisted job? -------------------------------------------- */
@@ -213,15 +195,29 @@ export default async function StudioPage( {
 
   sketchOptions.name = sketchName;
 
+  /* ---- breadcrumb items ------------------------------------------ */
+  const sketchTitle = formatSketchTitle( sketchName );
+  const breadcrumbItems = [
+    { name: "Home", url: baseUrl },
+    { name: "Templates", url: `${ baseUrl }/templates` },
+    { name: `${ engineLabel } Templates`, url: `${ baseUrl }/templates/${ engineId }` },
+    {
+      name: sketchTitle,
+      url: `${ baseUrl }${ buildCanonicalPath( engineId, sketchName, sketchMeta.category ) }`
+    }
+  ];
+
   /* ---- render ---------------------------------------------------- */
   return (
     <>
       <SketchJsonLd
         sketchName={ sketchName }
         engineId={ engineId }
+        engineLabel={ engineLabel }
         category={ sketchMeta.category }
         hasThumbnail={ sketchMeta.hasThumbnail }
       />
+      <BreadcrumbJsonLd items={ breadcrumbItems } />
 
       <SketchContextProvider
         name={ sketchName }

--- a/src/app/templates/[engine]/page.tsx
+++ b/src/app/templates/[engine]/page.tsx
@@ -14,8 +14,9 @@ import {
   hasEngine
 } from "@/engines/registry";
 import {
-  getBaseUrl, SITE_NAME
+  buildOgTitle, getBaseUrl, SITE_NAME
 } from "@/lib/seo";
+import BreadcrumbJsonLd from "@/components/BreadcrumbJsonLd/BreadcrumbJsonLd";
 import TemplatesList from "@/components/TemplatesList";
 import {
   getTemplatesData
@@ -35,17 +36,20 @@ export async function generateMetadata( {
   if ( !hasEngine( engine ) ) return {};
 
   const label = ( await getTemplatesData() ).engineLabels[ engine ] || engine;
+  const title = `${ label } Templates`;
+  const description = `Browse all ${ label } templates. Create stunning social media visuals with ${ label }.`;
 
   return {
-    title: `${ label } Templates`,
-    description: `Browse all ${ label } templates.`,
+    title,
+    description,
     alternates: {
       canonical: `/templates/${ engine }`
     },
     openGraph: {
-      title: `${ label } Templates | ${ SITE_NAME }`,
-      description: `Browse all ${ label } templates.`,
-      url: `${ getBaseUrl() }/templates/${ engine }`,
+      title: buildOgTitle( title ),
+      description,
+      url: `/templates/${ engine }`,
+      siteName: SITE_NAME,
       type: "website"
     }
   };
@@ -66,8 +70,18 @@ export default async function EngineTemplatesPage( {
     templatesByEngine, engineLabels
   } = await getTemplatesData();
 
+  const label = engineLabels[ engine ] || engine;
+  const baseUrl = getBaseUrl();
+
+  const breadcrumbItems = [
+    { name: "Home", url: baseUrl },
+    { name: "Templates", url: `${ baseUrl }/templates` },
+    { name: `${ label } Templates`, url: `${ baseUrl }/templates/${ engine }` }
+  ];
+
   return (
     <div className="p-3 sm:p-6">
+      <BreadcrumbJsonLd items={ breadcrumbItems } />
       <Suspense>
         <TemplatesList
           templates={ templatesByEngine }

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -6,25 +6,29 @@ import {
 } from "react";
 
 import {
-  getBaseUrl, SITE_NAME
+  buildOgTitle, getBaseUrl, SITE_NAME
 } from "@/lib/seo";
+import BreadcrumbJsonLd from "@/components/BreadcrumbJsonLd/BreadcrumbJsonLd";
 import TemplatesList from "@/components/TemplatesList";
 import {
   getTemplatesData
 } from "./getTemplatesData";
 
+const TITLE = "Templates";
+const DESCRIPTION =
+  "Browse all available social media templates. Choose from p5.js sketches, GSAP animations, and HTML templates to create stunning visual content.";
+
 export const metadata: Metadata = {
-  title: "Templates",
-  description:
-    "Browse all available social media templates. Choose from p5.js sketches, GSAP animations, and HTML templates to create stunning visual content.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: {
     canonical: "/templates"
   },
   openGraph: {
-    title: `Templates | ${ SITE_NAME }`,
-    description:
-      "Browse all available social media templates. Choose from p5.js sketches, GSAP animations, and HTML templates.",
-    url: `${ getBaseUrl() }/templates`,
+    title: buildOgTitle( TITLE ),
+    description: DESCRIPTION,
+    url: "/templates",
+    siteName: SITE_NAME,
     type: "website"
   }
 };
@@ -33,9 +37,16 @@ export default async function TemplatesPage() {
   const {
     templatesByEngine, engineLabels
   } = await getTemplatesData();
+  const baseUrl = getBaseUrl();
+
+  const breadcrumbItems = [
+    { name: "Home", url: baseUrl },
+    { name: "Templates", url: `${ baseUrl }/templates` }
+  ];
 
   return (
     <div className="p-3 sm:p-6">
+      <BreadcrumbJsonLd items={ breadcrumbItems } />
       <Suspense>
         <TemplatesList
           templates={ templatesByEngine }

--- a/src/components/BreadcrumbJsonLd/BreadcrumbJsonLd.tsx
+++ b/src/components/BreadcrumbJsonLd/BreadcrumbJsonLd.tsx
@@ -1,0 +1,19 @@
+import {
+  getBreadcrumbJsonLd
+} from "@/lib/seo";
+
+interface BreadcrumbJsonLdProps {
+  items: Array<{ name: string; url: string }>;
+}
+
+export default function BreadcrumbJsonLd( { items }: BreadcrumbJsonLdProps ) {
+  return (
+    <script
+      type="application/ld+json"
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={ {
+        __html: JSON.stringify( getBreadcrumbJsonLd( items ) )
+      } }
+    />
+  );
+}

--- a/src/components/SketchJsonLd/SketchJsonLd.tsx
+++ b/src/components/SketchJsonLd/SketchJsonLd.tsx
@@ -1,10 +1,15 @@
 import {
-  getBaseUrl
+  buildCanonicalPath,
+  buildThumbnailUrl,
+  formatSketchTitle,
+  getBaseUrl,
+  getSketchJsonLd
 } from "@/lib/seo";
 
 interface SketchJsonLdProps {
   sketchName: string;
   engineId: string;
+  engineLabel: string;
   category: string | null;
   hasThumbnail: boolean;
 }
@@ -12,30 +17,23 @@ interface SketchJsonLdProps {
 export default function SketchJsonLd( {
   sketchName,
   engineId,
+  engineLabel,
   category,
   hasThumbnail
 }: SketchJsonLdProps ) {
   const baseUrl = getBaseUrl();
-  const title = sketchName
-    .split( "-" )
-    .map( ( w ) => w.charAt( 0 ).toUpperCase() + w.slice( 1 ) )
-    .join( " " );
-  const canonicalPath = category
-    ? `/templates/${ engineId }/${ category }/${ sketchName }`
-    : `/templates/${ engineId }/${ sketchName }`;
+  const title = formatSketchTitle( sketchName );
+  const canonicalPath = buildCanonicalPath( engineId, sketchName, category );
+  const thumbnailUrl = hasThumbnail
+    ? buildThumbnailUrl( engineId, sketchName, baseUrl )
+    : undefined;
 
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    name: title,
-    applicationCategory: "DesignApplication",
-    operatingSystem: "Web",
-    description: `Create ${ title } content with ${ engineId }.`,
+  const jsonLd = getSketchJsonLd( {
+    title,
+    engineLabel,
     url: `${ baseUrl }${ canonicalPath }`,
-    ...( hasThumbnail && {
-      screenshot: `${ baseUrl }/assets/images/templates/${ engineId }/${ sketchName }/thumbnail.jpeg`
-    } )
-  };
+    thumbnailUrl
+  } );
 
   return (
     <script

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,55 @@
+// ─── Site Identity ────────────────────────────────────────────────────────────
+export const SITE_NAME = "Coded templates";
+export const SITE_SHORT_NAME = "Coded Templates";
+export const SITE_DESCRIPTION =
+  "Create stunning videos and images from customizable p5.js, GSAP, and HTML templates. Record, export, and share animated content for Instagram, TikTok, and more.";
+
+// ─── Author / Publisher ───────────────────────────────────────────────────────
+export const SITE_AUTHOR = "Steeve Pommier";
+
+// ─── Locale & Category ───────────────────────────────────────────────────────
+export const SITE_LOCALE = "en_US";
+export const SITE_CATEGORY = "technology";
+
+// ─── SEO Keywords ─────────────────────────────────────────────────────────────
+export const SITE_KEYWORDS: string[] = [
+  "code templates",
+  "social media templates",
+  "video generator",
+  "p5.js",
+  "GSAP animation",
+  "creative coding",
+  "social media content",
+  "video recording",
+  "animation templates",
+  "Instagram templates",
+  "TikTok templates",
+  "generative art",
+  "motion graphics",
+  "HTML templates",
+  "video export",
+  "content creation tool"
+];
+
+// ─── Default Open Graph Image ─────────────────────────────────────────────────
+export const OG_IMAGE = {
+  path: "/assets/images/icon-512x512.png",
+  width: 512,
+  height: 512,
+  alt: `${ SITE_NAME } — Create social media videos from code templates`
+};
+
+// ─── Theme Colors ─────────────────────────────────────────────────────────────
+export const THEME_COLOR_LIGHT = "#ffffff";
+export const THEME_COLOR_DARK = "#000000";
+
+// ─── App Feature List (for JSON-LD WebApplication) ───────────────────────────
+export const APP_FEATURE_LIST = [
+  "p5.js template rendering",
+  "GSAP animation templates",
+  "HTML template capture",
+  "Video recording and export",
+  "Customizable sketch options",
+  "EXIF data overlay",
+  "Multiple export formats"
+];

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,33 +1,26 @@
-/**
- * Centralized SEO configuration for the application.
- * All metadata, OpenGraph defaults, and structured data helpers live here.
- */
+import {
+  APP_FEATURE_LIST,
+  OG_IMAGE,
+  SITE_DESCRIPTION,
+  SITE_NAME
+} from "@/config/site";
 
-export const SITE_NAME = "Coded templates";
-export const SITE_DESCRIPTION =
-  "Create stunning videos and images from customizable p5.js, GSAP, and HTML templates. Record, export, and share animated content for Instagram, TikTok, and more.";
-export const SITE_KEYWORDS = [
-  "code templates",
-  "social media templates",
-  "video generator",
-  "p5.js",
-  "GSAP animation",
-  "creative coding",
-  "social media content",
-  "video recording",
-  "animation templates",
-  "Instagram templates",
-  "TikTok templates",
-  "generative art",
-  "motion graphics",
-  "HTML templates",
-  "video export",
-  "content creation tool"
-];
+// Re-export all site constants so existing imports keep working
+export {
+  APP_FEATURE_LIST,
+  OG_IMAGE,
+  SITE_AUTHOR,
+  SITE_CATEGORY,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+  SITE_LOCALE,
+  SITE_NAME,
+  SITE_SHORT_NAME,
+  THEME_COLOR_DARK,
+  THEME_COLOR_LIGHT
+} from "@/config/site";
 
-/**
- * Returns the base URL for the site from environment variables.
- */
+/** Returns the base URL from environment variables. */
 export function getBaseUrl(): string {
   return (
     process.env.NEXT_PUBLIC_SITE_URL ||
@@ -37,9 +30,71 @@ export function getBaseUrl(): string {
   );
 }
 
-/**
- * Generates a WebApplication JSON-LD structured data object.
- */
+// ─── String utilities ─────────────────────────────────────────────────────────
+
+/** Converts a kebab-case sketch name to Title Case: "photo-balloons" → "Photo Balloons". */
+export function formatSketchTitle( sketchName: string ): string {
+  return sketchName
+    .split( "-" )
+    .map( ( w ) => w.charAt( 0 ).toUpperCase() + w.slice( 1 ) )
+    .join( " " );
+}
+
+/** Builds a full OG/Twitter title: "{pageTitle} | {SITE_NAME}". */
+export function buildOgTitle( pageTitle: string ): string {
+  return `${ pageTitle } | ${ SITE_NAME }`;
+}
+
+// ─── Sketch page utilities ────────────────────────────────────────────────────
+
+/** Returns the canonical URL path for a sketch. */
+export function buildCanonicalPath(
+  engineId: string,
+  sketchName: string,
+  category?: string | null
+): string {
+  return category
+    ? `/templates/${ engineId }/${ category }/${ sketchName }`
+    : `/templates/${ engineId }/${ sketchName }`;
+}
+
+/** Returns the absolute thumbnail URL for a sketch. */
+export function buildThumbnailUrl(
+  engineId: string,
+  sketchName: string,
+  baseUrl: string
+): string {
+  return `${ baseUrl }/assets/images/templates/${ engineId }/${ sketchName }/thumbnail.jpeg`;
+}
+
+/** Builds the meta description for a sketch detail page. */
+export function buildSketchDescription(
+  sketchTitle: string,
+  engineLabel: string
+): string {
+  return `Create ${ sketchTitle } content with ${ engineLabel }. A template for generating social media visuals.`;
+}
+
+/** Builds the keyword list for a sketch detail page. */
+export function buildSketchKeywords(
+  sketchName: string,
+  engineLabel: string
+): string[] {
+  const title = formatSketchTitle( sketchName );
+
+  return [
+    title,
+    engineLabel,
+    "social media template",
+    "video generator",
+    "creative coding",
+    ...sketchName.split( "-" )
+  ];
+}
+
+// ─── JSON-LD generators ───────────────────────────────────────────────────────
+
+/** WebApplication schema for the root layout. */
 export function getWebApplicationJsonLd() {
   const baseUrl = getBaseUrl();
 
@@ -56,68 +111,49 @@ export function getWebApplicationJsonLd() {
       price: "0",
       priceCurrency: "USD"
     },
-    featureList: [
-      "p5.js template rendering",
-      "GSAP animation templates",
-      "HTML template capture",
-      "Video recording and export",
-      "Customizable sketch options",
-      "EXIF data overlay",
-      "Multiple export formats"
-    ],
-    screenshot: `${ baseUrl }/assets/images/icon-512x512.png`
+    featureList: APP_FEATURE_LIST,
+    screenshot: `${ baseUrl }${ OG_IMAGE.path }`
   };
 }
 
-/**
- * Generates a BreadcrumbList JSON-LD structured data object.
- */
-export function getBreadcrumbJsonLd( items: Array<{
-  name: string;
-  url: string
-}> ) {
+/** SoftwareApplication schema for an individual sketch page. */
+export function getSketchJsonLd( {
+  title,
+  engineLabel,
+  url,
+  thumbnailUrl
+}: {
+  title: string;
+  engineLabel: string;
+  url: string;
+  thumbnailUrl?: string;
+} ) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: title,
+    applicationCategory: "DesignApplication",
+    operatingSystem: "Web",
+    description: buildSketchDescription( title, engineLabel ),
+    url,
+    ...( thumbnailUrl && {
+      screenshot: thumbnailUrl
+    } )
+  };
+}
+
+/** BreadcrumbList schema for navigation hierarchy. */
+export function getBreadcrumbJsonLd(
+  items: Array<{ name: string; url: string }>
+) {
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    itemListElement: items.map( (
-      item, index
-    ) => ( {
+    itemListElement: items.map( ( item, index ) => ( {
       "@type": "ListItem",
       position: index + 1,
       name: item.name,
       item: item.url
     } ) )
-  };
-}
-
-/**
- * Generates a CreativeWork JSON-LD for an individual template.
- */
-export function getTemplateJsonLd( {
-  name,
-  description,
-  url,
-  thumbnailUrl,
-  category
-}: {
-  name: string;
-  description: string;
-  url: string;
-  thumbnailUrl: string;
-  category: string;
-} ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "CreativeWork",
-    name,
-    description,
-    url,
-    thumbnailUrl,
-    genre: category,
-    isAccessibleForFree: true,
-    provider: {
-      "@type": "WebApplication",
-      name: SITE_NAME
-    }
   };
 }


### PR DESCRIPTION
- Create src/config/site.ts as the single source of truth for all
  site-wide constants (name, description, author, keywords, OG image,
  theme colors, feature list)

- Refactor src/lib/seo.ts to re-export from config and add shared
  utility functions: formatSketchTitle, buildOgTitle, buildCanonicalPath,
  buildThumbnailUrl, buildSketchDescription, buildSketchKeywords.
  Replace unused getTemplateJsonLd (CreativeWork) with getSketchJsonLd
  (SoftwareApplication). getBreadcrumbJsonLd is now actually used.

- Fix title duplication bug in templates/[engine]/[...sketch]/page.tsx:
  `title` was set to "Photo Balloons | Coded templates" which the root
  layout template then wrapped into "Photo Balloons | Coded templates |
  Coded templates". Now only the page title is passed; the template
  handles the site name suffix.

- Always emit OpenGraph/Twitter metadata on sketch pages regardless of
  thumbnail availability, so bots always receive the page-specific
  title and description.

- Use engine label (e.g. "p5.js") instead of raw engine ID (e.g. "p5")
  in sketch descriptions and structured data.

- Add BreadcrumbJsonLd component and inject breadcrumb JSON-LD on all
  template pages (list, engine filter, sketch detail).

- Update SketchJsonLd to use shared utilities and accept engineLabel prop.

- Fix manifest.ts short_name: was "Social Templates", now uses
  SITE_SHORT_NAME ("Coded Templates") consistent with site branding.

- layout.tsx and manifest.ts now derive all string values from config,
  eliminating hardcoded strings scattered across files.

https://claude.ai/code/session_018uAoh1gF4wwGXmts7XGzoU