### PR TITLE
Extract asset utilities to shared library for multi-engine use

### DIFF
--- a/src/lib/assets/blobMap.ts
+++ b/src/lib/assets/blobMap.ts
@@ -1,0 +1,39 @@
+/**
+ * Browser-side registry that maps an asset path (`global/images/foo.png`,
+ * `slide-2/videos/clip.mp4`, …) to a transient `blob:` URL created from a
+ * `File` the user just dropped in the UI.
+ *
+ * Sketches resolve a path through `resolveAssetURL`, which prefers a
+ * registered blob URL when present so that newly-uploaded files render
+ * immediately without a round-trip to S3.
+ */
+declare global {
+  interface Window {
+    __blobAssetMap?: Record<string, string>;
+  }
+}
+
+export function registerBlob(
+  filename: string, file: Blob
+): void {
+  window.__blobAssetMap ??= {};
+
+  if ( window.__blobAssetMap[ filename ] ) {
+    URL.revokeObjectURL( window.__blobAssetMap[ filename ] );
+  }
+
+  window.__blobAssetMap[ filename ] = URL.createObjectURL( file );
+}
+
+export function getBlobURL( filename: string ): string | undefined {
+  return window.__blobAssetMap?.[ filename ];
+}
+
+export function revokeBlob( filename: string ): void {
+  const url = window.__blobAssetMap?.[ filename ];
+
+  if ( url ) {
+    URL.revokeObjectURL( url );
+    delete window.__blobAssetMap![ filename ];
+  }
+}

--- a/src/lib/assets/getScopeAssetPath.ts
+++ b/src/lib/assets/getScopeAssetPath.ts
@@ -1,0 +1,20 @@
+export type AssetScope =
+  | "global"
+  | { slide: number };
+
+/**
+ * Build the storage path for an asset under either the global pool or a
+ * specific slide. The shape `<scope>/<type>/<name>` is the contract shared
+ * between client uploads, S3 storage, and sketch-side asset loaders.
+ */
+export function getScopeAssetPath(
+  name: string,
+  type: string,
+  scope: AssetScope = "global"
+): string {
+  if ( scope !== "global" && scope?.slide !== undefined ) {
+    return `slide-${ scope.slide }/${ type }/${ name }`;
+  }
+
+  return `global/${ type }/${ name }`;
+}

--- a/src/lib/assets/index.ts
+++ b/src/lib/assets/index.ts
@@ -1,0 +1,12 @@
+export {
+  registerBlob, getBlobURL, revokeBlob
+} from "./blobMap";
+export {
+  resolveAssetURL
+} from "./resolveAssetURL";
+export {
+  getScopeAssetPath
+} from "./getScopeAssetPath";
+export type {
+  AssetScope
+} from "./getScopeAssetPath";

--- a/src/lib/assets/resolveAssetURL.ts
+++ b/src/lib/assets/resolveAssetURL.ts
@@ -1,0 +1,46 @@
+import {
+  getBlobURL
+} from "./blobMap";
+
+/**
+ * Resolve an asset path (as stored in sketch options) to a URL that can be
+ * fed to `<img>`, `<video>`, `<audio>`, p5's `loadImage`, etc.
+ *
+ * Resolution order:
+ *  1. A locally-registered blob URL (fresh upload, no S3 round-trip).
+ *  2. An already-absolute URL (`https:` / `blob:`) is returned as-is.
+ *  3. A `public/assets/…` path resolves to the static asset folder.
+ *  4. Otherwise, when a job `id` is provided, the path resolves through the
+ *     S3 proxy route; without an id it falls back to the origin root.
+ */
+export function resolveAssetURL(
+  path: string,
+  id?: string
+): string {
+  if ( !path ) {
+    return "";
+  }
+
+  const blobURL = getBlobURL( path );
+
+  if ( blobURL ) {
+    return blobURL;
+  }
+
+  if ( /^(https?:|blob:)/.test( path ) ) {
+    return path;
+  }
+
+  const normalizedPath = path.replace(
+    /^\/+/,
+    ""
+  );
+
+  if ( /^assets\//.test( normalizedPath ) ) {
+    return `${ location.origin }/${ normalizedPath }`;
+  }
+
+  return id
+    ? `${ location.origin }/api/s3/${ id }/assets/${ normalizedPath }`
+    : `${ location.origin }/${ normalizedPath }`;
+}

--- a/src/templates/p5/shared/blobMap.js
+++ b/src/templates/p5/shared/blobMap.js
@@ -1,12 +1,8 @@
-export function registerBlob(
-  filename, file
-) {
-  window.__blobAssetMap ??= {};
-
-  /* revoke old url if we re-use the name */
-  if ( window.__blobAssetMap[ filename ] ) {
-    URL.revokeObjectURL( window.__blobAssetMap[ filename ] );
-  }
-
-  window.__blobAssetMap[ filename ] = URL.createObjectURL( file );
-}
+/**
+ * Compatibility shim. The real implementation lives in
+ * `@/lib/assets/blobMap` so it can be used by any engine, not just p5.
+ * Remove this file once all consumers import from `@/lib/assets` directly.
+ */
+export {
+  registerBlob
+} from "@/lib/assets/blobMap";

