### PR TITLE
feat(sketch-settings): add per-sketch thumbnail/preview dev actions

### DIFF
--- a/src/app/api/dev/previews/generate/route.ts
+++ b/src/app/api/dev/previews/generate/route.ts
@@ -1,0 +1,80 @@
+import createSketchPreviews from "@/lib/createSketchPreviews";
+import {
+  findSketchMeta
+} from "@/engines/metadata";
+
+export async function POST( request: Request ) {
+  if ( process.env.NODE_ENV === "production" ) {
+    return new Response(
+      "Not found",
+      {
+        status: 404
+      }
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      "Invalid JSON body",
+      {
+        status: 400
+      }
+    );
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    typeof ( body as Record<string, unknown> ).sketch !== "string" ||
+    typeof ( body as Record<string, unknown> ).engineId !== "string"
+  ) {
+    return new Response(
+      "Missing required fields: sketch (string), engineId (string)",
+      {
+        status: 400
+      }
+    );
+  }
+
+  const {
+    sketch, engineId
+  } = body as { sketch: string;
+    engineId: string };
+
+  if ( !findSketchMeta(
+    sketch,
+    engineId
+  ) ) {
+    return new Response(
+      `Sketch "${ sketch }" not found in metadata`,
+      {
+        status: 404
+      }
+    );
+  }
+
+  try {
+    await createSketchPreviews( {
+      targetSketch: {
+        name: sketch,
+        engineId
+      },
+      overwrite: true
+    } );
+  } catch( err ) {
+    return new Response(
+      err instanceof Error ? err.message : String( err ),
+      {
+        status: 500
+      }
+    );
+  }
+
+  return Response.json( {
+    ok: true
+  } );
+}

