### PR TITLE
fix(photo-zoom-point): correct coordinate bugs and sync form with canvas clicks

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -37,6 +37,9 @@ import {
 import {
   useCollapsibleStates, CollapsibleProvider
 } from "./hooks/useCollapsibleStates";
+import {
+  subscribeSketchOptions
+} from "@/lib/syncSketchOptions";
 
 type TemplateOptionsProps = {
   name: string;
@@ -108,23 +111,57 @@ export default function TemplateOptions( {
     control, getValues, setValue, reset
   } = methods;
 
-  // Sync form with external options changes (e.g., from sketch interactions)
-  // useEffect(
-  //   () => {
-  //     const processedOptions = initOptions( initialOptions );
-  //     const currentFormValues = getValues();
-  //
-  //     // Only reset if the options actually changed to avoid unnecessary re-renders
-  //     if ( JSON.stringify( processedOptions ) !== JSON.stringify( currentFormValues ) ) {
-  //       reset( processedOptions );
-  //     }
-  //   },
-  //   [
-  //     initialOptions,
-  //     reset,
-  //     getValues
-  //   ]
-  // );
+  // Sync form with sketch-driven option changes (e.g., clicking the canvas to set a point).
+  // Only fires for non-"react" origins to avoid feedback loops with the form's own watch().
+  useEffect(
+    () => {
+      function syncLeafValues( newObj: unknown, currentObj: unknown, path: string ) {
+        if (
+          newObj === null ||
+          newObj === undefined ||
+          typeof newObj !== "object" ||
+          Array.isArray( newObj )
+        ) {
+          if ( JSON.stringify( newObj ) !== JSON.stringify( currentObj ) ) {
+            setValue(
+              path as any,
+              newObj,
+              {
+                shouldDirty: false,
+                shouldValidate: false
+              }
+            );
+          }
+          return;
+        }
+
+        for ( const key of Object.keys( newObj as Record<string, unknown> ) ) {
+          const childPath = path ? `${ path }.${ key }` : key;
+
+          syncLeafValues(
+            ( newObj as Record<string, unknown> )[ key ],
+            ( currentObj as Record<string, unknown> )?.[ key ],
+            childPath
+          );
+        }
+      }
+
+      return subscribeSketchOptions( ( opts, origin ) => {
+        if ( origin === "react" ) {
+          return;
+        }
+        syncLeafValues(
+          opts,
+          getValues(),
+          ""
+        );
+      } );
+    },
+    [
+      getValues,
+      setValue
+    ]
+  );
 
   const {
     fields: slideFields,

--- a/src/templates/p5/sketches/photo/photo-zoom-point/index.js
+++ b/src/templates/p5/sketches/photo/photo-zoom-point/index.js
@@ -38,6 +38,7 @@ const sketchState = {
  * Handles the canvas being inside a draggable/zoomable div.
  */
 function getInternalCanvasPoint( event ) {
+  const p = getP5();
   const canvasElement = sketch.engine?.getCanvasElement?.();
 
   if ( !canvasElement ) {
@@ -194,12 +195,15 @@ function displayPhoto( img ) {
     fill: options.sketch?.imageSettings?.fill ?? true,
     img,
     callback: (
-      x, y, w, h
+      cx, cy, w, h
     ) => {
-      // Store the image bounds relative to the UNZOOMED buffer
+      // marginImage passes the anchor point (center when center:true).
+      // Normalize to top-left so collision and UV math are consistent.
+      const isCenter = options.sketch?.imageSettings?.center ?? true;
+
       sketchState.photoRect = {
-        x,
-        y,
+        x: isCenter ? cx - w / 2 : cx,
+        y: isCenter ? cy - h / 2 : cy,
         w,
         h
       };
@@ -287,11 +291,6 @@ sketch.draw( () => {
     y: ty,
     scale: zoomScale
   };
-
-  console.log(
-    uvPoint,
-    options.sketch.point
-  );
 
   // 6. Apply & Draw
   p.push();

--- a/src/templates/p5/sketches/photo/photo-zoom-point/options.ts
+++ b/src/templates/p5/sketches/photo/photo-zoom-point/options.ts
@@ -59,14 +59,14 @@ export const formConfiguration: Record<string, any> = {
         label: "X",
         min: 0,
         max: 1,
-        step: 0.1
+        step: 0.01
       },
       y: {
         component: "slider",
         label: "Y",
         min: 0,
         max: 1,
-        step: 0.1
+        step: 0.01
       }
     }
   },


### PR DESCRIPTION
- Add missing `getP5()` call in `getInternalCanvasPoint` (p was undefined)
- Normalize `photoRect` to top-left corner when `center:true`; `marginImage`
  returns the anchor (center) so UV math and hit-detection were offset by w/2, h/2
- Remove per-frame console.log in draw loop
- Change point slider step from 0.1 to 0.01 for sub-pixel UV precision
- Add `subscribeSketchOptions` effect in TemplateOptions to push p5-origin
  option changes (e.g. canvas clicks) into react-hook-form via setValue,
  so the X/Y sliders reflect the clicked coordinates immediately

https://claude.ai/code/session_01SxSQkog8xU8mDRqatWJHFQ