### PR TITLE
fix(colors): stop rainbowCrazy palette from crashing the draw loop

### DIFF
--- a/src/templates/p5/utils/colors.js
+++ b/src/templates/p5/utils/colors.js
@@ -59,7 +59,7 @@ const colors = {
 
     return p.color(
       p.map(
-        ( easingFunction ?? p.cos )( hueOffset - hueIndex ),
+        ( easingFunction ?? Math.cos )( hueOffset - hueIndex ),
         -1,
         1,
         min,
@@ -67,7 +67,7 @@ const colors = {
       ) /
         opacityFactor,
       p.map(
-        ( easingFunction ?? p.sin )( hueOffset + hueIndex ),
+        ( easingFunction ?? Math.sin )( hueOffset + hueIndex ),
         -1,
         1,
         max,
@@ -75,7 +75,7 @@ const colors = {
       ) /
         opacityFactor,
       p.map(
-        ( easingFunction ?? p.cos )( hueOffset - hueIndex ),
+        ( easingFunction ?? Math.cos )( hueOffset - hueIndex ),
         -1,
         1,
         max,


### PR DESCRIPTION
## Problème

Sur de nombreux sketchs proposant un sélecteur de **palette / fonction de couleur** (flowers, noise-strips, tree-2d, ribbons, …), l'animation se fige dès qu'on change ce paramètre. Seule l'option par défaut **`rainbow`** fonctionne ; les autres semblent « buguer ».

## Cause racine

Dans le util partagé `src/templates/p5/utils/colors.js`, la palette `rainbowCrazy` résout sa trigonométrie ainsi :

```js
( easingFunction ?? p.cos )( hueOffset - hueIndex )
```

`p.cos` / `p.sin` sont ici **extraits de l'instance p5 puis appelés détachés**. Le binding `this` est perdu, donc l'implémentation interne de p5 (`return Math.cos(this._toRadians(angle))` → `this._angleMode`) lève :

```
TypeError: Cannot read properties of undefined (reading '_toRadians')
```

…ce qui casse la boucle `draw` et fige le canvas au moment où la palette est sélectionnée.

- `rainbow` ne plante pas car il utilise déjà `Math.cos` / `Math.sin`.
- `purple`, `darkBlueYellow` appellent `p.sin(...)` comme **méthode liée** → pas de crash.
- `purpleSimple` / `green` / `black` renvoient une couleur constante → pas de crash (couleur volontairement unie).

Le pattern détaché (`?? p.cos` / `?? p.sin`) n'existe **que** dans `rainbowCrazy`. Le projet connaît déjà ce piège : `mappers.js` utilise `p.cos.bind( p )`.

## Correctif

Aligner `rainbowCrazy` sur son jumeau `rainbow` en utilisant `Math.cos` / `Math.sin` par défaut.

```diff
-        ( easingFunction ?? p.cos )( hueOffset - hueIndex ),
+        ( easingFunction ?? Math.cos )( hueOffset - hueIndex ),
```

Aucun sketch n'utilise `angleMode(DEGREES)` (vérifié), donc en mode radians `p.cos(x) === Math.cos(x)` : **la sortie visuelle est identique, seul le crash disparaît**. Vérifié numériquement — la palette produit toujours des couleurs qui varient correctement (orange → violet → cyan → vert).

## Test

- Reproduction du `TypeError` sur appel détaché de `p.cos`, puis disparition après correctif.
- `node --check` sur le fichier édité : OK.

https://claude.ai/code/session_01TQMrpxbmphkQMCnWLQ6jVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQMrpxbmphkQMCnWLQ6jVG)_