--- a/src/app/api/dev/thumbnails/generate/route.ts
+++ b/src/app/api/dev/thumbnails/generate/route.ts
@@ -1,0 +1,80 @@
+import createSketchThumbnails from "@/lib/createSketchThumbnails";
+import {
+  findSketchMeta
+} from "@/engines/metadata";
+
+export async function POST( request: Request ) {
+  if ( process.env.NODE_ENV === "production" ) {
+    return new Response(
+      "Not found",
+      {
+        status: 404
+      }
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(
+      "Invalid JSON body",
+      {
+        status: 400
+      }
+    );
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    typeof ( body as Record<string, unknown> ).sketch !== "string" ||
+    typeof ( body as Record<string, unknown> ).engineId !== "string"
+  ) {
+    return new Response(
+      "Missing required fields: sketch (string), engineId (string)",
+      {
+        status: 400
+      }
+    );
+  }
+
+  const {
+    sketch, engineId
+  } = body as { sketch: string;
+    engineId: string };
+
+  if ( !findSketchMeta(
+    sketch,
+    engineId
+  ) ) {
+    return new Response(
+      `Sketch "${ sketch }" not found in metadata`,
+      {
+        status: 404
+      }
+    );
+  }
+
+  try {
+    await createSketchThumbnails( {
+      targetSketch: {
+        name: sketch,
+        engineId
+      },
+      overwrite: true
+    } );
+  } catch( err ) {
+    return new Response(
+      err instanceof Error ? err.message : String( err ),
+      {
+        status: 500
+      }
+    );
+  }
+
+  return Response.json( {
+    ok: true
+  } );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/GeneratePreviewButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/GeneratePreviewButton.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, {
+  useState
+} from "react";
+import {
+  Film, Loader2
+} from "lucide-react";
+import clsx from "clsx";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+
+type ActionState = "idle" | "generating" | "done" | "error";
+
+export default function GeneratePreviewButton() {
+  const [
+    {
+      name, engineId
+    }
+  ] = useSketch();
+  const [
+    state,
+    setState
+  ] = useState<ActionState>( "idle" );
+  const [
+    errorMessage,
+    setErrorMessage
+  ] = useState<string | null>( null );
+
+  if ( process.env.NODE_ENV !== "development" ) {
+    return null;
+  }
+
+  const handleClick = async( e: React.MouseEvent ) => {
+    e.stopPropagation();
+
+    if ( state === "generating" ) {
+      return;
+    }
+
+    setState( "generating" );
+    setErrorMessage( null );
+
+    try {
+      const res = await fetch(
+        "/api/dev/previews/generate",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify( {
+            sketch: name,
+            engineId
+          } )
+        }
+      );
+
+      if ( !res.ok ) {
+        const text = await res.text();
+
+        throw new Error( text || `HTTP ${ res.status }` );
+      }
+
+      setState( "done" );
+      setTimeout(
+        () => setState( "idle" ),
+        1500
+      );
+    } catch( err ) {
+      setErrorMessage( err instanceof Error ? err.message : String( err ) );
+      setState( "error" );
+      setTimeout(
+        () => setState( "idle" ),
+        3000
+      );
+    }
+  };
+
+  const title =
+    state === "error"
+      ? ( errorMessage ?? "Error" )
+      : "Generate preview for this sketch (overwrites existing)";
+
+  return (
+    <button
+      type="button"
+      onClick={ handleClick }
+      disabled={ state === "generating" }
+      title={ title }
+      aria-label={ title }
+      className={ clsx(
+        "flex items-center rounded transition-colors",
+        {
+          "hover:text-yellow-400 cursor-pointer":
+            state === "idle",
+          "text-yellow-400/50 cursor-wait":
+            state === "generating",
+          "text-green-400":
+            state === "done",
+          "text-red-400":
+            state === "error"
+        }
+      ) }
+    >
+      {state === "generating" ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Film className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/GenerateThumbnailButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/GenerateThumbnailButton.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, {
+  useState
+} from "react";
+import {
+  ImagePlus, Loader2
+} from "lucide-react";
+import clsx from "clsx";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+
+type ActionState = "idle" | "generating" | "done" | "error";
+
+export default function GenerateThumbnailButton() {
+  const [
+    {
+      name, engineId
+    }
+  ] = useSketch();
+  const [
+    state,
+    setState
+  ] = useState<ActionState>( "idle" );
+  const [
+    errorMessage,
+    setErrorMessage
+  ] = useState<string | null>( null );
+
+  if ( process.env.NODE_ENV !== "development" ) {
+    return null;
+  }
+
+  const handleClick = async( e: React.MouseEvent ) => {
+    e.stopPropagation();
+
+    if ( state === "generating" ) {
+      return;
+    }
+
+    setState( "generating" );
+    setErrorMessage( null );
+
+    try {
+      const res = await fetch(
+        "/api/dev/thumbnails/generate",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify( {
+            sketch: name,
+            engineId
+          } )
+        }
+      );
+
+      if ( !res.ok ) {
+        const text = await res.text();
+
+        throw new Error( text || `HTTP ${ res.status }` );
+      }
+
+      setState( "done" );
+      setTimeout(
+        () => setState( "idle" ),
+        1500
+      );
+    } catch( err ) {
+      setErrorMessage( err instanceof Error ? err.message : String( err ) );
+      setState( "error" );
+      setTimeout(
+        () => setState( "idle" ),
+        3000
+      );
+    }
+  };
+
+  const title =
+    state === "error"
+      ? ( errorMessage ?? "Error" )
+      : "Generate thumbnail for this sketch (overwrites existing)";
+
+  return (
+    <button
+      type="button"
+      onClick={ handleClick }
+      disabled={ state === "generating" }
+      title={ title }
+      aria-label={ title }
+      className={ clsx(
+        "flex items-center rounded transition-colors",
+        {
+          "hover:text-yellow-400 cursor-pointer":
+            state === "idle",
+          "text-yellow-400/50 cursor-wait":
+            state === "generating",
+          "text-green-400":
+            state === "done",
+          "text-red-400":
+            state === "error"
+        }
+      ) }
+    >
+      {state === "generating" ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <ImagePlus className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/SketchSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/SketchSettings.tsx
@@ -11,6 +11,8 @@ import CollapsibleItem from "@/components/CollapsibleItem";
 import RandomizeSettingsButton from "@/components/RandomizeSettingsButton";
 import ResetSettingsButton from "@/components/ResetSettingsButton";
 import SaveDefaultsButton from "./SaveDefaultsButton";
+import GenerateThumbnailButton from "./GenerateThumbnailButton";
+import GeneratePreviewButton from "./GeneratePreviewButton";
 import GenericObjectForm
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm";
 import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
@@ -103,6 +105,10 @@ export default function SketchSettings( {
             />
 
             <SaveDefaultsButton />
+
+            <GenerateThumbnailButton />
+
+            <GeneratePreviewButton />
           </div>
         </div>
       ) }

--- a/src/lib/createSketchPreviews.ts
+++ b/src/lib/createSketchPreviews.ts
@@ -31,14 +31,29 @@ const PREVIEW_SIZE = {
   height: 450
 };
 
-async function createSketchPreviews() {
+type CreateSketchPreviewsOptions = {
+  targetSketch?: {
+    name: string;
+    engineId: string;
+  };
+  overwrite?: boolean;
+};
+
+async function createSketchPreviews( options: CreateSketchPreviewsOptions = {} ) {
+  const {
+    targetSketch, overwrite = false
+  } = options;
   const state: { browser?: Browser;
     page?: Page } = {};
 
   try {
     const sketches = ( await getSketchList() ) ?? [];
 
-    const templates = sketches.map( ( {
+    const filtered = targetSketch
+      ? sketches.filter( ( s ) => s.name === targetSketch.name && s.engine === targetSketch.engineId )
+      : sketches;
+
+    const templates = filtered.map( ( {
       name, engine, category
     } ) => ( {
       href: category
@@ -73,7 +88,7 @@ async function createSketchPreviews() {
     } of templates ) {
       const previewPath = `${ ASSETS_DIRECTORY }/images/templates/${ engine }/${ name }/preview.webm`;
 
-      if ( await fileExists( previewPath ) ) {
+      if ( !overwrite && await fileExists( previewPath ) ) {
         console.log( `✅ ${ name }/preview.webm already exists` );
         continue;
       }

--- a/src/lib/createSketchThumbnails.ts
+++ b/src/lib/createSketchThumbnails.ts
@@ -31,7 +31,18 @@ const THUMBNAIL_VARIANTS = [
 ] as const;
 const THUMBNAIL_QUALITY = 80;
 
-async function createSketchThumbnails() {
+type CreateSketchThumbnailsOptions = {
+  targetSketch?: {
+    name: string;
+    engineId: string;
+  };
+  overwrite?: boolean;
+};
+
+async function createSketchThumbnails( options: CreateSketchThumbnailsOptions = {} ) {
+  const {
+    targetSketch, overwrite = false
+  } = options;
   const recordingState: {
     page?: Page;
     browser?: Browser;
@@ -42,7 +53,11 @@ async function createSketchThumbnails() {
   try {
     const sketches = ( await getSketchList() ) ?? [];
 
-    const templates = sketches.map( ( {
+    const filtered = targetSketch
+      ? sketches.filter( ( s ) => s.name === targetSketch.name && s.engine === targetSketch.engineId )
+      : sketches;
+
+    const templates = filtered.map( ( {
       name, engine, category
     } ) => ( {
       href: category ? `templates/${ engine }/${ category }/${ name }` : `templates/${ engine }/${ name }`,
@@ -66,11 +81,13 @@ async function createSketchThumbnails() {
       const thumbnailDir = `${ ASSETS_DIRECTORY }/images/templates/${ engine }/${ name }`;
       const variantPaths = THUMBNAIL_VARIANTS.map( ( v ) => `${ thumbnailDir }/thumbnail${ v.suffix }.webp` );
 
-      const existing = await Promise.all( variantPaths.map( fileExists ) );
+      if ( !overwrite ) {
+        const existing = await Promise.all( variantPaths.map( fileExists ) );
 
-      if ( existing.every( Boolean ) ) {
-        console.log( `✅ ${ name } thumbnails already exist!` );
-        continue;
+        if ( existing.every( Boolean ) ) {
+          console.log( `✅ ${ name } thumbnails already exist!` );
+          continue;
+        }
       }
 
       await recordingState.page.goto(


### PR DESCRIPTION
Adds two dev-only buttons next to the save-defaults button that regenerate the current sketch's thumbnail or preview, overwriting the existing files. The bulk generators now accept an optional targetSketch filter and overwrite flag so the new endpoints can reuse the same capture pipeline for a single sketch.

https://claude.ai/code/session_011X4V1VzgwkWU4edqXubqPe