### PR TITLE
Add specs overlay to display sketch settings and metadata

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
@@ -4,7 +4,8 @@ import {
   Image as ImageIcon,
   Layers as StackIcon,
   PaintBucket as BgIcon,
-  Sparkles as VisualIcon
+  Sparkles as VisualIcon,
+  Terminal as SpecsIcon
 } from "lucide-react";
 import {
   ItemKind,
@@ -17,6 +18,7 @@ export const ITEM_ORDER: ItemKind[] = [
   "image",
   "images-stack",
   "meta",
+  "specs",
   "background"
 ];
 
@@ -30,6 +32,11 @@ export const ITEM_META: Record<ItemKind, ItemKindMeta> = {
     label: "Meta",
     Icon: MetaIcon,
     description: "Title, author, date, etc."
+  },
+  specs: {
+    label: "Specs",
+    Icon: SpecsIcon,
+    description: "Technical overlay of the sketch settings"
   },
   image: {
     label: "Image",

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
@@ -2,6 +2,7 @@ export type ItemKind =
   | "visual"
   | "text"
   | "meta"
+  | "specs"
   | "image"
   | "images-stack"
   | "background";

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
@@ -3,6 +3,7 @@ import {
   ImageItemSchema,
   ImagesStackItemSchema,
   MetaItemSchema,
+  SpecsItemSchema,
   TextItemSchema,
   ContentItem,
   VisualItemSchema
@@ -29,6 +30,10 @@ export default function makeDefaultItem( type: ItemKind ): ContentItem {
       } );
     case "meta":
       return MetaItemSchema.parse( {
+        type
+      } );
+    case "specs":
+      return SpecsItemSchema.parse( {
         type
       } );
     case "background":

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -320,6 +320,105 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       }
     }
   },
