### PR TITLE
Fix dead easing controls across the noise-grid GPU sketches (v2, v6, v8, v12)

### DIFF
--- a/src/templates/p5/sketches/noise-grid/noise-grid-v12-field-on-fire/index.js
+++ b/src/templates/p5/sketches/noise-grid/noise-grid-v12-field-on-fire/index.js
@@ -4,7 +4,9 @@ import sketch, {
 } from "@/p5/utils/sketch.js";
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
-import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
+import createNoiseFieldRenderer, {
+  easingId
+} from "@/p5/utils/noiseFieldGpu.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GPU port of "noise grid v12 — field on fire".
@@ -29,6 +31,8 @@ const FRAGMENT = `
   uniform float uWaveSpeed;
   uniform float uOpacityMax;
   uniform float uOpacityMin;
+  uniform int uWaveEasing;
+  uniform int uFalloffEasing;
 
   float cellAngle(float c, float r) {
     float nx = (c * uCellWidth) / uColumns + uT * uXTimeMult;
@@ -41,12 +45,12 @@ const FRAGMENT = `
     float z = uZMax * cos(angle);
     float distToCenter = distance(cellCenter, uCenter);
 
-    float waveT = easeOutQuad(remap(sin(uT * uWaveSpeed + angle), -1.0, 1.0, 0.0, 1.0));
+    float waveT = applyEasing(uWaveEasing, remap(sin(uT * uWaveSpeed + angle), -1.0, 1.0, 0.0, 1.0));
     float w = remap(waveT, 0.0, 1.0, -uResolution.x * 0.5, uResolution.x * 0.5);
     float safeW = abs(w) < 0.001 ? (w < 0.0 ? -0.001 : 0.001) : w;
 
     float opacityFactor = remap(
-      easeOutQuad(remap(distToCenter, 0.0, safeW, 0.0, 1.0)),
+      applyEasing(uFalloffEasing, remap(distToCenter, 0.0, safeW, 0.0, 1.0)),
       0.0,
       1.0,
       uOpacityMax,
@@ -139,6 +143,8 @@ sketch.draw( (
   const yTimeMult = options.sketch.noise?.yTimeMultiplier ?? 0.125;
   const zTimeMult = options.sketch.noise?.zTimeMultiplier ?? 0.05;
   const waveSpeed = options.sketch.distance?.waveSpeed ?? 1;
+  const waveEasing = options.sketch.distance?.waveEasing ?? "easeOutQuad";
+  const falloffEasing = options.sketch.distance?.falloffEasing ?? "easeOutQuad";
   const hueOffsetSpeed = options.sketch.colors?.hueOffsetSpeed ?? 1;
   const hueIndexMultiplier = options.sketch.colors?.hueIndexMultiplier ?? 2;
   const opacityMax = options.sketch.colors?.opacityMax ?? 10;
@@ -169,7 +175,9 @@ sketch.draw( (
       uHueIndexMult: hueIndexMultiplier,
       uWaveSpeed: waveSpeed,
       uOpacityMax: opacityMax,
-      uOpacityMin: opacityMin
+      uOpacityMin: opacityMin,
+      uWaveEasing: easingId( waveEasing ),
+      uFalloffEasing: easingId( falloffEasing )
     }
   } );
 

--- a/src/templates/p5/sketches/noise-grid/noise-grid-v2-basic-with-easing/index.js
+++ b/src/templates/p5/sketches/noise-grid/noise-grid-v2-basic-with-easing/index.js
@@ -6,18 +6,18 @@ import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
   createInstancedFieldRenderer,
-  computeFieldRange
+  computeFieldRange,
+  easingId
 } from "@/p5/utils/noiseFieldGpu.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GPU port of "noise grid v2 — basic with easing" (instanced).
 //
 // One dot per cell, displaced by (sin, cos) of the noise angle and sized by an
-// easeInOutExpo mapping of the angle over the converged min..TAU range. Dots
-// cross cell borders, so each is drawn as its own instance in grid order.
-//
-// NOTE: the weight easing is baked to the preset's easeInOutExpo; the easing
-// dropdown isn't wired through to the shader (same as the other GPU ports).
+// eased mapping of the angle over the converged min..TAU range. Dots cross cell
+// borders, so each is drawn as its own instance in grid order. The weight easing
+// is selectable: the "Weight easing" control feeds applyEasing() in the vertex
+// shader (defaults to the preset's easeInOutExpo).
 // ─────────────────────────────────────────────────────────────────────────────
 
 const VERTEX = `
@@ -33,6 +33,7 @@ const VERTEX = `
   uniform float uHueRange;
   uniform float uHueOffset;
   uniform float uOpacityFactor;
+  uniform int uWeightEasing;
 
   void computeInstance(
     float col, float row,
@@ -47,7 +48,7 @@ const VERTEX = `
     )) * TAU * uAngleCycles;
 
     float weight = remap(
-      easeInOutExpo(remap(angle, uMin, TAU, 0.0, 1.0)),
+      applyEasing(uWeightEasing, remap(angle, uMin, TAU, 0.0, 1.0)),
       0.0,
       1.0,
       uWeightMin,
@@ -112,6 +113,7 @@ sketch.draw( () => {
   const angleCycles = options.sketch.angle?.cycles ?? 4;
   const weightMin = options.sketch.stroke?.weightMin ?? 1;
   const weightMaxScale = options.sketch.stroke?.weightMaxScale ?? 1;
+  const weightEasing = options.sketch.stroke?.weightEasing ?? "easeInOutExpo";
   const hueRange = options.sketch.colors?.hueRange ?? p.PI / 2;
   const hueOffset = options.sketch.colors?.hueOffset ?? 0;
   const opacityFactor = options.sketch.colors?.opacityFactor ?? 1.5;
@@ -213,7 +215,8 @@ sketch.draw( () => {
       uTranslateYMult: translateYMult,
       uHueRange: hueRange,
       uHueOffset: hueOffset,
-      uOpacityFactor: opacityFactor
+      uOpacityFactor: opacityFactor,
+      uWeightEasing: easingId( weightEasing )
     }
   } );
 

--- a/src/templates/p5/sketches/noise-grid/noise-grid-v6-field-with-dist-check/index.js
+++ b/src/templates/p5/sketches/noise-grid/noise-grid-v6-field-with-dist-check/index.js
@@ -5,7 +5,7 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import createNoiseFieldRenderer, {
-  computeFieldRange
+  computeFieldRange, easingId
 } from "@/p5/utils/noiseFieldGpu.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -31,6 +31,8 @@ const FRAGMENT = `
   uniform float uWaveSpeed;
   uniform float uOpacityMax;
   uniform float uOpacityMin;
+  uniform int uWaveEasing;
+  uniform int uFalloffEasing;
 
   void main() {
     vec2 frag = vec2(vUv.x * uResolution.x, (1.0 - vUv.y) * uResolution.y);
@@ -62,10 +64,10 @@ const FRAGMENT = `
 
     float hueIndex = remap(angle, uMin, TAU, -uHueRange, uHueRange);
 
-    float waveT = easeOutQuad(remap(sin(uT * uWaveSpeed + angle), -1.0, 1.0, 0.0, 1.0));
+    float waveT = applyEasing(uWaveEasing, remap(sin(uT * uWaveSpeed + angle), -1.0, 1.0, 0.0, 1.0));
     float w = remap(waveT, 0.0, 1.0, uResolution.x * uWaveMin, uResolution.x * uWaveMax);
     float opacityFactor = remap(
-      easeInQuad(remap(distToCenter, 0.0, w, 0.0, 1.0)),
+      applyEasing(uFalloffEasing, remap(distToCenter, 0.0, w, 0.0, 1.0)),
       0.0,
       1.0,
       uOpacityMax,
@@ -108,6 +110,8 @@ sketch.draw( (
   const waveMin = options.sketch.distance?.waveMin ?? 0.5;
   const waveMax = options.sketch.distance?.waveMax ?? 1;
   const waveSpeed = options.sketch.distance?.waveSpeed ?? 1;
+  const waveEasing = options.sketch.distance?.waveEasing ?? "easeOutQuad";
+  const falloffEasing = options.sketch.distance?.falloffEasing ?? "easeInQuad";
   const opacityMax = options.sketch.colors?.opacityMax ?? 100;
   const opacityMin = options.sketch.colors?.opacityMin ?? 1;
   const hueRange = options.sketch.colors?.hueRange ?? p.PI / 4;
@@ -163,7 +167,9 @@ sketch.draw( (
       uWaveMax: waveMax,
       uWaveSpeed: waveSpeed,
       uOpacityMax: opacityMax,
-      uOpacityMin: opacityMin
+      uOpacityMin: opacityMin,
+      uWaveEasing: easingId( waveEasing ),
+      uFalloffEasing: easingId( falloffEasing )
     }
   } );
 

--- a/src/templates/p5/sketches/noise-grid/noise-grid-v8-pulse-easing/index.js
+++ b/src/templates/p5/sketches/noise-grid/noise-grid-v8-pulse-easing/index.js
@@ -8,7 +8,8 @@ import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
   createInstancedFieldRenderer,
-  computeFieldRange
+  computeFieldRange,
+  easingId
 } from "@/p5/utils/noiseFieldGpu.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -33,6 +34,7 @@ const VERTEX = `
   uniform float uOpacityFactor;
   uniform float uWeightMin;
   uniform float uWeightMax;
+  uniform int uWeightEasing;
 
   void computeInstance(
     float col, float row,
@@ -49,7 +51,7 @@ const VERTEX = `
 
     // Unclamped, exactly like the original — extrapolates on the pulse.
     float weight = remap(
-      easeInOutCubic(remap(angle, uMin, TAU, 0.0, 1.0)),
+      applyEasing(uWeightEasing, remap(angle, uMin, TAU, 0.0, 1.0)),
       0.0,
       1.0,
       uWeightMin,
@@ -105,6 +107,7 @@ sketch.draw( () => {
   const zTimeMult = options.sketch.noise?.zTimeMultiplier ?? 0.1;
   const weightMin = options.sketch.stroke?.weightMin ?? 1;
   const weightMax = options.sketch.stroke?.weightMax ?? 10;
+  const weightEasing = options.sketch.stroke?.weightEasing ?? "easeInOutCubic";
   const hueRange = options.sketch.colors?.hueRange ?? p.PI / 2;
   const hueOffset = options.sketch.colors?.hueOffset ?? 0;
   const opacityFactor = options.sketch.colors?.opacityFactor ?? 1.5;
@@ -175,7 +178,8 @@ sketch.draw( () => {
       uHueOffset: hueOffset,
       uOpacityFactor: opacityFactor,
       uWeightMin: weightMin,
-      uWeightMax: weightMax
+      uWeightMax: weightMax,
+      uWeightEasing: easingId( weightEasing )
     }
   } );
 

--- a/src/templates/p5/utils/__tests__/easingIds.test.ts
+++ b/src/templates/p5/utils/__tests__/easingIds.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guards the JS <-> GLSL easing bridge used by the GPU noise-field sketches.
+ *
+ * The "easing" form control stores a key (e.g. "easeOutQuart"). easingGlsl.js
+ * maps that key to an int (EASING_IDS) that the shader's applyEasing() switches
+ * on. Three things must hold for a dropdown pick to actually change the render:
+ *   1. every easing in utils/easing.js has an id,
+ *   2. the ids are a clean 0..N range with no gaps or dupes,
+ *   3. applyEasing() in the GLSL has a branch for every non-zero id.
+ * If any drifts, the control silently falls back to linear again — exactly the
+ * bug this bridge was added to fix.
+ */
+
+import easing from "../easing.js";
+import {
+  EASING_IDS, EASINGS_GLSL, easingId
+} from "../easingGlsl.js";
+
+describe(
+  "easing id bridge",
+  () => {
+    const easingKeys = Object.keys( easing );
+    const idKeys = Object.keys( EASING_IDS );
+
+    it(
+      "covers exactly the keys exported by utils/easing.js",
+      () => {
+        expect( [
+          ...idKeys
+        ].sort() ).toEqual( [
+          ...easingKeys
+        ].sort() );
+      }
+    );
+
+    it(
+      "assigns a contiguous, unique 0..N id range",
+      () => {
+        const ids = Object.values( EASING_IDS );
+        const unique = new Set( ids );
+
+        expect( unique.size ).toBe( ids.length );
+
+        const sorted = [
+          ...ids
+        ].sort( (
+          a, b
+        ) => a - b );
+
+        expect( sorted[ 0 ] ).toBe( 0 );
+
+        sorted.forEach( (
+          id, index
+        ) => {
+          expect( id ).toBe( index );
+        } );
+      }
+    );
+
+    it(
+      "has a GLSL applyEasing branch for every non-zero id",
+      () => {
+        Object.values( EASING_IDS )
+          .filter( ( id ) => id !== 0 )
+          .forEach( ( id ) => {
+            expect( EASINGS_GLSL ).toContain( `if (id == ${ id })` );
+          } );
+      }
+    );
+
+    it(
+      "exposes linear as id 0 and falls back to it for unknown keys",
+      () => {
+        expect( EASING_IDS.linear ).toBe( 0 );
+        expect( easingId( "linear" ) ).toEqual( {
+          int: 0
+        } );
+        expect( easingId( "not-an-easing" ) ).toEqual( {
+          int: 0
+        } );
+        expect( easingId( undefined as unknown as string ) ).toEqual( {
+          int: 0
+        } );
+      }
+    );
+
+    it(
+      "wraps a known key as its int-uniform payload",
+      () => {
+        expect( easingId( "easeOutQuart" ) ).toEqual( {
+          int: EASING_IDS.easeOutQuart
+        } );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/easingGlsl.js
+++ b/src/templates/p5/utils/easingGlsl.js
@@ -1,0 +1,177 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Selectable easing for the GPU sketches.
+//
+// GLSL has no function pointers, so the noise-field shaders can't take an easing
+// function the way the CPU sketches do (mappers.fn(..., easing.easeFoo)). The
+// "easing" form control therefore used to be dead on every GPU port — the shader
+// baked one fixed curve and ignored the dropdown.
+//
+// This module closes that gap: EASING_IDS maps each easing key (the same keys as
+// utils/easing.js) to a small integer, and EASINGS_GLSL is a GLSL block whose
+// applyEasing(int id, float x) dispatches on that integer. A sketch passes
+// easingId(key) as an int uniform and calls applyEasing(uId, t) in the shader.
+//
+// The two halves MUST stay in sync — every key in utils/easing.js has an id
+// here, and applyEasing has a branch for every non-zero id. easingIds.test.ts
+// guards both directions.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Keys mirror utils/easing.js (plus "linear"). 0 == linear / unknown.
+export const EASING_IDS = {
+  linear: 0,
+  easeInSine: 1,
+  easeOutSine: 2,
+  easeInOutSine: 3,
+  easeInQuad: 4,
+  easeOutQuad: 5,
+  easeInOutQuad: 6,
+  easeInCubic: 7,
+  easeOutCubic: 8,
+  easeInOutCubic: 9,
+  easeInQuart: 10,
+  easeOutQuart: 11,
+  easeInOutQuart: 12,
+  easeInQuint: 13,
+  easeOutQuint: 14,
+  easeInOutQuint: 15,
+  easeInExpo: 16,
+  easeOutExpo: 17,
+  easeInOutExpo: 18,
+  easeInCirc: 19,
+  easeOutCirc: 20,
+  easeInOutCirc: 21,
+  easeInBack: 22,
+  easeOutBack: 23,
+  easeInOutBack: 24,
+  easeInElastic: 25,
+  easeOutElastic: 26,
+  easeInOutElastic: 27,
+  easeInBounce: 28,
+  easeOutBounce: 29,
+  easeInOutBounce: 30
+};
+
+/**
+ * The int-uniform payload for an easing key, ready to drop into a render()
+ * uniforms object. Unknown / missing keys fall back to linear (0).
+ *
+ * @param {string} key easing key (e.g. "easeOutQuart"), as stored by the form
+ * @returns {{ int: number }}
+ */
+export function easingId( key ) {
+  return {
+    int: EASING_IDS[ key ] ?? 0
+  };
+}
+
+// GLSL ports of the easings missing from MAPPERS_GLSL, plus applyEasing(). This
+// block is injected AFTER MAPPERS_GLSL, so it reuses the sine/quad/cubic/back
+// curves already defined there and only adds the rest. Polynomial families use
+// multiplication rather than pow() for the same reason MAPPERS_GLSL does: the
+// mappers feed unclamped inputs (outside 0..1), and pow(negative, n) is
+// undefined in GLSL whereas the JS originals use Math.pow with integer
+// exponents. exp2(n) == Math.pow(2, n), so the expo/elastic curves match too
+// (bar the x==0 / x==1 short-circuits, negligible for these inputs).
+export const EASINGS_GLSL = `
+  float easeInQuart(float x) { return x * x * x * x; }
+  float easeOutQuart(float x) { float u = 1.0 - x; return 1.0 - u * u * u * u; }
+
+  float easeInQuint(float x) { return x * x * x * x * x; }
+  float easeOutQuint(float x) { float u = 1.0 - x; return 1.0 - u * u * u * u * u; }
+  float easeInOutQuint(float x) {
+    if (x < 0.5) { return 16.0 * x * x * x * x * x; }
+    float u = -2.0 * x + 2.0;
+    return 1.0 - (u * u * u * u * u) / 2.0;
+  }
+
+  float easeInExpo(float x) { return exp2(10.0 * x - 10.0); }
+  float easeOutExpo(float x) { return 1.0 - exp2(-10.0 * x); }
+
+  float easeInCirc(float x) { return 1.0 - sqrt(1.0 - x * x); }
+  float easeOutCirc(float x) { float u = x - 1.0; return sqrt(1.0 - u * u); }
+  float easeInOutCirc(float x) {
+    if (x < 0.5) {
+      float u = 2.0 * x;
+      return (1.0 - sqrt(1.0 - u * u)) / 2.0;
+    }
+    float u = -2.0 * x + 2.0;
+    return (sqrt(1.0 - u * u) + 1.0) / 2.0;
+  }
+
+  float easeInOutBack(float x) {
+    float c1 = 1.70158;
+    float c2 = c1 * 1.525;
+    if (x < 0.5) {
+      float u = 2.0 * x;
+      return (u * u * ((c2 + 1.0) * u - c2)) / 2.0;
+    }
+    float u = 2.0 * x - 2.0;
+    return (u * u * ((c2 + 1.0) * u + c2) + 2.0) / 2.0;
+  }
+
+  float easeInElastic(float x) {
+    float c4 = TAU / 3.0;
+    return -exp2(10.0 * x - 10.0) * sin((x * 10.0 - 10.75) * c4);
+  }
+  float easeOutElastic(float x) {
+    float c4 = TAU / 3.0;
+    return exp2(-10.0 * x) * sin((x * 10.0 - 0.75) * c4) + 1.0;
+  }
+  float easeInOutElastic(float x) {
+    float c5 = TAU / 4.5;
+    if (x < 0.5) {
+      return -(exp2(20.0 * x - 10.0) * sin((20.0 * x - 11.125) * c5)) / 2.0;
+    }
+    return (exp2(-20.0 * x + 10.0) * sin((20.0 * x - 11.125) * c5)) / 2.0 + 1.0;
+  }
+
+  float easeOutBounce(float x) {
+    float n1 = 7.5625;
+    float d1 = 2.75;
+    if (x < 1.0 / d1) { return n1 * x * x; }
+    if (x < 2.0 / d1) { float u = x - 1.5 / d1; return n1 * u * u + 0.75; }
+    if (x < 2.5 / d1) { float u = x - 2.25 / d1; return n1 * u * u + 0.9375; }
+    float u = x - 2.625 / d1;
+    return n1 * u * u + 0.984375;
+  }
+  float easeInBounce(float x) { return 1.0 - easeOutBounce(1.0 - x); }
+  float easeInOutBounce(float x) {
+    if (x < 0.5) { return (1.0 - easeOutBounce(1.0 - 2.0 * x)) / 2.0; }
+    return (1.0 + easeOutBounce(2.0 * x - 1.0)) / 2.0;
+  }
+
+  // Runtime easing pick. IDs mirror EASING_IDS (JS); 0 / unknown -> linear.
+  float applyEasing(int id, float x) {
+    if (id == 1) { return easeInSine(x); }
+    if (id == 2) { return easeOutSine(x); }
+    if (id == 3) { return easeInOutSine(x); }
+    if (id == 4) { return easeInQuad(x); }
+    if (id == 5) { return easeOutQuad(x); }
+    if (id == 6) { return easeInOutQuad(x); }
+    if (id == 7) { return easeInCubic(x); }
+    if (id == 8) { return easeOutCubic(x); }
+    if (id == 9) { return easeInOutCubic(x); }
+    if (id == 10) { return easeInQuart(x); }
+    if (id == 11) { return easeOutQuart(x); }
+    if (id == 12) { return easeInOutQuart(x); }
+    if (id == 13) { return easeInQuint(x); }
+    if (id == 14) { return easeOutQuint(x); }
+    if (id == 15) { return easeInOutQuint(x); }
+    if (id == 16) { return easeInExpo(x); }
+    if (id == 17) { return easeOutExpo(x); }
+    if (id == 18) { return easeInOutExpo(x); }
+    if (id == 19) { return easeInCirc(x); }
+    if (id == 20) { return easeOutCirc(x); }
+    if (id == 21) { return easeInOutCirc(x); }
+    if (id == 22) { return easeInBack(x); }
+    if (id == 23) { return easeOutBack(x); }
+    if (id == 24) { return easeInOutBack(x); }
+    if (id == 25) { return easeInElastic(x); }
+    if (id == 26) { return easeOutElastic(x); }
+    if (id == 27) { return easeInOutElastic(x); }
+    if (id == 28) { return easeInBounce(x); }
+    if (id == 29) { return easeOutBounce(x); }
+    if (id == 30) { return easeInOutBounce(x); }
+    return x;
+  }
+`;

--- a/src/templates/p5/utils/noiseFieldGpu.js
+++ b/src/templates/p5/utils/noiseFieldGpu.js
@@ -3,6 +3,15 @@ import graphics from "./graphics.js";
 import {
   getP5
 } from "./sketch.js";
+import {
+  EASINGS_GLSL, easingId
+} from "./easingGlsl.js";
+
+// Re-exported so sketches can grab the renderer and the easing-uniform helper
+// from one place.
+export {
+  easingId
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared GPU engine for the noise-grid family.
@@ -685,7 +694,7 @@ export default function createNoiseFieldRenderer( fragmentSource ) {
     state.program = buildProgram(
       gl,
       VERT_SRC,
-      COMMON_GLSL + MAPPERS_GLSL + PALETTES_GLSL + SHAPES_GLSL + fragmentSource
+      COMMON_GLSL + MAPPERS_GLSL + EASINGS_GLSL + PALETTES_GLSL + SHAPES_GLSL + fragmentSource
     );
 
     state.locs = {};
@@ -1126,7 +1135,7 @@ export function createInstancedFieldRenderer( {
       gl.deleteProgram( state.program );
     }
 
-    const stdlib = COMMON_GLSL + MAPPERS_GLSL + PALETTES_GLSL + SHAPES_GLSL;
+    const stdlib = COMMON_GLSL + MAPPERS_GLSL + EASINGS_GLSL + PALETTES_GLSL + SHAPES_GLSL;
 
     state.program = buildProgram(
       gl,


### PR DESCRIPTION
## Problem

The easing dropdowns on the GPU-ported noise-grid sketches did nothing — changing them had zero visible effect:

- **v6** — Wave easing / Falloff easing
- **v12** — Wave easing / Falloff easing
- **v8** — Weight easing
- **v2** — Weight easing

Two reasons, shared across all of them:
1. `index.js` never read the easing values from the options, so the form picks were dropped on the floor.
2. The shaders **hard-coded** the curve (e.g. v6 baked `easeOutQuad`/`easeInQuad`).

Root cause is structural: GLSL has no function pointers, so the GPU ports couldn't accept a selectable easing the way the CPU sketches do (`mappers.fn(..., easing.easeFoo)`). v2 even documented the limitation in a comment.

## Fix

Added a reusable JS↔GLSL easing bridge in `easingGlsl.js`:
- `EASING_IDS` maps every easing key (same keys as `utils/easing.js`) to a small integer.
- `EASINGS_GLSL` adds the curves missing from the shader stdlib plus `applyEasing(int id, float x)` that dispatches on that integer.
- `easingId(key)` wraps a key as the `{ int }` uniform payload.

`noiseFieldGpu.js` injects the block into both render paths (full-screen and instanced), so `applyEasing()` is available in both the vertex and fragment stages. Each sketch now reads its easing option(s), passes them as `int` uniforms, and calls `applyEasing()` instead of the baked curve:

| Sketch | Control(s) | Was baked | Now |
|---|---|---|---|
| v6 | wave + falloff | `easeOutQuad` / `easeInQuad` | live |
| v12 | wave + falloff | `easeOutQuad` (both) | live |
| v8 | weight (vertex) | `easeInOutCubic` | live |
| v2 | weight (vertex) | `easeInOutExpo` | live |

Each falls back to its previously-baked curve when the option is absent, so nothing breaks if an option is missing.

## Note on default look

The saved presets sometimes differ from the previously-baked curve (e.g. v6's preset is `easeInOutQuad`/`easeOutQuart`, v12's falloff preset is `easeInSine`, v8's weight preset is `easeOutSine`). Honouring the preset — the whole point of the fix — shifts those sketches' default appearance slightly, so their thumbnails/previews may want regenerating. v2's preset already matched its baked curve, so it's unchanged by default.

## Tests

`easingIds.test.ts` guards that the JS ids and the GLSL `applyEasing` branches stay in sync with `utils/easing.js` (every key has an id, ids form a clean `0..N` range, every non-zero id has a GLSL branch).

https://claude.ai/code/session_01YbWgEdQpvn3iUTAzmJBb7g