### PR TITLE
Background pattern util (fractional + full-height) + new "background" sketch category

### DIFF
--- a/src/templates/p5/sketches/animated-text-points/animated-text-points-v12-counter/index.js
+++ b/src/templates/p5/sketches/animated-text-points/animated-text-points-v12-counter/index.js
@@ -9,7 +9,7 @@ import mappers from "@/p5/utils/mappers.js";
 import animation from "@/p5/utils/animation.js";
 import string from "@/p5/utils/string.js";
 import gridMask from "@/p5/utils/gridMask.js";
-import iterators from "@/p5/utils/iterators.js";
+import drawBackgroundPattern from "@/p5/utils/backgroundPattern.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 
 sketch.setup(
@@ -18,64 +18,6 @@ sketch.setup(
     type: "webgl"
   }
 );
-
-const drawBackgroundPattern = (
-  p, columns, time, weight, strokeColor
-) => {
-  p.push();
-  p.noFill();
-  p.stroke( ...strokeColor );
-  p.strokeWeight( weight );
-  p.translate(
-    -p.width / 2,
-    -p.height / 2,
-    -200
-  );
-
-  const columnSize = p.width / columns;
-  const halfColumnSize = columnSize / 2;
-  const columnPadding = weight + halfColumnSize;
-  const precision = 0.04;
-
-  for ( let i = 0; i < columns; i++ ) {
-    const x = i * columnSize + halfColumnSize;
-    const top = p.createVector(
-      x,
-      -200
-    );
-    const bottom = p.createVector(
-      x,
-      p.height + 200
-    );
-
-    p.beginShape();
-    iterators.vector(
-      top,
-      bottom,
-      precision,
-      (
-        position, lerpIndex
-      ) => {
-        const driftBound = ( halfColumnSize + columnPadding ) * p.sin( time + i );
-        const driftX = p.map(
-          easing.easeInOutBack( lerpIndex % 1 ),
-          0,
-          1,
-          -driftBound,
-          driftBound
-        );
-
-        p.vertex(
-          position.x + driftX,
-          position.y
-        );
-      }
-    );
-    p.endShape();
-  }
-
-  p.pop();
-};
 
 sketch.draw( async() => {
   const p = getP5();
@@ -127,9 +69,11 @@ sketch.draw( async() => {
       9,
       0
     ];
+    // Keep the count fractional so a new line fades/slides in progressively
+    // instead of snapping into place when the counter ticks over.
     const n = Math.max(
       1,
-      ~~animation.ease( {
+      animation.ease( {
         values: counterValues,
         currentTime: animation.progression * counterValues.length,
         duration: 1,
@@ -137,17 +81,19 @@ sketch.draw( async() => {
       } )
     );
 
-    drawBackgroundPattern(
-      p,
-      n,
-      animation.angle,
-      bgPattern.weight ?? 3,
-      bgPattern.color ?? [
+    drawBackgroundPattern( {
+      columns: n,
+      time: animation.angle,
+      weight: bgPattern.weight ?? 3,
+      color: bgPattern.color ?? [
         255,
         255,
         255
-      ]
-    );
+      ],
+      overshoot: bgPattern.overshoot ?? 200,
+      depth: bgPattern.depth ?? -200,
+      centered: true
+    } );
   }
 
   // return;

--- a/src/templates/p5/sketches/animated-text-points/animated-text-points-v12-counter/options.ts
+++ b/src/templates/p5/sketches/animated-text-points/animated-text-points-v12-counter/options.ts
@@ -35,6 +35,8 @@ export const formValues = {
     enabled: true,
     weight: 1.5,
     easing: "easeInOutExpo",
+    overshoot: 200,
+    depth: -200,
     color: [
       255,
       255,
@@ -223,13 +225,27 @@ export const formConfiguration: Record<string, any> = {
       weight: {
         label: "Line weight",
         component: "slider",
-        min: 0,
+        min: 0.5,
         max: 20,
         step: 0.5
       },
       easing: {
         component: "easing",
         label: "Counter easing"
+      },
+      overshoot: {
+        label: "Line overshoot (px past edges)",
+        component: "slider",
+        min: 0,
+        max: 600,
+        step: 10
+      },
+      depth: {
+        label: "Pattern depth (z)",
+        component: "slider",
+        min: -1000,
+        max: 0,
+        step: 10
       },
       color: {
         component: "color",

--- a/src/templates/p5/utils/backgroundPattern.js
+++ b/src/templates/p5/utils/backgroundPattern.js
@@ -1,0 +1,144 @@
+import easing from "./easing.js";
+import {
+  getP5
+} from "./sketch.js";
+
+/**
+ * Draws a set of vertical, drifting lines used as a background pattern across
+ * the "Animated Text Point" sketches (and any other sketch that wants it).
+ *
+ * Two behaviours are worth calling out:
+ *
+ * 1. `columns` may be fractional. The whole part controls how many fully
+ *    opaque lines are drawn, while the fractional part fades the newest line
+ *    in (and slides it across from the edge). Feeding it an easing value that
+ *    grows smoothly — instead of a truncated integer — makes a new line appear
+ *    progressively rather than snapping into place.
+ *
+ * 2. Every line spans the full canvas height. The polyline is iterated with an
+ *    inclusive end (lerp `0 … 1`), so the first vertex sits exactly on the top
+ *    edge and the last vertex exactly on the bottom edge (plus optional
+ *    `overshoot`). Previously the iteration stopped just short of `1`, leaving
+ *    the path "open" before it reached the bottom.
+ *
+ * @param {Object}   params
+ * @param {number}   params.columns       Number of lines (fractional allowed).
+ * @param {number}   [params.time]        Phase fed into the horizontal drift.
+ * @param {number}   [params.weight]      Stroke weight of each line.
+ * @param {number[]} [params.color]       Stroke color as [r, g, b] or [r, g, b, a].
+ * @param {number}   [params.overshoot]   Pixels the lines extend past the top/bottom edges.
+ * @param {number}   [params.depth]       Z translation (WEBGL only) to push the pattern back.
+ * @param {boolean}  [params.centered]    Translate from the centre to the top-left (WEBGL).
+ * @param {number}   [params.precision]   Lerp step between vertices (smaller = smoother).
+ * @param {Function} [params.easingFn]    Easing applied to the horizontal drift.
+ */
+export default function drawBackgroundPattern( {
+  columns,
+  time = 0,
+  weight = 3,
+  color = [
+    255,
+    255,
+    255
+  ],
+  overshoot = 0,
+  depth = 0,
+  centered = false,
+  precision = 0.04,
+  easingFn = easing.easeInOutBack
+} ) {
+  const p = getP5();
+
+  if ( !( columns > 0 ) ) {
+    return;
+  }
+
+  p.push();
+  p.noFill();
+  p.strokeWeight( weight );
+
+  if ( centered ) {
+    p.translate(
+      -p.width / 2,
+      -p.height / 2,
+      depth
+    );
+  } else if ( depth ) {
+    p.translate(
+      0,
+      0,
+      depth
+    );
+  }
+
+  const columnSize = p.width / columns;
+  const halfColumnSize = columnSize / 2;
+  const columnPadding = weight + halfColumnSize;
+
+  const top = -overshoot;
+  const bottom = p.height + overshoot;
+  const steps = Math.max(
+    1,
+    Math.ceil( 1 / precision )
+  );
+
+  const [
+    r,
+    g,
+    b,
+    a = 255
+  ] = color;
+
+  const lineCount = Math.ceil( columns );
+
+  for ( let i = 0; i < lineCount; i++ ) {
+    // Fractional `columns` fades the newest line in (0 → 1) so it shows up
+    // progressively instead of popping in at full strength.
+    const lineAlpha = p.constrain(
+      columns - i,
+      0,
+      1
+    );
+
+    if ( lineAlpha <= 0 ) {
+      continue;
+    }
+
+    const x = i * columnSize + halfColumnSize;
+    const driftBound = ( halfColumnSize + columnPadding ) * p.sin( time + i );
+
+    p.stroke(
+      r,
+      g,
+      b,
+      a * lineAlpha
+    );
+    p.beginShape();
+
+    for ( let step = 0; step <= steps; step++ ) {
+      // `0 … 1` inclusive → the line spans the full height, top to bottom.
+      const lerpIndex = step / steps;
+      const y = p.lerp(
+        top,
+        bottom,
+        lerpIndex
+      );
+      const driftX = p.map(
+        easingFn( lerpIndex ),
+        0,
+        1,
+        -driftBound,
+        driftBound
+      );
+
+      p.vertex(
+        x + driftX,
+        y
+      );
+    }
+
+    p.endShape();
+  }
+
+  p.pop();
+}


### PR DESCRIPTION
## Vue d'ensemble

Cette PR fait deux choses liées autour des fonds (« backgrounds ») :

1. **Corrige et factorise** le motif de lignes verticales dérivantes en util partagé.
2. **Crée une nouvelle catégorie de sketchs `background`** qui rassemble les techniques de fond éparpillées dans les autres sketchs, une par type.

---

## Partie 1 — Util partagé `backgroundPattern.js`

Dans `animated-text-points-v12-counter`, le motif de lignes verticales était codé en dur, avec deux bugs :

- **Apparition progressive** : le nombre de lignes accepte désormais une **valeur décimale** — la partie entière dessine les lignes pleines, la partie fractionnaire fait **apparaître la nouvelle ligne petit à petit** (fondu alpha + glissement). Le compteur ne tronque plus en entier (`~~` retiré).
- **Pleine hauteur** : le tracé est parcouru avec une borne **inclusive** (`lerp 0 → 1`), donc la ligne part exactement du haut et atteint exactement le bas. Avant, l'itération s'arrêtait juste avant `1` et laissait le chemin « ouvert ».

Extrait dans `src/templates/p5/utils/backgroundPattern.js`, options `overshoot`/`depth` exposées dans le formulaire de `v12-counter`.

---

## Partie 2 — Nouvelle catégorie `background`

`src/templates/p5/sketches/background/`, un sketch par technique (chacun avec son `options.ts` réglable depuis l'UI) :

| Sketch | Technique | Réutilise |
| --- | --- | --- |
| `background-lines` | lignes verticales dérivantes, le nombre de lignes respire (apparition progressive) | `backgroundPattern.js` |
| `background-grid` | grille droite (colonnes / lignes / bordure) | `shapes.grid` |
| `background-dots` | champ de points, pulsation de taille optionnelle (loop-safe) | `shapes.dots` |
| `background-crosses` | grille de croix / astérisques, couleur par palette + rotation continue | `shapes.cross` |

La catégorie est faite pour grandir : d'autres types de fond viendront s'ajouter (un dossier = un type). `metadata.json` régénéré pour les rendre découvrables.

---

## Vérifications
- `eslint` : OK
- `jest` : 808/808 ✅ (les tests de `metadata.json` valident la synchro disque ↔ métadonnées des 4 nouveaux sketchs)
- `next build` : OK

https://claude.ai/code/session_01UTqBcWedvFRbHh9r1Q226A