### PR TITLE
Refresh OG card to match home page, add /debug/opengraph

### DIFF
--- a/src/app/debug/opengraph/OpenGraphDiagnostics.tsx
+++ b/src/app/debug/opengraph/OpenGraphDiagnostics.tsx
@@ -1,0 +1,725 @@
+"use client";
+
+import {
+  useRouter, useSearchParams
+} from "next/navigation";
+import {
+  useEffect, useState, type ReactNode
+} from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  RefreshCw,
+  XCircle
+} from "lucide-react";
+import type {
+  ParsedMeta
+} from "./parseMeta";
+
+export type ImageProbeIssue = {
+  level: "error" | "warn";
+  msg: string;
+};
+
+export type ImageProbe = {
+  src: string;
+  absolute: string;
+  exists: boolean;
+  status: number | null;
+  contentType: string | null;
+  format: string | null;
+  width: number | null;
+  height: number | null;
+  sizeKB: number | null;
+  declaredWidth: string | null;
+  declaredHeight: string | null;
+  issues: ImageProbeIssue[];
+};
+
+export type FetchReport = {
+  input: string;
+  targetUrl: string;
+  baseUrl: string;
+  status: number | null;
+  finalUrl: string | null;
+  contentType: string | null;
+  error: string | null;
+  htmlBytes: number | null;
+  meta: ParsedMeta | null;
+  imageProbes: ImageProbe[];
+};
+
+type Props = {
+  report: FetchReport;
+  initialInput: string;
+};
+
+const INTRO =
+  "Local diagnostic page (dev only). Enter a path on this site (or a full URL) and we'll fetch it, parse the meta tags Next.js emitted, and show how the link will look in chat apps and social previews.";
+
+const QUICK_LINKS = [
+  {
+    label: "Home",
+    path: "/"
+  },
+  {
+    label: "Templates index",
+    path: "/templates"
+  },
+  {
+    label: "Recordings",
+    path: "/recordings"
+  },
+  {
+    label: "Icons debug",
+    path: "/debug/icons"
+  }
+];
+
+const SUGGESTED_CARDS: Array<{ label: string;
+  width: number;
+  height: number;
+  note: string }> = [
+  {
+    label: "Facebook / LinkedIn",
+    width: 524,
+    height: 274,
+    note: "summary_large_image, 1.91:1 crop"
+  },
+  {
+    label: "X (Twitter)",
+    width: 506,
+    height: 254,
+    note: "summary_large_image"
+  },
+  {
+    label: "Discord / iMessage",
+    width: 380,
+    height: 200,
+    note: "compact rich preview"
+  }
+];
+
+function StatusPill( {
+  status
+}: { status: "ok" | "warn" | "error" } ) {
+  if ( status === "error" ) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-medium text-foreground">
+        <XCircle className="h-3.5 w-3.5 text-red-500" />
+        Problem
+      </span>
+    );
+  }
+
+  if ( status === "warn" ) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-foreground">
+        <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+        Review
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-foreground">
+      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+      Pass
+    </span>
+  );
+}
+
+function Badge( {
+  children
+}: { children: ReactNode } ) {
+  return (
+    <span className="rounded border border-border bg-foreground/5 px-1.5 py-0.5 text-[11px] text-label">
+      { children }
+    </span>
+  );
+}
+
+function FieldRow( {
+  label,
+  value,
+  mono = true
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+} ) {
+  const missing = value == null || value === "" || value === "—";
+
+  return (
+    <div className="grid grid-cols-[160px_1fr] items-start gap-3 border-b border-border/60 py-1.5 last:border-b-0">
+      <dt className="text-[12px] uppercase tracking-[0.16em] text-label">
+        { label }
+      </dt>
+      <dd
+        className={ `${
+          mono ? "font-mono" : ""
+        } text-[13px] ${ missing ? "text-label/60 italic" : "text-foreground" } break-all` }
+      >
+        { missing ? "— not set —" : value }
+      </dd>
+    </div>
+  );
+}
+
+function Section( {
+  title,
+  children,
+  intro
+}: {
+  title: string;
+  children: ReactNode;
+  intro?: string;
+} ) {
+  return (
+    <section className="rounded-xl border border-border bg-background p-5">
+      <div className="mb-3">
+        <h2 className="text-base font-medium">{ title }</h2>
+        { intro
+          ? (
+            <p className="mt-1 text-[12px] text-label">{ intro }</p>
+          )
+          : null }
+      </div>
+      { children }
+    </section>
+  );
+}
+
+function ImageCard( {
+  probe,
+  index
+}: { probe: ImageProbe;
+  index: number } ) {
+  const status: "ok" | "warn" | "error" = !probe.exists ||
+  probe.issues.some( ( i ) => i.level === "error" )
+    ? "error"
+    : probe.issues.length > 0
+      ? "warn"
+      : "ok";
+
+  const ring =
+    status === "error"
+      ? "ring-red-400/60"
+      : status === "warn"
+        ? "ring-amber-400/60"
+        : "ring-emerald-400/50";
+
+  return (
+    <div
+      className={ `rounded-xl border border-border bg-background p-4 ring-1 ${ ring }` }
+    >
+      <div className="flex gap-4">
+        <div className="shrink-0">
+          <div
+            className="relative overflow-hidden rounded-lg border border-border bg-hover/40"
+            style={ {
+              width: 200,
+              height: 200
+            } }
+          >
+            { probe.exists
+              ? (
+
+                <img
+                  src={ probe.absolute }
+                  alt=""
+                  className="absolute inset-0 h-full w-full object-contain"
+                />
+              )
+              : (
+                <div className="absolute inset-0 grid place-items-center p-3 text-center text-[12px] text-label">
+                  Image could not be loaded
+                </div>
+              ) }
+          </div>
+          <div className="mt-1 text-center text-[11px] text-label">image { index + 1 }</div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 break-all font-mono text-[13px] text-foreground">
+              { probe.src }
+            </div>
+            <StatusPill status={ status } />
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 pt-2">
+            <Badge>{ `status: ${ probe.status ?? "—" }` }</Badge>
+            { probe.contentType
+              ? (
+                <Badge>{ probe.contentType }</Badge>
+              )
+              : null }
+            { probe.declaredWidth && probe.declaredHeight
+              ? (
+                <Badge>{ `declared ${ probe.declaredWidth }×${ probe.declaredHeight }` }</Badge>
+              )
+              : null }
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 pt-3 text-[13px]">
+            <dt className="text-label">Real</dt>
+            <dd className="font-mono text-foreground">
+              { probe.width != null && probe.height != null
+                ? `${ probe.width }×${ probe.height }`
+                : "—" }
+            </dd>
+            <dt className="text-label">Format</dt>
+            <dd className="font-mono text-foreground">{ probe.format ?? "—" }</dd>
+            <dt className="text-label">Size</dt>
+            <dd className="font-mono text-foreground">
+              { probe.sizeKB != null ? `${ probe.sizeKB } KB` : "—" }
+            </dd>
+          </dl>
+        </div>
+      </div>
+
+      { probe.issues.length > 0
+        ? (
+          <ul className="mt-3 space-y-1.5 border-t border-border pt-3">
+            { probe.issues.map( (
+              issue, idx
+            ) => (
+              <li
+                key={ idx }
+                className="flex items-start gap-2 text-[13px]"
+              >
+                { issue.level === "error"
+                  ? <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+                  : <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" /> }
+                <span className="text-foreground">{ issue.msg }</span>
+              </li>
+            ) ) }
+          </ul>
+        )
+        : null }
+    </div>
+  );
+}
+
+function originHost( url: string | null ): string {
+  if ( !url ) {
+    return "—";
+  }
+  try {
+    return new URL( url ).host.toLowerCase().replace(
+      /^www\./,
+      ""
+    );
+  } catch {
+    return url;
+  }
+}
+
+function SocialCardPreview( {
+  title,
+  description,
+  imageUrl,
+  url,
+  variant
+}: {
+  title: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  url: string | null;
+  variant: { label: string;
+    width: number;
+    height: number;
+    note: string };
+} ) {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.18em] text-label">
+        <span>{ variant.label }</span>
+        <span className="font-mono normal-case tracking-normal">{ variant.note }</span>
+      </div>
+      <div className="overflow-hidden rounded-md border border-border bg-background">
+        <div
+          className="w-full bg-hover/40"
+          style={ {
+            aspectRatio: `${ variant.width } / ${ variant.height }`
+          } }
+        >
+          { imageUrl
+            ? (
+
+              <img
+                src={ imageUrl }
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            )
+            : (
+              <div className="grid h-full w-full place-items-center text-xs text-label">
+                no image
+              </div>
+            ) }
+        </div>
+        <div className="border-t border-border px-3 py-2.5">
+          <div className="text-[11px] uppercase tracking-[0.16em] text-label">
+            { originHost( url ) }
+          </div>
+          <div className="mt-0.5 truncate text-sm font-medium text-foreground">
+            { title ?? "— no title —" }
+          </div>
+          <div className="mt-0.5 line-clamp-2 text-xs text-label">
+            { description ?? "— no description —" }
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OpenGraphDiagnostics( {
+  report,
+  initialInput
+}: Props ) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [
+    input,
+    setInput
+  ] = useState( initialInput );
+  const [
+    pending,
+    setPending
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      setInput( initialInput );
+      setPending( false );
+    },
+    [
+      initialInput
+    ]
+  );
+
+  const onSubmit = ( e: React.FormEvent ) => {
+    e.preventDefault();
+    const next = input.trim() || "/";
+    const search = new URLSearchParams( params.toString() );
+
+    search.set(
+      "url",
+      next
+    );
+    setPending( true );
+    router.push( `?${ search.toString() }` );
+    router.refresh();
+  };
+
+  const meta = report.meta;
+  const og = meta?.openGraph;
+  const tw = meta?.twitter;
+  const previewImage =
+    report.imageProbes.find( ( p ) => p.exists )?.absolute ??
+    og?.images[ 0 ]?.url ??
+    tw?.images[ 0 ] ??
+    null;
+
+  const previewTitle = og?.title ?? tw?.title ?? meta?.title ?? null;
+  const previewDescription =
+    og?.description ?? tw?.description ?? meta?.general.description ?? null;
+  const previewUrl = og?.url ?? report.finalUrl ?? report.targetUrl;
+
+  // Top-level status banner
+  const errorCount = report.imageProbes.filter( ( p ) => p.issues.some( ( i ) => i.level === "error" ) ).length +
+    ( report.error ? 1 : 0 ) +
+    ( meta && !meta.openGraph.title ? 1 : 0 ) +
+    ( meta && !meta.openGraph.description ? 1 : 0 ) +
+    ( meta && meta.openGraph.images.length === 0 ? 1 : 0 );
+
+  const warnCount = report.imageProbes.reduce(
+    (
+      acc, p
+    ) => acc + p.issues.filter( ( i ) => i.level === "warn" ).length,
+    0
+  );
+
+  return (
+    <div className="mx-auto max-w-5xl px-5 py-8 text-foreground">
+      <h1 className="text-2xl font-semibold tracking-tight">OpenGraph diagnostics</h1>
+      <p className="mt-2 max-w-3xl text-sm text-label">{ INTRO }</p>
+
+      {/* URL form */}
+      <form onSubmit={ onSubmit } className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="flex flex-1 items-center overflow-hidden rounded-lg border border-border bg-background">
+          <span className="border-r border-border px-3 py-2 font-mono text-[12px] text-label">
+            { originHost( report.baseUrl ) }
+          </span>
+          <input
+            value={ input }
+            onChange={ ( e ) => setInput( e.target.value ) }
+            placeholder="/ or /templates/p5/photo-balloons or a full URL"
+            className="flex-1 bg-transparent px-3 py-2 font-mono text-sm outline-none placeholder:text-label/60"
+            spellCheck={ false }
+            autoCapitalize="off"
+            autoCorrect="off"
+          />
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+          disabled={ pending }
+        >
+          <RefreshCw className={ `h-4 w-4 ${ pending ? "animate-spin" : "" }` } />
+          Inspect
+        </button>
+      </form>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px] text-label">
+        <span>Quick links:</span>
+        { QUICK_LINKS.map( ( q ) => (
+          <button
+            key={ q.path }
+            type="button"
+            onClick={ () => {
+              setInput( q.path );
+              const search = new URLSearchParams( params.toString() );
+
+              search.set(
+                "url",
+                q.path
+              );
+              setPending( true );
+              router.push( `?${ search.toString() }` );
+              router.refresh();
+            } }
+            className="rounded-full border border-border bg-hover/40 px-2.5 py-1 text-foreground hover:border-foreground/40"
+          >
+            { q.label }
+          </button>
+        ) ) }
+      </div>
+
+      {/* Top status row */}
+      <div className="mt-5 flex flex-wrap items-center gap-3 text-sm">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/10 px-2.5 py-1 font-medium">
+          <span>HTTP { report.status ?? "—" }</span>
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 font-medium text-foreground">
+          <span className="h-2 w-2 rounded-full bg-amber-500" />
+          { warnCount } to review
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-2.5 py-1 font-medium text-foreground">
+          <span className="h-2 w-2 rounded-full bg-red-500" />
+          { errorCount } problems
+        </span>
+        <a
+          href={ report.targetUrl }
+          target="_blank"
+          rel="noreferrer"
+          className="ml-auto inline-flex items-center gap-1 text-label hover:text-foreground"
+        >
+          open URL <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      { report.error
+        ? (
+          <div className="mt-4 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-foreground">
+            <span className="font-medium">Fetch failed.</span> { report.error }
+          </div>
+        )
+        : null }
+
+      {/* Live previews */}
+      <h2 className="mt-8 text-lg font-medium">Social previews</h2>
+      <p className="mt-1 text-[12px] text-label">
+        Mock-ups of how the link will be rendered by the most common chat apps.
+        Built from the OG title, description and the first reachable og:image.
+      </p>
+      <div className="mt-3 grid grid-cols-1 gap-4 md:grid-cols-3">
+        { SUGGESTED_CARDS.map( ( variant ) => (
+          <SocialCardPreview
+            key={ variant.label }
+            variant={ variant }
+            title={ previewTitle }
+            description={ previewDescription }
+            imageUrl={ previewImage }
+            url={ previewUrl }
+          />
+        ) ) }
+      </div>
+
+      {/* General */}
+      <div className="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Section title="General">
+          <dl>
+            <FieldRow
+              label="<title>"
+              value={ meta?.title ?? "—" }
+            />
+            <FieldRow
+              label="meta description"
+              value={ meta?.general.description ?? "—" }
+            />
+            <FieldRow
+              label="canonical"
+              value={ meta?.general.canonical ?? "—" }
+            />
+            <FieldRow
+              label="keywords"
+              value={ meta?.general.keywords ?? "—" }
+            />
+            <FieldRow
+              label="author"
+              value={ meta?.general.author ?? "—" }
+            />
+            <FieldRow
+              label="robots"
+              value={ meta?.general.robots ?? "—" }
+            />
+            <FieldRow
+              label="theme-color"
+              value={ meta?.general.themeColor ?? "—" }
+            />
+            <FieldRow
+              label="viewport"
+              value={ meta?.general.viewport ?? "—" }
+            />
+          </dl>
+        </Section>
+
+        <Section title="OpenGraph">
+          <dl>
+            <FieldRow label="og:title" value={ og?.title ?? "—" } />
+            <FieldRow label="og:description" value={ og?.description ?? "—" } />
+            <FieldRow label="og:type" value={ og?.type ?? "—" } />
+            <FieldRow label="og:url" value={ og?.url ?? "—" } />
+            <FieldRow label="og:site_name" value={ og?.siteName ?? "—" } />
+            <FieldRow label="og:locale" value={ og?.locale ?? "—" } />
+            <FieldRow
+              label="og:image count"
+              value={ og ? `${ og.images.length }` : "—" }
+            />
+          </dl>
+        </Section>
+
+        <Section title="Twitter">
+          <dl>
+            <FieldRow label="twitter:card" value={ tw?.card ?? "—" } />
+            <FieldRow label="twitter:title" value={ tw?.title ?? "—" } />
+            <FieldRow label="twitter:description" value={ tw?.description ?? "—" } />
+            <FieldRow label="twitter:site" value={ tw?.site ?? "—" } />
+            <FieldRow label="twitter:creator" value={ tw?.creator ?? "—" } />
+            <FieldRow
+              label="twitter:image count"
+              value={ tw ? `${ tw.images.length }` : "—" }
+            />
+          </dl>
+        </Section>
+
+        <Section title="Page">
+          <dl>
+            <FieldRow label="input" value={ report.input } />
+            <FieldRow label="resolved" value={ report.targetUrl } />
+            <FieldRow label="final URL" value={ report.finalUrl ?? "—" } />
+            <FieldRow label="status" value={ report.status ?? "—" } />
+            <FieldRow label="content-type" value={ report.contentType ?? "—" } />
+            <FieldRow
+              label="HTML size"
+              value={ report.htmlBytes != null
+                ? `${ Math.round( ( report.htmlBytes / 1024 ) * 10 ) / 10 } KB`
+                : "—" }
+            />
+          </dl>
+        </Section>
+      </div>
+
+      {/* Image probes */}
+      <h2 className="mt-8 text-lg font-medium">Image probes</h2>
+      <p className="mt-1 text-[12px] text-label">
+        Every <code>og:image</code> and <code>twitter:image</code> is re-fetched from this server with sharp to verify it actually exists and has sensible dimensions.
+      </p>
+      <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">
+        { report.imageProbes.length === 0
+          ? (
+            <div className="rounded-xl border border-border bg-background p-5 text-sm text-label">
+              No og:image or twitter:image tags found on this page.
+            </div>
+          )
+          : (
+            report.imageProbes.map( (
+              p, i
+            ) => (
+              <ImageCard key={ `${ p.src }-${ i }` } probe={ p } index={ i } />
+            ) )
+          ) }
+      </div>
+
+      {/* JSON-LD */}
+      { meta && meta.jsonLd.length > 0
+        ? (
+          <>
+            <h2 className="mt-8 text-lg font-medium">JSON-LD</h2>
+            <p className="mt-1 text-[12px] text-label">
+              Structured data emitted via <code>application/ld+json</code>. Google reads these for rich results.
+            </p>
+            <div className="mt-3 space-y-3">
+              { meta.jsonLd.map( (
+                block, i
+              ) => (
+                <pre
+                  key={ i }
+                  className="overflow-x-auto rounded-lg border border-border bg-hover/40 p-3 text-[12px] leading-relaxed text-foreground"
+                >
+                  { JSON.stringify(
+                    block,
+                    null,
+                    2
+                  ) }
+                </pre>
+              ) ) }
+            </div>
+          </>
+        )
+        : null }
+
+      {/* Raw meta */}
+      <h2 className="mt-8 text-lg font-medium">All meta tags</h2>
+      <p className="mt-1 text-[12px] text-label">
+        Every <code>&lt;meta&gt;</code> tag the parser found, in the order it appeared in the HTML.
+      </p>
+      <div className="mt-3 overflow-x-auto rounded-xl border border-border bg-background">
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="border-b border-border bg-hover/40 text-left text-label">
+              <th className="px-3 py-2 font-medium">attr</th>
+              <th className="px-3 py-2 font-medium">key</th>
+              <th className="px-3 py-2 font-medium">content</th>
+            </tr>
+          </thead>
+          <tbody>
+            { meta?.rawMeta.map( (
+              row, i
+            ) => (
+              <tr key={ i } className="border-b border-border/60 last:border-b-0">
+                <td className="px-3 py-1.5 font-mono text-label">{ row.source }</td>
+                <td className="px-3 py-1.5 font-mono">{ row.key }</td>
+                <td className="px-3 py-1.5 break-all">{ row.value }</td>
+              </tr>
+            ) ) }
+            { !meta || meta.rawMeta.length === 0
+              ? (
+                <tr>
+                  <td colSpan={ 3 } className="px-3 py-3 text-label">
+                    no meta tags parsed
+                  </td>
+                </tr>
+              )
+              : null }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/debug/opengraph/page.tsx
+++ b/src/app/debug/opengraph/page.tsx
@@ -1,0 +1,268 @@
+import type {
+  Metadata
+} from "next";
+import {
+  notFound
+} from "next/navigation";
+import sharp from "sharp";
+import {
+  getBaseUrl
+} from "@/lib/seo";
+import {
+  parseMeta, type ParsedMeta
+} from "./parseMeta";
+import OpenGraphDiagnostics, {
+  type FetchReport,
+  type ImageProbe
+} from "./OpenGraphDiagnostics";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "OpenGraph diagnostics"
+};
+
+/** Coerce the optional ?url=... search param into a path or absolute URL. */
+function normalizeInput( raw: string | undefined ): string {
+  const v = ( raw ?? "/" ).trim();
+
+  if ( !v ) {
+    return "/";
+  }
+
+  return v;
+}
+
+/** Build the absolute URL we'll fetch from a user-provided path/URL. */
+function resolveTarget(
+  input: string, baseUrl: string
+): string {
+  if ( /^https?:\/\//i.test( input ) ) {
+    return input;
+  }
+
+  return `${ baseUrl.replace(
+    /\/$/,
+    ""
+  ) }${ input.startsWith( "/" ) ? input : `/${ input }` }`;
+}
+
+/** Verify the image actually exists and grab its real dimensions. */
+async function probeImage(
+  src: string,
+  baseUrl: string,
+  context: { ogWidth?: string;
+    ogHeight?: string }
+): Promise<ImageProbe> {
+  const absolute = /^https?:\/\//i.test( src )
+    ? src
+    : resolveTarget(
+      src,
+      baseUrl
+    );
+  const probe: ImageProbe = {
+    src,
+    absolute,
+    exists: false,
+    status: null,
+    contentType: null,
+    format: null,
+    width: null,
+    height: null,
+    sizeKB: null,
+    declaredWidth: context.ogWidth ?? null,
+    declaredHeight: context.ogHeight ?? null,
+    issues: []
+  };
+
+  try {
+    const res = await fetch(
+      absolute,
+      {
+        cache: "no-store",
+        redirect: "follow"
+      }
+    );
+
+    probe.status = res.status;
+
+    if ( !res.ok ) {
+      probe.issues.push( {
+        level: "error",
+        msg: `Image request returned HTTP ${ res.status } — crawlers will see a broken image.`
+      } );
+      return probe;
+    }
+
+    probe.exists = true;
+    probe.contentType = res.headers.get( "content-type" );
+
+    const buf = Buffer.from( await res.arrayBuffer() );
+
+    probe.sizeKB = Math.round( ( buf.byteLength / 1024 ) * 10 ) / 10;
+
+    try {
+      const meta = await sharp( buf ).metadata();
+
+      probe.format = meta.format ?? null;
+      probe.width = meta.width ?? null;
+      probe.height = meta.height ?? null;
+    } catch {
+      probe.issues.push( {
+        level: "warn",
+        msg: "Could not parse the image with sharp — unexpected format?"
+      } );
+    }
+
+    // Sanity checks
+    if ( probe.width != null && probe.height != null ) {
+      if ( probe.width < 600 || probe.height < 315 ) {
+        probe.issues.push( {
+          level: "warn",
+          msg: `Image is small (${ probe.width }×${ probe.height }) — Facebook recommends at least 1200×630 for summary_large_image cards.`
+        } );
+      }
+
+      const declaredW = context.ogWidth ? Number( context.ogWidth ) : null;
+      const declaredH = context.ogHeight ? Number( context.ogHeight ) : null;
+
+      if (
+        declaredW &&
+        declaredH &&
+        ( declaredW !== probe.width || declaredH !== probe.height )
+      ) {
+        probe.issues.push( {
+          level: "warn",
+          msg: `Declared ${ declaredW }×${ declaredH } but real image is ${ probe.width }×${ probe.height }.`
+        } );
+      }
+    }
+
+    if ( probe.sizeKB != null && probe.sizeKB > 8000 ) {
+      probe.issues.push( {
+        level: "warn",
+        msg: `Image is heavy (${ probe.sizeKB } KB) — many crawlers cap at ~8 MB.`
+      } );
+    }
+  } catch( e ) {
+    probe.issues.push( {
+      level: "error",
+      msg: `Image fetch failed: ${ ( e as Error ).message }`
+    } );
+  }
+
+  return probe;
+}
+
+/** Collect every image referenced in og:image and twitter:image tags. */
+function collectImageSources( meta: ParsedMeta ): Array<{
+  src: string;
+  origin: "og" | "twitter";
+  width?: string;
+  height?: string;
+}> {
+  const sources: Array<{ src: string;
+    origin: "og" | "twitter";
+    width?: string;
+    height?: string }> = [];
+
+  for ( const img of meta.openGraph.images ) {
+    sources.push( {
+      src: img.url,
+      origin: "og",
+      width: img.width,
+      height: img.height
+    } );
+  }
+
+  for ( const t of meta.twitter.images ) {
+    // Avoid duplicates if the same URL was already collected via og:image
+    if ( !sources.some( ( s ) => s.src === t ) ) {
+      sources.push( {
+        src: t,
+        origin: "twitter"
+      } );
+    }
+  }
+
+  return sources;
+}
+
+export default async function OpenGraphDebugPage( {
+  searchParams
+}: {
+  searchParams: Promise<{ url?: string }>;
+} ) {
+  if ( process.env.NODE_ENV === "production" ) {
+    notFound();
+  }
+
+  const params = await searchParams;
+  const input = normalizeInput( params.url );
+  const baseUrl = getBaseUrl();
+  const targetUrl = resolveTarget(
+    input,
+    baseUrl
+  );
+
+  const report: FetchReport = {
+    input,
+    targetUrl,
+    baseUrl,
+    status: null,
+    finalUrl: null,
+    contentType: null,
+    error: null,
+    htmlBytes: null,
+    meta: null,
+    imageProbes: []
+  };
+
+  try {
+    const res = await fetch(
+      targetUrl,
+      {
+        cache: "no-store",
+        redirect: "follow",
+        headers: {
+          // Some apps detect crawlers; pretend to be a friendly link-preview bot
+          "user-agent": "OG-Debug/1.0 (+https://localhost)"
+        }
+      }
+    );
+
+    report.status = res.status;
+    report.finalUrl = res.url;
+    report.contentType = res.headers.get( "content-type" );
+
+    if ( !res.ok ) {
+      report.error = `Page request returned HTTP ${ res.status }.`;
+    } else {
+      const html = await res.text();
+
+      report.htmlBytes = html.length;
+      report.meta = parseMeta( html );
+
+      const sources = collectImageSources( report.meta );
+
+      report.imageProbes = await Promise.all( sources.map( ( s ) =>
+        probeImage(
+          s.src,
+          baseUrl,
+          {
+            ogWidth: s.width,
+            ogHeight: s.height
+          }
+        ) ) );
+    }
+  } catch( e ) {
+    report.error = `Page fetch failed: ${ ( e as Error ).message }`;
+  }
+
+  return (
+    <OpenGraphDiagnostics
+      report={ report }
+      initialInput={ input }
+    />
+  );
+}

