### PR TITLE
Add useMidi, useAudio, useJoypad handlers; fix mouse/touch coordinate bug

### DIFF
--- a/src/templates/p5/sketches/kinetic/interaction-test/index.js
+++ b/src/templates/p5/sketches/kinetic/interaction-test/index.js
@@ -13,45 +13,31 @@ import {
 
 // Color palette per source (RGB)
 const SOURCE_COLORS = {
-  mouse: [
-    66,
-    133,
-    244
-  ], // blue
-  touch: [
-    52,
-    168,
-    83
-  ], // green
-  vision: [
-    234,
-    67,
-    53
-  ], // red
-  orbit: [
-    251,
-    188,
-    4
-  ], // yellow
-  perlinNoise: [
-    0,
-    188,
-    168
-  ], // teal
-  gyroscope: [
-    156,
-    39,
-    176
-  ] // purple
+  mouse:       [ 66, 133, 244 ],  // blue
+  touch:       [ 52, 168, 83 ],   // green
+  hands:       [ 255, 109, 0 ],   // orange
+  face:        [ 233, 30, 99 ],   // pink
+  body:        [ 0, 188, 212 ],   // cyan
+  orbit:       [ 251, 188, 4 ],   // yellow
+  perlinNoise: [ 0, 150, 136 ],   // teal
+  gyroscope:   [ 96, 125, 139 ],  // blue-grey
+  midi:        [ 156, 39, 176 ],  // purple
+  audio:       [ 244, 67, 54 ],   // red
+  joypad:      [ 77, 182, 172 ]   // teal-green
 };
 
 const SOURCE_LABELS = {
-  mouse: "Mouse",
-  touch: "Touch",
-  vision: "Vision (hands/face/body)",
-  orbit: "Orbit",
+  mouse:       "Mouse",
+  touch:       "Touch",
+  hands:       "Hands (MediaPipe)",
+  face:        "Face (MediaPipe)",
+  body:        "Body (MediaPipe)",
+  orbit:       "Orbit",
   perlinNoise: "Perlin Noise",
-  gyroscope: "Gyroscope"
+  gyroscope:   "Gyroscope",
+  midi:        "MIDI",
+  audio:       "Audio (Mic)",
+  joypad:      "Joypad / Gamepad"
 };
 
 sketch.setup( async() => {
@@ -131,7 +117,9 @@ sketch.draw( () => {
   } );
 
   // ── Webcam preview (top-right) ─────────────────────────────────────────
-  if ( interaction.vision?.camera?.showPreview && mediapipe.capture?.element ) {
+  const vision = interaction.vision;
+
+  if ( vision?.camera?.showPreview && mediapipe.capture?.element ) {
     const previewW = p.width / 5;
     const previewH = p.height / 5;
 
@@ -235,12 +223,12 @@ function _drawLegend(
     y += lineH;
   } );
 
-  // Reload hint when vision enabled but mediapipe not yet running
+  // Camera hint when vision enabled but mediapipe not yet running
   const vision = interaction.vision;
   const needsCamera = vision?.hands?.enabled || vision?.face?.enabled || vision?.body?.enabled;
   const cameraRunning = !!mediapipe.capture?.element;
 
-  if ( needsCamera && !cameraRunning ) {
+  if ( needsCamera && !cameraRunning && vision?.enabled !== false ) {
     p.fill(
       251,
       188,

--- a/src/templates/p5/utils/interaction/defaults.js
+++ b/src/templates/p5/utils/interaction/defaults.js
@@ -80,6 +80,25 @@ export const interactionFormValues = {
     clampAngle: 45
   },
 
+  midi: {
+    enabled: false,
+    maxNotes: 10
+  },
+
+  audio: {
+    enabled: false,
+    count: 1,
+    smoothing: 0.8,
+    fftSize: 1024,
+    margin: 50
+  },
+
+  joypad: {
+    enabled: false,
+    count: 1,
+    deadzone: 0.1
+  },
+
   visualization: {
     enabled: true,
     showImages: false,
@@ -455,6 +474,100 @@ export const interactionFormConfiguration = {
           min: 5,
           max: 90,
           step: 5
+        }
+      }
+    },
+
+    midi: {
+      component: "nested-object",
+      label: "MIDI",
+      fields: {
+        enabled: {
+          component: "checkbox",
+          label: "Enabled"
+        },
+        maxNotes: {
+          component: "slider",
+          label: "Max simultaneous notes",
+          min: 1,
+          max: 32,
+          step: 1
+        }
+      }
+    },
+
+    audio: {
+      component: "nested-object",
+      label: "Audio (Microphone)",
+      fields: {
+        enabled: {
+          component: "checkbox",
+          label: "Enabled"
+        },
+        count: {
+          component: "slider",
+          label: "Frequency bands",
+          min: 1,
+          max: 16,
+          step: 1
+        },
+        smoothing: {
+          component: "slider",
+          label: "Smoothing",
+          min: 0,
+          max: 0.99,
+          step: 0.01
+        },
+        fftSize: {
+          component: "select",
+          label: "FFT size",
+          asNumber: true,
+          options: [
+            {
+              label: "512",
+              value: "512"
+            },
+            {
+              label: "1024",
+              value: "1024"
+            },
+            {
+              label: "2048",
+              value: "2048"
+            }
+          ]
+        },
+        margin: {
+          component: "slider",
+          label: "Margin",
+          min: 0,
+          max: 300,
+          step: 1
+        }
+      }
+    },
+
+    joypad: {
+      component: "nested-object",
+      label: "Joypad / Gamepad",
+      fields: {
+        enabled: {
+          component: "checkbox",
+          label: "Enabled"
+        },
+        count: {
+          component: "slider",
+          label: "Max gamepads",
+          min: 1,
+          max: 4,
+          step: 1
+        },
+        deadzone: {
+          component: "slider",
+          label: "Deadzone",
+          min: 0,
+          max: 0.5,
+          step: 0.01
         }
       }
     },

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -38,6 +38,15 @@ export const BODY_HIP_INDICES = [
 ];
 
 // ── Module-level state ─────────────────────────────────────────────────────
+
+// Raw mouse/touch: tracked via window listeners so coordinates are correct
+// even when the canvas is panned/zoomed inside ScalableViewport (CSS transform).
+const _rawMouse = {
+  clientX: null,
+  clientY: null
+};
+let _rawTouches = []; // Array of { clientX, clientY }
+
 let _noiseOffset = 0;
 const _smoothedMouse = {
   x: 0,
@@ -47,7 +56,144 @@ const _gyro = {
   beta: 0,
   gamma: 0
 };
+
+// Listeners
 let _gyroListener = null;
+let _pointerMoveListener = null;
+let _touchListeners = null;
+
+// MIDI state
+let _midiInitialized = false;
+let _midiAccess = null;
+const _midiNotes = new Map(); // noteNumber → velocity
+
+// Audio state
+let _audioInitialized = false;
+let _audioContext = null;
+let _audioAnalyser = null;
+let _audioFreqData = null;
+
+// ── Coordinate conversion ──────────────────────────────────────────────────
+
+/**
+ * Convert viewport-space clientX/clientY to p5 canvas-space coordinates.
+ * Uses getBoundingClientRect() so it correctly accounts for any CSS transforms
+ * (e.g. the ScalableViewport's translate/scale) applied to the canvas's ancestors.
+ */
+function _clientToCanvas(
+  clientX, clientY, p
+) {
+  if ( typeof document === "undefined" ) {
+    return {
+      x: 0,
+      y: 0
+    };
+  }
+
+  const canvas = document.querySelector( "canvas.p5Canvas" );
+
+  if ( !canvas ) {
+    return {
+      x: 0,
+      y: 0
+    };
+  }
+
+  const rect = canvas.getBoundingClientRect();
+
+  if ( rect.width === 0 || rect.height === 0 ) {
+    return {
+      x: 0,
+      y: 0
+    };
+  }
+
+  return {
+    x: ( clientX - rect.left ) * ( p.width / rect.width ),
+    y: ( clientY - rect.top ) * ( p.height / rect.height )
+  };
+}
+
+// ── MIDI helpers ───────────────────────────────────────────────────────────
+
+function _wireMidiInputs() {
+  if ( !_midiAccess ) {
+    return;
+  }
+
+  _midiAccess.inputs.forEach( ( input ) => {
+    input.onmidimessage = _onMidiMessage;
+  } );
+}
+
+function _onMidiMessage( msg ) {
+  if ( !msg.data || msg.data.length < 3 ) {
+    return;
+  }
+
+  const command = msg.data[ 0 ] & 0xf0;
+  const note = msg.data[ 1 ];
+  const velocity = msg.data[ 2 ];
+
+  if ( command === 0x90 && velocity > 0 ) {
+    _midiNotes.set(
+      note,
+      velocity
+    );
+  } else if ( command === 0x80 || ( command === 0x90 && velocity === 0 ) ) {
+    _midiNotes.delete( note );
+  }
+}
+
+async function _initMidi() {
+  if ( _midiInitialized ) {
+    return;
+  }
+
+  _midiInitialized = true;
+
+  if ( typeof navigator === "undefined" || typeof navigator.requestMIDIAccess !== "function" ) {
+    return;
+  }
+
+  try {
+    _midiAccess = await navigator.requestMIDIAccess();
+    _wireMidiInputs();
+    _midiAccess.onstatechange = () => _wireMidiInputs();
+  } catch {
+    // Permission denied or MIDI not available
+  }
+}
+
+// ── Audio helpers ──────────────────────────────────────────────────────────
+
+async function _initAudio( opts ) {
+  if ( _audioInitialized ) {
+    return;
+  }
+
+  _audioInitialized = true;
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia( {
+      audio: true,
+      video: false
+    } );
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+
+    _audioContext = new AudioCtx();
+    _audioAnalyser = _audioContext.createAnalyser();
+    _audioAnalyser.fftSize = opts.audio?.fftSize ?? 1024;
+    _audioAnalyser.smoothingTimeConstant = opts.audio?.smoothing ?? 0.8;
+
+    const source = _audioContext.createMediaStreamSource( stream );
+
+    source.connect( _audioAnalyser );
+    _audioFreqData = new Uint8Array( _audioAnalyser.frequencyBinCount );
+  } catch {
+    // Microphone permission denied or not available
+  }
+}
 
 // ── Public API ─────────────────────────────────────────────────────────────
 
@@ -68,15 +214,26 @@ export async function initInteraction( opts = {} ) {
     if ( vision.hands?.enabled ) {
       tasks.push( "hands" );
     }
+
     if ( vision.body?.enabled ) {
       tasks.push( "poses" );
     }
+
     if ( vision.face?.enabled ) {
       tasks.push( "faces" );
     }
   }
 
   _noiseOffset = opts.perlinNoise?.seed ?? 0;
+
+  // ── Gyroscope ────────────────────────────────────────────────────────────
+  if ( _gyroListener && typeof window !== "undefined" ) {
+    window.removeEventListener(
+      "deviceorientation",
+      _gyroListener
+    );
+    _gyroListener = null;
+  }
 
   if ( opts.gyroscope?.enabled && typeof window !== "undefined" ) {
     _gyroListener = ( e ) => {
@@ -89,6 +246,105 @@ export async function initInteraction( opts = {} ) {
     );
   }
 
+  // ── Raw mouse / touch tracking ───────────────────────────────────────────
+  // We track raw clientX/Y ourselves so _clientToCanvas() can give correct
+  // canvas-space coordinates regardless of CSS transforms in ScalableViewport.
+  if ( typeof window !== "undefined" ) {
+    // Remove stale listeners from a previous initInteraction call
+    if ( _pointerMoveListener ) {
+      window.removeEventListener(
+        "pointermove",
+        _pointerMoveListener
+      );
+    }
+
+    _rawMouse.clientX = null;
+    _rawMouse.clientY = null;
+
+    _pointerMoveListener = ( e ) => {
+      _rawMouse.clientX = e.clientX;
+      _rawMouse.clientY = e.clientY;
+    };
+    window.addEventListener(
+      "pointermove",
+      _pointerMoveListener,
+      {
+        passive: true
+      }
+    );
+
+    if ( _touchListeners ) {
+      window.removeEventListener(
+        "touchstart",
+        _touchListeners.fn
+      );
+      window.removeEventListener(
+        "touchmove",
+        _touchListeners.fn
+      );
+      window.removeEventListener(
+        "touchend",
+        _touchListeners.fn
+      );
+    }
+
+    _rawTouches = [];
+
+    const _onTouch = ( e ) => {
+      _rawTouches = Array.from( e.touches ).map( ( t ) => ( {
+        clientX: t.clientX,
+        clientY: t.clientY
+      } ) );
+    };
+
+    _touchListeners = {
+      fn: _onTouch
+    };
+    window.addEventListener(
+      "touchstart",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+    window.addEventListener(
+      "touchmove",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+    window.addEventListener(
+      "touchend",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+  }
+
+  // ── MIDI reset (lazy init triggered by _collectMidi) ─────────────────────
+  if ( _midiAccess ) {
+    _midiAccess.inputs.forEach( ( input ) => {
+      input.onmidimessage = null;
+    } );
+  }
+
+  _midiAccess = null;
+  _midiInitialized = false;
+  _midiNotes.clear();
+
+  // ── Audio reset (lazy init triggered by _collectAudio) ───────────────────
+  if ( _audioContext ) {
+    _audioContext.close().catch( () => {} );
+    _audioContext = null;
+    _audioAnalyser = null;
+    _audioFreqData = null;
+  }
+
+  _audioInitialized = false;
+
+  // ── MediaPipe ────────────────────────────────────────────────────────────
   if ( tasks.length > 0 ) {
     const cam = vision.camera ?? {};
 
@@ -105,16 +361,73 @@ export async function initInteraction( opts = {} ) {
 }
 
 /**
- * Call when tearing down the sketch to remove the gyroscope listener.
+ * Call when tearing down the sketch to remove event listeners and free resources.
  */
 export function disposeInteraction() {
-  if ( _gyroListener && typeof window !== "undefined" ) {
+  if ( typeof window === "undefined" ) {
+    return;
+  }
+
+  // Gyroscope
+  if ( _gyroListener ) {
     window.removeEventListener(
       "deviceorientation",
       _gyroListener
     );
     _gyroListener = null;
   }
+
+  // Mouse
+  if ( _pointerMoveListener ) {
+    window.removeEventListener(
+      "pointermove",
+      _pointerMoveListener
+    );
+    _pointerMoveListener = null;
+  }
+
+  _rawMouse.clientX = null;
+  _rawMouse.clientY = null;
+
+  // Touch
+  if ( _touchListeners ) {
+    window.removeEventListener(
+      "touchstart",
+      _touchListeners.fn
+    );
+    window.removeEventListener(
+      "touchmove",
+      _touchListeners.fn
+    );
+    window.removeEventListener(
+      "touchend",
+      _touchListeners.fn
+    );
+    _touchListeners = null;
+  }
+
+  _rawTouches = [];
+
+  // MIDI
+  if ( _midiAccess ) {
+    _midiAccess.inputs.forEach( ( input ) => {
+      input.onmidimessage = null;
+    } );
+    _midiAccess = null;
+  }
+
+  _midiInitialized = false;
+  _midiNotes.clear();
+
+  // Audio
+  if ( _audioContext ) {
+    _audioContext.close().catch( () => {} );
+    _audioContext = null;
+    _audioAnalyser = null;
+    _audioFreqData = null;
+  }
+
+  _audioInitialized = false;
 }
 
 /**
@@ -143,7 +456,18 @@ export function getPointers( opts ) {
     p,
     vectors
   );
-  _collectVision(
+  _syncVisionEnabled( opts );
+  _collectHands(
+    opts,
+    p,
+    vectors
+  );
+  _collectFace(
+    opts,
+    p,
+    vectors
+  );
+  _collectBody(
     opts,
     p,
     vectors
@@ -159,6 +483,21 @@ export function getPointers( opts ) {
     vectors
   );
   _collectGyroscope(
+    opts,
+    p,
+    vectors
+  );
+  _collectMidi(
+    opts,
+    p,
+    vectors
+  );
+  _collectAudio(
+    opts,
+    p,
+    vectors
+  );
+  _collectJoypad(
     opts,
     p,
     vectors
@@ -201,6 +540,7 @@ export function getPointersDebug( opts ) {
     "mouse",
     m
   );
+
   const t = [];
 
   _collectTouch(
@@ -211,16 +551,42 @@ export function getPointersDebug( opts ) {
     "touch",
     t
   );
-  const v = [];
 
-  _collectVision(
+  _syncVisionEnabled( opts );
+
+  const h = [];
+
+  _collectHands(
     opts,
     p,
-    v
+    h
   ); push(
-    "vision",
-    v
+    "hands",
+    h
   );
+
+  const f = [];
+
+  _collectFace(
+    opts,
+    p,
+    f
+  ); push(
+    "face",
+    f
+  );
+
+  const b = [];
+
+  _collectBody(
+    opts,
+    p,
+    b
+  ); push(
+    "body",
+    b
+  );
+
   const o = [];
 
   _collectOrbit(
@@ -231,6 +597,7 @@ export function getPointersDebug( opts ) {
     "orbit",
     o
   );
+
   const n = [];
 
   _collectPerlinNoise(
@@ -241,6 +608,7 @@ export function getPointersDebug( opts ) {
     "perlinNoise",
     n
   );
+
   const g = [];
 
   _collectGyroscope(
@@ -250,6 +618,39 @@ export function getPointersDebug( opts ) {
   ); push(
     "gyroscope",
     g
+  );
+
+  const mid = [];
+
+  _collectMidi(
+    opts,
+    p,
+    mid
+  ); push(
+    "midi",
+    mid
+  );
+
+  const aud = [];
+
+  _collectAudio(
+    opts,
+    p,
+    aud
+  ); push(
+    "audio",
+    aud
+  );
+
+  const joy = [];
+
+  _collectJoypad(
+    opts,
+    p,
+    joy
+  ); push(
+    "joypad",
+    joy
   );
 
   return tagged;
@@ -270,15 +671,35 @@ function _collectMouse(
   const oy = mouse.offsetY ?? 0;
   const smoothing = mouse.smoothing ?? 0;
 
+  // Use raw client coordinates converted through getBoundingClientRect() so
+  // the result is correct even when ScalableViewport has panned/zoomed the
+  // canvas (CSS transform on the parent doesn't affect the formula).
+  let rawX, rawY;
+
+  if ( _rawMouse.clientX === null ) {
+    // No pointermove yet — fall back to p5's values for the first frame
+    rawX = p.mouseX;
+    rawY = p.mouseY;
+  } else {
+    const coords = _clientToCanvas(
+      _rawMouse.clientX,
+      _rawMouse.clientY,
+      p
+    );
+
+    rawX = coords.x;
+    rawY = coords.y;
+  }
+
   if ( smoothing > 0 ) {
     _smoothedMouse.x = p.lerp(
       _smoothedMouse.x,
-      p.mouseX,
+      rawX,
       1 - smoothing
     );
     _smoothedMouse.y = p.lerp(
       _smoothedMouse.y,
-      p.mouseY,
+      rawY,
       1 - smoothing
     );
     out.push( p.createVector(
@@ -287,8 +708,8 @@ function _collectMouse(
     ) );
   } else {
     out.push( p.createVector(
-      p.mouseX + ox,
-      p.mouseY + oy
+      rawX + ox,
+      rawY + oy
     ) );
   }
 }
@@ -303,139 +724,61 @@ function _collectTouch(
   }
 
   const maxTouches = touch.maxTouches ?? 5;
-  const touches = p.touches ?? [];
   const count = Math.min(
-    touches.length,
+    _rawTouches.length,
     maxTouches
   );
 
   for ( let i = 0; i < count; i++ ) {
+    const {
+      x, y
+    } = _clientToCanvas(
+      _rawTouches[ i ].clientX,
+      _rawTouches[ i ].clientY,
+      p
+    );
+
     out.push( p.createVector(
-      touches[ i ].x,
-      touches[ i ].y
+      x,
+      y
     ) );
   }
 }
 
-function _collectVision(
+// Sync the mediapipe enabled state based on current options.
+// Must be called once per frame before the vision collectors.
+function _syncVisionEnabled( opts ) {
+  const vision = opts.vision;
+  const anyVision = vision?.enabled !== false &&
+    ( vision?.hands?.enabled || vision?.face?.enabled || vision?.body?.enabled );
+
+  setMediapipeEnabled( !!anyVision );
+}
+
+function _collectHands(
   opts, p, out
 ) {
   const vision = opts.vision;
-  const anyVision = vision?.enabled !== false &&
-                      ( vision?.hands?.enabled || vision?.face?.enabled || vision?.body?.enabled );
+  const hands = vision?.hands;
 
-  setMediapipeEnabled( !!anyVision );
-
-  if ( !anyVision ) {
+  if ( vision?.enabled === false || !hands?.enabled ) {
     return;
   }
 
   const flip = vision?.camera?.flip ?? true;
+  const lm = hands.landmarks ?? {};
+  const maxHands = hands.maxHands ?? 2;
+  const results = mediapipe.tasks?.hands?.result?.landmarks ?? [];
 
-  // ── Hands ────────────────────────────────────────────────────────────────
-  const hands = vision?.hands;
-
-  if ( hands?.enabled ) {
-    const lm = hands.landmarks ?? {};
-    const maxHands = hands.maxHands ?? 2;
-    const results = mediapipe.tasks?.hands?.result?.landmarks ?? [];
-
-    results.slice(
-      0,
-      maxHands
-    ).forEach( ( hand ) => {
-      if ( lm.fingertips !== false ) {
-        HAND_FINGERTIP_INDICES.forEach( ( i ) => {
-          const pt = hand[ i ];
-
-          if ( !pt ) {
-            return;
-          }
-          out.push( p.createVector(
-            ( flip ? common.inverseX( pt.x ) : pt.x ) * p.width,
-            pt.y * p.height
-          ) );
-        } );
-      }
-
-      if ( lm.palm ) {
-        const pt = hand[ HAND_PALM_INDEX ];
-
-        if ( pt ) {
-          out.push( p.createVector(
-            ( flip ? common.inverseX( pt.x ) : pt.x ) * p.width,
-            pt.y * p.height
-          ) );
-        }
-      }
-    } );
-  }
-
-  // ── Face ─────────────────────────────────────────────────────────────────
-  const face = vision?.face;
-
-  if ( face?.enabled ) {
-    const detections = mediapipe.tasks?.faces?.result?.detections ?? [];
-    const maxFaces = face.maxFaces ?? 1;
-    const capW = mediapipe.capture?.size?.width ?? 320;
-    const capH = mediapipe.capture?.size?.height ?? 240;
-
-    detections.slice(
-      0,
-      maxFaces
-    ).forEach( ( det ) => {
-      const bbox = det.boundingBox;
-
-      if ( !bbox ) {
-        return;
-      }
-
-      // FaceDetector returns pixel-space bbox relative to capture size
-      const cx = ( bbox.originX + bbox.width / 2 ) / capW;
-      const cy = ( bbox.originY + bbox.height / 2 ) / capH;
-
-      out.push( p.createVector(
-        ( flip ? 1 - cx : cx ) * p.width,
-        cy * p.height
-      ) );
-    } );
-  }
-
-  // ── Body ──────────────────────────────────────────────────────────────────
-  const body = vision?.body;
-
-  if ( body?.enabled ) {
-    const lm = body.landmarks ?? {};
-    const maxPoses = body.maxPoses ?? 1;
-    const minConf = body.confidence ?? 0.3;
-    const results = mediapipe.tasks?.poses?.result?.landmarks ?? [];
-
-    results.slice(
-      0,
-      maxPoses
-    ).forEach( ( pose ) => {
-      const indices = [];
-
-      if ( lm.wrists !== false ) {
-        indices.push( ...BODY_WRIST_INDICES );
-      }
-      if ( lm.elbows ) {
-        indices.push( ...BODY_ELBOW_INDICES );
-      }
-      if ( lm.shoulders ) {
-        indices.push( ...BODY_SHOULDER_INDICES );
-      }
-      if ( lm.hips ) {
-        indices.push( ...BODY_HIP_INDICES );
-      }
-
-      indices.forEach( ( i ) => {
-        const pt = pose[ i ];
+  results.slice(
+    0,
+    maxHands
+  ).forEach( ( hand ) => {
+    if ( lm.fingertips !== false ) {
+      HAND_FINGERTIP_INDICES.forEach( ( i ) => {
+        const pt = hand[ i ];
 
         if ( !pt ) {
-          return;
-        }
-        if ( ( pt.visibility ?? 1 ) < minConf ) {
           return;
         }
 
@@ -444,8 +787,113 @@ function _collectVision(
           pt.y * p.height
         ) );
       } );
-    } );
+    }
+
+    if ( lm.palm ) {
+      const pt = hand[ HAND_PALM_INDEX ];
+
+      if ( pt ) {
+        out.push( p.createVector(
+          ( flip ? common.inverseX( pt.x ) : pt.x ) * p.width,
+          pt.y * p.height
+        ) );
+      }
+    }
+  } );
+}
+
+function _collectFace(
+  opts, p, out
+) {
+  const vision = opts.vision;
+  const face = vision?.face;
+
+  if ( vision?.enabled === false || !face?.enabled ) {
+    return;
   }
+
+  const flip = vision?.camera?.flip ?? true;
+  const detections = mediapipe.tasks?.faces?.result?.detections ?? [];
+  const maxFaces = face.maxFaces ?? 1;
+  const capW = mediapipe.capture?.size?.width ?? 320;
+  const capH = mediapipe.capture?.size?.height ?? 240;
+
+  detections.slice(
+    0,
+    maxFaces
+  ).forEach( ( det ) => {
+    const bbox = det.boundingBox;
+
+    if ( !bbox ) {
+      return;
+    }
+
+    // FaceDetector returns pixel-space bbox relative to capture size
+    const cx = ( bbox.originX + bbox.width / 2 ) / capW;
+    const cy = ( bbox.originY + bbox.height / 2 ) / capH;
+
+    out.push( p.createVector(
+      ( flip ? 1 - cx : cx ) * p.width,
+      cy * p.height
+    ) );
+  } );
+}
+
+function _collectBody(
+  opts, p, out
+) {
+  const vision = opts.vision;
+  const body = vision?.body;
+
+  if ( vision?.enabled === false || !body?.enabled ) {
+    return;
+  }
+
+  const flip = vision?.camera?.flip ?? true;
+  const lm = body.landmarks ?? {};
+  const maxPoses = body.maxPoses ?? 1;
+  const minConf = body.confidence ?? 0.3;
+  const results = mediapipe.tasks?.poses?.result?.landmarks ?? [];
+
+  results.slice(
+    0,
+    maxPoses
+  ).forEach( ( pose ) => {
+    const indices = [];
+
+    if ( lm.wrists !== false ) {
+      indices.push( ...BODY_WRIST_INDICES );
+    }
+
+    if ( lm.elbows ) {
+      indices.push( ...BODY_ELBOW_INDICES );
+    }
+
+    if ( lm.shoulders ) {
+      indices.push( ...BODY_SHOULDER_INDICES );
+    }
+
+    if ( lm.hips ) {
+      indices.push( ...BODY_HIP_INDICES );
+    }
+
+    indices.forEach( ( i ) => {
+      const pt = pose[ i ];
+
+      if ( !pt ) {
+        return;
+      }
+
+      if ( ( pt.visibility ?? 1 ) < minConf ) {
+        return;
+      }
+
+      out.push( p.createVector(
+        ( flip ? common.inverseX( pt.x ) : pt.x ) * p.width,
+        pt.y * p.height
+      ) );
+    } );
+  } );
 }
 
 function _collectOrbit(
@@ -566,4 +1014,171 @@ function _collectGyroscope(
       p.height
     )
   ) );
+}
+
+function _collectMidi(
+  opts, p, out
+) {
+  const midi = opts.midi;
+
+  if ( !midi?.enabled ) {
+    return;
+  }
+
+  // Trigger lazy MIDI access request on first call
+  if ( !_midiInitialized ) {
+    _initMidi();
+
+    return;
+  }
+
+  const maxNotes = midi.maxNotes ?? 10;
+  let count = 0;
+
+  for ( const [ note, velocity ] of _midiNotes ) {
+    if ( count >= maxNotes ) {
+      break;
+    }
+
+    // Note number (0–127) → X, velocity (0–127) → Y (loud = top)
+    out.push( p.createVector(
+      p.map(
+        note,
+        0,
+        127,
+        0,
+        p.width
+      ),
+      p.map(
+        velocity,
+        0,
+        127,
+        p.height,
+        0
+      )
+    ) );
+    count++;
+  }
+}
+
+function _collectAudio(
+  opts, p, out
+) {
+  const audio = opts.audio;
+
+  if ( !audio?.enabled ) {
+    return;
+  }
+
+  // Trigger lazy mic request on first call
+  if ( !_audioInitialized ) {
+    _initAudio( opts );
+
+    return;
+  }
+
+  if ( !_audioAnalyser || !_audioFreqData ) {
+    return;
+  }
+
+  // Resume AudioContext if it was suspended (browsers require user gesture)
+  if ( _audioContext?.state === "suspended" ) {
+    _audioContext.resume().catch( () => {} );
+  }
+
+  _audioAnalyser.getByteFrequencyData( _audioFreqData );
+
+  const count = audio.count ?? 1;
+  const margin = audio.margin ?? 50;
+  const bins = _audioFreqData.length;
+
+  for ( let i = 0; i < count; i++ ) {
+    const binStart = Math.floor( i * bins / count );
+    const binEnd = Math.floor( ( i + 1 ) * bins / count );
+    let sum = 0;
+
+    for ( let b = binStart; b < binEnd; b++ ) {
+      sum += _audioFreqData[ b ];
+    }
+
+    const avg = sum / Math.max(
+      1,
+      binEnd - binStart
+    );
+
+    // X = evenly spaced across canvas, Y = amplitude (loud = top, quiet = bottom)
+    out.push( p.createVector(
+      p.map(
+        i + 0.5,
+        0,
+        count,
+        margin,
+        p.width - margin
+      ),
+      p.map(
+        avg,
+        0,
+        255,
+        p.height - margin,
+        margin
+      )
+    ) );
+  }
+}
+
+function _collectJoypad(
+  opts, p, out
+) {
+  const joypad = opts.joypad;
+
+  if ( !joypad?.enabled ) {
+    return;
+  }
+
+  if ( typeof navigator.getGamepads !== "function" ) {
+    return;
+  }
+
+  const gamepads = navigator.getGamepads();
+  const maxCount = joypad.count ?? 1;
+  const deadzone = joypad.deadzone ?? 0.1;
+  let added = 0;
+
+  for ( let i = 0; i < gamepads.length && added < maxCount; i++ ) {
+    const gp = gamepads[ i ];
+
+    if ( !gp || !gp.connected ) {
+      continue;
+    }
+
+    // Left stick: axes[0] = X, axes[1] = Y
+    let axisX = gp.axes[ 0 ] ?? 0;
+    let axisY = gp.axes[ 1 ] ?? 0;
+
+    if ( Math.abs( axisX ) < deadzone ) {
+      axisX = 0;
+    }
+
+    if ( Math.abs( axisY ) < deadzone ) {
+      axisY = 0;
+    }
+
+    out.push( p.createVector(
+      p.map(
+        axisX,
+        -1,
+        1,
+        0,
+        p.width
+      ),
+      p.map(
+        axisY,
+        -1,
+        1,
+        0,
+        p.height
+      )
+    ) );
+    added++;
+  }
 }


### PR DESCRIPTION
- Fix useMouse and useTouch: track raw clientX/Y via window listeners and
  convert to canvas space with getBoundingClientRect(), so coordinates are
  correct when ScalableViewport has panned/zoomed the canvas via CSS transform

- Split the 'vision' source into separate 'hands', 'face', 'body' tags in
  getPointersDebug() so the debug sketch can color-code each vision sub-type

- Add useMidi: maps active MIDI notes (note# → X, velocity → Y); lazy-inits
  Web MIDI access on first use

- Add useAudio: divides mic spectrum into N frequency-band pointers; lazy-inits
  getUserMedia + AnalyserNode on first use

- Add useJoypad: maps gamepad left-stick axes to canvas coordinates, polls
  navigator.getGamepads() each frame (no setup needed)

- Update defaults.js: add midi/audio/joypad default values and form config

- Update interaction-test sketch: new source colors/labels for all 11 sources
  (hands, face, body split from vision; midi, audio, joypad added)

https://claude.ai/code/session_012GasyHfwkZTEwNrGUpkLQ1