### PR TITLE
refactor(recording): pulse realtime button, prefix picker by mode, harden lifecycle

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -27,13 +27,42 @@ type BrowserRecordingButtonProps = {
 };
 
 const FORMAT_LABEL: Record<RecordingFormat, string> = {
-  webm: "WebM",
-  gif: "GIF",
-  mp4: "MP4"
+  webm: ".webm",
+  gif: ".gif",
+  mp4: ".mp4"
 };
 
+const MODE_LABEL: Record<RecordingMode, string> = {
+  "async-loop": "Async loop",
+  realtime: "Realtime"
+};
+
+// Per-mode format availability — gif is async-loop only; webm/mp4 work
+// in both modes via MediaRecorder (realtime) or mediabunny (async-loop).
+// First entry in each group is the default for that mode. mp4 leads
+// because it plays in every consumer (X, Instagram, native browsers)
+// without re-encoding, unlike webm.
+const MODE_FORMATS: Record<RecordingMode, RecordingFormat[]> = {
+  "async-loop": [
+    "mp4",
+    "webm",
+    "gif"
+  ],
+  realtime: [
+    "mp4",
+    "webm"
+  ]
+};
+
+const MODE_ORDER: ReadonlyArray<RecordingMode> = [
+  "async-loop",
+  "realtime"
+];
+
 // Composite value encoded in <option value=...>. One option per
-// (format, mode) pair, grouped by mode via <optgroup>.
+// (format, mode) pair, grouped by mode via <optgroup>. Including the
+// mode in the visible label too — "Realtime: .mp4" — keeps the active
+// choice readable without re-opening the dropdown.
 type Choice = {
   format: RecordingFormat;
   mode: RecordingMode;
@@ -55,27 +84,11 @@ function decodeChoice( value: string ): Choice {
   };
 }
 
