### PR TITLE
Add animated preview support to template cards

### DIFF
--- a/src/components/TemplatesList.tsx
+++ b/src/components/TemplatesList.tsx
@@ -560,14 +560,25 @@ function TemplateCard( {
       }` }
     >
       <div
-        className="w-12 sm:w-16 flex-shrink-0 rounded-lg sm:rounded-xl overflow-hidden border border-border"
+        className="w-12 sm:w-16 aspect-[4/5] flex-shrink-0 relative rounded-lg sm:rounded-xl overflow-hidden border border-border"
       >
-        <Thumbnail
-          src={ thumbnail }
-          alt={ name }
-          eager={ eager }
-          className="w-full h-full object-contain transition-transform duration-300 group-hover:scale-105"
-        />
+        { preview ? (
+          <AnimatedPreview
+            previewUrl={ preview }
+            thumbnailUrl={ thumbnail }
+            name={ name }
+            eager={ eager }
+            animationsEnabled={ animationsEnabled }
+            imgClassName="w-full h-full object-contain transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <Thumbnail
+            src={ thumbnail }
+            alt={ name }
+            eager={ eager }
+            className="absolute top-0 left-0 w-full h-full object-contain transition-transform duration-300 group-hover:scale-105"
+          />
+        ) }
       </div>
 
       <div className="flex-grow min-w-0 flex items-center gap-2">


### PR DESCRIPTION
## Summary
Enhanced template cards to display animated previews when available, while maintaining fallback to static thumbnails for templates without preview data.

## Key Changes
- Updated template card thumbnail container with `aspect-[4/5]` ratio constraint and `relative` positioning for proper layout
- Added conditional rendering to display `AnimatedPreview` component when preview URL is available
- Fallback to existing `Thumbnail` component for templates without preview data, with updated positioning (`absolute top-0 left-0`) to work with the new relative container
- Passed `animationsEnabled` prop to `AnimatedPreview` to respect user animation preferences
- Maintained existing hover scale animation and object-contain styling for both preview and thumbnail paths

## Implementation Details
- The animated preview takes priority when a `preview` prop is provided
- Both preview and thumbnail paths preserve the smooth scale-up transition on hover
- The aspect ratio constraint ensures consistent card dimensions regardless of content type
- Absolute positioning on the fallback thumbnail ensures it fills the container properly when animations are not available

https://claude.ai/code/session_016rLVReAsDmtZoY4AeZH7jo