### PR TITLE
Add animated previews toggle on templates page

### DIFF
--- a/src/components/AnimatedPreview.tsx
+++ b/src/components/AnimatedPreview.tsx
@@ -11,6 +11,9 @@ interface AnimatedPreviewProps {
   name: string;
   imgClassName?: string;
   eager?: boolean;
+  // When defined, overrides the OS `prefers-reduced-motion` setting:
+  // `true` forces playback to be allowed, `false` keeps the static thumbnail.
+  animationsEnabled?: boolean;
 }
 
 // Read once at module level — safe in both browser and SSR (defaults to false on server)
@@ -32,11 +35,13 @@ export default function AnimatedPreview( {
   thumbnailUrl,
   name,
   imgClassName = "",
-  eager = false
+  eager = false,
+  animationsEnabled
 }: AnimatedPreviewProps ) {
   const containerRef = useRef<HTMLDivElement>( null );
   const videoRef = useRef<HTMLVideoElement>( null );
   const prefersReducedRef = useRef( false );
+  const animationsEnabledRef = useRef( animationsEnabled );
   const [
     wantsToPlay,
     setWantsToPlay
@@ -57,7 +62,8 @@ export default function AnimatedPreview( {
       const handler = ( e: MediaQueryListEvent ) => {
         prefersReducedRef.current = e.matches;
 
-        if ( e.matches ) {
+        // Only honour OS changes when the parent hasn't opted-in explicitly.
+        if ( e.matches && animationsEnabledRef.current !== true ) {
           stopVideo();
         }
       };
@@ -74,10 +80,36 @@ export default function AnimatedPreview( {
     []
   );
 
+  // Stop or resume when the parent toggles animations on/off.
+  useEffect(
+    () => {
+      animationsEnabledRef.current = animationsEnabled;
+
+      if ( animationsEnabled === false ) {
+        stopVideo();
+      } else if ( animationsEnabled === true && wantsToPlay && isPageVisible ) {
+        playVideo();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      animationsEnabled
+    ]
+  );
+
   function playVideo() {
     const video = videoRef.current;
 
-    if ( !video || prefersReducedRef.current ) {
+    if ( !video ) {
+      return;
+    }
+
+    // Explicit override from the parent wins over the OS preference.
+    if ( animationsEnabledRef.current === false ) {
+      return;
+    }
+
+    if ( animationsEnabledRef.current !== true && prefersReducedRef.current ) {
       return;
     }
 

--- a/src/components/AnimationsToggle.tsx
+++ b/src/components/AnimationsToggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+interface AnimationsToggleProps {
+  enabled: boolean;
+  onChange: ( value: boolean ) => void;
+  disabled?: boolean;
+}
+
+/**
+ * iOS-style switch for toggling animated previews on the templates page.
+ */
+export default function AnimationsToggle( {
+  enabled,
+  onChange,
+  disabled = false
+}: AnimationsToggleProps ) {
+  return (
+    <label
+      className={ `inline-flex items-center gap-2 select-none ${
+        disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+      }` }
+      title={ enabled ? "Disable animated previews" : "Enable animated previews" }
+    >
+      <span className="text-xs sm:text-sm text-foreground/70 font-medium">
+        Live previews
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={ enabled }
+        aria-label="Toggle animated previews"
+        disabled={ disabled }
+        onClick={ () => onChange( !enabled ) }
+        className={ `relative inline-flex h-5 w-9 sm:h-6 sm:w-11 flex-shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-foreground/20 ${
+          enabled ? "bg-foreground" : "bg-border"
+        }` }
+      >
+        <span
+          className={ `inline-block h-4 w-4 sm:h-5 sm:w-5 transform rounded-full bg-background shadow-sm transition-transform duration-200 ${
+            enabled ? "translate-x-4 sm:translate-x-5" : "translate-x-0.5"
+          }` }
+        />
+      </button>
+    </label>
+  );
+}

--- a/src/components/TemplatesList.tsx
+++ b/src/components/TemplatesList.tsx
@@ -18,9 +18,13 @@ import type {
 
 import Link from "@/components/HardLink";
 import AnimatedPreview from "@/components/AnimatedPreview";
+import AnimationsToggle from "@/components/AnimationsToggle";
 import {
   usePersistedViewMode
 } from "@/hooks/usePersistedViewMode";
+import {
+  useAnimationsEnabled
+} from "@/hooks/useAnimationsEnabled";
 import {
   useMarqueeOnHover
 } from "@/hooks/useMarqueeOnHover";
@@ -49,6 +53,11 @@ export default function TemplatesList( {
     "templates-view-mode",
     "grid"
   );
+  const [
+    animationsEnabled,
+    setAnimationsEnabled,
+    animationsHydrated
+  ] = useAnimationsEnabled();
   const [
     search,
     setSearch
@@ -170,9 +179,16 @@ export default function TemplatesList( {
     <div className="space-y-3 sm:space-y-6">
       {/* Header */}
       <div className="flex flex-col gap-3 sm:gap-4">
-        <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-          Templates
-        </h1>
+        <div className="flex items-center justify-between gap-3">
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
+            Templates
+          </h1>
+          <AnimationsToggle
+            enabled={ animationsEnabled }
+            onChange={ setAnimationsEnabled }
+            disabled={ !animationsHydrated }
+          />
+        </div>
 
         <div className="flex items-center gap-2 w-full">
           {/* Search Input */}
@@ -377,6 +393,7 @@ export default function TemplatesList( {
                           hiddenFromTemplates={ hiddenFromTemplates }
                           view={ view }
                           eager={ index === 0 }
+                          animationsEnabled={ animationsEnabled }
                         />
                       ) ) }
                     </div>
@@ -419,6 +436,7 @@ export default function TemplatesList( {
                           hiddenFromTemplates={ hiddenFromTemplates }
                           view={ view }
                           eager={ index === 0 }
+                          animationsEnabled={ animationsEnabled }
                         />
                       ) ) }
                     </div>
@@ -439,7 +457,8 @@ function TemplateCard( {
   preview,
   hiddenFromTemplates = false,
   view,
-  eager = false
+  eager = false,
+  animationsEnabled
 }: {
   href: string;
   name: string;
@@ -449,6 +468,7 @@ function TemplateCard( {
   hiddenFromTemplates?: boolean;
   view: "grid" | "list";
   eager?: boolean;
+  animationsEnabled?: boolean;
 } ) {
   const {
     ref: nameRef,
@@ -495,6 +515,7 @@ function TemplateCard( {
               thumbnailUrl={ thumbnail }
               name={ name }
               eager={ eager }
+              animationsEnabled={ animationsEnabled }
               imgClassName="w-full h-full object-contain transition-transform duration-300"
             />
           ) : (

--- a/src/hooks/useAnimationsEnabled.ts
+++ b/src/hooks/useAnimationsEnabled.ts
@@ -1,0 +1,79 @@
+import {
+  useCallback, useEffect, useState
+} from "react";
+
+const STORAGE_KEY = "templates-animations-enabled";
+
+function readStored(): boolean | null {
+  try {
+    const raw = localStorage.getItem( STORAGE_KEY );
+
+    if ( raw === null ) {
+      return null;
+    }
+
+    const parsed = JSON.parse( raw );
+
+    return typeof parsed === "boolean" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tracks whether animated previews should play.
+ *
+ * Defaults to the user's `prefers-reduced-motion` setting (motion allowed
+ * unless the OS asks for reduced motion). The choice is persisted in
+ * localStorage and, once set, takes precedence over the OS preference.
+ */
+export function useAnimationsEnabled(): [boolean, ( value: boolean ) => void, boolean] {
+  // Start disabled on the server so SSR/CSR match; we resolve the real value after mount.
+  const [
+    enabled,
+    setEnabled
+  ] = useState<boolean>( false );
+  const [
+    hydrated,
+    setHydrated
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      const stored = readStored();
+
+      if ( stored !== null ) {
+        setEnabled( stored );
+      } else {
+        const prefersReduced = window.matchMedia( "(prefers-reduced-motion: reduce)" ).matches;
+
+        setEnabled( !prefersReduced );
+      }
+
+      setHydrated( true );
+    },
+    []
+  );
+
+  const update = useCallback(
+    ( value: boolean ) => {
+      setEnabled( value );
+
+      try {
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify( value )
+        );
+      } catch {
+        // Ignore storage errors (quota, private mode, etc.)
+      }
+    },
+    []
+  );
+
+  return [
+    enabled,
+    update,
+    hydrated
+  ];
+}


### PR DESCRIPTION
Adds an iOS-style switch next to the Templates headline that lets users disable the video previews. The initial value mirrors the OS `prefers-reduced-motion` setting and the choice is persisted in localStorage. AnimatedPreview now accepts an `animationsEnabled` override so an explicit user choice wins over the OS preference in either direction.

https://claude.ai/code/session_01A4jhCw4QoDWJwXj2ZTUEja