-// Per-mode format availability — gif is async-loop only; webm/mp4 work
-// in both modes via MediaRecorder (realtime) or mediabunny (async-loop).
-// First entry in each group is the default for that mode. mp4 leads
-// because it plays in every consumer (X, Instagram, native browsers)
-// without re-encoding, unlike webm.
-const MODE_FORMATS: Record<RecordingMode, RecordingFormat[]> = {
-  "async-loop": [
-    "mp4",
-    "webm",
-    "gif"
-  ],
-  realtime: [
-    "mp4",
-    "webm"
-  ]
-};
-
-const MODE_LABEL: Record<RecordingMode, string> = {
-  "async-loop": "Async loop",
-  realtime: "Realtime"
-};
+function formatChoiceLabel(
+  mode: RecordingMode, format: RecordingFormat
+): string {
+  return `${ MODE_LABEL[ mode ] }: ${ FORMAT_LABEL[ format ] }`;
+}
 
 export default function BrowserRecordingButton( {
   capabilities,
@@ -91,13 +104,12 @@ export default function BrowserRecordingButton( {
     () => {
       const supported = new Set( capabilities.supportedFormats );
 
-      return ( [
-        "async-loop",
-        "realtime"
-      ] as const ).map( ( mode ) => ( {
-        mode,
-        formats: MODE_FORMATS[ mode ].filter( ( f ) => supported.has( f ) )
-      } ) ).filter( ( g ) => g.formats.length > 0 );
+      return MODE_ORDER
+        .map( ( mode ) => ( {
+          mode,
+          formats: MODE_FORMATS[ mode ].filter( ( f ) => supported.has( f ) )
+        } ) )
+        .filter( ( g ) => g.formats.length > 0 );
     },
     [
       capabilities.supportedFormats
@@ -125,86 +137,31 @@ export default function BrowserRecordingButton( {
     setChoice
   ] = useState<Choice>( defaultChoice );
 
-  const progressLabel = useMemo(
-    () => {
-      if ( !progress ) {
-        return null;
-      }
-
-      const pct = progress.percentage.toFixed( 0 );
-
-      if ( progress.stage === "capturing" ) {
-        return `${ pct }% (${ progress.frame }/${ progress.totalFrames })`;
-      }
-
-      if ( progress.stage === "encoding" ) {
-        return "Encoding…";
-      }
-
-      return "Finalising…";
-    },
-    [
-      progress
-    ]
-  );
-
-  // Target fill % for the red progress bar inside the button. Encoding +
-  // finalising stages park the bar at 100% so the user gets "almost
-  // done" feedback while the encoder finishes. The smooth chase to this
-  // target happens in `useSmoothFill` so React's batching of bursty
-  // progress events can't strand the bar at 0%.
-  const targetFillPct = progress
-    ? progress.stage === "capturing"
-      ? progress.percentage
-      : 100
-    : 0;
-  const fillRef = useSmoothFill<HTMLSpanElement>(
-    isRecording,
-    targetFillPct
-  );
-
   if ( isRecording ) {
     const isRealtime = choice.mode === "realtime";
 
+    if ( isRealtime ) {
+      return (
+        <RealtimeRecordingControls onStop={ onStop } />
+      );
+    }
+
     return (
-      <div className="flex flex-col gap-1">
-        <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
-          {progressLabel ?? ( isRealtime ? "Recording…" : "Starting…" )}
-        </div>
-        <button
-          type="button"
-          onClick={ isRealtime ? onStop : onCancel }
-          className="relative overflow-hidden rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
-        >
-          <span
-            ref={ fillRef }
-            aria-hidden="true"
-            className="absolute inset-y-0 left-0 bg-red-500/20 pointer-events-none"
-            style={ {
-              width: "0%"
-            } }
-          />
-          <StopCircle className="relative h-4 w-4 flex-shrink-0" />
-          <span className="relative truncate">
-            {isRealtime ? "Stop recording" : "Cancel recording"}
-          </span>
-        </button>
-      </div>
+      <AsyncLoopRecordingControls
+        progress={ progress }
+        onCancel={ onCancel }
+      />
     );
   }
 
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-stretch gap-1 rounded-xl border border-border overflow-hidden bg-background">
-        {/* <label htmlFor="recording-format" className="visibility px-2 py-2 text-xs text-foreground inline-flex items-center">*/}
-        {/*  Record in*/}
-        {/* </label>*/}
-
         <select
           id="recording-format"
           value={ encodeChoice( choice ) }
           onChange={ ( e ) => setChoice( decodeChoice( e.target.value ) ) }
-          className="flex-1 px-2 py-2 bg-background text-foreground text-xs focus:outline-none border-l_"
+          className="flex-1 px-2 py-2 bg-background text-foreground text-xs focus:outline-none"
           aria-label="Recording format"
         >
           {groups.map( ( group ) => (
@@ -217,7 +174,10 @@ export default function BrowserRecordingButton( {
                     mode: group.mode
                   } ) }
                 >
-                  {FORMAT_LABEL[ f ]}
+                  {formatChoiceLabel(
+                    group.mode,
+                    f
+                  )}
                 </option>
               ) )}
             </optgroup>
@@ -246,6 +206,109 @@ export default function BrowserRecordingButton( {
           {error.message}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Realtime capture has no known duration — the user stops it when
+ * they're happy. A fill bar would be misleading, so the button just
+ * pulses a red dot while recording.
+ */
+function RealtimeRecordingControls( {
+  onStop
+}: { onStop: () => void } ) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
+        Recording…
+      </div>
+      <button
+        type="button"
+        onClick={ onStop }
+        aria-label="Stop recording"
+        className="relative rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
+      >
+        <span
+          aria-hidden="true"
+          className="block h-2.5 w-2.5 rounded-full bg-red-500 ring-1 ring-red-500/40 animate-pulse-soft"
+        />
+        <span className="truncate">Stop recording</span>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Deterministic capture has a known frame count. The button doubles
+ * as a progress bar by tweening its fill width toward the latest
+ * percentage and parking at 100% during the encode/finalise stages.
+ */
+function AsyncLoopRecordingControls( {
+  progress,
+  onCancel
+}: {
+  progress: RecorderProgress | null;
+  onCancel: () => void;
+} ) {
+  const progressLabel = useMemo(
+    () => {
+      if ( !progress ) {
+        return "Starting…";
+      }
+
+      if ( progress.stage === "encoding" ) {
+        return "Encoding…";
+      }
+
+      if ( progress.stage === "finalizing" ) {
+        return "Finalising…";
+      }
+
+      const pct = progress.percentage.toFixed( 0 );
+
+      return `${ pct }% (${ progress.frame }/${ progress.totalFrames })`;
+    },
+    [
+      progress
+    ]
+  );
+
+  // Encoding + finalising park the fill at 100% so the user gets
+  // "almost done" feedback while the encoder flushes.
+  const targetFillPct = progress
+    ? progress.stage === "capturing"
+      ? progress.percentage
+      : 100
+    : 0;
+
+  const fillRef = useSmoothFill<HTMLSpanElement>(
+    true,
+    targetFillPct
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
+        {progressLabel}
+      </div>
+      <button
+        type="button"
+        onClick={ onCancel }
+        aria-label="Cancel recording"
+        className="relative overflow-hidden rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
+      >
+        <span
+          ref={ fillRef }
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 bg-red-500/20 pointer-events-none"
+          style={ {
+            width: "0%"
+          } }
+        />
+        <StopCircle className="relative h-4 w-4 flex-shrink-0" />
+        <span className="relative truncate">Cancel recording</span>
+      </button>
     </div>
   );
 }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
@@ -6,6 +6,7 @@ import {
 import {
   createEngineHost,
   createRecorder,
+  type Recorder,
   type RecorderProgress,
   type RecorderResult,
   type RecordingFormat,
@@ -50,7 +51,7 @@ function triggerDownload(
   a.click();
   setTimeout(
     () => {
-      document.body.removeChild( a );
+      a.remove();
       URL.revokeObjectURL( url );
     },
     100
@@ -62,7 +63,8 @@ function triggerDownload(
  * creates the right strategy, wires progress events into React state,
  * and triggers a download on completion.
  *
- * Re-entering `start()` while a recording is active is a no-op.
+ * Re-entering `start()` while a recording is active is a no-op — clicks
+ * on the start button while a capture is in flight must not abort it.
  */
 export function useBrowserRecorder( {
   engine,
@@ -83,12 +85,20 @@ export function useBrowserRecorder( {
     setError
   ] = useState<Error | null>( null );
 
-  const recorderRef = useRef<ReturnType<typeof createRecorder> | null>( null );
+  const recorderRef = useRef<Recorder | null>( null );
+
+  // Keep mutable refs to the names used in completion handlers so the
+  // download filename always reflects the latest sketch name, even if
+  // the user renames mid-recording.
+  const sketchNameRef = useRef( sketchName );
+
+  sketchNameRef.current = sketchName;
 
   const cleanup = useCallback(
     () => {
       recorderRef.current = null;
       setIsRecording( false );
+      setProgress( null );
     },
     []
   );
@@ -115,7 +125,7 @@ export function useBrowserRecorder( {
         activeSlideIndex
       );
 
-      let recorder: ReturnType<typeof createRecorder>;
+      let recorder: Recorder;
 
       try {
         recorder = createRecorder( {
@@ -124,9 +134,7 @@ export function useBrowserRecorder( {
           mode
         } );
       } catch( e ) {
-        const err = e instanceof Error ? e : new Error( String( e ) );
-
-        setError( err );
+        setError( e instanceof Error ? e : new Error( String( e ) ) );
         return;
       }
 
@@ -137,7 +145,15 @@ export function useBrowserRecorder( {
       recorder.on(
         "stop",
         ( result: RecorderResult ) => {
-          const fileName = `${ sketchName || "sketch" }.${ result.fileExtension }`;
+          // Only the recorder we own should be allowed to trigger a
+          // download — guards against late events from a cancelled
+          // run racing with a new one.
+          if ( recorderRef.current !== recorder ) {
+            return;
+          }
+
+          const safeName = sketchNameRef.current || "sketch";
+          const fileName = `${ safeName }.${ result.fileExtension }`;
 
           triggerDownload(
             result.blob,
@@ -149,6 +165,9 @@ export function useBrowserRecorder( {
       recorder.on(
         "error",
         ( e: Error ) => {
+          if ( recorderRef.current !== recorder ) {
+            return;
+          }
           setError( e );
           cleanup();
         }
@@ -156,6 +175,9 @@ export function useBrowserRecorder( {
       recorder.on(
         "cancel",
         () => {
+          if ( recorderRef.current !== recorder ) {
+            return;
+          }
           cleanup();
         }
       );
@@ -166,17 +188,18 @@ export function useBrowserRecorder( {
       try {
         await recorder.start();
       } catch( e ) {
-        const err = e instanceof Error ? e : new Error( String( e ) );
-
-        setError( err );
-        cleanup();
+        // start() failures emit "error" already — but a synchronous
+        // throw before any listener fires would leave us stuck.
+        if ( recorderRef.current === recorder ) {
+          setError( e instanceof Error ? e : new Error( String( e ) ) );
+          cleanup();
+        }
       }
     },
     [
       engine,
       options,
       activeSlideIndex,
-      sketchName,
       cleanup
     ]
   );
@@ -192,7 +215,7 @@ export function useBrowserRecorder( {
       try {
         await recorder.stop();
       } catch {
-        // already handled via on("error")
+        // Already handled via on("error").
       }
     },
     []
@@ -205,6 +228,8 @@ export function useBrowserRecorder( {
     []
   );
 
+  // On unmount, abort any in-flight capture so the host engine isn't
+  // left paused with a dangling mirror loop.
   useEffect(
     () => () => {
       recorderRef.current?.cancel();

--- a/src/engines/recording/strategies/AsyncLoopRecorder.ts
+++ b/src/engines/recording/strategies/AsyncLoopRecorder.ts
@@ -30,6 +30,7 @@ export class AsyncLoopRecorder extends BaseRecorder {
   private encoder: FrameEncoder | null = null;
   private cancelled = false;
   private runPromise: Promise<RecorderResult> | null = null;
+  private hostPaused = false;
 
   constructor(
     private host: RecorderHost,
@@ -56,34 +57,49 @@ export class AsyncLoopRecorder extends BaseRecorder {
     // snapshot dimensions into the encoder. Otherwise a reset-triggered
     // resize would invalidate the encoder's codec string mid-recording.
     this.host.pause();
-    await this.host.resetToStart();
+    this.hostPaused = true;
 
-    const {
-      width, height
-    } = source;
+    try {
+      await this.host.resetToStart();
 
-    if ( !width || !height ) {
-      throw new Error( "AsyncLoopRecorder: capture source has no dimensions." );
+      const {
+        width, height
+      } = source;
+
+      if ( !width || !height ) {
+        throw new Error( "AsyncLoopRecorder: capture source has no dimensions." );
+      }
+
+      this.encoder = this.encoderFactory( {
+        width,
+        height,
+        frameRate: this.host.frameRate,
+        totalFrames
+      } );
+    } catch( error ) {
+      // Setup failure must not leave the host stuck in paused state.
+      this.resumeHost();
+      this.encoder?.dispose();
+      this.encoder = null;
+      throw error;
     }
-
-    this.encoder = this.encoderFactory( {
-      width,
-      height,
-      frameRate: this.host.frameRate,
-      totalFrames
-    } );
 
     this.cancelled = false;
     this._isRecording = true;
     this.emit(
       "start",
-      undefined as any
+      undefined as never
     );
 
     this.runPromise = this.run(
       source,
       totalFrames
     );
+
+    // Swallow the rejection here — `stop()` is the one that surfaces it
+    // to the caller. Without this, the unhandled rejection from an early
+    // failure (e.g. immediate cancel) would taint the global handler.
+    this.runPromise.catch( () => undefined );
   }
 
   private async run(
@@ -159,7 +175,7 @@ export class AsyncLoopRecorder extends BaseRecorder {
       if ( this.cancelled ) {
         this.emit(
           "cancel",
-          undefined as any
+          undefined as never
         );
       } else {
         this.emit(
@@ -173,13 +189,13 @@ export class AsyncLoopRecorder extends BaseRecorder {
       this._isRecording = false;
       this.encoder?.dispose();
       this.encoder = null;
-      this.host.resume();
+      this.resumeHost();
     }
   }
 
   stop(): Promise<RecorderResult> {
     if ( !this.runPromise ) {
-      throw new Error( "AsyncLoopRecorder: stop() called before start()." );
+      return Promise.reject( new Error( "AsyncLoopRecorder: stop() called before start()." ) );
     }
 
     return this.runPromise;
@@ -191,5 +207,18 @@ export class AsyncLoopRecorder extends BaseRecorder {
     }
 
     this.cancelled = true;
+  }
+
+  private resumeHost(): void {
+    if ( !this.hostPaused ) {
+      return;
+    }
+    this.hostPaused = false;
+    try {
+      this.host.resume();
+    } catch {
+      // Resuming should never throw, but if it does we don't want to
+      // mask the original error from `run`.
+    }
   }
 }

--- a/src/engines/recording/strategies/RealtimeRecorder.ts
+++ b/src/engines/recording/strategies/RealtimeRecorder.ts
@@ -43,6 +43,10 @@ function pickMimeType( format: RecordingFormat ): string {
  *
  * Only `webm` (always) and `mp4` (Safari 14.1+ / Chromium 105+) are
  * available here — `gif` falls back to the deterministic strategy.
+ *
+ * Realtime has no known end time — the user stops it when they like.
+ * The UI surfaces this with a pulsing button rather than a progress
+ * fill, so we don't bother emitting per-frame progress events.
  */
 export class RealtimeRecorder extends BaseRecorder {
   readonly mode = "realtime" as const;
@@ -55,7 +59,8 @@ export class RealtimeRecorder extends BaseRecorder {
   private resolveResult: ( ( r: RecorderResult ) => void ) | null = null;
   private rejectResult: ( ( e: Error ) => void ) | null = null;
   private autoStopTimer: ReturnType<typeof setTimeout> | null = null;
-  private progressRafId: number | null = null;
+  private hostPaused = false;
+  private mirrorStarted = false;
 
   constructor(
     private host: RecorderHost,
@@ -71,160 +76,117 @@ export class RealtimeRecorder extends BaseRecorder {
 
     const source = this.host.getCaptureSource();
 
-    // Start mirroring the rendered output into the stream canvas before we
-    // grab it — DOM engines only paint their mirror canvas while this loop
-    // is running, so the captured stream would be blank otherwise.
-    source.beginRealtime();
-
-    const canvas = source.getStreamCanvas();
-
-    if ( !canvas ) {
-      source.endRealtime();
-      throw new Error( "RealtimeRecorder: capture source has no stream canvas." );
-    }
-
-    this.mimeType = pickMimeType( this.format );
-
-    const stream = canvas.captureStream( this.host.frameRate );
-
     this.source = source;
 
-    this.mediaRecorder = new MediaRecorder(
-      stream,
-      {
-        mimeType: this.mimeType,
-        videoBitsPerSecond: options.videoBitsPerSecond ?? 15_000_000
+    try {
+      // Start mirroring the rendered output into the stream canvas before
+      // we grab it — DOM engines only paint their mirror canvas while this
+      // loop is running, so the captured stream would be blank otherwise.
+      source.beginRealtime();
+      this.mirrorStarted = true;
+
+      const canvas = source.getStreamCanvas();
+
+      if ( !canvas ) {
+        throw new Error( "RealtimeRecorder: capture source has no stream canvas." );
       }
-    );
 
-    this.chunks = [];
+      this.mimeType = pickMimeType( this.format );
 
-    this.mediaRecorder.ondataavailable = ( event ) => {
-      if ( event.data.size > 0 ) {
-        this.chunks.push( event.data );
-      }
-    };
+      const stream = canvas.captureStream( this.host.frameRate );
 
-    this.resultPromise = new Promise<RecorderResult>( (
-      resolve, reject
-    ) => {
-      this.resolveResult = resolve;
-      this.rejectResult = reject;
-    } );
-
-    this.mediaRecorder.onstop = () => {
-      const blob = new Blob(
-        this.chunks,
+      this.mediaRecorder = new MediaRecorder(
+        stream,
         {
-          type: this.mimeType
+          mimeType: this.mimeType,
+          videoBitsPerSecond: options.videoBitsPerSecond ?? 15_000_000
         }
       );
-      const result: RecorderResult = {
-        blob,
-        mimeType: this.mimeType,
-        fileExtension: this.format === "mp4" ? "mp4" : "webm"
+
+      this.chunks = [];
+
+      this.mediaRecorder.ondataavailable = ( event ) => {
+        if ( event.data.size > 0 ) {
+          this.chunks.push( event.data );
+        }
       };
 
-      this._isRecording = false;
-      this.stopProgressTicker();
-      this.source?.endRealtime();
-      this.emit(
-        "stop",
-        result
-      );
-      this.resolveResult?.( result );
-    };
+      this.resultPromise = new Promise<RecorderResult>( (
+        resolve, reject
+      ) => {
+        this.resolveResult = resolve;
+        this.rejectResult = reject;
+      } );
 
-    this.mediaRecorder.onerror = ( event: Event ) => {
-      const error = new Error( `MediaRecorder error: ${ event.type }` );
-
-      this._isRecording = false;
-      this.stopProgressTicker();
-      this.source?.endRealtime();
-      this.emit(
-        "error",
-        error
-      );
-      this.rejectResult?.( error );
-    };
-
-    // Pause the draw loop, jump to frame 0 + zero the time bridge,
-    // then resume drawing — MediaRecorder captures the canvas stream
-    // from the very first frame of the loop, matching backend behaviour.
-    this.host.pause();
-    await this.host.resetToStart();
-
-    this._isRecording = true;
-    this.mediaRecorder.start( 16 );
-    this.host.resume();
-    this.emit(
-      "start",
-      undefined as any
-    );
-
-    // Wall-clock progress estimate: realtime has no frame counter, so
-    // we tick percentage against the sketch's expected loop duration
-    // (totalFrames / frameRate). Caps at 100% if the user lets the
-    // recording run past one loop. Without this the button's fill bar
-    // would stay at 0% for the whole capture.
-    const expectedDurationMs =
-      this.host.frameRate > 0
-        ? ( this.host.totalFrames / this.host.frameRate ) * 1000
-        : 0;
-
-    if ( expectedDurationMs > 0 ) {
-      const startedAt = performance.now();
-      const totalFrames = this.host.totalFrames;
-      const frameRate = this.host.frameRate;
-
-      const tick = () => {
-        if ( !this._isRecording ) {
-          return;
-        }
-
-        const elapsed = performance.now() - startedAt;
-        const pct = Math.min(
-          100,
-          ( elapsed / expectedDurationMs ) * 100
-        );
-        const frame = Math.min(
-          totalFrames,
-          Math.round( ( elapsed / 1000 ) * frameRate )
-        );
-
-        this.emit(
-          "progress",
+      this.mediaRecorder.onstop = () => {
+        const blob = new Blob(
+          this.chunks,
           {
-            frame,
-            totalFrames,
-            percentage: pct,
-            stage: "capturing"
+            type: this.mimeType
           }
         );
+        const result: RecorderResult = {
+          blob,
+          mimeType: this.mimeType,
+          fileExtension: this.format === "mp4" ? "mp4" : "webm"
+        };
 
-        this.progressRafId = requestAnimationFrame( tick );
+        this.teardown();
+        this.emit(
+          "stop",
+          result
+        );
+        this.resolveResult?.( result );
       };
 
-      this.progressRafId = requestAnimationFrame( tick );
-    }
+      this.mediaRecorder.onerror = ( event: Event ) => {
+        const error = new Error( `MediaRecorder error: ${ event.type }` );
 
-    if ( options.maxDurationMs && options.maxDurationMs > 0 ) {
-      this.autoStopTimer = setTimeout(
-        () => this.stop().catch( () => undefined ),
-        options.maxDurationMs
+        this.teardown();
+        this.emit(
+          "error",
+          error
+        );
+        this.rejectResult?.( error );
+      };
+
+      // Pause the draw loop, jump to frame 0 + zero the time bridge, then
+      // resume — MediaRecorder captures the canvas stream from the very
+      // first frame of the loop, matching backend behaviour.
+      this.host.pause();
+      this.hostPaused = true;
+      await this.host.resetToStart();
+
+      this._isRecording = true;
+      this.mediaRecorder.start( 16 );
+      this.host.resume();
+      this.hostPaused = false;
+      this.emit(
+        "start",
+        undefined as never
       );
-    }
-  }
 
-  private stopProgressTicker(): void {
-    if ( this.progressRafId !== null ) {
-      cancelAnimationFrame( this.progressRafId );
-      this.progressRafId = null;
+      if ( options.maxDurationMs && options.maxDurationMs > 0 ) {
+        this.autoStopTimer = setTimeout(
+          () => this.stop().catch( () => undefined ),
+          options.maxDurationMs
+        );
+      }
+    } catch( error ) {
+      // Any failure during setup must leave the host as we found it: no
+      // mirror loop spinning, no paused engine, no stale MediaRecorder.
+      this.teardown();
+      throw error instanceof Error ? error : new Error( String( error ) );
     }
   }
 
   async stop(): Promise<RecorderResult> {
-    if ( !this._isRecording || !this.mediaRecorder ) {
+    if ( !this._isRecording ) {
+      // Already settled — return the existing promise (or a clean reject).
+      if ( this.resultPromise ) {
+        return this.resultPromise;
+      }
+
       throw new Error( "RealtimeRecorder: not recording." );
     }
 
@@ -233,7 +195,7 @@ export class RealtimeRecorder extends BaseRecorder {
       this.autoStopTimer = null;
     }
 
-    if ( this.mediaRecorder.state !== "inactive" ) {
+    if ( this.mediaRecorder && this.mediaRecorder.state !== "inactive" ) {
       this.mediaRecorder.stop();
     }
 
@@ -245,26 +207,58 @@ export class RealtimeRecorder extends BaseRecorder {
       return;
     }
 
+    const recorder = this.mediaRecorder;
+
+    if ( recorder && recorder.state !== "inactive" ) {
+      // Drop the natural stop path so we don't surface a partial blob to
+      // the caller.
+      recorder.ondataavailable = null;
+      recorder.onstop = null;
+      try {
+        recorder.stop();
+      } catch {
+        // Ignore — recorder may already be transitioning.
+      }
+    }
+
+    this.chunks = [];
+    this.teardown();
+    this.emit(
+      "cancel",
+      undefined as never
+    );
+    this.rejectResult?.( new Error( "Recording cancelled." ) );
+  }
+
+  /**
+   * Unwind every side effect of {@link start} — mirror loop, paused
+   * engine, pending auto-stop. Safe to call from any code path
+   * (success, failure, cancel) and idempotent.
+   */
+  private teardown(): void {
+    this._isRecording = false;
+
     if ( this.autoStopTimer ) {
       clearTimeout( this.autoStopTimer );
       this.autoStopTimer = null;
     }
 
-    this.stopProgressTicker();
-
-    if ( this.mediaRecorder && this.mediaRecorder.state !== "inactive" ) {
-      this.mediaRecorder.ondataavailable = null;
-      this.mediaRecorder.onstop = null;
-      this.mediaRecorder.stop();
+    if ( this.mirrorStarted ) {
+      try {
+        this.source?.endRealtime();
+      } catch {
+        // Engine teardown shouldn't mask the originating error.
+      }
+      this.mirrorStarted = false;
     }
 
-    this.source?.endRealtime();
-    this.chunks = [];
-    this._isRecording = false;
-    this.emit(
-      "cancel",
-      undefined as any
-    );
-    this.rejectResult?.( new Error( "Recording cancelled." ) );
+    if ( this.hostPaused ) {
+      try {
+        this.host.resume();
+      } catch {
+        // Same — never throw from teardown.
+      }
+      this.hostPaused = false;
+    }
   }
 }


### PR DESCRIPTION
UI
- Realtime capture has no known end time, so the in-recording button now
  pulses a red dot instead of pretending to fill toward a 100% mark.
- Async-loop keeps the deterministic fill bar + "XX% (frame/total)" /
  "Encoding…" / "Finalising…" labels.
- Picker options now read "Realtime: .mp4" / "Async loop: .webm" so the
  active choice stays readable without re-opening the dropdown.
- Split the in-recording view into two small components keyed off the
  mode, removing the conditional fill-vs-pulse branching inside one
  button.

Recorder robustness
- RealtimeRecorder: setup is now wrapped so a failure between
  beginRealtime/pause and MediaRecorder.start always tears the host back
  down (mirror loop ended, draw loop resumed). stop() is idempotent and
  returns the existing result promise on re-entry instead of throwing.
  cancel() neutralises onstop before stopping so the partial blob isn't
  surfaced. Dropped the wall-clock progress estimator that capped at
  100% after one loop — the pulse UX replaces it.
- AsyncLoopRecorder: ensure the host is resumed even when setup fails
  before run() is kicked off (previously the host stayed paused if
  resetToStart, dimensions, or encoder factory threw). stop() now
  rejects cleanly instead of throwing synchronously. The early-rejection
  unhandled-promise warning from a fast cancel is swallowed at the call
  site — stop() still surfaces it.
- useBrowserRecorder: reset progress on cleanup, guard download/error/
  cancel handlers against late events from a previous recorder, and
  pull sketchName through a ref so a rename mid-recording reaches the
  filename.