### PR TITLE
Fix p5 draw loop frame rate by preventing duplicate animation chains

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ const config = {
     "**/__tests__/**/*.test.tsx"
   ],
   transform: {
-    "^.+\\.(ts|tsx)$": [
+    "^.+\\.(ts|tsx|js|jsx)$": [
       "ts-jest",
       {
         tsconfig: {

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -27,6 +27,9 @@ import {
 import {
   getAnimationBridge
 } from "@/lib/animationBridge";
+import {
+  pauseLoop, resumeLoop
+} from "@/p5/utils/loopControl.js";
 
 type P5SketchRuntime = {
   start: ( container: HTMLElement ) => Promise<any>;
@@ -197,7 +200,7 @@ export class P5Engine implements SketchEngine {
       surfaceSelector: "canvas.p5Canvas",
       prepare: () => {
         window.enableRecordingMode?.();
-        this.sketchRuntime?.getP5()?.noLoop();
+        pauseLoop( this.sketchRuntime?.getP5() );
       },
       renderFrame: () => {
         // enableRecordingMode makes incrementElapsedTime advance frame-based
@@ -254,19 +257,19 @@ export class P5Engine implements SketchEngine {
       bridge.setProgression( bridge.getProgression() );
     }
 
-    this.sketchRuntime?.getP5()?.loop();
+    resumeLoop( this.sketchRuntime?.getP5() );
     this.perfSample.paused = false;
     this.emitPerformanceSample();
   }
 
   pause(): void {
-    this.sketchRuntime?.getP5()?.noLoop();
+    pauseLoop( this.sketchRuntime?.getP5() );
     this.perfSample.paused = true;
     this.emitPerformanceSample();
   }
 
   stop(): void {
-    this.sketchRuntime?.getP5()?.noLoop();
+    pauseLoop( this.sketchRuntime?.getP5() );
     this.perfSample.paused = true;
 
     const p = this.sketchRuntime?.getP5();

--- a/src/templates/p5/utils/__tests__/loopControl.test.ts
+++ b/src/templates/p5/utils/__tests__/loopControl.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for the safe p5 draw-loop helpers.
+ *
+ * The bug these guard against: toggling p5's `noLoop()` / `loop()` faster
+ * than one browser frame leaves a trailing `requestAnimationFrame(_draw)`
+ * queued, which then spawns a *second* `_draw` chain once looping resumes.
+ * Two chains == double the draw rate == FPS readout shooting past the
+ * configured target. The helpers must keep at most one pending draw frame.
+ */
+import {
+  pauseLoop, resumeLoop
+} from "../loopControl.js";
+
+/**
+ * Minimal stand-in that mirrors the parts of p5's loop machinery the helpers
+ * touch: an internal `_loop` flag, the `_requestAnimId` handle, and a
+ * synchronous `loop()` that schedules a frame (as p5 does via `_draw`).
+ */
+function createFakeP5() {
+  let nextHandle = 1;
+  const scheduled = new Set<number>();
+
+  ( global as any ).cancelAnimationFrame = ( id: number ) => {
+    scheduled.delete( id );
+  };
+
+  const p: any = {
+    _loop: false,
+    _requestAnimId: 0,
+    isLooping() {
+      return this._loop;
+    },
+    noLoop() {
+      this._loop = false;
+    },
+    loop() {
+      if ( !this._loop ) {
+        this._loop = true;
+        // p5's loop() synchronously kicks a draw which schedules the next rAF.
+        this._requestAnimId = nextHandle++;
+        scheduled.add( this._requestAnimId );
+      }
+    },
+    // Test helper: how many draw frames are still queued in the browser.
+    // p5 only ever *tracks* one (`_requestAnimId`), but a leaked trailing
+    // frame stays queued even though nothing tracks it — that's the bug.
+    _pendingFrames() {
+      return scheduled.size;
+    }
+  };
+
+  return p;
+}
+
+describe(
+  "loopControl",
+  () => {
+    it(
+      "pauseLoop stops the loop and clears the trailing frame",
+      () => {
+        const p = createFakeP5();
+
+        p.loop();
+        expect( p._pendingFrames() ).toBe( 1 );
+
+        pauseLoop( p );
+
+        expect( p.isLooping() ).toBe( false );
+        expect( p._requestAnimId ).toBe( 0 );
+        expect( p._pendingFrames() ).toBe( 0 );
+      }
+    );
+
+    it(
+      "resumeLoop after pauseLoop keeps a single draw chain",
+      () => {
+        const p = createFakeP5();
+
+        p.loop();
+        pauseLoop( p );
+        resumeLoop( p );
+
+        expect( p.isLooping() ).toBe( true );
+        expect( p._pendingFrames() ).toBe( 1 );
+      }
+    );
+
+    it(
+      "raw p5 loop() leaks a second chain across a quick noLoop/loop toggle",
+      () => {
+        // Baseline that documents the bug the helper exists to prevent:
+        // resuming with p5's own loop() before the trailing frame fires
+        // leaves two frames queued — a doubled draw rate.
+        const p = createFakeP5();
+
+        p.loop();
+        p.noLoop(); // trailing frame still queued, not cancelled
+        p.loop(); // schedules a fresh frame on top of the trailing one
+
+        expect( p._pendingFrames() ).toBe( 2 );
+      }
+    );
+
+    it(
+      "resumeLoop never spawns a second chain across a quick toggle",
+      () => {
+        const p = createFakeP5();
+
+        p.loop();
+        p.noLoop(); // trailing frame still queued when we resume
+
+        resumeLoop( p );
+
+        // The trailing frame must have been cancelled — exactly one chain.
+        expect( p.isLooping() ).toBe( true );
+        expect( p._pendingFrames() ).toBe( 1 );
+      }
+    );
+
+    it(
+      "resumeLoop is a no-op while already looping (no duplicate chain)",
+      () => {
+        const p = createFakeP5();
+
+        p.loop();
+        expect( p._pendingFrames() ).toBe( 1 );
+
+        resumeLoop( p );
+        resumeLoop( p );
+
+        expect( p._pendingFrames() ).toBe( 1 );
+      }
+    );
+
+    it(
+      "survives rapid pause/resume cycles without leaking frames",
+      () => {
+        const p = createFakeP5();
+
+        p.loop();
+
+        for ( let i = 0; i < 50; i++ ) {
+          pauseLoop( p );
+          resumeLoop( p );
+        }
+
+        expect( p.isLooping() ).toBe( true );
+        expect( p._pendingFrames() ).toBe( 1 );
+      }
+    );
+
+    it(
+      "tolerates a null p5 instance",
+      () => {
+        expect( () => pauseLoop( null ) ).not.toThrow();
+        expect( () => resumeLoop( null ) ).not.toThrow();
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/loopControl.js
+++ b/src/templates/p5/utils/loopControl.js
@@ -1,0 +1,64 @@
+/**
+ * Safe p5 draw-loop control.
+ *
+ * p5's `noLoop()` only flips an internal `_loop` flag — the
+ * `requestAnimationFrame(_draw)` it scheduled on the previous frame stays
+ * queued and fires one last time. If `loop()` runs *before* that trailing
+ * frame fires, p5 ends up with two concurrent `_draw` chains: the one
+ * `loop()` starts synchronously, plus the trailing rAF which reschedules
+ * itself now that `_loop` is true again. Each extra chain makes the sketch
+ * draw an extra time per browser frame, so the effective frame rate climbs
+ * to a multiple of the target and the on-screen FPS readout becomes erratic,
+ * shooting well past the configured framerate.
+ *
+ * Viewport gestures (pan / zoom / wheel) and tab-visibility changes pause and
+ * resume the loop frequently, which makes this race trivial to hit. These
+ * helpers preserve the invariant "at most one pending `_draw` rAF", so the
+ * configured target frame rate is always respected.
+ *
+ * Always pause/resume the loop through these helpers — never call
+ * `p.loop()` / `p.noLoop()` directly.
+ */
+
+function cancelPendingDraw( p ) {
+  // `_requestAnimId` is the handle p5 stores for the next scheduled `_draw`.
+  // Dropping it guarantees the trailing frame can't pair up with a fresh
+  // chain on the next resume.
+  if ( p._requestAnimId && typeof cancelAnimationFrame === "function" ) {
+    cancelAnimationFrame( p._requestAnimId );
+  }
+
+  p._requestAnimId = 0;
+}
+
+/**
+ * Stop the draw loop and drop the trailing frame p5 leaves scheduled.
+ */
+export function pauseLoop( p ) {
+  if ( !p ) {
+    return;
+  }
+
+  p.noLoop();
+  cancelPendingDraw( p );
+}
+
+/**
+ * Resume the draw loop without ever creating a second `_draw` chain.
+ */
+export function resumeLoop( p ) {
+  if ( !p ) {
+    return;
+  }
+
+  // Already looping: a single chain is live and p5's own `loop()` would be a
+  // no-op, so leave it running rather than risk kicking a duplicate.
+  if ( typeof p.isLooping === "function" && p.isLooping() ) {
+    return;
+  }
+
+  // Clear any trailing frame before starting a fresh chain so we never run
+  // two at once.
+  cancelPendingDraw( p );
+  p.loop();
+}

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -8,6 +8,9 @@ import options, {
 import {
   registerAnimationBridge
 } from "@/lib/animationBridge";
+import {
+  pauseLoop, resumeLoop
+} from "./loopControl.js";
 
 let _p5 = null;
 let _container = null;
@@ -515,9 +518,9 @@ const sketch = {
       sketch.paused = !sketch.paused;
 
       if ( sketch.paused ) {
-        getP5()?.noLoop();
+        pauseLoop( getP5() );
       } else {
-        getP5()?.loop();
+        resumeLoop( getP5() );
       }
     },
     "engine-get-key-typed": () => getP5()?.key,
@@ -553,8 +556,8 @@ const sketch = {
 
       p?.fullscreen( !p?.fullscreen() );
     },
-    "engine-pause": () => getP5()?.noLoop(),
-    "engine-resume": () => getP5()?.loop(),
+    "engine-pause": () => pauseLoop( getP5() ),
+    "engine-resume": () => resumeLoop( getP5() ),
     "engine-redraw": () => getP5()?.redraw(),
     "engine-canvas-save": (
       name, type


### PR DESCRIPTION
## Summary
This PR fixes a race condition in p5's draw loop that causes the frame rate to spike unpredictably when the loop is paused and resumed in quick succession. The issue occurs because p5's `noLoop()` only sets a flag but leaves a `requestAnimationFrame` queued, which can pair with a fresh chain started by `loop()` before the trailing frame fires, resulting in two concurrent draw chains and doubled frame rates.

## Key Changes
- **New module `loopControl.js`**: Introduces `pauseLoop()` and `resumeLoop()` helper functions that safely manage p5's draw loop by:
  - Cancelling any pending `requestAnimationFrame` before resuming to prevent duplicate chains
  - Checking if the loop is already running before starting a new chain
  - Handling null p5 instances gracefully

- **Comprehensive test suite**: Added `loopControl.test.ts` with regression tests covering:
  - Basic pause/resume functionality
  - Prevention of duplicate draw chains during rapid toggles
  - Idempotency of resume operations
  - Stress testing with 50 rapid pause/resume cycles
  - Null instance tolerance

- **Updated P5Engine**: Replaced direct calls to `p.loop()` and `p.noLoop()` with the new safe helpers in:
  - Recording mode preparation
  - Resume/pause/stop lifecycle methods

- **Updated sketch template**: Replaced direct loop control calls with safe helpers in:
  - Pause/resume toggle handler
  - Engine pause/resume message handlers

- **Jest configuration**: Extended TypeScript transform to include `.js` and `.jsx` files to support testing the new JavaScript module

## Implementation Details
The solution maintains the invariant "at most one pending `_draw` requestAnimationFrame" by:
1. Always cancelling the tracked `_requestAnimId` before starting a new chain
2. Checking `isLooping()` to avoid redundant calls when already running
3. Ensuring the helpers are idempotent and safe to call with null instances

This prevents the frame rate from becoming a multiple of the configured target, which was particularly problematic during viewport gestures (pan/zoom) and tab visibility changes that frequently pause and resume the loop.

https://claude.ai/code/session_013xWA7MkbqnApPjKHaSgdnH