### PR TITLE
Add GA4 client-side route-change pageview tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import {
   Suspense
 } from "react";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import GoogleAnalyticsTracker from "@/components/GoogleAnalyticsTracker";
 import MenuBar from "@/components/MenuBar";
 import {
   MenuBarSlotProvider
@@ -148,6 +149,9 @@ export default function RootLayout( {
       </head>
       <body>
         <GoogleAnalytics />
+        <Suspense>
+          <GoogleAnalyticsTracker />
+        </Suspense>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,9 +1,10 @@
 import Script from "next/script";
-
-const GA_MEASUREMENT_ID = "G-CXPSS8NM77";
+import {
+  GA_MEASUREMENT_ID, isAnalyticsEnabled
+} from "@/lib/analytics/gtag";
 
 export default function GoogleAnalytics() {
-  if ( process.env.NODE_ENV !== "production" ) {
+  if ( !isAnalyticsEnabled ) {
     return null;
   }
 
@@ -22,7 +23,7 @@ export default function GoogleAnalytics() {
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${ GA_MEASUREMENT_ID }');
+            gtag('config', '${ GA_MEASUREMENT_ID }', { send_page_view: false });
           `
         } }
       />

--- a/src/components/GoogleAnalyticsTracker.tsx
+++ b/src/components/GoogleAnalyticsTracker.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  usePathname, useSearchParams
+} from "next/navigation";
+import {
+  useEffect
+} from "react";
+import {
+  pageview
+} from "@/lib/analytics/gtag";
+
+/**
+ * Tracks client-side navigations in the App Router. The gtag config sets
+ * `send_page_view: false`, so this component is responsible for every
+ * page_view event — including the initial load.
+ */
+export default function GoogleAnalyticsTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(
+    () => {
+      if ( !pathname ) {
+        return;
+      }
+
+      const query = searchParams?.toString();
+      const url = query ? `${ pathname }?${ query }` : pathname;
+
+      pageview( url );
+    },
+    [
+      pathname,
+      searchParams
+    ]
+  );
+
+  return null;
+}

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -1,0 +1,66 @@
+export const GA_MEASUREMENT_ID = "G-CXPSS8NM77";
+
+type GtagCommand = "config" | "event" | "js" | "set";
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: ( command: GtagCommand, ...args: unknown[] ) => void;
+  }
+}
+
+export const isAnalyticsEnabled = process.env.NODE_ENV === "production";
+
+/**
+ * Sends a page_view event to GA4 for the given path. Used to track
+ * client-side route changes in the App Router, since gtag only fires a
+ * pageview automatically on the initial document load.
+ */
+export function pageview( url: string ): void {
+  if ( !isAnalyticsEnabled || typeof window === "undefined" || !window.gtag ) {
+    return;
+  }
+
+  window.gtag(
+    "event",
+    "page_view",
+    {
+      page_path: url,
+      page_location: window.location.origin + url
+    }
+  );
+}
+
+type GtagEventParams = {
+  action: string;
+  category?: string;
+  label?: string;
+  value?: number;
+} & Record<string, unknown>;
+
+/**
+ * Sends a custom event to GA4. Categories/labels/values are mapped to the
+ * conventional GA4 parameter names.
+ */
+export function event( {
+  action,
+  category,
+  label,
+  value,
+  ...rest
+}: GtagEventParams ): void {
+  if ( !isAnalyticsEnabled || typeof window === "undefined" || !window.gtag ) {
+    return;
+  }
+
+  window.gtag(
+    "event",
+    action,
+    {
+      event_category: category,
+      event_label: label,
+      value,
+      ...rest
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Google Analytics was wired up (`GoogleAnalytics.tsx` loading `gtag.js` in the layout, production-only), but in this App Router app it only fired a **single pageview on initial document load**. Client-side navigations between pages/templates were not being tracked.

This PR completes the GA4 integration:

- **`gtag('config', …, { send_page_view: false })`** — the auto pageview is disabled so we own every pageview explicitly (no double-counting).
- **New `GoogleAnalyticsTracker` client component** — uses `usePathname` / `useSearchParams` to emit a `page_view` on every route/query change, including the initial load. Wired into `layout.tsx` behind a `<Suspense>` boundary (required by `useSearchParams`).
- **New shared `src/lib/analytics/gtag.ts`** — holds the (still hardcoded, as requested) measurement ID, an `isAnalyticsEnabled` production guard, `window.gtag` typing, and reusable `pageview()` / `event()` helpers for future custom event tracking.

The measurement ID remains hardcoded (`G-CXPSS8NM77`) per the current request — only de-duplicated into the shared module.

## Notes
- Production-only behavior unchanged: nothing fires when `NODE_ENV !== "production"`.
- `event()` helper is exported for convenience/future use (custom event tracking) and is not yet called anywhere.

## Testing
- `npm run lint` — passes (one pre-existing, unrelated warning).
- `tsc --noEmit` — no errors in the changed files.
- `next build` (pre-push hook) — succeeds.

https://claude.ai/code/session_01AALsR59dFCRdEKsdeJs62o

---
_Generated by [Claude Code](https://claude.ai/code/session_01AALsR59dFCRdEKsdeJs62o)_