### PR TITLE
Add smooth fill animation to recording progress bar

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {
-  useEffect, useMemo, useRef, useState
+  useMemo, useState
 } from "react";
 import {
   StopCircle
@@ -9,6 +9,9 @@ import {
 import type {
   RecorderCapabilities, RecorderProgress, RecordingFormat, RecordingMode
 } from "@/engines/recording";
+import {
+  useSmoothFill
+} from "@/hooks/useSmoothFill";
 
 type BrowserRecordingButtonProps = {
   capabilities: RecorderCapabilities;
@@ -145,58 +148,19 @@ export default function BrowserRecordingButton( {
     ]
   );
 
-  // Target fill % for the red progress bar inside the button. Computed
-  // synchronously from `progress` so it tracks the freshest React commit,
-  // but the actual animation is driven imperatively below (see fillRef
-  // effect) to stay smooth even when React batches many progress events
-  // into a single commit on fast captures.
+  // Target fill % for the red progress bar inside the button. Encoding +
+  // finalising stages park the bar at 100% so the user gets "almost
+  // done" feedback while the encoder finishes. The smooth chase to this
+  // target happens in `useSmoothFill` so React's batching of bursty
+  // progress events can't strand the bar at 0%.
   const targetFillPct = progress
     ? progress.stage === "capturing"
       ? progress.percentage
       : 100
     : 0;
-
-  // Imperative rAF tween for the fill bar. The bar always smoothly
-  // catches up to `targetFillPct`, regardless of how often React commits
-  // — fixes "no feedback at all" on very fast recordings (where React
-  // may only commit once) and "jumps unevenly" on bursty progress
-  // streams (where setState calls collapse).
-  const fillRef = useRef<HTMLSpanElement>( null );
-  const targetFillRef = useRef( targetFillPct );
-
-  targetFillRef.current = targetFillPct;
-
-  useEffect(
-    () => {
-      if ( !isRecording ) {
-        return;
-      }
-
-      let rafId = 0;
-      let current = 0;
-
-      const tick = () => {
-        const target = targetFillRef.current;
-        const diff = target - current;
-
-        // ~15% of the gap per frame ⇒ ≈200 ms to converge, matching
-        // the previous CSS transition's feel.
-        current = Math.abs( diff ) < 0.1 ? target : current + diff * 0.15;
-
-        if ( fillRef.current ) {
-          fillRef.current.style.width = `${ current }%`;
-        }
-
-        rafId = requestAnimationFrame( tick );
-      };
-
-      rafId = requestAnimationFrame( tick );
-
-      return () => cancelAnimationFrame( rafId );
-    },
-    [
-      isRecording
-    ]
+  const fillRef = useSmoothFill<HTMLSpanElement>(
+    isRecording,
+    targetFillPct
   );
 
   if ( isRecording ) {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {
-  useMemo, useState
+  useEffect, useMemo, useRef, useState
 } from "react";
 import {
   StopCircle
@@ -145,17 +145,62 @@ export default function BrowserRecordingButton( {
     ]
   );
 
+  // Target fill % for the red progress bar inside the button. Computed
+  // synchronously from `progress` so it tracks the freshest React commit,
+  // but the actual animation is driven imperatively below (see fillRef
+  // effect) to stay smooth even when React batches many progress events
+  // into a single commit on fast captures.
+  const targetFillPct = progress
+    ? progress.stage === "capturing"
+      ? progress.percentage
+      : 100
+    : 0;
+
+  // Imperative rAF tween for the fill bar. The bar always smoothly
+  // catches up to `targetFillPct`, regardless of how often React commits
+  // — fixes "no feedback at all" on very fast recordings (where React
+  // may only commit once) and "jumps unevenly" on bursty progress
+  // streams (where setState calls collapse).
+  const fillRef = useRef<HTMLSpanElement>( null );
+  const targetFillRef = useRef( targetFillPct );
+
+  targetFillRef.current = targetFillPct;
+
+  useEffect(
+    () => {
+      if ( !isRecording ) {
+        return;
+      }
+
+      let rafId = 0;
+      let current = 0;
+
+      const tick = () => {
+        const target = targetFillRef.current;
+        const diff = target - current;
+
+        // ~15% of the gap per frame ⇒ ≈200 ms to converge, matching
+        // the previous CSS transition's feel.
+        current = Math.abs( diff ) < 0.1 ? target : current + diff * 0.15;
+
+        if ( fillRef.current ) {
+          fillRef.current.style.width = `${ current }%`;
+        }
+
+        rafId = requestAnimationFrame( tick );
+      };
+
+      rafId = requestAnimationFrame( tick );
+
+      return () => cancelAnimationFrame( rafId );
+    },
+    [
+      isRecording
+    ]
+  );
+
   if ( isRecording ) {
     const isRealtime = choice.mode === "realtime";
-    // Fill ratio drives the red progress bar inside the button.
-    // Realtime has no frame-based progress so we leave it empty (the
-    // user stops it manually); async-loop hits 100% while encoding +
-    // finalising so the bar reads as "almost done" in those stages.
-    const fillPct = progress
-      ? progress.stage === "capturing"
-        ? progress.percentage
-        : 100
-      : 0;
 
     return (
       <div className="flex flex-col gap-1">
@@ -168,10 +213,11 @@ export default function BrowserRecordingButton( {
           className="relative overflow-hidden rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
         >
           <span
+            ref={ fillRef }
             aria-hidden="true"
-            className="absolute inset-y-0 left-0 bg-red-500/20 transition-[width] duration-200 ease-out pointer-events-none"
+            className="absolute inset-y-0 left-0 bg-red-500/20 pointer-events-none"
             style={ {
-              width: `${ fillPct }%`
+              width: "0%"
             } }
           />
           <StopCircle className="relative h-4 w-4 flex-shrink-0" />

--- a/src/engines/recording/strategies/RealtimeRecorder.ts
+++ b/src/engines/recording/strategies/RealtimeRecorder.ts
@@ -55,6 +55,7 @@ export class RealtimeRecorder extends BaseRecorder {
   private resolveResult: ( ( r: RecorderResult ) => void ) | null = null;
   private rejectResult: ( ( e: Error ) => void ) | null = null;
   private autoStopTimer: ReturnType<typeof setTimeout> | null = null;
+  private progressRafId: number | null = null;
 
   constructor(
     private host: RecorderHost,
@@ -125,6 +126,7 @@ export class RealtimeRecorder extends BaseRecorder {
       };
 
       this._isRecording = false;
+      this.stopProgressTicker();
       this.source?.endRealtime();
       this.emit(
         "stop",
@@ -137,6 +139,7 @@ export class RealtimeRecorder extends BaseRecorder {
       const error = new Error( `MediaRecorder error: ${ event.type }` );
 
       this._isRecording = false;
+      this.stopProgressTicker();
       this.source?.endRealtime();
       this.emit(
         "error",
@@ -159,11 +162,64 @@ export class RealtimeRecorder extends BaseRecorder {
       undefined as any
     );
 
+    // Wall-clock progress estimate: realtime has no frame counter, so
+    // we tick percentage against the sketch's expected loop duration
+    // (totalFrames / frameRate). Caps at 100% if the user lets the
+    // recording run past one loop. Without this the button's fill bar
+    // would stay at 0% for the whole capture.
+    const expectedDurationMs =
+      this.host.frameRate > 0
+        ? ( this.host.totalFrames / this.host.frameRate ) * 1000
+        : 0;
+
+    if ( expectedDurationMs > 0 ) {
+      const startedAt = performance.now();
+      const totalFrames = this.host.totalFrames;
+      const frameRate = this.host.frameRate;
+
+      const tick = () => {
+        if ( !this._isRecording ) {
+          return;
+        }
+
+        const elapsed = performance.now() - startedAt;
+        const pct = Math.min(
+          100,
+          ( elapsed / expectedDurationMs ) * 100
+        );
+        const frame = Math.min(
+          totalFrames,
+          Math.round( ( elapsed / 1000 ) * frameRate )
+        );
+
+        this.emit(
+          "progress",
+          {
+            frame,
+            totalFrames,
+            percentage: pct,
+            stage: "capturing"
+          }
+        );
+
+        this.progressRafId = requestAnimationFrame( tick );
+      };
+
+      this.progressRafId = requestAnimationFrame( tick );
+    }
+
     if ( options.maxDurationMs && options.maxDurationMs > 0 ) {
       this.autoStopTimer = setTimeout(
         () => this.stop().catch( () => undefined ),
         options.maxDurationMs
       );
+    }
+  }
+
+  private stopProgressTicker(): void {
+    if ( this.progressRafId !== null ) {
+      cancelAnimationFrame( this.progressRafId );
+      this.progressRafId = null;
     }
   }
 
@@ -193,6 +249,8 @@ export class RealtimeRecorder extends BaseRecorder {
       clearTimeout( this.autoStopTimer );
       this.autoStopTimer = null;
     }
+
+    this.stopProgressTicker();
 
     if ( this.mediaRecorder && this.mediaRecorder.state !== "inactive" ) {
       this.mediaRecorder.ondataavailable = null;

--- a/src/hooks/useSmoothFill.ts
+++ b/src/hooks/useSmoothFill.ts
@@ -1,0 +1,61 @@
+import {
+  useEffect, useRef
+} from "react";
+
+/**
+ * Imperatively tween an element's `style.width` (as a percentage) toward
+ * a target that may itself change every render. The rAF loop reads the
+ * latest target from a ref, so streamed updates collapsed by React 18's
+ * batching still produce a visibly smooth fill — useful for progress
+ * bars whose source events fire faster than React renders (eg. an
+ * async-loop recorder pushing per-frame events on a short sketch).
+ *
+ * `factor` is the fraction of the remaining gap closed per animation
+ * frame. The default (~0.15) converges in ≈200 ms at 60 fps, matching
+ * the feel of a `transition: width 200ms ease-out` without the
+ * batching pitfalls.
+ */
+export function useSmoothFill<T extends HTMLElement = HTMLElement>(
+  enabled: boolean,
+  targetPercentage: number,
+  factor = 0.15
+) {
+  const elementRef = useRef<T | null>( null );
+  const targetRef = useRef( targetPercentage );
+
+  targetRef.current = targetPercentage;
+
+  useEffect(
+    () => {
+      if ( !enabled ) {
+        return;
+      }
+
+      let rafId = 0;
+      let current = 0;
+
+      const tick = () => {
+        const target = targetRef.current;
+        const diff = target - current;
+
+        current = Math.abs( diff ) < 0.1 ? target : current + diff * factor;
+
+        if ( elementRef.current ) {
+          elementRef.current.style.width = `${ current }%`;
+        }
+
+        rafId = requestAnimationFrame( tick );
+      };
+
+      rafId = requestAnimationFrame( tick );
+
+      return () => cancelAnimationFrame( rafId );
+    },
+    [
+      enabled,
+      factor
+    ]
+  );
+
+  return elementRef;
+}


### PR DESCRIPTION
## Summary
This PR improves the visual feedback during browser-based recording by implementing a smooth, animated progress bar fill that gracefully handles React's batching of rapid progress events.

## Key Changes

- **New `useSmoothFill` hook** (`src/hooks/useSmoothFill.ts`): A custom React hook that imperatively tweens an element's width toward a target percentage using `requestAnimationFrame`. This decouples the animation loop from React's render cycle, ensuring smooth visual updates even when progress events are batched together by React 18.

- **Progress tracking in `RealtimeRecorder`** (`src/engines/recording/strategies/RealtimeRecorder.ts`):
  - Added wall-clock based progress estimation for realtime recordings (which lack frame counters)
  - Emits progress events at 60fps via `requestAnimationFrame` with calculated percentage and frame count
  - Properly cleans up the animation frame on stop/error with new `stopProgressTicker()` method
  - Progress caps at 100% during encoding/finalizing stages to provide "almost done" feedback

- **Updated `BrowserRecordingButton`** (`src/components/ClientProcessingSketch/components/TemplateActions/components/CaptureActions/components/BrowserRecordingButton.tsx`):
  - Integrated `useSmoothFill` hook to animate the red progress bar fill
  - Removed CSS transition in favor of imperative animation (eliminates batching issues)
  - Calculates target fill percentage based on recording stage (capturing vs. encoding/finalizing)

## Implementation Details

The solution addresses a key issue: when recording events fire faster than React renders (e.g., per-frame events), React batches multiple progress updates into a single render. This would cause the progress bar to jump rather than animate smoothly. By using `requestAnimationFrame` with a ref-based target, the animation loop continuously reads the latest progress value and smoothly interpolates toward it, independent of React's batching behavior.

The default easing factor (~0.15) converges in approximately 200ms at 60fps, matching the feel of a CSS `transition: width 200ms ease-out` without the batching pitfalls.

https://claude.ai/code/session_015j5554NzhQgTpmDqZfwoVx