### PR TITLE
Redesign asset stack UI with full-width settings banner

### DIFF
--- a/src/lib/assets/components/AssetDialog.tsx
+++ b/src/lib/assets/components/AssetDialog.tsx
@@ -30,10 +30,11 @@ const fileName = ( p: string ) => p.split( /[\\/]/ ).pop() || p;
  *
  * Full-screen layout (inspired by the recordings `VideoPreviewModal`): a
  * blurred backdrop with a near-viewport panel that always fits the screen.
- * The preview and the options sit side-by-side on desktop and stack
- * vertically on mobile; the body scrolls internally so the panel never grows
- * past the viewport — which is exactly what made the previous small dialog
- * unusable once the params editor and timeline were added.
+ * On desktop (md+) the preview sits on the left and the params editor on
+ * the right; on mobile they stack vertically and the body scrolls
+ * internally so the panel never grows past the viewport — fixing the
+ * previous small dialog that became unusable once the params editor and
+ * mini timeline were added.
  *
  * Rendered in a portal at the top of the tree (Headless UI `Dialog`), so its
  * controls are never clipped by the thumbnail's `overflow-hidden` nor
@@ -62,7 +63,7 @@ export default function AssetDialog<P>( {
       <DialogBackdrop className="fixed inset-0 bg-black/80 backdrop-blur-md" />
 
       <div className="fixed inset-0 flex items-center justify-center p-3 sm:p-4 md:p-8">
-        <DialogPanel className="w-full md:w-[90vw] lg:w-[85vw] xl:w-[80vw] max-h-[calc(100vh-1.5rem)] sm:max-h-[calc(100vh-2rem)] md:max-h-[95vh] bg-background border border-theme rounded-2xl sm:rounded-3xl shadow-2xl overflow-hidden flex flex-col">
+        <DialogPanel className="w-full md:w-[92vw] lg:w-[88vw] xl:w-[80vw] max-w-[1400px] max-h-[calc(100vh-1.5rem)] sm:max-h-[calc(100vh-2rem)] md:max-h-[95vh] bg-background border border-theme rounded-2xl sm:rounded-3xl shadow-2xl overflow-hidden flex flex-col">
           <header className="flex items-center justify-between gap-2 px-4 py-3 sm:px-6 sm:py-4 border-b border-theme flex-shrink-0">
             <DialogTitle
               className="text-sm sm:text-base font-bold text-foreground truncate"
@@ -80,16 +81,24 @@ export default function AssetDialog<P>( {
             </button>
           </header>
 
-          {/* Body: preview + options side-by-side on desktop, stacked on
-              mobile. Scrolls internally so the panel always fits the screen. */}
-          <div className="flex-1 min-h-0 overflow-y-auto p-3 sm:p-4 md:p-6 flex flex-col md:flex-row gap-4 md:gap-6">
-            <div className="md:flex-1 md:min-w-0 flex items-start justify-center">
-              <div className="w-full aspect-video bg-black rounded-xl sm:rounded-2xl border border-theme overflow-hidden grid place-items-center shadow-lg">
+          {/* Body: side-by-side on desktop (preview left, options right),
+              stacked on mobile. The flex direction is set explicitly on
+              md+ so it is unambiguous, and `min-h-0` lets both panes shrink
+              within the panel's viewport-bound height. */}
+          <div className="flex flex-1 min-h-0 flex-col md:flex-row">
+            {/* Preview pane: black background fills the left side on
+                desktop and lets the video sit at any aspect ratio centered
+                inside, without stretching. */}
+            <div className="flex items-center justify-center bg-black md:flex-1 md:min-w-0 p-3 sm:p-4 md:p-6">
+              <div className="w-full aspect-video grid place-items-center overflow-hidden rounded-xl">
                 <Preview url={ url } path={ instance.path } />
               </div>
             </div>
 
-            <div className="md:w-80 lg:w-96 flex-shrink-0 flex flex-col gap-4">
+            {/* Options pane: fixed width on desktop, full width on mobile.
+                Scrolls vertically when its content overflows so the modal
+                never grows past the viewport. */}
+            <div className="md:w-80 lg:w-96 flex-shrink-0 flex flex-col gap-4 p-3 sm:p-4 md:p-6 overflow-y-auto border-t border-theme md:border-t-0 md:border-l">
               {ParamsEditor ? (
                 <ParamsEditor value={ instance.params } onChange={ onParamsChange } />
               ) : null}

--- a/src/lib/assets/components/AssetDialog.tsx
+++ b/src/lib/assets/components/AssetDialog.tsx
@@ -86,11 +86,12 @@ export default function AssetDialog<P>( {
               md+ so it is unambiguous, and `min-h-0` lets both panes shrink
               within the panel's viewport-bound height. */}
           <div className="flex flex-1 min-h-0 flex-col md:flex-row">
-            {/* Preview pane: black background fills the left side on
-                desktop and lets the video sit at any aspect ratio centered
-                inside, without stretching. */}
-            <div className="flex items-center justify-center bg-black md:flex-1 md:min-w-0 p-3 sm:p-4 md:p-6">
-              <div className="w-full aspect-video grid place-items-center overflow-hidden rounded-xl">
+            {/* Preview pane: the preview owns its own background (e.g. the
+                <video> element); the pane just centers it and gives it room
+                to breathe. The aspect-video wrapper constrains the preview
+                so it does not stretch arbitrarily inside the flex pane. */}
+            <div className="flex items-center justify-center md:flex-1 md:min-w-0 p-3 sm:p-4 md:p-6">
+              <div className="w-full aspect-video overflow-hidden rounded-xl">
                 <Preview url={ url } path={ instance.path } />
               </div>
             </div>

--- a/src/lib/assets/components/AssetDialog.tsx
+++ b/src/lib/assets/components/AssetDialog.tsx
@@ -24,14 +24,21 @@ const fileName = ( p: string ) => p.split( /[\\/]/ ).pop() || p;
 
 /**
  * Asset detail modal: a large preview plus the kind's optional
- * `ParamsEditor` and a Remove action. Tapping a thumbnail opens it, so all
- * per-asset controls live here instead of being crammed onto a small tile.
+ * `ParamsEditor` and a Remove action. Opened from the "Settings" banner on a
+ * stack tile, so all per-asset controls live here instead of being crammed
+ * onto a small thumbnail.
+ *
+ * Full-screen layout (inspired by the recordings `VideoPreviewModal`): a
+ * blurred backdrop with a near-viewport panel that always fits the screen.
+ * The preview and the options sit side-by-side on desktop and stack
+ * vertically on mobile; the body scrolls internally so the panel never grows
+ * past the viewport — which is exactly what made the previous small dialog
+ * unusable once the params editor and timeline were added.
  *
  * Rendered in a portal at the top of the tree (Headless UI `Dialog`), so its
  * controls are never clipped by the thumbnail's `overflow-hidden` nor
- * captured by the options panel — which is exactly what broke the previous
- * on-tile buttons. Centered on desktop, bottom-anchored full-width on mobile,
- * with focus trap, Escape, and overlay-click to close.
+ * captured by the options panel, with focus trap, Escape, and overlay-click
+ * to close.
  */
 export default function AssetDialog<P>( {
   open,
@@ -51,42 +58,51 @@ export default function AssetDialog<P>( {
   }
 
   return (
-    <Dialog open={ open } onClose={ onClose } className="relative z-50">
-      <DialogBackdrop className="fixed inset-0 bg-black/60" />
+    <Dialog open={ open } onClose={ onClose } className="relative z-[9999]">
+      <DialogBackdrop className="fixed inset-0 bg-black/80 backdrop-blur-md" />
 
-      <div className="fixed inset-0 flex items-end sm:items-center justify-center p-0 sm:p-4">
-        <DialogPanel className="w-full sm:max-w-md bg-background border border-theme rounded-t-2xl sm:rounded-2xl shadow-xl overflow-hidden flex flex-col max-h-[90vh]">
-          <header className="flex items-center justify-between gap-2 px-3 py-2 border-b border-theme">
-            <DialogTitle className="text-xs font-medium truncate" title={ instance.path }>
+      <div className="fixed inset-0 flex items-center justify-center p-3 sm:p-4 md:p-8">
+        <DialogPanel className="w-full md:w-[90vw] lg:w-[85vw] xl:w-[80vw] max-h-[calc(100vh-1.5rem)] sm:max-h-[calc(100vh-2rem)] md:max-h-[95vh] bg-background border border-theme rounded-2xl sm:rounded-3xl shadow-2xl overflow-hidden flex flex-col">
+          <header className="flex items-center justify-between gap-2 px-4 py-3 sm:px-6 sm:py-4 border-b border-theme flex-shrink-0">
+            <DialogTitle
+              className="text-sm sm:text-base font-bold text-foreground truncate"
+              title={ instance.path }
+            >
               {kind.label} · {fileName( instance.path )}
             </DialogTitle>
             <button
               type="button"
               onClick={ onClose }
-              className="h-7 w-7 grid place-items-center text-gray-500 hover:text-foreground hover:bg-theme/20 rounded-md"
+              className="flex-shrink-0 p-2 rounded-xl text-foreground/70 hover:text-foreground hover:bg-hover transition-colors"
               aria-label="Close"
             >
-              <X className="h-4 w-4" />
+              <X className="h-5 w-5" />
             </button>
           </header>
 
-          <div className="aspect-video bg-black grid place-items-center overflow-hidden">
-            <Preview url={ url } path={ instance.path } />
-          </div>
+          {/* Body: preview + options side-by-side on desktop, stacked on
+              mobile. Scrolls internally so the panel always fits the screen. */}
+          <div className="flex-1 min-h-0 overflow-y-auto p-3 sm:p-4 md:p-6 flex flex-col md:flex-row gap-4 md:gap-6">
+            <div className="md:flex-1 md:min-w-0 flex items-start justify-center">
+              <div className="w-full aspect-video bg-black rounded-xl sm:rounded-2xl border border-theme overflow-hidden grid place-items-center shadow-lg">
+                <Preview url={ url } path={ instance.path } />
+              </div>
+            </div>
 
-          <div className="p-3 overflow-y-auto flex flex-col gap-3">
-            {ParamsEditor ? (
-              <ParamsEditor value={ instance.params } onChange={ onParamsChange } />
-            ) : null}
+            <div className="md:w-80 lg:w-96 flex-shrink-0 flex flex-col gap-4">
+              {ParamsEditor ? (
+                <ParamsEditor value={ instance.params } onChange={ onParamsChange } />
+              ) : null}
 
-            <button
-              type="button"
-              onClick={ handleRemove }
-              className="flex items-center justify-center gap-2 h-10 rounded-lg border border-red-500/40 text-red-600 hover:bg-red-500/10 text-sm font-medium"
-            >
-              <Trash2 className="h-4 w-4" />
-              Remove
-            </button>
+              <button
+                type="button"
+                onClick={ handleRemove }
+                className="flex items-center justify-center gap-2 h-10 rounded-lg border border-red-500/40 text-red-600 hover:bg-red-500/10 text-sm font-medium"
+              >
+                <Trash2 className="h-4 w-4" />
+                Remove
+              </button>
+            </div>
           </div>
         </DialogPanel>
       </div>

--- a/src/lib/assets/components/ControlledAssetStackInput.tsx
+++ b/src/lib/assets/components/ControlledAssetStackInput.tsx
@@ -74,6 +74,12 @@ export default function ControlledAssetStackInput<P>( {
     )
   } ) );
 
+  /** Kinds with params get a "Settings" banner at the bottom of each tile, so
+   *  their tiles (and the matching DropZone slot) need extra height to keep
+   *  the preview area readable. */
+  const hasParams = Boolean( kind.hasParams && kind.ParamsEditor );
+  const tileHeightClass = hasParams ? "h-32" : "h-24";
+
   async function onFiles( files: FileList ) {
     const paths = await uploadFiles(
       files,
@@ -130,6 +136,7 @@ export default function ControlledAssetStackInput<P>( {
                 kind={ kind }
                 instance={ row.instance }
                 url={ row.url }
+                heightClass={ tileHeightClass }
                 onDelete={ () => onDelete( index ) }
                 onParamsChange={ ( params ) => updateParams(
                   index,
@@ -142,7 +149,7 @@ export default function ControlledAssetStackInput<P>( {
           <DropZoneButton
             onFiles={ onFiles }
             multiple
-            className="h-24"
+            className={ tileHeightClass }
             accept={ kind.accept }
           />
         </div>
@@ -177,12 +184,14 @@ function SortableThumb<P>( {
   kind,
   instance,
   url,
+  heightClass,
   onDelete,
   onParamsChange
 }: {
   kind: AssetKind<P>;
   instance: AssetInstance<P>;
   url: string;
+  heightClass: string;
   onDelete: () => void;
   onParamsChange: ( params: P ) => void;
 } ) {
@@ -214,44 +223,53 @@ function SortableThumb<P>( {
 
   return (
     <>
+      {/* Vertical layout: preview area (flex-1) on top, optional "Settings"
+          banner in normal flow at the bottom. Using flex-col rather than
+          absolute positioning for the banner makes its position unambiguous
+          — it is always the last child, always at the bottom, regardless of
+          transforms or stacking. */}
       <div
         ref={ setNodeRef }
         style={ style }
-        className="relative h-24 rounded-lg border border-theme overflow-hidden bg-background"
+        className={ `relative ${ heightClass } rounded-lg border border-theme overflow-hidden bg-background flex flex-col` }
       >
-        {/* Preview as a background layer: absolutely filling the tile so it
-            can never push the layout or shift the overlaid controls out of
-            bounds, whatever the asset's intrinsic size. */}
-        <div className="absolute inset-0">
-          <Preview url={ url } path={ instance.path } />
+        {/* Preview area: takes all remaining space above the banner. The
+            preview itself absolutely fills it so it can never push the
+            layout or shift the overlaid corner controls out of bounds,
+            whatever the asset's intrinsic size. */}
+        <div className="relative flex-1 min-h-0">
+          <div className="absolute inset-0">
+            <Preview url={ url } path={ instance.path } />
+          </div>
+
+          {/* Top-left: delete. Matches the image stack design. */}
+          <CornerButton
+            ariaLabel="Remove"
+            onClick={ onDelete }
+            tone="danger"
+            className="left-1 top-1"
+          >
+            <Trash2 className="h-4 w-4" />
+          </CornerButton>
+
+          {/* Top-right: drag handle. Sole dnd-kit activator. `touch-none`
+              lets it own touch gestures without blocking panel scroll. */}
+          <button
+            type="button"
+            ref={ setActivatorNodeRef }
+            { ...attributes }
+            { ...listeners }
+            aria-label="Drag to reorder"
+            className="absolute right-1 top-1 z-10 h-7 w-7 grid place-items-center rounded-md text-white bg-black/55 hover:bg-black/75 cursor-grab active:cursor-grabbing touch-none"
+          >
+            <GripVertical className="h-4 w-4" />
+          </button>
         </div>
 
-        {/* Top-right: drag handle. Sole dnd-kit activator. `touch-none`
-            lets it own touch gestures without blocking panel scroll. */}
-        <button
-          type="button"
-          ref={ setActivatorNodeRef }
-          { ...attributes }
-          { ...listeners }
-          aria-label="Drag to reorder"
-          className="absolute right-1 top-1 z-10 h-7 w-7 grid place-items-center rounded-md text-white bg-black/55 hover:bg-black/75 cursor-grab active:cursor-grabbing touch-none"
-        >
-          <GripVertical className="h-4 w-4" />
-        </button>
-
-        <CornerButton
-          ariaLabel="Remove"
-          onClick={ onDelete }
-          tone="danger"
-          className="left-1 top-1"
-        >
-          <Trash2 className="h-4 w-4" />
-        </CornerButton>
-
-        {/* Bottom: full-width "Settings" banner. Opens the AssetDialog where
-            the preview and params editor have room to breathe. Same
-            stopPropagation guard as the corner buttons so dnd-kit's
-            PointerSensor (on the drag handle) cannot read a tap as a drag. */}
+        {/* Bottom banner: opens the AssetDialog where the preview and params
+            editor have room to breathe. Same stopPropagation guard as the
+            corner buttons so dnd-kit's PointerSensor (on the drag handle)
+            cannot read a tap as a drag. */}
         {hasParams ? (
           <button
             type="button"
@@ -261,7 +279,7 @@ function SortableThumb<P>( {
             } }
             onPointerDown={ ( e ) => e.stopPropagation() }
             aria-label="Open settings"
-            className="absolute inset-x-0 bottom-0 z-10 flex h-7 items-center justify-center gap-1.5 bg-black/55 text-xs font-medium text-white hover:bg-black/75"
+            className="flex h-7 flex-shrink-0 items-center justify-center gap-1.5 border-t border-theme bg-foreground/85 text-xs font-medium text-background hover:bg-foreground"
           >
             <Settings2 className="h-3.5 w-3.5" />
             Settings

--- a/src/lib/assets/components/ControlledAssetStackInput.tsx
+++ b/src/lib/assets/components/ControlledAssetStackInput.tsx
@@ -152,25 +152,26 @@ export default function ControlledAssetStackInput<P>( {
 }
 
 /**
- * A single asset tile with one control per corner — no overlap, legible
- * even on a ~50 px mobile cell:
+ * A single asset tile: delete and drag in the top corners (matching the
+ * image tiles), and — for kinds with params — a full-width "Settings" banner
+ * along the bottom. Legible even on a ~50 px mobile cell:
  *
  *   ┌─────────────┐
- *   │           ⠿ │  drag (sole dnd-kit activator)
+ *   │ 🗑        ⠿ │  delete (top-left) · drag (top-right, sole dnd-kit activator)
  *   │   preview   │
- *   │ 🗑       ⚙ │  delete (bottom-left) · settings (bottom-right)
+ *   │ ⚙ Settings  │  settings banner (full-width bottom)
  *   └─────────────┘
  *
  * No overlay button: the preview keeps `mouseenter` reachable (so the video
- * preview can hover-play), and clicks on the corner buttons route directly
- * to their handlers — they explicitly `stopPropagation` on `pointerdown` so
- * dnd-kit's PointerSensor (attached to the drag handle only) cannot
- * pre-empt them.
+ * preview can hover-play), and clicks on the corner buttons and banner route
+ * directly to their handlers — they explicitly `stopPropagation` on
+ * `pointerdown` so dnd-kit's PointerSensor (attached to the drag handle only)
+ * cannot pre-empt them.
  *
- * The settings button opens an `AssetDialog` — portaled at the top of the
+ * The settings banner opens an `AssetDialog` — portaled at the top of the
  * tree, so its own controls (Remove, ParamsEditor) cannot be clipped by the
  * tile or captured by the options panel. Kinds without params hide the
- * settings button: images get Delete + Drag, videos get the full set.
+ * banner: images get Delete + Drag, videos add the bottom Settings banner.
  */
 function SortableThumb<P>( {
   kind,
@@ -247,14 +248,24 @@ function SortableThumb<P>( {
           <Trash2 className="h-4 w-4" />
         </CornerButton>
 
+        {/* Bottom: full-width "Settings" banner. Opens the AssetDialog where
+            the preview and params editor have room to breathe. Same
+            stopPropagation guard as the corner buttons so dnd-kit's
+            PointerSensor (on the drag handle) cannot read a tap as a drag. */}
         {hasParams ? (
-          <CornerButton
-            ariaLabel="Open settings"
-            onClick={ () => setDialogOpen( true ) }
-            className="right-1 bottom-1"
+          <button
+            type="button"
+            onClick={ ( e ) => {
+              e.stopPropagation();
+              setDialogOpen( true );
+            } }
+            onPointerDown={ ( e ) => e.stopPropagation() }
+            aria-label="Open settings"
+            className="absolute inset-x-0 bottom-0 z-10 flex h-7 items-center justify-center gap-1.5 bg-black/55 text-xs font-medium text-white hover:bg-black/75"
           >
-            <Settings2 className="h-4 w-4" />
-          </CornerButton>
+            <Settings2 className="h-3.5 w-3.5" />
+            Settings
+          </button>
         ) : null}
       </div>
 

--- a/src/lib/assets/components/ControlledAssetStackInput.tsx
+++ b/src/lib/assets/components/ControlledAssetStackInput.tsx
@@ -260,7 +260,7 @@ function SortableThumb<P>( {
             { ...attributes }
             { ...listeners }
             aria-label="Drag to reorder"
-            className="absolute right-1 top-1 z-10 h-7 w-7 grid place-items-center rounded-md text-white bg-black/55 hover:bg-black/75 cursor-grab active:cursor-grabbing touch-none"
+            className="absolute right-1 top-1 z-10 h-7 w-7 grid place-items-center rounded-md text-foreground/70 hover:text-foreground bg-background/90 hover:bg-background border border-theme cursor-grab active:cursor-grabbing touch-none"
           >
             <GripVertical className="h-4 w-4" />
           </button>
@@ -279,7 +279,7 @@ function SortableThumb<P>( {
             } }
             onPointerDown={ ( e ) => e.stopPropagation() }
             aria-label="Open settings"
-            className="flex h-7 flex-shrink-0 items-center justify-center gap-1.5 border-t border-theme bg-foreground/85 text-xs font-medium text-background hover:bg-foreground"
+            className="flex h-7 flex-shrink-0 items-center justify-center gap-1.5 border-t border-theme bg-background text-xs font-medium text-foreground hover:bg-hover"
           >
             <Settings2 className="h-3.5 w-3.5" />
             Settings
@@ -328,8 +328,8 @@ function CornerButton( {
       } }
       onPointerDown={ ( e ) => e.stopPropagation() }
       aria-label={ ariaLabel }
-      className={ `absolute z-10 h-7 w-7 grid place-items-center rounded-md bg-black/55 hover:bg-black/75 ${
-        tone === "danger" ? "text-red-300 hover:text-red-200" : "text-white"
+      className={ `absolute z-10 h-7 w-7 grid place-items-center rounded-md bg-background/90 hover:bg-background border border-theme ${
+        tone === "danger" ? "text-red-600 hover:text-red-700" : "text-foreground/70 hover:text-foreground"
       } ${ className }` }
     >
       {children}

--- a/src/lib/assets/kinds/videos/index.tsx
+++ b/src/lib/assets/kinds/videos/index.tsx
@@ -33,13 +33,29 @@ function VideoPreview( {
       preload="metadata"
       className="object-cover h-full w-full bg-black"
       title={ path }
+      // Force a first-frame paint as soon as metadata is available.
+      // Without this nudge, some browsers (Chrome especially) leave the
+      // video element rendering its black background until the user
+      // interacts with it — which made existing thumbnails appear to
+      // "vanish" when a sibling tile was added and the grid re-rendered.
+      onLoadedMetadata={ () => {
+        const el = ref.current;
+
+        if ( el && el.currentTime === 0 ) {
+          try {
+            el.currentTime = 0.001;
+          } catch {
+            /* noop */
+          }
+        }
+      } }
       onMouseEnter={ () => ref.current?.play().catch( () => {} ) }
       onMouseLeave={ () => {
         const el = ref.current;
 
         if ( el ) {
           el.pause();
-          el.currentTime = 0;
+          el.currentTime = 0.001;
         }
       } }
     />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,8 @@ export default {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/lib/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
Redesigned the asset stack tile UI to use a full-width "Settings" banner at the bottom for assets with parameters, replacing the previous corner button layout. Also significantly improved the `AssetDialog` modal with a responsive side-by-side layout on desktop and better viewport handling on mobile.

## Key Changes

### Asset Stack Tiles (`ControlledAssetStackInput.tsx`)
- **Dynamic tile height**: Tiles with parameters now use `h-32` instead of `h-24` to accommodate the new settings banner
- **Settings banner redesign**: Replaced bottom-right corner button with a full-width banner containing the Settings icon and label
- **Layout restructuring**: Changed from absolute positioning to flexbox layout (`flex flex-col`) for clearer positioning semantics
- **Preview area**: Wrapped in a flex container with `flex-1` to take remaining space above the banner
- **Drag handle styling**: Updated colors to use theme variables (`text-foreground/70`, `bg-background/90`) instead of hardcoded black
- **Corner button styling**: Unified styling across delete and drag buttons with theme-aware colors and borders

### Asset Dialog (`AssetDialog.tsx`)
- **Responsive layout**: Full-screen modal with blurred backdrop (`backdrop-blur-md`)
- **Desktop layout**: Side-by-side preview (left) and options pane (right) on `md+` breakpoints
- **Mobile layout**: Stacked vertically with internal scrolling to prevent viewport overflow
- **Improved sizing**: Uses viewport-relative dimensions (`md:w-[92vw]`, `max-h-[calc(100vh-...)]`) for better responsiveness
- **Enhanced header**: Larger, bolder title with improved close button styling
- **Options pane**: Fixed width on desktop (`md:w-80 lg:w-96`), scrollable content area with proper spacing

### Video Preview (`videos/index.tsx`)
- **First-frame rendering fix**: Added `onLoadedMetadata` handler to force initial frame paint by setting `currentTime = 0.001`
- **Prevents blank thumbnails**: Solves issue where video elements would show black background until user interaction
- **Hover behavior**: Updated `onMouseLeave` to reset to `0.001` instead of `0` for consistency

### Tailwind Config
- Added `./src/lib/**/*.{js,ts,jsx,tsx,mdx}` to content paths for proper style scanning

## Notable Implementation Details
- The settings banner uses `flex-shrink-0` to maintain fixed height while the preview area uses `flex-1 min-h-0` to allow proper flex shrinking
- The modal uses `min-h-0` on flex containers to enable proper overflow handling within viewport-constrained layouts
- Video preview timing uses `0.001` instead of `0` to trigger rendering while appearing as the first frame
- All interactive elements (`stopPropagation` on `pointerdown`) prevent dnd-kit's PointerSensor from interfering with button clicks

https://claude.ai/code/session_011XhJD49JPYBxkYeTgFF4Pw