+  specs: {
+    style: {
+      label: "Style",
+      component: "select",
+      options: [
+        {
+          value: "boot-log",
+          label: "Boot log"
+        },
+        {
+          value: "ticker",
+          label: "Ticker"
+        }
+      ]
+    },
+    fill: {
+      label: "Fill",
+      component: "color"
+    },
+    font: {
+      label: "Font",
+      component: "select",
+      options: fontNames.map( ( fontName ) => ( {
+        value: fontName,
+        label: fontName
+      } ) )
+    },
+    size: {
+      label: "Size",
+      component: "slider",
+      min: 8,
+      max: 96,
+      step: 1
+    },
+    lineHeight: {
+      label: "Line height",
+      component: "slider",
+      min: 1,
+      max: 3,
+      step: 0.05
+    },
+    blend: {
+      label: "Blend",
+      component: "select",
+      options: Blend.options.map( ( blendOption ) => ( {
+        value: blendOption,
+        label: blendOption
+      } ) )
+    },
+    showCursor: {
+      label: "Blinking cursor",
+      component: "checkbox"
+    },
+    includeSketchSettings: {
+      label: "Include sketch settings",
+      component: "checkbox"
+    },
+    position: {
+      label: "Position",
+      component: "nested-object",
+      fields: {
+        x: {
+          label: "x",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.01
+        },
+        y: {
+          label: "y",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.01
+        }
+      }
+    },
+    revealEnd: {
+      label: "Reveal end",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.01
+    },
+    holdEnd: {
+      label: "Hold end",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.01
+    },
+    fadeEnd: {
+      label: "Fade end",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.01
+    }
+  },
   text: {
     content: {
       label: "Content",

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/OptionsPanel.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/OptionsPanel.tsx
@@ -96,10 +96,7 @@ export default function OptionsPanel( {
     <CollapsibleItem
       swipeToCollapse
       className="flex flex-col gap-1 glass p-2 border border-theme rounded-2xl shadow-lg w-full"
-      contentClassName="flex flex-col gap-1"
-      style={ {
-        maxHeight: "calc(80svh)"
-      } }
+      contentClassName="flex flex-col gap-1 min-h-0"
       header={ (
         expanded, title
       ) => (
@@ -139,98 +136,105 @@ export default function OptionsPanel( {
         </div>
       ) }
     >
-      <RootSettings
-        activeSlideIndex={ activeSlideIndex }
-        expanded={ collapsibleStates.rootSettings }
-        onToggle={ () => onCollapsibleToggle( "rootSettings" ) }
-      />
-
-      <CollapsibleItem
-        expanded={ collapsibleStates.globalContent }
-        onToggle={ ( expanded ) => onCollapsibleToggle( "globalContent" ) }
-        className="p-1 border border-theme rounded-lg text-foreground bg-background overflow-y-auto"
-        headerContainerClassName="leading-none"
-        header={ ( expanded ) => (
-          <button
-            className={ clsx(
-              "truncate text-foreground text-xs w-full text-left -ml-1 align-text-top",
-              {
-                "mb-1": expanded
-              }
-            ) }
-            aria-label={ expanded ? "Collapse" : "Expand" }
-          >
-            <ListCollapse
-              className="inline text-foreground h-3"
-              style={ {
-                rotate: expanded ? "180deg" : "0deg"
-              } }
-            />
-            <span>
-              global content{" "}
-              {rootContentLength ? `(${ rootContentLength })` : null}
-            </span>
-          </button>
-        ) }
+      <div
+        className="flex flex-col gap-1 min-h-0 overflow-y-auto overflow-x-hidden pr-0.5"
+        style={ {
+          maxHeight: "calc(80svh - 3rem)"
+        } }
       >
-        <TemplateAssetsProvider
-          scope="global"
-          assetsName="assets"
-          jobId={ jobId }
+        <RootSettings
+          activeSlideIndex={ activeSlideIndex }
+          expanded={ collapsibleStates.rootSettings }
+          onToggle={ () => onCollapsibleToggle( "rootSettings" ) }
+        />
+
+        <CollapsibleItem
+          expanded={ collapsibleStates.globalContent }
+          onToggle={ ( expanded ) => onCollapsibleToggle( "globalContent" ) }
+          className="p-1 border border-theme rounded-lg text-foreground bg-background overflow-y-auto"
+          headerContainerClassName="leading-none"
+          header={ ( expanded ) => (
+            <button
+              className={ clsx(
+                "truncate text-foreground text-xs w-full text-left -ml-1 align-text-top",
+                {
+                  "mb-1": expanded
+                }
+              ) }
+              aria-label={ expanded ? "Collapse" : "Expand" }
+            >
+              <ListCollapse
+                className="inline text-foreground h-3"
+                style={ {
+                  rotate: expanded ? "180deg" : "0deg"
+                } }
+              />
+              <span>
+                global content{" "}
+                {rootContentLength ? `(${ rootContentLength })` : null}
+              </span>
+            </button>
+          ) }
         >
-          <ContentArrayProvider name="content">
-            <ContentItems baseFieldName="content" />
-          </ContentArrayProvider>
-        </TemplateAssetsProvider>
-      </CollapsibleItem>
-
-      {slides && (
-        <Fragment>
-          <CollapsibleItem
-            expanded={ collapsibleStates.slides }
-            onToggle={ ( expanded ) => onCollapsibleToggle( "slides" ) }
-            className="p-1 border border-theme rounded-lg bg-background overflow-y-auto"
-            headerContainerClassName="leading-none"
-            header={ ( expanded ) => (
-              <button
-                className={ clsx(
-                  "text-foreground text-xs w-full text-left -ml-1 align-text-top",
-                  {
-                    "mb-1": expanded
-                  }
-                ) }
-                aria-label={ expanded ? "Collapse" : "Expand" }
-              >
-                <ListCollapse
-                  className="inline text-foreground h-3"
-                  style={ {
-                    rotate: expanded ? "180deg" : "0deg"
-                  } }
-                />
-                <span>slides {slidesLength ? `(${ slidesLength })` : null}</span>
-              </button>
-            ) }
+          <TemplateAssetsProvider
+            scope="global"
+            assetsName="assets"
+            jobId={ jobId }
           >
-            <SlideCarousel
-              slideFields={ slideFields }
-              slides={ slides }
-              thumbnails={ enableThumbnails ? thumbnails : {} }
-              activeIndex={ activeSlideIndex }
-              isAdding={ isAdding }
-              onAdd={ onAddSlide }
-              onSelect={ onSelectSlide }
-              onReorder={ onReorderSlides }
-              onDuplicate={ onDuplicateSlide }
-              onDelete={ onDeleteSlide }
-              onRename={ onRenameSlide }
-            />
+            <ContentArrayProvider name="content">
+              <ContentItems baseFieldName="content" />
+            </ContentArrayProvider>
+          </TemplateAssetsProvider>
+        </CollapsibleItem>
 
-            {activeSlideIndex !== undefined && (
-              <SlideEditor key={ editorKey } activeIndex={ activeSlideIndex } />
-            )}
-          </CollapsibleItem>
-        </Fragment>
-      )}
+        {slides && (
+          <Fragment>
+            <CollapsibleItem
+              expanded={ collapsibleStates.slides }
+              onToggle={ ( expanded ) => onCollapsibleToggle( "slides" ) }
+              className="p-1 border border-theme rounded-lg bg-background overflow-y-auto"
+              headerContainerClassName="leading-none"
+              header={ ( expanded ) => (
+                <button
+                  className={ clsx(
+                    "text-foreground text-xs w-full text-left -ml-1 align-text-top",
+                    {
+                      "mb-1": expanded
+                    }
+                  ) }
+                  aria-label={ expanded ? "Collapse" : "Expand" }
+                >
+                  <ListCollapse
+                    className="inline text-foreground h-3"
+                    style={ {
+                      rotate: expanded ? "180deg" : "0deg"
+                    } }
+                  />
+                  <span>slides {slidesLength ? `(${ slidesLength })` : null}</span>
+                </button>
+              ) }
+            >
+              <SlideCarousel
+                slideFields={ slideFields }
+                slides={ slides }
+                thumbnails={ enableThumbnails ? thumbnails : {} }
+                activeIndex={ activeSlideIndex }
+                isAdding={ isAdding }
+                onAdd={ onAddSlide }
+                onSelect={ onSelectSlide }
+                onReorder={ onReorderSlides }
+                onDuplicate={ onDuplicateSlide }
+                onDelete={ onDeleteSlide }
+                onRename={ onRenameSlide }
+              />
+
+              {activeSlideIndex !== undefined && (
+                <SlideEditor key={ editorKey } activeIndex={ activeSlideIndex } />
+              )}
+            </CollapsibleItem>
+          </Fragment>
+        )}
+      </div>
     </CollapsibleItem>
   );
 }

--- a/src/templates/p5/utils/slides/common/drawSlideSpecs.js
+++ b/src/templates/p5/utils/slides/common/drawSlideSpecs.js
@@ -1,0 +1,157 @@
+import string from "../../string.js";
+import sketch, {
+  getP5
+} from "../../sketch.js";
+import animation from "../../animation.js";
+import buildSpecsLines from "./specsData.js";
+
+/**
+ * Technical / BIOS-style overlay that reveals the current sketch settings.
+ *
+ * Two styles (selectable via specsOption.style):
+ *   - "boot-log": lines stream in top-down with a per-character typewriter on
+ *     the line currently being typed, plus a blinking cursor (boot sequence).
+ *   - "ticker": a single line shows one parameter at a time and cycles through
+ *     all of them.
+ *
+ * Timing is driven by animation.progression (0..1 over the loop) split into
+ * three phases via revealEnd / holdEnd / fadeEnd: reveal -> hold -> fade-out.
+ * Past fadeEnd nothing is drawn (plays once, then disappears).
+ */
+export default function drawSlideSpecs( specsOption ) {
+  const p = getP5();
+  const progress = animation.progression;
+
+  const revealEnd = specsOption.revealEnd ?? 0.45;
+  const holdEnd = specsOption.holdEnd ?? 0.7;
+  const fadeEnd = specsOption.fadeEnd ?? 0.8;
+
+  // Past the fade window the overlay is gone.
+  if ( progress >= fadeEnd ) {
+    return;
+  }
+
+  const lines = buildSpecsLines( specsOption );
+
+  if ( !lines.length ) {
+    return;
+  }
+
+  // Global alpha for the fade-out phase.
+  let alpha = 255;
+
+  if ( progress >= holdEnd ) {
+    alpha = p.map(
+      progress,
+      holdEnd,
+      fadeEnd,
+      255,
+      0,
+      true
+    );
+  }
+
+  // Reveal fraction (0..1) across the reveal phase.
+  const revealAmount = revealEnd > 0 ? p.constrain(
+    progress / revealEnd,
+    0,
+    1
+  ) : 1;
+
+  const size = specsOption.size ?? 22;
+  const lineStep = size * ( specsOption.lineHeight ?? 1.4 );
+  const font = string.fonts?.[ specsOption.font ] ?? string.fonts.spaceMonoRegular;
+  const fill = p.color( ...specsOption.fill );
+
+  fill.setAlpha( alpha );
+
+  const textStyle = {
+    size,
+    font,
+    fill,
+    stroke: false,
+    strokeWeight: 0,
+    blendMode: specsOption.blend,
+    textWidth: -1,
+    textAlign: [
+      p.LEFT,
+      p.TOP
+    ]
+  };
+
+  // Blinking cursor character (toggles a few times per loop).
+  const cursorVisible =
+    specsOption.showCursor && animation.sinOscillation( 6 ) > 0;
+  const cursor = cursorVisible ? "_" : "";
+
+  p.push();
+  if ( sketch.sketchOptions.type === "webgl" ) {
+    p.translate(
+      -p.width / 2,
+      -p.height / 2
+    );
+  }
+
+  const originX = p.width * ( specsOption.position?.x ?? 0.05 );
+  const originY = p.height * ( specsOption.position?.y ?? 0.06 );
+
+  if ( specsOption.style === "ticker" ) {
+    // Single line cycling through all parameters.
+    const index = Math.min(
+      Math.floor( revealAmount * lines.length ),
+      lines.length - 1
+    );
+    const line = lines[ index ];
+
+    string.write(
+      `${ line.label }: ${ line.value }${ cursor }`,
+      originX,
+      originY,
+      textStyle
+    );
+
+    p.pop();
+    return;
+  }
+
+  // Default "boot-log" style: stream lines in top-down with typewriter.
+  const exactLines = revealAmount * lines.length;
+  const fullyVisible = Math.floor( exactLines );
+  const typingFraction = exactLines - fullyVisible;
+
+  for ( let i = 0; i < lines.length; i++ ) {
+    if ( i > fullyVisible ) {
+      break;
+    }
+
+    const line = lines[ i ];
+    const full = `${ line.label }: ${ line.value }`;
+    const y = originY + i * lineStep;
+
+    if ( i < fullyVisible ) {
+      string.write(
+        full,
+        originX,
+        y,
+        textStyle
+      );
+      continue;
+    }
+
+    // Line currently being typed: reveal character by character.
+    const visibleCount = Math.ceil( full.length * typingFraction );
+    const typed = full.slice(
+      0,
+      visibleCount
+    );
+
+    string.write(
+      `${ typed }${ cursor }`,
+      originX,
+      y,
+      textStyle
+    );
+  }
+
+  p.pop();
+}

--- a/src/templates/p5/utils/slides/common/drawSlideText.js
+++ b/src/templates/p5/utils/slides/common/drawSlideText.js
@@ -1,4 +1,7 @@
 import string from "../../string.js";
+import {
+  getP5
+} from "../../sketch";
 
 const parseFloatDefault = (
   value, _default = 0.015
@@ -13,13 +16,14 @@ const parseFloatDefault = (
 };
 
 export default function drawSlideText( textOption ) {
+  const p = getP5();
   const horizontalMargin = parseFloatDefault( textOption.margin.horizontal );
   const verticalMargin = parseFloatDefault( textOption.margin.vertical );
 
   string.write(
     textOption.content,
-    width * horizontalMargin + width * textOption.position.x,
-    height * verticalMargin + height * textOption.position.y,
+    p.width * horizontalMargin + p.width * textOption.position.x,
+    p.height * verticalMargin + p.height * textOption.position.y,
     {
       size: Number( textOption.size ),
       font: string.fonts?.[ textOption.font ] ?? string.fonts.martian,
@@ -30,8 +34,8 @@ export default function drawSlideText( textOption ) {
       blendMode: textOption.blend,
       fill: p.color( ...textOption.fill ),
       stroke: p.color( ...textOption.stroke ),
-      textWidth: width - 2 * ( width * horizontalMargin ),
-      textHeight: height - 2 * ( height * verticalMargin )
+      textWidth: p.width - 2 * ( p.width * horizontalMargin ),
+      textHeight: p.height - 2 * ( p.height * verticalMargin )
     }
   );
 }

--- a/src/templates/p5/utils/slides/common/specsData.js
+++ b/src/templates/p5/utils/slides/common/specsData.js
@@ -1,0 +1,134 @@
+import options from "../../options.js";
+
+const MAX_LINES = 40;
+
+function formatNumber( value ) {
+  if ( Number.isInteger( value ) ) {
+    return String( value );
+  }
+
+  return String( Math.round( value * 100 ) / 100 );
+}
+
+function looksLikeColor( arr ) {
+  return (
+    ( arr.length === 3 || arr.length === 4 ) &&
+    arr.every( ( v ) => typeof v === "number" )
+  );
+}
+
+function formatValue( value ) {
+  if ( value === null || value === undefined ) {
+    return null;
+  }
+
+  switch ( typeof value ) {
+    case "number":
+      return formatNumber( value );
+    case "boolean":
+      return value ? "on" : "off";
+    case "string":
+      return value;
+    case "function":
+      return null;
+    default:
+      break;
+  }
+
+  if ( Array.isArray( value ) ) {
+    if ( looksLikeColor( value ) ) {
+      return `rgba(${ value.map( formatNumber ).join( ", " ) })`;
+    }
+
+    return `[${ value.length }]`;
+  }
+
+  return null; // objects are recursed by the flattener, not formatted here
+}
+
+function flatten(
+  obj, prefix, out
+) {
+  if ( !obj || typeof obj !== "object" ) {
+    return;
+  }
+
+  for ( const key of Object.keys( obj ) ) {
+    if ( out.length >= MAX_LINES ) {
+      return;
+    }
+
+    const value = obj[ key ];
+    const label = prefix ? `${ prefix }.${ key }` : key;
+
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray( value )
+    ) {
+      flatten(
+        value,
+        label,
+        out
+      );
+      continue;
+    }
+
+    const formatted = formatValue( value );
+
+    if ( formatted !== null ) {
+      out.push( {
+        label: label.toUpperCase(),
+        value: formatted
+      } );
+    }
+  }
+}
+
+/**
+ * Build the list of { label, value } lines displayed by the specs overlay.
+ * Reads the live options store (resolution, framerate, duration, slides) and,
+ * optionally, flattens the current sketch settings (options.sketch, already
+ * merged with per-slide overrides via the options proxy).
+ */
+export default function buildSpecsLines( specsOption ) {
+  const size = options.size || {};
+  const animation = options.animation || {};
+  const slides = options.slides || [];
+
+  const framerate = animation.framerate || 0;
+  const duration = animation.duration || 0;
+
+  const lines = [
+    {
+      label: "RESOLUTION",
+      value: `${ size.width || 0 }x${ size.height || 0 }`
+    },
+    {
+      label: "FRAMERATE",
+      value: `${ framerate } fps`
+    },
+    {
+      label: "DURATION",
+      value: `${ duration }s`
+    },
+    {
+      label: "FRAMES",
+      value: String( Math.round( duration * framerate ) )
+    },
+    {
+      label: "SLIDES",
+      value: String( slides.length || 1 )
+    }
+  ];
+
+  if ( specsOption?.includeSketchSettings ) {
+    flatten(
+      options.sketch || {},
+      "",
+      lines
+    );
+  }
+
+  return lines;
+}

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -1,10 +1,9 @@
-import options from "../options.js";
-import {
+import options, {
   syncEffectivePrevious
 } from "../options.js";
 import events from "../events.js";
 import {
-  getP5, getContainer
+  getContainer, getP5
 } from "../sketch.js";
 
 import {

--- a/src/templates/p5/utils/slides/layouts/freeLayout.js
+++ b/src/templates/p5/utils/slides/layouts/freeLayout.js
@@ -1,5 +1,6 @@
 import drawSlideVisual from "../common/drawSlideVisual.js";
 import drawSlideMeta from "../common/drawSlideMeta.js";
+import drawSlideSpecs from "../common/drawSlideSpecs.js";
 import drawSlideText from "../common/drawSlideText.js";
 import drawSlideImage from "../common/drawSlideImage.js";
 import drawSlideImages from "../common/drawSlideImages.js";
@@ -14,6 +15,9 @@ export default function freeLayout( options ) {
         break;
       case "meta":
         drawSlideMeta( item );
+        break;
+      case "specs":
+        drawSlideSpecs( item );
         break;
       case "text":
         drawSlideText( item );

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -163,6 +163,41 @@ export const MetaItemSchema = z.object( {
     } )
 } );
 
+export const SpecsItemSchema = z.object( {
+  type: z.literal( "specs" ),
+  style: z.enum( [
+    "boot-log",
+    "ticker"
+  ] ).default( "boot-log" ),
+  font: z.string().default( "spaceMonoRegular" ),
+  size: z.number().positive()
+    .default( 22 ),
+  fill: RGBA.default( [
+    0,
+    255,
+    120
+  ] ),
+  blend: Blend.default( "source-over" ),
+  position: Vec2.default( {
+    x: 0.05,
+    y: 0.06
+  } ),
+  lineHeight: z.number().positive()
+    .default( 1.4 ),
+  showCursor: z.boolean().default( true ),
+  includeSketchSettings: z.boolean().default( true ),
+  // timing as a fraction of the animation loop (0..1)
+  revealEnd: z.number().min( 0 )
+    .max( 1 )
+    .default( 0.45 ),
+  holdEnd: z.number().min( 0 )
+    .max( 1 )
+    .default( 0.7 ),
+  fadeEnd: z.number().min( 0 )
+    .max( 1 )
+    .default( 0.8 )
+} );
+
 export const TextItemSchema = z.object( {
   type: z.literal( "text" ),
   content: z.string().default( "" ),
@@ -343,6 +378,7 @@ export const ContentItemSchema = z.discriminatedUnion(
   [
     BackgroundItemSchema,
     MetaItemSchema,
+    SpecsItemSchema,
     TextItemSchema,
     ImagesStackItemSchema,
     ImageItemSchema,


### PR DESCRIPTION
## Summary
This PR introduces a new "specs" content item type that displays a technical overlay showing sketch settings, resolution, framerate, duration, and other metadata. The overlay supports two visual styles and integrates with the animation timeline for reveal, hold, and fade-out phases.

## Key Changes

- **New `drawSlideSpecs.js` module**: Renders a technical overlay with two display styles:
  - "boot-log": Lines stream in top-down with per-character typewriter effect and blinking cursor
  - "ticker": Single line cycles through parameters one at a time
  - Timing driven by animation progression with configurable reveal/hold/fade phases

- **New `specsData.js` module**: Builds the list of specification lines by:
  - Reading live options (resolution, framerate, duration, slide count)
  - Optionally flattening and formatting sketch settings with recursive object traversal
  - Formatting values (numbers, booleans, colors, arrays) for display
  - Limiting output to 40 lines maximum

- **Schema and type definitions**: Added `SpecsItemSchema` to `sketch.types.ts` with full configuration options including:
  - Style selection (boot-log/ticker)
  - Typography (font, size, line height)
  - Appearance (fill color, blend mode, cursor visibility)
  - Positioning and timing (x/y position, reveal/hold/fade end times)
  - Content control (include sketch settings toggle)

- **UI configuration**: Added form field configuration in `field-config.ts` with controls for all specs options (sliders, color picker, checkboxes, selects)

- **Integration**: 
  - Added "specs" to item kinds with Terminal icon
  - Integrated into `freeLayout.js` rendering pipeline
  - Added to content item discriminated union for proper type handling

## Notable Implementation Details

- The overlay uses p5.js `animation.progression` (0..1) to drive three-phase timing, allowing precise control over when content appears and disappears
- Value formatting handles special cases like color arrays (formatted as rgba) and distinguishes between arrays and objects
- The typewriter effect is achieved by calculating a typing fraction and slicing the full text string character-by-character
- Cursor visibility uses `animation.sinOscillation()` for smooth blinking at ~6 cycles per loop
- WebGL sketch support includes coordinate translation to account for centered origin

https://claude.ai/code/session_017VinuhFGcivGydPPfPnJgU