### PR TITLE
Pause sketches and video previews when tab is hidden

### DIFF
--- a/src/components/AnimatedPreview.tsx
+++ b/src/components/AnimatedPreview.tsx
@@ -3,6 +3,7 @@
 import {
   useEffect, useRef, useState
 } from "react";
+import usePageVisibility from "@/hooks/usePageVisibility";
 
 interface AnimatedPreviewProps {
   previewUrl: string;
@@ -24,6 +25,7 @@ const TRIGGER_ON_HOVER =
  * (default) or by hover when NEXT_PUBLIC_PREVIEW_ON_HOVER=true.
  *
  * Respects prefers-reduced-motion: shows the static thumbnail only.
+ * Pauses video playback when the tab is hidden to save CPU/GPU/battery.
  */
 export default function AnimatedPreview( {
   previewUrl,
@@ -36,32 +38,48 @@ export default function AnimatedPreview( {
   const videoRef = useRef<HTMLVideoElement>( null );
   const prefersReducedRef = useRef( false );
   const [
+    wantsToPlay,
+    setWantsToPlay
+  ] = useState( false );
+  const [
     isPlaying,
     setIsPlaying
   ] = useState( false );
+  const isPageVisible = usePageVisibility();
 
   // Track prefers-reduced-motion without causing re-render on each frame
-  useEffect( () => {
-    const mq = window.matchMedia( "(prefers-reduced-motion: reduce)" );
+  useEffect(
+    () => {
+      const mq = window.matchMedia( "(prefers-reduced-motion: reduce)" );
 
-    prefersReducedRef.current = mq.matches;
+      prefersReducedRef.current = mq.matches;
 
-    const handler = ( e: MediaQueryListEvent ) => {
-      prefersReducedRef.current = e.matches;
+      const handler = ( e: MediaQueryListEvent ) => {
+        prefersReducedRef.current = e.matches;
 
-      if ( e.matches ) {
-        stopVideo();
-      }
-    };
+        if ( e.matches ) {
+          stopVideo();
+        }
+      };
 
-    mq.addEventListener( "change", handler );
-    return () => mq.removeEventListener( "change", handler );
-  }, [] );
+      mq.addEventListener(
+        "change",
+        handler
+      );
+      return () => mq.removeEventListener(
+        "change",
+        handler
+      );
+    },
+    []
+  );
 
   function playVideo() {
     const video = videoRef.current;
 
-    if ( !video || prefersReducedRef.current ) return;
+    if ( !video || prefersReducedRef.current ) {
+      return;
+    }
 
     if ( !video.src ) {
       video.src = previewUrl;
@@ -74,41 +92,60 @@ export default function AnimatedPreview( {
   function stopVideo() {
     const video = videoRef.current;
 
-    if ( !video ) return;
+    if ( !video ) {
+      return;
+    }
     video.pause();
     setIsPlaying( false );
   }
 
-  // Viewport-based playback (default mode)
-  useEffect( () => {
-    if ( TRIGGER_ON_HOVER || !containerRef.current ) return;
-
-    const el = containerRef.current;
-
-    const observer = new IntersectionObserver(
-      ( entries ) => {
-        for ( const entry of entries ) {
-          if ( entry.isIntersecting ) {
-            playVideo();
-          } else {
-            stopVideo();
-          }
-        }
-      },
-      {
-        threshold: 0.4
+  // Viewport-based intent (default mode)
+  useEffect(
+    () => {
+      if ( TRIGGER_ON_HOVER || !containerRef.current ) {
+        return;
       }
-    );
 
-    observer.observe( el );
-    return () => observer.disconnect();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [] );
+      const el = containerRef.current;
+
+      const observer = new IntersectionObserver(
+        ( entries ) => {
+          for ( const entry of entries ) {
+            setWantsToPlay( entry.isIntersecting );
+          }
+        },
+        {
+          threshold: 0.4
+        }
+      );
+
+      observer.observe( el );
+      return () => observer.disconnect();
+    },
+    []
+  );
+
+  // Combine intent (viewport/hover) with permission (tab visibility).
+  // The video only plays when the user can actually see it.
+  useEffect(
+    () => {
+      if ( wantsToPlay && isPageVisible ) {
+        playVideo();
+      } else {
+        stopVideo();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      wantsToPlay,
+      isPageVisible
+    ]
+  );
 
   const hoverHandlers = TRIGGER_ON_HOVER
     ? {
-      onMouseEnter: playVideo,
-      onMouseLeave: stopVideo
+      onMouseEnter: () => setWantsToPlay( true ),
+      onMouseLeave: () => setWantsToPlay( false )
     }
     : {};
 

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import type React from "react";
 import {
-  useCallback, useMemo, useRef, useState
+  useCallback, useEffect, useMemo, useRef, useState
 } from "react";
 import AnimationProgressionBar from "@/components/AnimationProgressionBar";
 import EngineSketchRenderer from "@/components/TemplateSketchPage/EngineSketchRenderer";
@@ -24,6 +24,7 @@ import {
   useSketchThumbnail
 } from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketchThumbnail";
 import useSketchDevWatch from "@/hooks/useSketchDevWatch";
+import usePageVisibility from "@/hooks/usePageVisibility";
 import getSketchThumbnailURL from "@/utils/getSketchThumbnailURL";
 
 const TemplateOptions = dynamic( () =>
@@ -48,45 +49,85 @@ export default function TemplateSketchPage() {
   const wasLoopingRef = useRef( false );
   // Keep a stable ref to the latest engine/looping values to avoid stale closures.
   const interactionStateRef = useRef( {
-    engine, looping
+    engine,
+    looping
   } );
+
   interactionStateRef.current = {
-    engine, looping
+    engine,
+    looping
   };
 
-  const handleInteractionStart = useCallback( ( mode: "panning" | "zooming" ) => {
-    setInteractionMode( mode );
+  const handleInteractionStart = useCallback(
+    ( mode: "panning" | "zooming" ) => {
+      setInteractionMode( mode );
 
-    const {
-      engine: e, looping: l
-    } = interactionStateRef.current;
+      const {
+        engine: e, looping: l
+      } = interactionStateRef.current;
 
-    if ( e && l ) {
-      wasLoopingRef.current = true;
-      e.pause();
-    }
-  }, [] );
+      if ( e && l ) {
+        wasLoopingRef.current = true;
+        e.pause();
+      }
+    },
+    []
+  );
 
-  const handleInteractionEnd = useCallback( () => {
-    setInteractionMode( null );
+  const handleInteractionEnd = useCallback(
+    () => {
+      setInteractionMode( null );
 
-    const {
-      engine: e
-    } = interactionStateRef.current;
+      const {
+        engine: e
+      } = interactionStateRef.current;
 
-    if ( e && wasLoopingRef.current ) {
-      wasLoopingRef.current = false;
-      e.play();
-    }
-  }, [] );
+      if ( e && wasLoopingRef.current ) {
+        wasLoopingRef.current = false;
+        e.play();
+      }
+    },
+    []
+  );
 
-  const handleSeekStart = useCallback( () => {
-    setInteractionMode( "seeking" );
-  }, [] );
+  // Pause the engine when the tab is hidden, resume it when the tab
+  // comes back — but only if the user actually intended the sketch to
+  // be playing (looping state). This is engine-agnostic: any engine
+  // that implements SketchEngine.play/pause benefits automatically.
+  const isPageVisible = usePageVisibility();
 
-  const handleSeekEnd = useCallback( () => {
-    setInteractionMode( null );
-  }, [] );
+  useEffect(
+    () => {
+      if ( !engine || !looping ) {
+        return;
+      }
+
+      if ( isPageVisible ) {
+        engine.play();
+      } else {
+        engine.pause();
+      }
+    },
+    [
+      engine,
+      looping,
+      isPageVisible
+    ]
+  );
+
+  const handleSeekStart = useCallback(
+    () => {
+      setInteractionMode( "seeking" );
+    },
+    []
+  );
+
+  const handleSeekEnd = useCallback(
+    () => {
+      setInteractionMode( null );
+    },
+    []
+  );
 
   const {
     thumbnailUrl

--- a/src/hooks/usePageVisibility.ts
+++ b/src/hooks/usePageVisibility.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  useSyncExternalStore
+} from "react";
+
+// Single shared subscription: every consumer of the hook reads the same
+// snapshot, and the app attaches at most one `visibilitychange` listener
+// regardless of how many components subscribe.
+const listeners = new Set<() => void>();
+let isAttached = false;
+
+function handleChange(): void {
+  for ( const listener of listeners ) {
+    listener();
+  }
+}
+
+function subscribe( listener: () => void ): () => void {
+  listeners.add( listener );
+
+  if ( !isAttached && typeof document !== "undefined" ) {
+    document.addEventListener(
+      "visibilitychange",
+      handleChange
+    );
+    isAttached = true;
+  }
+
+  return () => {
+    listeners.delete( listener );
+
+    if (
+      listeners.size === 0 &&
+      isAttached &&
+      typeof document !== "undefined"
+    ) {
+      document.removeEventListener(
+        "visibilitychange",
+        handleChange
+      );
+      isAttached = false;
+    }
+  };
+}
+
+function getSnapshot(): boolean {
+  if ( typeof document === "undefined" ) {
+    return true;
+  }
+
+  return !document.hidden;
+}
+
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+/**
+ * Whether the current tab/page is visible.
+ *
+ * Use this to pause expensive work (animations, looping videos, sketches,
+ * polling, etc.) while the user is on another tab or has the window
+ * minimized. Engine-agnostic and reusable across the whole app.
+ *
+ * SSR-safe: returns `true` during server rendering and initial hydration.
+ */
+export default function usePageVisibility(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+}


### PR DESCRIPTION
Adds a shared usePageVisibility hook backed by useSyncExternalStore so the whole app pays for a single visibilitychange listener regardless of how many components subscribe. Wires it into:

- TemplateSketchPage: pauses the active engine when the tab is hidden and resumes it on return, only when the user actually intended the sketch to be playing. Engine-agnostic — uses the SketchEngine play/pause contract so p5, GSAP and any future engine benefit.
- AnimatedPreview: decouples play intent (viewport/hover) from playback permission (tab visibility) so looping video thumbnails on the home and gallery pages stop decoding when the tab is in the background.