### PR TITLE
Fix animation clock desync when resuming from paused state

### DIFF
--- a/src/components/AnimationProgressionBar.tsx
+++ b/src/components/AnimationProgressionBar.tsx
@@ -14,6 +14,7 @@ import useSketch from "@/components/ClientProcessingSketch/components/SketchProv
 import {
   getEffectiveSlideSettings
 } from "@/lib/effectiveSlideSettings";
+import usePageVisibility from "@/hooks/usePageVisibility";
 
 interface AnimationProgressionBarProps {
   className?: string;
@@ -79,6 +80,10 @@ export default function AnimationProgressionBar( {
   const activeSlideIndexRef = useRef( activeSlideIndex );
 
   activeSlideIndexRef.current = activeSlideIndex;
+
+  // While the tab is hidden the engine is paused and progression can't
+  // change, so there's no point spinning our polling RAF.
+  const isPageVisible = usePageVisibility();
 
   const [
     progression,
@@ -179,7 +184,7 @@ export default function AnimationProgressionBar( {
   // originating from an effect context, which triggers "maximum update depth".
   useEffect(
     () => {
-      if ( disabled ) {
+      if ( disabled || !isPageVisible ) {
         return;
       }
 
@@ -208,7 +213,8 @@ export default function AnimationProgressionBar( {
       return () => cancelAnimationFrame( rafId );
     },
     [
-      disabled
+      disabled,
+      isPageVisible
     ]
   );
 

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -243,6 +243,17 @@ export class P5Engine implements SketchEngine {
   /* ---- playback -------------------------------------------------- */
 
   play(): void {
+    // Re-anchor the animation clock before resuming the draw loop.
+    // Elapsed time is derived from p5 `millis()`, which keeps advancing
+    // while the loop is stopped (tab hidden, viewport gesture, …). Without
+    // this, the first pre-draw after resume would add the entire paused
+    // duration in one jump and the animation would "teleport" forward.
+    const bridge = getAnimationBridge();
+
+    if ( bridge ) {
+      bridge.setProgression( bridge.getProgression() );
+    }
+
     this.sketchRuntime?.getP5()?.loop();
     this.perfSample.paused = false;
     this.emitPerformanceSample();


### PR DESCRIPTION
## Summary
This PR fixes an issue where animations would "teleport" forward when resuming after the sketch engine was paused (e.g., when a tab is hidden or during viewport gestures). The fix re-anchors the animation clock before resuming the draw loop and optimizes the animation progression bar to stop polling when the page is not visible.

## Key Changes
- **P5Engine.ts**: Added clock re-anchoring in the `play()` method to prevent elapsed time from accumulating during paused periods. The animation bridge's progression is reset to its current value before resuming, ensuring smooth continuation rather than a sudden jump forward.
- **AnimationProgressionBar.tsx**: Integrated page visibility detection to prevent unnecessary RAF polling when the tab is hidden. The progression update effect now skips execution when the page is not visible, reducing unnecessary work while the engine is paused.

## Implementation Details
- The animation clock issue occurred because p5's `millis()` continues advancing even when the draw loop is stopped, causing a large time delta on the first frame after resume.
- By calling `bridge.setProgression(bridge.getProgression())` before resuming, the animation clock is re-anchored to the current progression value, preventing the accumulated pause duration from being applied as a single jump.
- The page visibility optimization uses a new `usePageVisibility` hook to conditionally disable the RAF polling loop, improving performance during inactive tab periods.

https://claude.ai/code/session_01XWknLVWPnyeevk57NhgGBw