### PR TITLE
Add 540x675 preview-md variant for desktop home page previews

### DIFF
--- a/src/app/templates/getTemplatesData.ts
+++ b/src/app/templates/getTemplatesData.ts
@@ -10,6 +10,7 @@ export type TemplateItem = {
   name: string;
   thumbnail: string;
   preview: string | null;
+  previewMd: string | null;
   hasSketchForm: boolean;
   category?: string | null;
   hiddenFromHome?: boolean;
@@ -45,6 +46,11 @@ export async function getTemplatesData() {
         preview: hasPreview ? getSketchPreviewURL(
           engine,
           name
+        ) : null,
+        previewMd: hasPreview ? getSketchPreviewURL(
+          engine,
+          name,
+          "md"
         ) : null,
         href: category
           ? `/templates/${ engine }/${ category }/${ name }`

--- a/src/components/AnimatedPreview.tsx
+++ b/src/components/AnimatedPreview.tsx
@@ -7,6 +7,9 @@ import usePageVisibility from "@/hooks/usePageVisibility";
 
 interface AnimatedPreviewProps {
   previewUrl: string;
+  // Higher-res variant to use at the `md` breakpoint and above. When omitted,
+  // `previewUrl` is used at all sizes.
+  previewUrlDesktop?: string;
   thumbnailUrl: string;
   name: string;
   imgClassName?: string;
@@ -21,6 +24,10 @@ const TRIGGER_ON_HOVER =
   typeof process !== "undefined" &&
   process.env.NEXT_PUBLIC_PREVIEW_ON_HOVER === "true";
 
+// Matches Tailwind's `md:` — the breakpoint at which the home page layout
+// switches to multi-column, making the higher-res preview worthwhile.
+const DESKTOP_PREVIEW_QUERY = "(min-width: 768px)";
+
 /**
  * Renders a static thumbnail with an animated WebM overlay.
  *
@@ -32,6 +39,7 @@ const TRIGGER_ON_HOVER =
  */
 export default function AnimatedPreview( {
   previewUrl,
+  previewUrlDesktop,
   thumbnailUrl,
   name,
   imgClassName = "",
@@ -50,7 +58,66 @@ export default function AnimatedPreview( {
     isPlaying,
     setIsPlaying
   ] = useState( false );
+  // Mobile-first: start with the baseline URL so SSR + client hydration match.
+  // If a desktop variant is provided, swap to it after mount when the breakpoint matches.
+  const [
+    effectivePreviewUrl,
+    setEffectivePreviewUrl
+  ] = useState( previewUrl );
   const isPageVisible = usePageVisibility();
+
+  useEffect(
+    () => {
+      if ( !previewUrlDesktop ) {
+        setEffectivePreviewUrl( previewUrl );
+        return;
+      }
+
+      const mq = window.matchMedia( DESKTOP_PREVIEW_QUERY );
+      const pick = () => setEffectivePreviewUrl( mq.matches ? previewUrlDesktop : previewUrl );
+
+      pick();
+      mq.addEventListener(
+        "change",
+        pick
+      );
+      return () => mq.removeEventListener(
+        "change",
+        pick
+      );
+    },
+    [
+      previewUrl,
+      previewUrlDesktop
+    ]
+  );
+
+  // If the chosen URL changes after we've already loaded one, swap the
+  // underlying <video> source so the next play picks it up.
+  useEffect(
+    () => {
+      const video = videoRef.current;
+
+      if ( !video || !video.src ) {
+        return;
+      }
+
+      if ( video.src.endsWith( effectivePreviewUrl ) ) {
+        return;
+      }
+
+      const wasPlaying = !video.paused;
+
+      video.src = effectivePreviewUrl;
+
+      if ( wasPlaying ) {
+        video.play().catch( () => {} );
+      }
+    },
+    [
+      effectivePreviewUrl
+    ]
+  );
 
   // Track prefers-reduced-motion without causing re-render on each frame
   useEffect(
@@ -114,7 +181,7 @@ export default function AnimatedPreview( {
     }
 
     if ( !video.src ) {
-      video.src = previewUrl;
+      video.src = effectivePreviewUrl;
     }
 
     video.play().catch( () => {} );

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -210,6 +210,7 @@ function PreviewSurface( {
     return (
       <AnimatedPreview
         previewUrl={ template.preview }
+        previewUrlDesktop={ template.previewMd ?? undefined }
         thumbnailUrl={ template.thumbnail }
         name={ template.name }
         imgClassName={ imgClassName }

--- a/src/lib/createSketchPreviews.ts
+++ b/src/lib/createSketchPreviews.ts
@@ -26,10 +26,25 @@ import {
 const PREVIEW_FPS = 20;
 const PREVIEW_SECS = 9;
 const TOTAL_FRAMES = PREVIEW_FPS * PREVIEW_SECS;
-const PREVIEW_SIZE = {
-  width: 360,
-  height: 450
-};
+// Multiple output sizes, encoded from the same captured frames.
+// `preview.webm` is the baseline used everywhere (incl. mobile);
+// `preview-md.webm` is a higher-res variant served to desktop home-page tiles.
+const PREVIEW_VARIANTS: ReadonlyArray<{
+  filename: string;
+  width: number;
+  height: number;
+}> = [
+  {
+    filename: "preview.webm",
+    width: 360,
+    height: 450
+  },
+  {
+    filename: "preview-md.webm",
+    width: 540,
+    height: 675
+  }
+];
 
 type CreateSketchPreviewsOptions = {
   targetSketch?: {
@@ -86,10 +101,27 @@ async function createSketchPreviews( options: CreateSketchPreviewsOptions = {} )
     for ( const {
       href, name, engine
     } of templates ) {
-      const previewPath = `${ ASSETS_DIRECTORY }/images/templates/${ engine }/${ name }/preview.webm`;
+      const outputDir = `${ ASSETS_DIRECTORY }/images/templates/${ engine }/${ name }`;
+      const variants = PREVIEW_VARIANTS.map( ( v ) => ( {
+        ...v,
+        outputPath: `${ outputDir }/${ v.filename }`
+      } ) );
 
-      if ( !overwrite && await fileExists( previewPath ) ) {
-        console.log( `✅ ${ name }/preview.webm already exists` );
+      const variantsToBuild = overwrite
+        ? variants
+        : ( await Promise.all( variants.map( async( v ) => ( {
+          variant: v,
+          exists: await fileExists( v.outputPath )
+        } ) ) ) )
+          .filter( ( {
+            exists
+          } ) => !exists )
+          .map( ( {
+            variant
+          } ) => variant );
+
+      if ( variantsToBuild.length === 0 ) {
+        console.log( `✅ ${ name } previews already exist` );
         continue;
       }
 
@@ -123,19 +155,25 @@ async function createSketchPreviews( options: CreateSketchPreviewsOptions = {} )
         } );
 
         await fs.mkdir(
-          path.dirname( previewPath ),
+          outputDir,
           {
             recursive: true
           }
         );
 
-        await encodePreviewFromFrames(
-          tmpDir,
-          previewPath,
-          PREVIEW_SECS,
-          PREVIEW_FPS,
-          PREVIEW_SIZE
-        );
+        for ( const v of variantsToBuild ) {
+          await encodePreviewFromFrames(
+            tmpDir,
+            v.outputPath,
+            PREVIEW_SECS,
+            PREVIEW_FPS,
+            {
+              width: v.width,
+              height: v.height
+            }
+          );
+          console.log( `💾 ${ name }/${ v.filename } generated` );
+        }
 
         const raw = await fs.readFile(
           metadataPath,
@@ -156,8 +194,6 @@ async function createSketchPreviews( options: CreateSketchPreviewsOptions = {} )
             "utf-8"
           );
         }
-
-        console.log( `💾 ${ name }/preview.webm generated` );
       } finally {
         await fs.rm(
           tmpDir,

--- a/src/utils/getSketchPreviewURL.ts
+++ b/src/utils/getSketchPreviewURL.ts
@@ -1,5 +1,7 @@
 export default function getSketchPreviewURL(
-  engine: string, name: string
+  engine: string, name: string, variant?: "md"
 ) {
-  return `/assets/images/templates/${ engine }/${ name }/preview.webm`;
+  const file = variant === "md" ? "preview-md.webm" : "preview.webm";
+
+  return `/assets/images/templates/${ engine }/${ name }/${ file }`;
 }


### PR DESCRIPTION
Encodes a higher-res preview-md.webm alongside preview.webm from the same captured frames, and swaps to it on the home page at the md breakpoint. Mobile and the templates grid keep using preview.webm.

https://claude.ai/code/session_01JnTiiZptErs3NT524gFra9