--- a/src/app/debug/opengraph/parseMeta.ts
+++ b/src/app/debug/opengraph/parseMeta.ts
@@ -1,0 +1,357 @@
+/**
+ * Minimal HTML meta-tag parser used by the OpenGraph diagnostics page.
+ *
+ * Regex-based because this is a dev-only tool and we don't want to pull a
+ * full HTML parser into the dependency tree. It handles the tags Next.js
+ * emits (meta, link rel="canonical", title, JSON-LD scripts) and tolerates
+ * single- or double-quoted attributes in any order.
+ */
+
+export type OgImage = {
+  url: string;
+  secureUrl?: string;
+  type?: string;
+  width?: string;
+  height?: string;
+  alt?: string;
+};
+
+export type ParsedMeta = {
+  title: string | null;
+  general: {
+    description: string | null;
+    canonical: string | null;
+    keywords: string | null;
+    author: string | null;
+    robots: string | null;
+    themeColor: string | null;
+    viewport: string | null;
+    generator: string | null;
+  };
+  openGraph: {
+    title: string | null;
+    description: string | null;
+    type: string | null;
+    url: string | null;
+    siteName: string | null;
+    locale: string | null;
+    images: OgImage[];
+  };
+  twitter: {
+    card: string | null;
+    title: string | null;
+    description: string | null;
+    images: string[];
+    site: string | null;
+    creator: string | null;
+  };
+  jsonLd: unknown[];
+  rawMeta: Array<{ key: string;
+    value: string;
+    source: "name" | "property" | "http-equiv" }>;
+};
+
+function stripHtml( html: string ): string {
+  // Remove script/style blocks so meta tags inside them don't confuse us
+  return html
+    .replace(
+      /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+      ""
+    )
+    .replace(
+      /<style\b[^>]*>[\s\S]*?<\/style>/gi,
+      ""
+    );
+}
+
+function getAttr(
+  tag: string, attr: string
+): string | null {
+  const re = new RegExp(
+    `\\b${ attr }\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`,
+    "i"
+  );
+  const m = tag.match( re );
+
+  if ( !m ) {
+    return null;
+  }
+
+  return ( m[ 1 ] ?? m[ 2 ] ?? m[ 3 ] ?? "" ).trim();
+}
+
+function decodeEntities( s: string ): string {
+  return s
+    .replace(
+      /&amp;/g,
+      "&"
+    )
+    .replace(
+      /&lt;/g,
+      "<"
+    )
+    .replace(
+      /&gt;/g,
+      ">"
+    )
+    .replace(
+      /&quot;/g,
+      "\""
+    )
+    .replace(
+      /&#39;/g,
+      "'"
+    )
+    .replace(
+      /&#x27;/g,
+      "'"
+    )
+    .replace(
+      /&apos;/g,
+      "'"
+    );
+}
+
+export function parseMeta( html: string ): ParsedMeta {
+  const result: ParsedMeta = {
+    title: null,
+    general: {
+      description: null,
+      canonical: null,
+      keywords: null,
+      author: null,
+      robots: null,
+      themeColor: null,
+      viewport: null,
+      generator: null
+    },
+    openGraph: {
+      title: null,
+      description: null,
+      type: null,
+      url: null,
+      siteName: null,
+      locale: null,
+      images: []
+    },
+    twitter: {
+      card: null,
+      title: null,
+      description: null,
+      images: [],
+      site: null,
+      creator: null
+    },
+    jsonLd: [],
+    rawMeta: []
+  };
+
+  // ── <title> ───────────────────────────────────────────────────────────
+  const titleMatch = html.match( /<title[^>]*>([\s\S]*?)<\/title>/i );
+
+  if ( titleMatch ) {
+    result.title = decodeEntities( titleMatch[ 1 ].trim() );
+  }
+
+  // ── <link rel="canonical"> ────────────────────────────────────────────
+  const linkRegex = /<link\b[^>]*>/gi;
+
+  for ( const m of html.matchAll( linkRegex ) ) {
+    const tag = m[ 0 ];
+    const rel = getAttr(
+      tag,
+      "rel"
+    );
+
+    if ( rel && rel.toLowerCase() === "canonical" ) {
+      result.general.canonical = getAttr(
+        tag,
+        "href"
+      );
+    }
+  }
+
+  // ── JSON-LD <script> blocks (run before stripHtml strips them) ────────
+  const ldRegex =
+    /<script\b[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+  for ( const m of html.matchAll( ldRegex ) ) {
+    const raw = m[ 1 ].trim();
+
+    if ( !raw ) {
+      continue;
+    }
+
+    try {
+      result.jsonLd.push( JSON.parse( raw ) );
+    } catch {
+      result.jsonLd.push( {
+        _parseError: true,
+        raw: raw.slice(
+          0,
+          400
+        )
+      } );
+    }
+  }
+
+  // ── <meta> tags ───────────────────────────────────────────────────────
+  const head = stripHtml( html );
+  const metaRegex = /<meta\b[^>]*>/gi;
+  const ogImageBucket: OgImage = {
+    url: ""
+  };
+  const ogImages: OgImage[] = [];
+
+  function flushOgImage() {
+    if ( ogImageBucket.url ) {
+      ogImages.push( {
+        ...ogImageBucket
+      } );
+    }
+    ogImageBucket.url = "";
+    ogImageBucket.secureUrl = undefined;
+    ogImageBucket.type = undefined;
+    ogImageBucket.width = undefined;
+    ogImageBucket.height = undefined;
+    ogImageBucket.alt = undefined;
+  }
+
+  for ( const m of head.matchAll( metaRegex ) ) {
+    const tag = m[ 0 ];
+    const name = getAttr(
+      tag,
+      "name"
+    );
+    const property = getAttr(
+      tag,
+      "property"
+    );
+    const httpEquiv = getAttr(
+      tag,
+      "http-equiv"
+    );
+    const content = getAttr(
+      tag,
+      "content"
+    );
+
+    if ( content == null ) {
+      continue;
+    }
+
+    const value = decodeEntities( content );
+    const key = ( property ?? name ?? httpEquiv ?? "" ).toLowerCase();
+
+    if ( !key ) {
+      continue;
+    }
+
+    result.rawMeta.push( {
+      key,
+      value,
+      source: property ? "property" : name ? "name" : "http-equiv"
+    } );
+
+    // OpenGraph
+    if ( key.startsWith( "og:" ) ) {
+      switch ( key ) {
+        case "og:title":
+          result.openGraph.title = value;
+          break;
+        case "og:description":
+          result.openGraph.description = value;
+          break;
+        case "og:type":
+          result.openGraph.type = value;
+          break;
+        case "og:url":
+          result.openGraph.url = value;
+          break;
+        case "og:site_name":
+          result.openGraph.siteName = value;
+          break;
+        case "og:locale":
+          result.openGraph.locale = value;
+          break;
+        case "og:image":
+        case "og:image:url":
+        // New image starts here — flush the previous bucket
+          flushOgImage();
+          ogImageBucket.url = value;
+          break;
+        case "og:image:secure_url":
+          ogImageBucket.secureUrl = value;
+          break;
+        case "og:image:type":
+          ogImageBucket.type = value;
+          break;
+        case "og:image:width":
+          ogImageBucket.width = value;
+          break;
+        case "og:image:height":
+          ogImageBucket.height = value;
+          break;
+        case "og:image:alt":
+          ogImageBucket.alt = value;
+          break;
+      }
+      continue;
+    }
+
+    // Twitter
+    if ( key.startsWith( "twitter:" ) ) {
+      switch ( key ) {
+        case "twitter:card":
+          result.twitter.card = value;
+          break;
+        case "twitter:title":
+          result.twitter.title = value;
+          break;
+        case "twitter:description":
+          result.twitter.description = value;
+          break;
+        case "twitter:image":
+          result.twitter.images.push( value );
+          break;
+        case "twitter:site":
+          result.twitter.site = value;
+          break;
+        case "twitter:creator":
+          result.twitter.creator = value;
+          break;
+      }
+      continue;
+    }
+
+    // General
+    switch ( key ) {
+      case "description":
+        result.general.description = value;
+        break;
+      case "keywords":
+        result.general.keywords = value;
+        break;
+      case "author":
+        result.general.author = value;
+        break;
+      case "robots":
+        result.general.robots = value;
+        break;
+      case "theme-color":
+        result.general.themeColor = value;
+        break;
+      case "viewport":
+        result.general.viewport = value;
+        break;
+      case "generator":
+        result.general.generator = value;
+        break;
+    }
+  }
+
+  flushOgImage();
+  result.openGraph.images = ogImages;
+
+  return result;
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,18 +1,35 @@
+import fs from "fs";
+import path from "path";
 import {
   ImageResponse
 } from "next/og";
 import {
-  SITE_DESCRIPTION, SITE_NAME
+  SITE_DESCRIPTION, SITE_NAME, SITE_TAGLINE
 } from "@/lib/seo";
 
-export const runtime = "edge";
+// Read the project icon from disk and embed it as a data URL so the OG card
+// always shows the real project mark, even when generated offline.
+export const runtime = "nodejs";
 
-export const alt = SITE_NAME;
+export const alt = `${ SITE_NAME } — ${ SITE_TAGLINE }`;
 export const size = {
   width: 1200,
   height: 630
 };
 export const contentType = "image/png";
+
+const ICON_DATA_URL = ( () => {
+  const filePath = path.join(
+    process.cwd(),
+    "public",
+    "assets",
+    "images",
+    "icon-512x512.png"
+  );
+  const buf = fs.readFileSync( filePath );
+
+  return `data:image/png;base64,${ buf.toString( "base64" ) }`;
+} )();
 
 export default async function Image() {
   return new ImageResponse(
@@ -21,66 +38,171 @@ export default async function Image() {
         height: "100%",
         width: "100%",
         display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
         backgroundColor: "#000",
         color: "#fff",
-        fontFamily: "system-ui, sans-serif"
+        fontFamily: "system-ui, sans-serif",
+        padding: "72px 80px",
+        position: "relative"
       } }
     >
-      {/* Decorative circles inspired by the app icon */}
+      {/* Subtle dot-grid backdrop reminiscent of the home page */}
+      <div
+        style={ {
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "radial-gradient(rgba(255,255,255,0.08) 1px, transparent 1px)",
+          backgroundSize: "28px 28px",
+          display: "flex"
+        } }
+      />
+      {/* Soft fuchsia glow in the corner */}
+      <div
+        style={ {
+          position: "absolute",
+          top: "-180px",
+          right: "-160px",
+          width: "560px",
+          height: "560px",
+          borderRadius: "50%",
+          background:
+            "radial-gradient(closest-side, rgba(236,72,153,0.35), transparent 70%)",
+          display: "flex"
+        } }
+      />
+
+      {/* Top metadata bar */}
+      <div
+        style={ {
+          position: "absolute",
+          top: "48px",
+          left: "80px",
+          right: "80px",
+          display: "flex",
+          alignItems: "center",
+          gap: "20px",
+          fontSize: "20px",
+          color: "rgba(255,255,255,0.55)",
+          letterSpacing: "0.24em",
+          textTransform: "uppercase",
+          fontFamily: "system-ui, sans-serif"
+        } }
+      >
+        <span>v.0.1</span>
+        <span
+          style={ {
+            width: "6px",
+            height: "6px",
+            borderRadius: "50%",
+            background: "#ec4899",
+            display: "flex"
+          } }
+        />
+        <span>{SITE_NAME}</span>
+        <span
+          style={ {
+            width: "6px",
+            height: "6px",
+            borderRadius: "50%",
+            background: "rgba(255,255,255,0.3)",
+            display: "flex"
+          } }
+        />
+        <span>browser-native</span>
+      </div>
+
+      {/* Main split: icon on the left, text on the right */}
       <div
         style={ {
           display: "flex",
-          gap: "24px",
-          marginBottom: "48px"
+          alignItems: "center",
+          gap: "72px",
+          width: "100%",
+          position: "relative"
         } }
       >
-        {[
-          "#f7941d",
-          "#ed5a4b",
-          "#e8558e",
-          "#f5c525",
-          "#2da77a",
-          "#42c5d9",
-          "#4cbcac",
-          "#2a6fb5",
-          "#5e548e"
-        ].map( ( color ) => (
-          <div
-            key={ color }
+        <div
+          style={ {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "440px",
+            height: "440px",
+            flexShrink: 0
+          } }
+        >
+          { }
+          <img
+            src={ ICON_DATA_URL }
+            alt=""
+            width={ 440 }
+            height={ 440 }
             style={ {
-              width: "48px",
-              height: "48px",
-              borderRadius: "50%",
-              backgroundColor: color
+              width: "440px",
+              height: "440px",
+              objectFit: "contain"
             } }
           />
-        ) )}
-      </div>
+        </div>
 
-      <div
-        style={ {
-          fontSize: "64px",
-          fontWeight: 700,
-          letterSpacing: "-0.02em",
-          marginBottom: "16px"
-        } }
-      >
-        {SITE_NAME}
-      </div>
+        <div
+          style={ {
+            display: "flex",
+            flexDirection: "column",
+            gap: "28px",
+            flex: 1
+          } }
+        >
+          <div
+            style={ {
+              fontSize: "104px",
+              fontWeight: 900,
+              lineHeight: 0.92,
+              letterSpacing: "-0.045em",
+              display: "flex",
+              flexDirection: "column",
+              color: "#fff"
+            } }
+          >
+            <span style={ {
+              display: "flex"
+            } }>a studio</span>
+            <span style={ {
+              display: "flex",
+              gap: "20px"
+            } }>
+              <span>for</span>
+              <span style={ {
+                fontWeight: 200,
+                fontStyle: "italic",
+                color: "rgba(255,255,255,0.85)"
+              } }
+              >
+                social
+              </span>
+            </span>
+            <span style={ {
+              display: "flex"
+            } }>
+              <span>visuals</span>
+              <span style={ {
+                color: "#ec4899"
+              } }>.</span>
+            </span>
+          </div>
 
-      <div
-        style={ {
-          fontSize: "24px",
-          color: "#999",
-          maxWidth: "800px",
-          textAlign: "center",
-          lineHeight: 1.4
-        } }
-      >
-        {SITE_DESCRIPTION}
+          <div
+            style={ {
+              fontSize: "22px",
+              color: "rgba(255,255,255,0.62)",
+              lineHeight: 1.45,
+              maxWidth: "560px",
+              display: "flex"
+            } }
+          >
+            {SITE_DESCRIPTION}
+          </div>
+        </div>
       </div>
     </div>,
     {

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,6 +1,6 @@
 // Re-export the OpenGraph image as the Twitter card image
 // Note: `runtime` must be a direct literal — Next.js static analysis cannot resolve re-exports
-export const runtime = "edge";
+export const runtime = "nodejs";
 export {
   alt, contentType, default, size
 } from "./opengraph-image";

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,8 +1,9 @@
 // ─── Site Identity ────────────────────────────────────────────────────────────
 export const SITE_NAME = "Coded templates";
 export const SITE_SHORT_NAME = "Coded Templates";
+export const SITE_TAGLINE = "a studio for social visuals.";
 export const SITE_DESCRIPTION =
-  "Create stunning videos and images from customizable p5.js, GSAP, and HTML templates. Record, export, and share animated content for Instagram, TikTok, and more.";
+  "Customizable templates built on p5.js, gsap, and html stages. Tweak parameters in a live editor, then export images or record full animations to video — never leaving the browser.";
 
 // ─── Author / Publisher ───────────────────────────────────────────────────────
 export const SITE_AUTHOR = "Steeve Pommier";
@@ -36,7 +37,7 @@ export const OG_IMAGE = {
   path: "/assets/images/icon-512x512.png",
   width: 512,
   height: 512,
-  alt: `${ SITE_NAME } — Create social media videos from code templates`
+  alt: `${ SITE_NAME } — ${ SITE_TAGLINE }`
 };
 
 // ─── Theme Colors ─────────────────────────────────────────────────────────────

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -16,6 +16,7 @@ export {
   SITE_LOCALE,
   SITE_NAME,
   SITE_SHORT_NAME,
+  SITE_TAGLINE,
   THEME_COLOR_DARK,
   THEME_COLOR_LIGHT
 } from "@/config/site";
@@ -134,7 +135,10 @@ export function getSketchJsonLd( {
     name: title,
     applicationCategory: "DesignApplication",
     operatingSystem: "Web",
-    description: buildSketchDescription( title, engineLabel ),
+    description: buildSketchDescription(
+      title,
+      engineLabel
+    ),
     url,
     ...( thumbnailUrl && {
       screenshot: thumbnailUrl
@@ -143,13 +147,14 @@ export function getSketchJsonLd( {
 }
 
 /** BreadcrumbList schema for navigation hierarchy. */
-export function getBreadcrumbJsonLd(
-  items: Array<{ name: string; url: string }>
-) {
+export function getBreadcrumbJsonLd( items: Array<{ name: string;
+  url: string }> ) {
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    itemListElement: items.map( ( item, index ) => ( {
+    itemListElement: items.map( (
+      item, index
+    ) => ( {
       "@type": "ListItem",
       position: index + 1,
       name: item.name,


### PR DESCRIPTION
The OG card previously crawled by chat apps used an out-of-date copy and a generic colored-circles graphic — neither matched what the home page now shows. Bring the social card and the home page back in sync, and add a diagnostics route so the next mismatch is easy to catch before it ships.

- Update SITE_DESCRIPTION to mirror the home page hero subtitle and add a SITE_TAGLINE constant for the "a studio for social visuals." line.
- Rewrite app/opengraph-image.tsx to compose a 1200x630 card that pairs the large project icon with the home page headline, description and fuchsia accent. Run it under the Node runtime so the icon can be embedded from disk.
- Add /debug/opengraph (dev-only, mirroring /debug/icons) with a URL field: fetches any path on the site, parses its emitted meta + JSON-LD, probes every og:image / twitter:image through sharp, and previews how the link will render in Facebook / X / Discord-style cards.