### PR TITLE
debug links in menu: (Icons → /debug/icons, OpenGraph → /debug/opengraph)

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -85,6 +85,21 @@ const themeOptions = [
   }
 ] as const;
 
+// Dev-only diagnostic pages. Each route 404s in production (see the
+// notFound() guard inside the pages), so the section is gated the same way.
+const DEBUG_LINKS: NavLink[] = [
+  {
+    href: "/debug/icons",
+    label: "Icons",
+    Icon: ImageIcon
+  },
+  {
+    href: "/debug/opengraph",
+    label: "OpenGraph",
+    Icon: Share2
+  }
+];
+
 function urlBase64ToUint8Array( base64String: string ) {
   const padding = "=".repeat( ( 4 - ( base64String.length % 4 ) ) % 4 );
   const base64 = ( base64String + padding ).replace(
@@ -323,22 +338,6 @@ function MenuBar( {
     } );
   }
 
-  // Dev-only diagnostics — match the gating used inside each /debug page
-  if ( IS_DEV ) {
-    navLinks.push(
-      {
-        href: "/debug/icons",
-        label: "Icons",
-        Icon: ImageIcon
-      },
-      {
-        href: "/debug/opengraph",
-        label: "OpenGraph",
-        Icon: Share2
-      }
-    );
-  }
-
   if ( GITHUB_REPO_URL ) {
     navLinks.push( {
       href: GITHUB_REPO_URL,
@@ -357,7 +356,10 @@ function MenuBar( {
     external: true
   } );
 
-  const internalRoutes = navLinks
+  const internalRoutes = [
+    ...navLinks,
+    ...( IS_DEV ? DEBUG_LINKS : [] )
+  ]
     .filter( ( link ) => !link.external && link.href !== "/" )
     .map( ( link ) => link.href );
 
@@ -439,6 +441,45 @@ function MenuBar( {
             </MenuItem>
           );
         } )}
+
+        {IS_DEV && (
+          <>
+            <Divider />
+            <SectionLabel>Debug</SectionLabel>
+            {DEBUG_LINKS.map( ( {
+              href, label, Icon
+            } ) => {
+              const active = isActive( href );
+
+              return (
+                <MenuItem key={ href }>
+                  {( {
+                    focus
+                  } ) => (
+                    <Link
+                      href={ href }
+                      onClick={ pauseSketchForNav }
+                      className={ clsx(
+                        itemClass,
+                        focus && "bg-hover",
+                        active && "font-semibold"
+                      ) }
+                    >
+                      <Icon className="h-4 w-4 text-foreground/70" />
+                      <span className="flex-1">{label}</span>
+                      {active && (
+                        <span
+                          aria-hidden
+                          className="h-1.5 w-1.5 rounded-full bg-foreground"
+                        />
+                      )}
+                    </Link>
+                  )}
+                </MenuItem>
+              );
+            } )}
+          </>
+        )}
 
         {hasPendingActions && (
           <>

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -12,11 +12,13 @@ import {
   Film,
   Github,
   Home,
+  ImageIcon,
   ImagePlus,
   Menu as MenuIcon,
   Monitor,
   Moon,
   Paintbrush,
+  Share2,
   Sun,
   Video
 } from "lucide-react";
@@ -63,6 +65,7 @@ const BACKEND_RECORDING = process.env.NEXT_PUBLIC_BACKEND_RECORDING === "true";
 const NOTIFICATIONS_ENABLED = process.env.NEXT_PUBLIC_NOTIFICATIONS === "true";
 const SHOW_NOTIFICATIONS = BACKEND_RECORDING && NOTIFICATIONS_ENABLED;
 const GITHUB_REPO_URL = process.env.NEXT_PUBLIC_GITHUB_REPO_URL;
+const IS_DEV = process.env.NODE_ENV === "development";
 
 const themeOptions = [
   {
@@ -318,6 +321,22 @@ function MenuBar( {
       label: "Recordings",
       Icon: Video
     } );
+  }
+
+  // Dev-only diagnostics — match the gating used inside each /debug page
+  if ( IS_DEV ) {
+    navLinks.push(
+      {
+        href: "/debug/icons",
+        label: "Icons",
+        Icon: ImageIcon
+      },
+      {
+        href: "/debug/opengraph",
+        label: "OpenGraph",
+        Icon: Share2
+      }
+    );
   }
 
   if ( GITHUB_REPO_URL ) {


### PR DESCRIPTION
What changed in MenuBar.tsx:

Extracted a module-level DEBUG_LINKS constant (Icons → /debug/icons, OpenGraph → /debug/opengraph).
Removed them from the navLinks push so they no longer appear under "Navigate".
Added a new {IS_DEV && (...)} block that renders <Divider /> + <SectionLabel>Debug</SectionLabel> followed by the two links, mirroring the existing Pending / Theme / Notifications section structure (active-state dot, focus highlight, pauseSketchForNav on click).
Kept the debug routes in internalRoutes (when in dev) so the Home item doesn't falsely highlight as active while you're on a /debug/* page.
Still gated on NODE_ENV === "development", so the whole section is absent from production builds — matching the notFound() guard inside each debug page. Branch remains one commit ahead of origin/main.