### PR TITLE
fix(p5-engine): guard against destroy during async init

### DIFF
--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -118,19 +118,30 @@ export class P5Engine implements SketchEngine {
         throw error;
       } );
 
+    // destroy() may have run while we were awaiting the dynamic imports
+    // (e.g. React tearing down the tree on a parent error). Bail out
+    // before touching sketchRuntime — otherwise `runtime._setupFn` throws.
+    if ( !this.sketchRuntime || !sketchPath ) {
+      return;
+    }
+
     // ES modules are cached — on second visit the module doesn't re-run,
     // leaving _setupFn/_drawFn null. Restore them from our static cache.
-    // (sketchPath is guaranteed non-null here: the import above would have thrown otherwise.)
     const runtime = this.sketchRuntime as any;
-    if ( sketchPath && !P5Engine._sketchModuleCache.has( sketchPath ) ) {
+
+    if ( !P5Engine._sketchModuleCache.has( sketchPath ) ) {
       P5Engine._sketchModuleCache.add( sketchPath );
-      P5Engine._sketchFnCache.set( sketchPath, {
-        setupFn: runtime._setupFn,
-        drawFn: runtime._drawFn,
-        sketchOptions: runtime.sketchOptions
-      } );
-    } else if ( sketchPath ) {
+      P5Engine._sketchFnCache.set(
+        sketchPath,
+        {
+          setupFn: runtime._setupFn,
+          drawFn: runtime._drawFn,
+          sketchOptions: runtime.sketchOptions
+        }
+      );
+    } else {
       const cached = P5Engine._sketchFnCache.get( sketchPath );
+
       if ( cached ) {
         runtime._setupFn = cached.setupFn;
         runtime._drawFn = cached.drawFn;
@@ -141,6 +152,10 @@ export class P5Engine implements SketchEngine {
     }
 
     await this.sketchRuntime.start( container );
+
+    if ( !this.sketchRuntime ) {
+      return;
+    }
 
     const p = this.sketchRuntime?.getP5();
 


### PR DESCRIPTION
If the React tree unmounts while P5Engine.init() is awaiting the dynamic
sketch import, destroy() runs and nulls this.sketchRuntime — the await
then resolves and `runtime._setupFn` throws "Cannot read properties of
null". This surfaces on every sketch page load whenever a parent render
errors out (e.g. an RSC stream-decode failure caused by a browser
extension tampering with intrinsics), masking the real cause with a
noisy "[EngineSketchRenderer] init failed" stack.

Check sketchRuntime after each await and bail out cleanly when it has
been torn down.

https://claude.ai/code/session_01YEppD5SaoQnyGBrNp2Ko4E