### PR TITLE
feat(sketch): mobile bottom-sheet options layout (1/2)

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -13,11 +13,13 @@ import type {
 import type {
   SketchOption, SlideOption
 } from "@/types/sketch.types";
+import useIsMobile from "@/hooks/useIsMobile";
 import useSketch from "../SketchProvider/hooks/useSketch";
 import CaptureActions, {
   type CaptureActionsRef
 } from "./components/CaptureActions";
 import useBrowserRecordingSupported from "./components/CaptureActions/hooks/useBrowserRecordingSupported";
+import MobileOptionsSheet from "./components/MobileOptionsSheet/MobileOptionsSheet";
 import OptionsPanel from "./components/OptionsPanel";
 import RecordingLockBanner from "./components/RecordingLockBanner";
 import SketchSettings from "./components/SketchSettings/SketchSettings";
@@ -370,32 +372,21 @@ export default function TemplateOptions( {
     reset( processedOptions );
   };
 
+  const isMobile = useIsMobile();
+
   return (
     <FormProvider { ...methods }>
       <CollapsibleProvider>
-        <div
-          className="w-64 absolute right-2 bottom-2 md:right-4 md:bottom-4 space-y-2"
-          style={ {
-            maxWidth: "calc(50% - 0.75rem)"
-          } }
-        >
-          {lifecycle.isLocked && (
-            <RecordingLockBanner
-              state={ lifecycle.state }
-              onClone={ handleBannerClone }
-              cloning={ bannerCloning }
-            />
-          )}
-
-          <OptionsPanel
+        {isMobile ? (
+          <MobileOptionsSheet
             methods={ methods }
             name={ name }
             persistedJob={ persistedJob }
             activeSlideIndex={ activeSlideIndex }
             slideFields={ slideFields }
-            thumbnails={ thumbnails }
             slides={ slides }
-            jobStatus={ lifecycle.currentStatus }
+            thumbnails={ thumbnails }
+            enableThumbnails={ enableThumbnails }
             isAdding={ isAdding }
             onAddSlide={ handleAddSlide }
             onSelectSlide={ handleSlideSelect }
@@ -404,38 +395,80 @@ export default function TemplateOptions( {
             onDeleteSlide={ handleDeleteSlide }
             onRenameSlide={ handleRenameSlide }
             onImportOptions={ handleImportOptions }
-            enableThumbnails={ enableThumbnails }
-            collapsibleStates={ collapsibleStates }
-            onCollapsibleToggle={ toggleSection }
+            lifecycle={ lifecycle }
+            bannerCloning={ bannerCloning }
+            onBannerClone={ handleBannerClone }
+            captureActionsRef={ captureActionsRef as React.RefObject<CaptureActionsRef> }
+            recordingProgress={ recordingProgress }
+            subscribeToRecordingStatus={ subscribeToRecordingStatus }
           />
+        ) : (
+          <div
+            className="w-64 absolute right-2 bottom-2 md:right-4 md:bottom-4 space-y-2"
+            style={ {
+              maxWidth: "calc(50% - 0.75rem)"
+            } }
+          >
+            {lifecycle.isLocked && (
+              <RecordingLockBanner
+                state={ lifecycle.state }
+                onClone={ handleBannerClone }
+                cloning={ bannerCloning }
+              />
+            )}
 
-          {( backendRecording || browserRecordingSupported ) && (
-            <CaptureActions
-              ref={ captureActionsRef }
+            <OptionsPanel
+              methods={ methods }
               name={ name }
-              options={ methods.watch() }
               persistedJob={ persistedJob }
               activeSlideIndex={ activeSlideIndex }
-              backendRecording={ backendRecording }
-              browserRecordingSupported={ browserRecordingSupported }
-              thumbnails={ enableThumbnails ? thumbnails : {} }
-              lifecycle={ lifecycle }
-              recordingProgress={ recordingProgress }
-              subscribeToRecordingStatus={ subscribeToRecordingStatus }
+              slideFields={ slideFields }
+              thumbnails={ thumbnails }
+              slides={ slides }
+              jobStatus={ lifecycle.currentStatus }
+              isAdding={ isAdding }
+              onAddSlide={ handleAddSlide }
+              onSelectSlide={ handleSlideSelect }
+              onReorderSlides={ handleReorderSlides }
+              onDuplicateSlide={ handleDuplicateSlide }
+              onDeleteSlide={ handleDeleteSlide }
+              onRenameSlide={ handleRenameSlide }
+              onImportOptions={ handleImportOptions }
+              enableThumbnails={ enableThumbnails }
+              collapsibleStates={ collapsibleStates }
+              onCollapsibleToggle={ toggleSection }
             />
-          )}
-        </div>
 
-        <TemplateAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
-          <SketchSettings
-            activeSlideIndex={ activeSlideIndex }
-            expanded={ collapsibleStates.sketchSettings }
-            onToggle={ ( expanded ) => setSection(
-              "sketchSettings",
-              expanded
-            ) }
-          />
-        </TemplateAssetsProvider>
+            {( backendRecording || browserRecordingSupported ) && (
+              <CaptureActions
+                ref={ captureActionsRef }
+                name={ name }
+                options={ methods.watch() }
+                persistedJob={ persistedJob }
+                activeSlideIndex={ activeSlideIndex }
+                backendRecording={ backendRecording }
+                browserRecordingSupported={ browserRecordingSupported }
+                thumbnails={ enableThumbnails ? thumbnails : {} }
+                lifecycle={ lifecycle }
+                recordingProgress={ recordingProgress }
+                subscribeToRecordingStatus={ subscribeToRecordingStatus }
+              />
+            )}
+          </div>
+        ) }
+
+        {!isMobile && (
+          <TemplateAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
+            <SketchSettings
+              activeSlideIndex={ activeSlideIndex }
+              expanded={ collapsibleStates.sketchSettings }
+              onToggle={ ( expanded ) => setSection(
+                "sketchSettings",
+                expanded
+              ) }
+            />
+          </TemplateAssetsProvider>
+        )}
       </CollapsibleProvider>
     </FormProvider>
   );

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/MobileOptionsSheet.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/MobileOptionsSheet.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import {
+  Film, Image as ImageIcon, Settings2, Sliders, Upload
+} from "lucide-react";
+import type {
+  RefObject
+} from "react";
+import {
+  useMemo, useState
+} from "react";
+import {
+  UseFormReturn, useWatch
+} from "react-hook-form";
+
+import MobileSheet, {
+  type SheetSnap
+} from "@/components/MobileSheet/MobileSheet";
+import type {
+  JobModel
+} from "@/types/recording.types";
+import type {
+  SketchOption, SketchOptionInput, SlideOption
+} from "@/types/sketch.types";
+import type {
+  RecordingLifecycle
+} from "../../hooks/useRecordingLifecycle";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+import RandomizeSettingsButton from "@/components/RandomizeSettingsButton";
+import ResetSettingsButton from "@/components/ResetSettingsButton";
+import initOptions from "@/utils/initOptions";
+
+import type {
+  CaptureActionsRef
+} from "../CaptureActions";
+import CaptureActions from "../CaptureActions";
+import useBrowserRecordingSupported from "../CaptureActions/hooks/useBrowserRecordingSupported";
+import OptionsImportExport from "../CaptureActions/components/OptionsImportExport";
+import ContentArrayProvider from "../ContentArrayProvider/ContentArrayProvider";
+import ContentItems from "../ContentItems/ContentItems";
+import GenericObjectForm from "../RootSettings/components/GenericObjectForm/GenericObjectForm";
+import rootFormConfig from "../RootSettings/constants/root-field-config";
+import RecordingLockBanner from "../RecordingLockBanner";
+import SlideCarousel from "../SlideCarousel";
+import SlideEditor from "../SlideEditor";
+import SaveDefaultsButton from "../SketchSettings/SaveDefaultsButton";
+import GenerateThumbnailButton from "../SketchSettings/GenerateThumbnailButton";
+import GeneratePreviewButton from "../SketchSettings/GeneratePreviewButton";
+import {
+  injectSketchSchemas
+} from "../SketchSettings/utils/injectSketchSchemas";
+import TemplateAssetsProvider from "../TemplateAssetsProvider/TemplateAssetsProvider";
+
+import SheetPeekBar from "./SheetPeekBar";
+import SheetTabBar, {
+  type TabDef, type TabId
+} from "./SheetTabBar";
+
+type MobileOptionsSheetProps = {
+  methods: UseFormReturn<SketchOptionInput>;
+  name: string;
+  persistedJob?: JobModel;
+  activeSlideIndex: number | undefined;
+  slideFields: { id: string }[];
+  slides?: SlideOption[];
+  thumbnails: Record<string, string>;
+  enableThumbnails: boolean;
+  isAdding: boolean;
+  onAddSlide: () => void;
+  onSelectSlide: ( index: number | undefined ) => void;
+  onReorderSlides: ( oldIndex: number, newIndex: number ) => void;
+  onDuplicateSlide: ( index: number ) => void;
+  onDeleteSlide: ( index: number ) => void;
+  onRenameSlide: ( index: number, newName: string ) => void;
+  onImportOptions: ( options: SketchOption ) => void;
+  // Lifecycle / capture wiring (parity with desktop)
+  lifecycle: RecordingLifecycle;
+  bannerCloning: boolean;
+  onBannerClone: () => void | Promise<void>;
+  captureActionsRef: RefObject<CaptureActionsRef>;
+  recordingProgress: Parameters<typeof CaptureActions>[ 0 ][ "recordingProgress" ];
+  subscribeToRecordingStatus: Parameters<typeof CaptureActions>[ 0 ][ "subscribeToRecordingStatus" ];
+};
+
+const STORAGE_KEY = "p5-templates:mobile-sheet:tab";
+
+function readStoredTab( fallback: TabId ): TabId {
+  if ( typeof window === "undefined" ) {
+    return fallback;
+  }
+
+  try {
+    const stored = window.localStorage.getItem( STORAGE_KEY );
+
+    if ( stored === "sketch" || stored === "slides" || stored === "content" || stored === "settings" || stored === "export" ) {
+      return stored;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return fallback;
+}
+
+export default function MobileOptionsSheet( props: MobileOptionsSheetProps ) {
+  const {
+    methods,
+    name,
+    persistedJob,
+    activeSlideIndex,
+    slideFields,
+    slides,
+    thumbnails,
+    enableThumbnails,
+    isAdding,
+    onAddSlide,
+    onSelectSlide,
+    onReorderSlides,
+    onDuplicateSlide,
+    onDeleteSlide,
+    onRenameSlide,
+    onImportOptions,
+    lifecycle,
+    bannerCloning,
+    onBannerClone,
+    captureActionsRef,
+    recordingProgress,
+    subscribeToRecordingStatus
+  } = props;
+
+  const [
+    {
+      backendRecording, sketchFormConfiguration, sketchFormValues
+    }
+  ] = useSketch();
+
+  const browserRecordingSupported = useBrowserRecordingSupported();
+
+  const {
+    control, watch
+  } = methods;
+
+  const rootContentLength = ( useWatch( {
+    control,
+    name: "content"
+  } ) as unknown[] | undefined )?.length ?? 0;
+  const slidesLength = slides?.length ?? 0;
+  const jobId = useWatch( {
+    control,
+    name: "id"
+  } ) as string | undefined;
+
+  // Sheet snap point + active tab (persisted).
+  const [
+    snap,
+    setSnap
+  ] = useState<SheetSnap>( "peek" );
+
+  const slideIds = slideFields.map( ( f ) => f.id );
+  const hasSlides = slidesLength > 0;
+  const slideContext = activeSlideIndex !== undefined;
+
+  const [
+    activeTab,
+    setActiveTab
+  ] = useState<TabId>( () => readStoredTab( "sketch" ) );
+
+  const changeTab = ( id: TabId ) => {
+    setActiveTab( id );
+
+    if ( snap === "peek" ) {
+      setSnap( "half" );
+    }
+
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        id
+      );
+    } catch {
+      /* ignore */
+    }
+  };
+
+  // Sketch-specific form config (with runtime schema injection).
+  const sketchConfigWithSchemas = useMemo(
+    () => {
+      if ( !sketchFormConfiguration ) {
+        return undefined;
+      }
+
+      return injectSketchSchemas(
+        name,
+        sketchFormConfiguration
+      );
+    },
+    [
+      name,
+      sketchFormConfiguration
+    ]
+  );
+
+  const sketchBasePath = slideContext
+    ? `slides.${ activeSlideIndex }.sketch`
+    : "sketch";
+
+  const generalBasePath = slideContext ? `slides.${ activeSlideIndex }` : "";
+
+  const sketchOptionsCount = sketchFormValues
+    ? Object.keys( sketchFormValues ).length
+    : 0;
+
+  // Build tabs dynamically (slides hidden when sketch has no slide support).
+  const tabs: TabDef[] = [];
+
+  if ( sketchConfigWithSchemas && Object.keys( sketchConfigWithSchemas ).length > 0 ) {
+    tabs.push( {
+      id: "sketch",
+      label: "Sketch",
+      icon: Sliders,
+      badge: sketchOptionsCount
+    } );
+  }
+
+  if ( hasSlides ) {
+    tabs.push( {
+      id: "slides",
+      label: "Slides",
+      icon: Film,
+      badge: slidesLength
+    } );
+  }
+
+  tabs.push( {
+    id: "content",
+    label: "Content",
+    icon: ImageIcon,
+    badge: rootContentLength
+  } );
+
+  tabs.push( {
+    id: "settings",
+    label: "Canvas",
+    icon: Settings2
+  } );
+
+  tabs.push( {
+    id: "export",
+    label: "Export",
+    icon: Upload
+  } );
+
+  // Guard: if the active tab is unavailable (e.g. sketch has no options or no
+  // slides), fall back to the first available tab.
+  const resolvedActiveTab: TabId = tabs.some( ( t ) => t.id === activeTab )
+    ? activeTab
+    : tabs[ 0 ].id;
+
+  const editorKey =
+    activeSlideIndex !== undefined && slideIds[ activeSlideIndex ]
+      ? slideIds[ activeSlideIndex ]
+      : `no-slides-${ slideFields.length }`;
+
+  const options = watch();
+
+  return (
+    <MobileSheet
+      snap={ snap }
+      onSnapChange={ setSnap }
+      peekBar={ (
+        <SheetPeekBar
+          snap={ snap }
+          onSnapChange={ setSnap }
+        />
+      ) }
+      tabBar={ (
+        <SheetTabBar
+          tabs={ tabs }
+          active={ resolvedActiveTab }
+          onChange={ changeTab }
+        />
+      ) }
+    >
+      {lifecycle.isLocked && (
+        <div className="mb-3">
+          <RecordingLockBanner
+            state={ lifecycle.state }
+            onClone={ onBannerClone }
+            cloning={ bannerCloning }
+          />
+        </div>
+      )}
+
+      {resolvedActiveTab === "sketch" && sketchConfigWithSchemas && (
+        <TemplateAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
+          <section aria-label="Sketch options">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-sm font-semibold">
+                {slideContext
+                  ? `Slide ${ ( activeSlideIndex ?? 0 ) + 1 } · Sketch options`
+                  : "Sketch options"}
+              </h2>
+              <div className="flex items-center gap-2">
+                <ResetSettingsButton basePath={ sketchBasePath } />
+                <RandomizeSettingsButton
+                  config={ sketchConfigWithSchemas }
+                  basePath={ sketchBasePath }
+                />
+                <SaveDefaultsButton />
+                <GenerateThumbnailButton />
+                <GeneratePreviewButton />
+              </div>
+            </div>
+
+            <GenericObjectForm
+              key={ sketchBasePath }
+              basePath={ sketchBasePath }
+              config={ sketchConfigWithSchemas }
+            />
+          </section>
+        </TemplateAssetsProvider>
+      )}
+
+      {resolvedActiveTab === "slides" && hasSlides && (
+        <section aria-label="Slides">
+          <h2 className="text-sm font-semibold mb-2">
+            Slides{slidesLength ? ` (${ slidesLength })` : ""}
+          </h2>
+
+          <SlideCarousel
+            slideFields={ slideFields }
+            slides={ slides }
+            thumbnails={ enableThumbnails ? thumbnails : {} }
+            activeIndex={ activeSlideIndex }
+            isAdding={ isAdding }
+            onAdd={ onAddSlide }
+            onSelect={ onSelectSlide }
+            onReorder={ onReorderSlides }
+            onDuplicate={ onDuplicateSlide }
+            onDelete={ onDeleteSlide }
+            onRename={ onRenameSlide }
+          />
+
+          {activeSlideIndex !== undefined && (
+            <div className="mt-4">
+              <SlideEditor key={ editorKey } activeIndex={ activeSlideIndex } />
+            </div>
+          )}
+        </section>
+      )}
+
+      {resolvedActiveTab === "content" && (
+        <section aria-label="Global content">
+          <h2 className="text-sm font-semibold mb-2">
+            Global content{rootContentLength ? ` (${ rootContentLength })` : ""}
+          </h2>
+
+          <TemplateAssetsProvider
+            scope="global"
+            assetsName="assets"
+            jobId={ jobId }
+          >
+            <ContentArrayProvider name="content">
+              <ContentItems baseFieldName="content" />
+            </ContentArrayProvider>
+          </TemplateAssetsProvider>
+        </section>
+      )}
+
+      {resolvedActiveTab === "settings" && (
+        <section aria-label="Canvas & general settings">
+          <h2 className="text-sm font-semibold mb-2">
+            {slideContext
+              ? `Slide ${ ( activeSlideIndex ?? 0 ) + 1 } overrides`
+              : "Canvas & general"}
+          </h2>
+
+          <GenericObjectForm
+            key={ generalBasePath || "root" }
+            basePath={ generalBasePath }
+            config={ rootFormConfig }
+          />
+        </section>
+      )}
+
+      {resolvedActiveTab === "export" && (
+        <section aria-label="Export & recording">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold">Export</h2>
+            <OptionsImportExport
+              options={ options }
+              name={ name }
+              persistedJobId={ persistedJob?.id }
+              jobStatus={ lifecycle.currentStatus }
+              onImportInMemory={ ( importedOptions ) => {
+                const processed = initOptions( importedOptions as SketchOption );
+
+                onImportOptions( processed );
+              } }
+            />
+          </div>
+
+          {( backendRecording || browserRecordingSupported ) && (
+            <CaptureActions
+              ref={ captureActionsRef }
+              name={ name }
+              options={ options }
+              persistedJob={ persistedJob }
+              activeSlideIndex={ activeSlideIndex }
+              backendRecording={ backendRecording }
+              browserRecordingSupported={ browserRecordingSupported }
+              thumbnails={ enableThumbnails ? thumbnails : {} }
+              lifecycle={ lifecycle }
+              recordingProgress={ recordingProgress }
+              subscribeToRecordingStatus={ subscribeToRecordingStatus }
+            />
+          )}
+        </section>
+      )}
+    </MobileSheet>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/SheetPeekBar.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/SheetPeekBar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Camera, ChevronUp, Pause, Play
+} from "lucide-react";
+import {
+  ReactNode
+} from "react";
+import clsx from "clsx";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+import type {
+  SheetSnap
+} from "@/components/MobileSheet/MobileSheet";
+
+type SheetPeekBarProps = {
+  snap: SheetSnap;
+  onSnapChange: ( snap: SheetSnap ) => void;
+  /** Optional trailing slot (e.g. record button). */
+  trailing?: ReactNode;
+};
+
+export default function SheetPeekBar( {
+  snap, onSnapChange, trailing
+}: SheetPeekBarProps ) {
+  const [
+    {
+      engine, looping, name, engineId
+    },
+    dispatch
+  ] = useSketch();
+
+  const expanded = snap !== "peek";
+
+  const togglePlay = () => {
+    if ( looping ) {
+      engine?.pause();
+    } else {
+      engine?.play();
+    }
+    dispatch( {
+      type: "SET_LOOPING",
+      payload: !looping
+    } );
+  };
+
+  const saveCanvas = () => {
+    const canvas = engine?.getCanvas();
+
+    if ( !canvas ) {
+      return;
+    }
+
+    const link = document.createElement( "a" );
+
+    link.download = `${ name }.png`;
+    link.href = canvas.toDataURL( "image/png" );
+    link.click();
+  };
+
+  const toggleExpand = () => {
+    if ( snap === "peek" ) {
+      onSnapChange( "half" );
+    } else if ( snap === "half" ) {
+      onSnapChange( "full" );
+    } else {
+      onSnapChange( "peek" );
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1 w-full">
+      <button
+        type="button"
+        onClick={ togglePlay }
+        className="h-10 w-10 inline-flex items-center justify-center rounded-xl bg-foreground/5 active:bg-foreground/10"
+        aria-label={ looping ? "Pause animation" : "Play animation" }
+      >
+        {looping
+          ? <Pause className="h-5 w-5" />
+          : <Play className="h-5 w-5" />}
+      </button>
+
+      <button
+        type="button"
+        onClick={ saveCanvas }
+        className="h-10 w-10 inline-flex items-center justify-center rounded-xl bg-foreground/5 active:bg-foreground/10"
+        aria-label="Save canvas as image"
+      >
+        <Camera className="h-5 w-5" />
+      </button>
+
+      <div className="flex-1 min-w-0 text-xs font-mono text-foreground/60 truncate px-1">
+        {name}
+        <span className="text-foreground/30"> · {engineId}</span>
+      </div>
+
+      {trailing}
+
+      <button
+        type="button"
+        onClick={ toggleExpand }
+        className="h-10 px-3 inline-flex items-center justify-center rounded-xl bg-foreground/5 active:bg-foreground/10 text-xs font-medium"
+        aria-label={ expanded ? "Collapse options" : "Expand options" }
+      >
+        <ChevronUp
+          className={ clsx(
+            "h-5 w-5 transition-transform",
+            expanded && "rotate-180"
+          ) }
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/SheetTabBar.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileOptionsSheet/SheetTabBar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import clsx from "clsx";
+import type {
+  LucideIcon
+} from "lucide-react";
+
+export type TabId = "sketch" | "slides" | "content" | "settings" | "export";
+
+export type TabDef = {
+  id: TabId;
+  label: string;
+  icon: LucideIcon;
+  badge?: number;
+};
+
+type SheetTabBarProps = {
+  tabs: TabDef[];
+  active: TabId;
+  onChange: ( id: TabId ) => void;
+};
+
+export default function SheetTabBar( {
+  tabs, active, onChange
+}: SheetTabBarProps ) {
+  return (
+    <div
+      className="flex items-stretch gap-1 overflow-x-auto pb-1 -mx-2 px-2 scrollbar-none"
+      role="tablist"
+      aria-label="Options sections"
+    >
+      {tabs.map( ( tab ) => {
+        const Icon = tab.icon;
+        const isActive = tab.id === active;
+
+        return (
+          <button
+            key={ tab.id }
+            type="button"
+            role="tab"
+            aria-selected={ isActive }
+            onClick={ () => onChange( tab.id ) }
+            className={ clsx(
+              "flex-1 min-w-[64px] flex flex-col items-center justify-center gap-0.5 py-2 px-2 rounded-lg transition-colors text-[11px] font-medium",
+              isActive
+                ? "bg-foreground/10 text-foreground"
+                : "text-foreground/60 hover:text-foreground hover:bg-foreground/5"
+            ) }
+          >
+            <span className="relative inline-flex">
+              <Icon className="h-5 w-5" />
+              {typeof tab.badge === "number" && tab.badge > 0 && (
+                <span className="absolute -top-1.5 -right-2 min-w-[16px] h-[16px] px-1 rounded-full bg-foreground text-background text-[10px] font-semibold flex items-center justify-center">
+                  {tab.badge}
+                </span>
+              )}
+            </span>
+            <span>{tab.label}</span>
+          </button>
+        );
+      } )}
+    </div>
+  );
+}

--- a/src/components/MobileSheet/MobileSheet.tsx
+++ b/src/components/MobileSheet/MobileSheet.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import {
+  useDrag
+} from "@use-gesture/react";
+import clsx from "clsx";
+import {
+  ReactNode, useEffect, useRef, useState
+} from "react";
+
+export type SheetSnap = "peek" | "half" | "full";
+
+type MobileSheetProps = {
+  /** Controlled snap point. Omit for uncontrolled. */
+  snap?: SheetSnap;
+  /** Fires when the user drags or taps to a new snap point. */
+  onSnapChange?: ( snap: SheetSnap ) => void;
+  /** Initial snap for uncontrolled mode. */
+  defaultSnap?: SheetSnap;
+  /** Always-visible bar below the drag handle (e.g. play/pause, record). */
+  peekBar?: ReactNode;
+  /** Sticky row shown when sheet is `half` or `full` (e.g. tab bar). */
+  tabBar?: ReactNode;
+  /** Scrollable body shown when sheet is `half` or `full`. */
+  children: ReactNode;
+  className?: string;
+};
+
+const PEEK_PX = 64;
+const HALF_VH = 55;
+const FULL_VH = 92;
+
+const SNAP_ORDER: SheetSnap[] = [
+  "peek",
+  "half",
+  "full"
+];
+
+// Pixel thresholds used to decide whether a drag becomes a snap change.
+const DRAG_COMMIT_PX = 48;
+const FLICK_VELOCITY = 0.5;
+
+export default function MobileSheet( {
+  snap: controlledSnap,
+  onSnapChange,
+  defaultSnap = "peek",
+  peekBar,
+  tabBar,
+  children,
+  className
+}: MobileSheetProps ) {
+  const [
+    internalSnap,
+    setInternalSnap
+  ] = useState<SheetSnap>( defaultSnap );
+
+  const isControlled = controlledSnap !== undefined;
+  const snap = isControlled ? controlledSnap : internalSnap;
+
+  const setSnap = ( next: SheetSnap ) => {
+    if ( isControlled ) {
+      onSnapChange?.( next );
+    } else {
+      setInternalSnap( next );
+
+      if ( onSnapChange ) {
+        onSnapChange( next );
+      }
+    }
+  };
+
+  // Honor reduced-motion: skip enter/snap transition for users who request it.
+  const [
+    prefersReducedMotion,
+    setPrefersReducedMotion
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      const mq = window.matchMedia( "(prefers-reduced-motion: reduce)" );
+
+      setPrefersReducedMotion( mq.matches );
+
+      const handler = ( e: MediaQueryListEvent ) => setPrefersReducedMotion( e.matches );
+
+      mq.addEventListener(
+        "change",
+        handler
+      );
+
+      return () => mq.removeEventListener(
+        "change",
+        handler
+      );
+    },
+    []
+  );
+
+  // Drag state for the handle. `dragOffset` is a transient offset applied
+  // during a drag; on release we commit to a new snap and reset to 0.
+  const [
+    dragOffset,
+    setDragOffset
+  ] = useState( 0 );
+  const startSnapRef = useRef<SheetSnap>( snap );
+
+  const bindHandle = useDrag(
+    ( {
+      first, last, tap, movement: [
+        , my
+      ], velocity: [
+        , vy
+      ], direction: [
+        , dy
+      ]
+    } ) => {
+      if ( first ) {
+        startSnapRef.current = snap;
+      }
+
+      if ( !last ) {
+        setDragOffset( my );
+
+        return;
+      }
+
+      setDragOffset( 0 );
+
+      if ( tap ) {
+        // Tap on handle: cycle through snap points.
+        const next = SNAP_ORDER[ ( SNAP_ORDER.indexOf( startSnapRef.current ) + 1 ) % SNAP_ORDER.length ];
+
+        setSnap( next );
+
+        return;
+      }
+
+      const flick = vy > FLICK_VELOCITY;
+      const idx = SNAP_ORDER.indexOf( startSnapRef.current );
+
+      if ( my < -DRAG_COMMIT_PX || ( flick && dy < 0 ) ) {
+        setSnap( SNAP_ORDER[ Math.min(
+          SNAP_ORDER.length - 1,
+          idx + 1
+        ) ] );
+      } else if ( my > DRAG_COMMIT_PX || ( flick && dy > 0 ) ) {
+        setSnap( SNAP_ORDER[ Math.max(
+          0,
+          idx - 1
+        ) ] );
+      }
+    },
+    {
+      axis: "y",
+      filterTaps: true,
+      from: () => [
+        0,
+        0
+      ]
+    }
+  );
+
+  const height = snap === "peek"
+    ? `${ PEEK_PX }px`
+    : snap === "half"
+      ? `${ HALF_VH }svh`
+      : `${ FULL_VH }svh`;
+
+  const expanded = snap !== "peek";
+
+  return (
+    <div
+      className={ clsx(
+        "fixed inset-x-0 bottom-0 z-40 glass border-t border-theme shadow-2xl rounded-t-2xl flex flex-col",
+        className
+      ) }
+      style={ {
+        height,
+        transform: dragOffset !== 0 ? `translateY(${ Math.max(
+          -200,
+          Math.min(
+            200,
+            dragOffset
+          )
+        ) }px)` : undefined,
+        transition: dragOffset !== 0 || prefersReducedMotion
+          ? "none"
+          : "height 250ms ease-out, transform 200ms ease-out",
+        paddingBottom: "env(safe-area-inset-bottom)"
+      } }
+      role="dialog"
+      aria-label="Sketch options"
+    >
+      {/* Drag handle (tap to cycle, drag vertically to snap) */}
+      <div
+        { ...bindHandle() }
+        className="flex flex-col items-center justify-center pt-2 pb-1 select-none touch-none cursor-grab active:cursor-grabbing"
+        style={ {
+          touchAction: "none"
+        } }
+        aria-label={
+          expanded
+            ? "Sheet handle. Tap to expand more, drag down to collapse."
+            : "Sheet handle. Tap or drag up to expand."
+        }
+        role="button"
+      >
+        <div className="w-10 h-1.5 rounded-full bg-foreground/30" />
+      </div>
+
+      {/* Peek bar: always visible */}
+      {peekBar && (
+        <div className="flex items-center gap-2 px-3 pb-2 shrink-0">
+          {peekBar}
+        </div>
+      )}
+
+      {/* Expanded content */}
+      <div
+        className={ clsx(
+          "flex flex-col flex-1 min-h-0 overflow-hidden transition-opacity duration-150",
+          expanded ? "opacity-100" : "opacity-0 pointer-events-none"
+        ) }
+        aria-hidden={ !expanded }
+      >
+        {tabBar && (
+          <div className="shrink-0 border-t border-theme/40 px-2 pt-1">
+            {tabBar}
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TemplateSketchPage/EngineControls.tsx
+++ b/src/components/TemplateSketchPage/EngineControls.tsx
@@ -173,7 +173,7 @@ export function EngineControls( ) {
       : undefined;
 
   return (
-    <div className="absolute top-2 left-[3.25rem] md:top-4 md:left-[3.75rem] flex items-center gap-2 z-50">
+    <div className="absolute top-2 left-[3.25rem] md:top-4 md:left-[3.75rem] items-center gap-2 z-50 hidden md:flex">
       <div className="flex items-center h-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md overflow-hidden">
         { githubUrl && (
           <Link

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -228,9 +228,10 @@ export default function TemplateSketchPage() {
         </div>
       )}
 
-      {/* Sketch viewport */}
+      {/* Sketch viewport — on mobile, leave room at the bottom for the
+          options sheet's peek bar so the canvas never sits under it. */}
       <div
-        className="h-full w-full relative"
+        className="w-full relative h-[calc(100%-5rem)] md:h-full"
         hidden={ !sketchLoaded }
       >
         <ScalableViewport

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  useEffect, useState
+} from "react";
+
+// Matches Tailwind's `md` breakpoint (≥768px = desktop, <768px = mobile).
+const MOBILE_BREAKPOINT_PX = 768;
+
+export default function useIsMobile(): boolean {
+  const [
+    isMobile,
+    setIsMobile
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      const mq = window.matchMedia( `(max-width: ${ MOBILE_BREAKPOINT_PX - 1 }px)` );
+
+      const update = ( e?: MediaQueryListEvent ) => {
+        setIsMobile( e ? e.matches : mq.matches );
+      };
+
+      update();
+      mq.addEventListener(
+        "change",
+        update
+      );
+
+      return () => mq.removeEventListener(
+        "change",
+        update
+      );
+    },
+    []
+  );
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

First of two PRs redesigning the sketch page options form for mobile. This one is the **layout / shell** change — the next one will upgrade the field-level touch targets (sliders, switches, color swatches).

On mobile today, the page stacks three floating panels that all compete with the canvas on a ~390 px viewport:

- `EngineControls` — top-left pill (play / pause / save / GitHub)
- `OptionsPanel` (form + slides + capture) — bottom-right, `w-64` clamped to `calc(50% - 0.75rem)` → ~170 px wide
- `SketchSettings` (sketch-specific options) — bottom-left, same `w-64` clamp → ~170 px wide

Sliders end up ~80 px wide with a 16 px thumb, slide thumbnails are ~45 px tall, and the two bottom panels cover the lower 40 – 50 % of the canvas.

### Change

Replace the two bottom panels (and the top-left engine pill, on mobile) with a **single bottom sheet** at `<md`. Desktop (≥768 px) keeps the existing layout untouched.

The sheet has three snap points driven by drag or tap on the handle:

- **Peek** (~80 px) — just the handle + a horizontal action bar (play / pause, save canvas, sketch name, expand chevron). Canvas gets ~95 % of the screen.
- **Half** (55 svh) — tab bar + active tab content. Canvas still visible above for live feedback.
- **Full** (92 svh) — for deep editing.

Inside the expanded sheet, content is split into segmented tabs so each editing context gets the full screen width:

| Tab | Contents |
|---|---|
| **Sketch** | The sketch-specific options form (`SketchSettings`) |
| **Slides** | `SlideCarousel` + `SlideEditor` (hidden if sketch has no slides) |
| **Content** | Global content array |
| **Canvas** | `RootSettings` (size, framerate, animation duration…) |
| **Export** | `CaptureActions` + import / export options |

The active tab is persisted in `localStorage` so reopening the sheet returns you where you were.

### Notes

- The canvas viewport reserves `5rem` at the bottom on mobile (`h-[calc(100%-5rem)] md:h-full`) so the sketch fits cleanly above the peek bar rather than being hidden under it.
- `EngineControls` becomes `hidden md:flex` — its functionality (play / pause, save canvas) now lives in the sheet's peek bar.
- Existing components (`SlideCarousel`, `SlideEditor`, `ContentItems`, `GenericObjectForm`, `CaptureActions`, `OptionsImportExport`) are reused as-is and slotted into the right tabs — no rewrites of leaf components.
- `TemplateAssetsProvider` is preserved around the sketch-options form (parity with desktop) so image fields keep working.
- Reuses the `@use-gesture/react` drag pattern already proven in `CollapsibleItem` for the sheet handle, and respects `prefers-reduced-motion`.

### Follow-up (PR 2/2)

- Bigger touch targets in `FieldRenderer.tsx`: full-width slider with a 24 px thumb, switch instead of checkbox, 32 px color swatch, 40 px tappable nested-object headers, reset as a button not text.
- Native `<select>` height bumped to `h-10` on mobile.

## Test plan

- [ ] On mobile (≤767 px): bottom sheet appears with peek bar visible. Top-left engine controls are hidden.
- [ ] Tap the handle: sheet cycles peek → half → full → peek.
- [ ] Drag handle down/up: snap points respond to drag distance and flick velocity.
- [ ] Switch tabs: each tab renders its content; tab choice persists across page reloads.
- [ ] Sketch tab: sketch options form renders and edits sync to the canvas.
- [ ] Slides tab: carousel + editor work; slides badge shows count.
- [ ] Content tab: global content edits work; image fields can upload (verifies `TemplateAssetsProvider`).
- [ ] Canvas tab: root settings (size, framerate, etc.) render and apply.
- [ ] Export tab: record/save/import-export buttons work; recording lock banner appears when locked.
- [ ] Peek bar: play/pause toggles animation; save canvas downloads a PNG.
- [ ] Canvas viewport: sketch fits cleanly above the peek bar without being clipped.
- [ ] Desktop (≥768 px): no visual change — twin corner panels render exactly as before.
- [ ] `prefers-reduced-motion`: sheet height transition is skipped.

https://claude.ai/code/session_01NHLLFiv4wK8VeHi78PYAc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHLLFiv4wK8VeHi78PYAc3)_