--- a/src/templates/p5/shared/utils.js
+++ b/src/templates/p5/shared/utils.js
@@ -1,44 +1,18 @@
-/* ------------------------------------------------------------------ */
-/*  Helper: resolve a path → URL (prefers local blob URL)             */
-/* ------------------------------------------------------------------ */
-
 /**
- * @param {string} path
- * @param {string} [id]
- * @returns {string}
+ * Asset-related helpers (`resolveAssetURL`, `getScopeAssetPath`) have moved
+ * to `@/lib/assets` so they can be consumed by any rendering engine. They
+ * are re-exported here only to keep existing imports working — prefer
+ * importing from `@/lib/assets` in new code.
+ *
+ * `deepMerge` and `structuredClone` remain here for now: they are not
+ * asset-specific and only used by the option-sync layer.
  */
-export const resolveAssetURL = (
-  path, id
-) => {
-  if ( !path ) {
-    return "";
-  }
-
-  const blobURL = window.__blobAssetMap?.[ path ];
-
-  if ( blobURL ) {
-    return blobURL;
-  }
-
-  // Keep already-resolved remote/blob URLs untouched.
-  if ( /^(https?:|blob:)/.test( path ) ) {
-    return path;
-  }
-
-  const normalizedPath = path.replace(
-    /^\/+/,
-    ""
-  );
-
-  // Public assets must always resolve from /assets (even when an id exists).
-  if ( /^assets\//.test( normalizedPath ) ) {
-    return `${ location.origin }/${ normalizedPath }`;
-  }
-
-  return id
-    ? `${ location.origin }/api/s3/${ id }/assets/${ normalizedPath }`
-    : `${ location.origin }/${ normalizedPath }`;
-};
+export {
+  resolveAssetURL
+} from "@/lib/assets/resolveAssetURL";
+export {
+  getScopeAssetPath
+} from "@/lib/assets/getScopeAssetPath";
 
 export function deepMerge(
   targetObject, sourceObject
@@ -99,25 +73,4 @@ export function structuredClone( value ) {
   } catch {}
 
   return JSON.parse( JSON.stringify( value ) );
-}
-
-/**
- * @typedef {Object} SlideScope
- * @property {number} slide
- */
-
-/**
- * @param {string} name
- * @param {string} type
- * @param {"global" | SlideScope} [scope="global"]
- * @returns {string}
- */
-export function getScopeAssetPath(
-  name, type, scope = "global"
-) {
-  if ( scope !== "global" && scope?.slide !== undefined ) {
-    return `slide-${ scope.slide }/${ type }/${ name }`;
-  }
-
-  return `global/${ type }/${ name }`;
 }


### PR DESCRIPTION
## Summary
Refactored asset-related utilities (`resolveAssetURL`, `getScopeAssetPath`, and blob URL management) from p5-specific template code into a shared library (`@/lib/assets`) that can be consumed by any rendering engine.

## Key Changes
- **Created `@/lib/assets/` library** with three new TypeScript modules:
  - `resolveAssetURL.ts`: Resolves asset paths to URLs with blob URL preference, improved JSDoc documentation
  - `getScopeAssetPath.ts`: Builds storage paths for global or slide-scoped assets with proper TypeScript types
  - `blobMap.ts`: Manages transient blob URLs for newly-uploaded files with `registerBlob`, `getBlobURL`, and `revokeBlob` functions
  - `index.ts`: Barrel export for convenient consumption

- **Updated p5 template files** to re-export from the new library:
  - `src/templates/p5/shared/utils.js`: Now re-exports `resolveAssetURL` and `getScopeAssetPath` from `@/lib/assets` with a note that new code should import directly from the library
  - `src/templates/p5/shared/blobMap.js`: Converted to a compatibility shim re-exporting from `@/lib/assets`

- **Preserved backward compatibility**: Existing imports from p5 template files continue to work via re-exports

## Implementation Details
- Converted JavaScript implementations to TypeScript with proper type annotations
- Added comprehensive JSDoc comments explaining the resolution order and purpose of each utility
- Introduced `AssetScope` type for better type safety around global vs. slide-scoped assets
- Blob URL management now uses a global `__blobAssetMap` registry with proper cleanup via `URL.revokeObjectURL`
- The shared library is engine-agnostic and can be imported by any rendering system

https://claude.ai/code/session_011DARVjXkvKtoW7Sm5pAYh3