### PR TITLE
Portal menubar into page headers, add scroll-to-top on home

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,9 @@ import {
 } from "react";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import MenuBar from "@/components/MenuBar";
+import {
+  MenuBarSlotProvider
+} from "@/components/MenuBarPortal";
 import ServiceWorkerUpdateNotifier from "@/components/ServiceWorkerUpdateNotifier";
 import {
   getBaseUrl,
@@ -151,17 +154,19 @@ export default function RootLayout( {
           enableSystem
           disableTransitionOnChange
         >
-          <div className="h-[100svh] bg-hover/50">
-            <main className="h-full overflow-auto overscroll-contain relative">{children}</main>
+          <MenuBarSlotProvider>
+            <div className="h-[100svh] bg-hover/50">
+              <main className="h-full overflow-auto overscroll-contain relative">{children}</main>
 
-            <Suspense>
-              <MenuBar
-                showRecordings={ process.env.BACKEND_RECORDING === "true" }
-                hasMissingThumbnails={ hasMissingThumbnails }
-                hasMissingPreviews={ hasMissingPreviews }
-              />
-            </Suspense>
-          </div>
+              <Suspense>
+                <MenuBar
+                  showRecordings={ process.env.BACKEND_RECORDING === "true" }
+                  hasMissingThumbnails={ hasMissingThumbnails }
+                  hasMissingPreviews={ hasMissingPreviews }
+                />
+              </Suspense>
+            </div>
+          </MenuBarSlotProvider>
 
           <ServiceWorkerUpdateNotifier />
         </ThemeProvider>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -21,6 +21,7 @@ import {
   Triangle
 } from "lucide-react";
 import AnimatedPreview from "@/components/AnimatedPreview";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 import type {
   TemplateItem
 } from "@/app/templates/getTemplatesData";
@@ -954,6 +955,8 @@ export default function HomePage( {
           ) : null}
         </div>
       </section>
+
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -32,11 +32,17 @@ import {
   useCallback, useEffect, useState
 } from "react";
 import {
+  createPortal
+} from "react-dom";
+import {
   subscribeUser, unsubscribeUser
 } from "@/app/actions/notifications";
 import {
   pauseSketchForNav
 } from "@/lib/navigationPauseSignal";
+import {
+  useMenuBarSlot
+} from "@/components/MenuBarPortal";
 import sleep from "@/utils/sleep";
 
 type MenuBarProps = {
@@ -120,6 +126,7 @@ function MenuBar( {
 }: MenuBarProps ) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const slot = useMenuBarSlot();
   const {
     theme, setTheme
   } = useTheme();
@@ -354,181 +361,194 @@ function MenuBar( {
 
   const hasPendingActions = hasMissingThumbnails || hasMissingPreviews;
 
-  return (
-    <div className="fixed top-2 left-2 md:top-4 md:left-4 z-50">
-      <Menu as="div" className="relative">
-        <MenuButton
-          aria-label="Open menu"
-          title="Menu"
-          className="relative h-9 w-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md inline-flex items-center justify-center hover:bg-hover transition-colors group"
-        >
-          <MenuIcon className="h-4 w-4 text-foreground/70 group-hover:text-foreground transition-colors" />
-          {hasPendingActions && (
-            <span
-              aria-hidden
-              className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-red-500 border-2 border-background animate-pulse-soft"
-            />
-          )}
-        </MenuButton>
+  const renderInline = Boolean( slot?.slotEl && slot.inlineVisible );
 
-        <MenuItems
-          anchor="bottom start"
-          className="z-50 w-60 border border-border rounded-xl bg-background/95 backdrop-blur-xl shadow-xl overflow-hidden focus:outline-none [--anchor-gap:0.5rem]"
-        >
-          <SectionLabel>Navigate</SectionLabel>
-          {navLinks.map( ( {
-            href, label, Icon, target, external
-          } ) => {
-            const active = isActive(
-              href,
-              external
-            );
+  const menuNode = (
+    <Menu as="div" className="relative">
+      <MenuButton
+        aria-label="Open menu"
+        title="Menu"
+        className="relative h-9 w-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md inline-flex items-center justify-center hover:bg-hover transition-colors group"
+      >
+        <MenuIcon className="h-4 w-4 text-foreground/70 group-hover:text-foreground transition-colors" />
+        {hasPendingActions && (
+          <span
+            aria-hidden
+            className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-red-500 border-2 border-background animate-pulse-soft"
+          />
+        )}
+      </MenuButton>
 
-            return (
-              <MenuItem key={ href }>
-                {( {
-                  focus
-                } ) => (
-                  <Link
-                    href={ href }
-                    target={ target }
-                    onClick={ external ? undefined : pauseSketchForNav }
-                    className={ clsx(
-                      itemClass,
-                      focus && "bg-hover",
-                      active && "font-semibold"
-                    ) }
-                  >
-                    <Icon className="h-4 w-4 text-foreground/70" />
-                    <span className="flex-1">{label}</span>
-                    {active && (
-                      <span
-                        aria-hidden
-                        className="h-1.5 w-1.5 rounded-full bg-foreground"
-                      />
-                    )}
-                  </Link>
-                )}
-              </MenuItem>
-            );
-          } )}
+      <MenuItems
+        anchor="bottom start"
+        className="z-50 w-60 border border-border rounded-xl bg-background/95 backdrop-blur-xl shadow-xl overflow-hidden focus:outline-none [--anchor-gap:0.5rem]"
+      >
+        <SectionLabel>Navigate</SectionLabel>
+        {navLinks.map( ( {
+          href, label, Icon, target, external
+        } ) => {
+          const active = isActive(
+            href,
+            external
+          );
 
-          {hasPendingActions && (
-            <>
-              <Divider />
-              <SectionLabel>Pending</SectionLabel>
-              {hasMissingPreviews && (
-                <MenuItem>
-                  {( {
-                    focus
-                  } ) => (
-                    <button
-                      type="button"
-                      onClick={ handleGeneratePreviews }
-                      disabled={ generatingPreviews }
-                      className={ clsx(
-                        itemClass,
-                        focus && "bg-hover"
-                      ) }
-                    >
-                      <Film className={ clsx(
-                        "h-4 w-4 text-foreground/70",
-                        generatingPreviews && "animate-pulse"
-                      ) } />
-                      <span className="flex-1 text-left">
-                        {generatingPreviews ? "Generating…" : "Generate previews"}
-                      </span>
-                    </button>
-                  )}
-                </MenuItem>
-              )}
-              {hasMissingThumbnails && (
-                <MenuItem>
-                  {( {
-                    focus
-                  } ) => (
-                    <button
-                      type="button"
-                      onClick={ handleGenerateThumbnails }
-                      disabled={ generatingThumbnails }
-                      className={ clsx(
-                        itemClass,
-                        focus && "bg-hover"
-                      ) }
-                    >
-                      <ImagePlus className={ clsx(
-                        "h-4 w-4 text-foreground/70",
-                        generatingThumbnails && "animate-pulse"
-                      ) } />
-                      <span className="flex-1 text-left">
-                        {generatingThumbnails ? "Generating…" : "Generate thumbnails"}
-                      </span>
-                    </button>
-                  )}
-                </MenuItem>
-              )}
-            </>
-          )}
-
-          <Divider />
-          <SectionLabel>Theme</SectionLabel>
-          {themeOptions.map( ( {
-            value, label, Icon
-          } ) => (
-            <MenuItem key={ value }>
+          return (
+            <MenuItem key={ href }>
               {( {
                 focus
               } ) => (
-                <button
-                  type="button"
-                  onClick={ () => setTheme( value ) }
+                <Link
+                  href={ href }
+                  target={ target }
+                  onClick={ external ? undefined : pauseSketchForNav }
                   className={ clsx(
                     itemClass,
-                    focus && "bg-hover"
+                    focus && "bg-hover",
+                    active && "font-semibold"
                   ) }
                 >
                   <Icon className="h-4 w-4 text-foreground/70" />
-                  <span className="flex-1 text-left">{label}</span>
-                  {mounted && theme === value && (
-                    <Check className="h-4 w-4 text-foreground" />
+                  <span className="flex-1">{label}</span>
+                  {active && (
+                    <span
+                      aria-hidden
+                      className="h-1.5 w-1.5 rounded-full bg-foreground"
+                    />
                   )}
-                </button>
+                </Link>
               )}
             </MenuItem>
-          ) )}
+          );
+        } )}
 
-          {SHOW_NOTIFICATIONS && pushSupported && (
-            <>
-              <Divider />
-              <SectionLabel>Notifications</SectionLabel>
+        {hasPendingActions && (
+          <>
+            <Divider />
+            <SectionLabel>Pending</SectionLabel>
+            {hasMissingPreviews && (
               <MenuItem>
                 {( {
                   focus
                 } ) => (
                   <button
                     type="button"
-                    onClick={ pushSubscription ? unsubscribeFromPush : subscribeToPush }
-                    disabled={ pushLoading }
+                    onClick={ handleGeneratePreviews }
+                    disabled={ generatingPreviews }
                     className={ clsx(
                       itemClass,
                       focus && "bg-hover"
                     ) }
                   >
-                    {pushSubscription ? (
-                      <Bell className="h-4 w-4 text-foreground/70" />
-                    ) : (
-                      <BellOff className="h-4 w-4 text-foreground/70" />
-                    )}
+                    <Film className={ clsx(
+                      "h-4 w-4 text-foreground/70",
+                      generatingPreviews && "animate-pulse"
+                    ) } />
                     <span className="flex-1 text-left">
-                      {pushSubscription ? "Disable notifications" : "Enable notifications"}
+                      {generatingPreviews ? "Generating…" : "Generate previews"}
                     </span>
                   </button>
                 )}
               </MenuItem>
-            </>
-          )}
-        </MenuItems>
-      </Menu>
+            )}
+            {hasMissingThumbnails && (
+              <MenuItem>
+                {( {
+                  focus
+                } ) => (
+                  <button
+                    type="button"
+                    onClick={ handleGenerateThumbnails }
+                    disabled={ generatingThumbnails }
+                    className={ clsx(
+                      itemClass,
+                      focus && "bg-hover"
+                    ) }
+                  >
+                    <ImagePlus className={ clsx(
+                      "h-4 w-4 text-foreground/70",
+                      generatingThumbnails && "animate-pulse"
+                    ) } />
+                    <span className="flex-1 text-left">
+                      {generatingThumbnails ? "Generating…" : "Generate thumbnails"}
+                    </span>
+                  </button>
+                )}
+              </MenuItem>
+            )}
+          </>
+        )}
+
+        <Divider />
+        <SectionLabel>Theme</SectionLabel>
+        {themeOptions.map( ( {
+          value, label, Icon
+        } ) => (
+          <MenuItem key={ value }>
+            {( {
+              focus
+            } ) => (
+              <button
+                type="button"
+                onClick={ () => setTheme( value ) }
+                className={ clsx(
+                  itemClass,
+                  focus && "bg-hover"
+                ) }
+              >
+                <Icon className="h-4 w-4 text-foreground/70" />
+                <span className="flex-1 text-left">{label}</span>
+                {mounted && theme === value && (
+                  <Check className="h-4 w-4 text-foreground" />
+                )}
+              </button>
+            )}
+          </MenuItem>
+        ) )}
+
+        {SHOW_NOTIFICATIONS && pushSupported && (
+          <>
+            <Divider />
+            <SectionLabel>Notifications</SectionLabel>
+            <MenuItem>
+              {( {
+                focus
+              } ) => (
+                <button
+                  type="button"
+                  onClick={ pushSubscription ? unsubscribeFromPush : subscribeToPush }
+                  disabled={ pushLoading }
+                  className={ clsx(
+                    itemClass,
+                    focus && "bg-hover"
+                  ) }
+                >
+                  {pushSubscription ? (
+                    <Bell className="h-4 w-4 text-foreground/70" />
+                  ) : (
+                    <BellOff className="h-4 w-4 text-foreground/70" />
+                  )}
+                  <span className="flex-1 text-left">
+                    {pushSubscription ? "Disable notifications" : "Enable notifications"}
+                  </span>
+                </button>
+              )}
+            </MenuItem>
+          </>
+        )}
+      </MenuItems>
+    </Menu>
+  );
+
+  if ( renderInline && slot?.slotEl ) {
+    return createPortal(
+      menuNode,
+      slot.slotEl
+    );
+  }
+
+  return (
+    <div className="fixed top-2 left-2 md:top-4 md:left-4 z-50">
+      {menuNode}
     </div>
   );
 }

--- a/src/components/MenuBarPortal.tsx
+++ b/src/components/MenuBarPortal.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  createContext, useCallback, useContext, useEffect, useRef, useState
+} from "react";
+
+type MenuBarSlotContextValue = {
+  registerSlot: ( el: HTMLElement | null ) => void;
+  slotEl: HTMLElement | null;
+  inlineVisible: boolean;
+};
+
+const MenuBarSlotContext = createContext<MenuBarSlotContextValue | null>( null );
+
+export function useMenuBarSlot() {
+  return useContext( MenuBarSlotContext );
+}
+
+function findScrollParent( el: HTMLElement ): Element {
+  let parent: HTMLElement | null = el.parentElement;
+
+  while ( parent ) {
+    const style = window.getComputedStyle( parent );
+
+    if ( /(auto|scroll)/.test( style.overflowY ) ) {
+      return parent;
+    }
+
+    parent = parent.parentElement;
+  }
+
+  return document.documentElement;
+}
+
+export function MenuBarSlotProvider( {
+  children
+}: { children: React.ReactNode } ) {
+  const [
+    slotEl,
+    setSlotEl
+  ] = useState<HTMLElement | null>( null );
+  const [
+    inlineVisible,
+    setInlineVisible
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      if ( !slotEl ) {
+        setInlineVisible( false );
+        return;
+      }
+
+      const root = findScrollParent( slotEl );
+
+      const observer = new IntersectionObserver(
+        ( entries ) => {
+          for ( const entry of entries ) {
+            setInlineVisible( entry.isIntersecting );
+          }
+        },
+        {
+          root: root === document.documentElement ? null : root,
+          threshold: 0
+        }
+      );
+
+      observer.observe( slotEl );
+
+      // Initial state — if the slot mounts already out of view, treat as not visible.
+      const rect = slotEl.getBoundingClientRect();
+      const rootRect =
+        root === document.documentElement
+          ? {
+            top: 0,
+            bottom: window.innerHeight
+          }
+          : root.getBoundingClientRect();
+
+      setInlineVisible( rect.bottom > rootRect.top && rect.top < rootRect.bottom );
+
+      return () => observer.disconnect();
+    },
+    [
+      slotEl
+    ]
+  );
+
+  const registerSlot = useCallback(
+    ( el: HTMLElement | null ) => {
+      setSlotEl( el );
+
+      // Seed as visible when a slot mounts so the menu portals immediately
+      // instead of briefly flashing in its floating position on first paint.
+      if ( el ) {
+        setInlineVisible( true );
+      }
+    },
+    []
+  );
+
+  return (
+    <MenuBarSlotContext.Provider
+      value={ {
+        registerSlot,
+        slotEl,
+        inlineVisible
+      } }
+    >
+      {children}
+    </MenuBarSlotContext.Provider>
+  );
+}
+
+type MenuBarSlotProps = {
+  className?: string;
+};
+
+export function MenuBarSlot( {
+  className
+}: MenuBarSlotProps ) {
+  const ctx = useMenuBarSlot();
+  const ref = useRef<HTMLDivElement>( null );
+  // Depend only on the stable callback — not the whole ctx object, which
+  // re-creates whenever `inlineVisible` changes and would otherwise cause
+  // the observer's updates to be immediately overridden by re-seeding.
+  const registerSlot = ctx?.registerSlot;
+
+  useEffect(
+    () => {
+      if ( !registerSlot ) {
+        return;
+      }
+
+      registerSlot( ref.current );
+
+      return () => registerSlot( null );
+    },
+    [
+      registerSlot
+    ]
+  );
+
+  // Reserve space matching the menu button (h-9 w-9 in MenuBar.tsx)
+  // so the layout doesn't reflow as the menubar appears/disappears.
+  return (
+    <div
+      ref={ ref }
+      className={ clsx(
+        "h-9 w-9 shrink-0",
+        className
+      ) }
+    />
+  );
+}

--- a/src/components/RecordingsPage/components/RecordingsToolbar.tsx
+++ b/src/components/RecordingsPage/components/RecordingsToolbar.tsx
@@ -1,6 +1,9 @@
 import {
   Grid, List
 } from "lucide-react";
+import {
+  MenuBarSlot
+} from "@/components/MenuBarPortal";
 import SortControls from "./SortControls";
 import type {
   SortConfig
@@ -32,14 +35,17 @@ export default function RecordingsToolbar( {
   return (
     <div className="flex flex-col gap-3 sm:gap-4">
       {/* Header */}
-      <div>
-        <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-          Recordings
-        </h1>
-        <p className="text-xs sm:text-sm text-foreground/60 mt-0.5 sm:mt-1">
-          {recordingsCount} {recordingsCount === 1 ? "recording" : "recordings"}
-          {statusFilter !== "all" && ` • ${ statusFilter }`}
-        </p>
+      <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+        <MenuBarSlot />
+        <div className="min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold text-foreground truncate">
+            Recordings
+          </h1>
+          <p className="text-xs sm:text-sm text-foreground/60 mt-0.5 sm:mt-1">
+            {recordingsCount} {recordingsCount === 1 ? "recording" : "recordings"}
+            {statusFilter !== "all" && ` • ${ statusFilter }`}
+          </p>
+        </div>
       </div>
 
       {/* Desktop: Single row with all controls */}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  ArrowUp
+} from "lucide-react";
+import {
+  useCallback, useEffect, useState
+} from "react";
+
+function getScrollContainer(): HTMLElement | null {
+  if ( typeof document === "undefined" ) {
+    return null;
+  }
+
+  return document.querySelector( "main" );
+}
+
+export default function ScrollToTopButton() {
+  const [
+    show,
+    setShow
+  ] = useState( false );
+
+  useEffect(
+    () => {
+      const el = getScrollContainer();
+
+      if ( !el ) {
+        return;
+      }
+
+      const update = () => {
+        const threshold = Math.max(
+          window.innerHeight * 0.8,
+          400
+        );
+
+        setShow( el.scrollTop > threshold );
+      };
+
+      update();
+      el.addEventListener(
+        "scroll",
+        update,
+        {
+          passive: true
+        }
+      );
+
+      return () => el.removeEventListener(
+        "scroll",
+        update
+      );
+    },
+    []
+  );
+
+  const handleClick = useCallback(
+    () => {
+      const el = getScrollContainer();
+
+      el?.scrollTo( {
+        top: 0,
+        behavior: "smooth"
+      } );
+    },
+    []
+  );
+
+  return (
+    <button
+      type="button"
+      aria-label="Back to top"
+      title="Back to top"
+      onClick={ handleClick }
+      className={ clsx(
+        "fixed bottom-4 right-4 md:bottom-6 md:right-6 z-40",
+        "h-10 w-10 rounded-full bg-foreground text-background",
+        "border border-border shadow-lg",
+        "inline-flex items-center justify-center",
+        "transition-all duration-200 hover:scale-105 active:scale-95",
+        show ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none"
+      ) }
+    >
+      <ArrowUp className="w-4 h-4" />
+    </button>
+  );
+}

--- a/src/components/TemplatesList.tsx
+++ b/src/components/TemplatesList.tsx
@@ -20,6 +20,9 @@ import Link from "@/components/HardLink";
 import AnimatedPreview from "@/components/AnimatedPreview";
 import AnimationsToggle from "@/components/AnimationsToggle";
 import {
+  MenuBarSlot
+} from "@/components/MenuBarPortal";
+import {
   usePersistedViewMode
 } from "@/hooks/usePersistedViewMode";
 import {
@@ -180,9 +183,12 @@ export default function TemplatesList( {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:gap-4">
         <div className="flex items-center justify-between gap-3">
-          <h1 className="text-2xl sm:text-3xl font-bold text-foreground">
-            Templates
-          </h1>
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+            <MenuBarSlot />
+            <h1 className="text-2xl sm:text-3xl font-bold text-foreground truncate">
+              Templates
+            </h1>
+          </div>
           <AnimationsToggle
             enabled={ animationsEnabled }
             onChange={ setAnimationsEnabled }


### PR DESCRIPTION
The floating top-left menubar was rendering on top of the "Templates" and "Recordings" page headings. A MenuBarSlot context now lets pages declare an inline location for the menu; MenuBar portals into the slot when it's mounted and visible, and falls back to its original fixed top-left position otherwise (other pages, or once the slot scrolls out of view).

Adds a back-to-top button on the home page that fades in past the hero.