### PR TITLE
Cours de shaders (M0-M1) + playground live

### DIFF
--- a/learning/shaders/PROGRESS.md
+++ b/learning/shaders/PROGRESS.md
@@ -1,0 +1,41 @@
+# Progression & répétition espacée
+
+> **Pour une future session Claude** : c'est la mémoire du cours.
+> - **Session de révision** (ex. déclenchée par un rappel programmé) : prends les
+>   notions dont `Prochaine révision` ≤ date du jour, interroge l'élève dessus
+>   (de mémoire, pas de copier-coller), puis recale la date selon l'intervalle de
+>   répétition espacée ci-dessous. Ne révise QUE ce qui est dû, max ~4 notions.
+> - **Session de cours** : commence par 1–2 révisions dues, puis enchaîne sur la
+>   prochaine leçon non commencée.
+> - Mets toujours ce fichier à jour à la fin de la session, et commit.
+
+**Intervalles** (à partir de la date où la notion est jugée acquise) :
+`1j → 3j → 7j → 16j → 35j → 70j`. Si l'élève sèche sur une révision, on repart à `1j`.
+
+**Statuts** : `à voir` · `en cours` · `acquis` · `à réviser`
+
+## État par module
+
+| Module | Notion clé | Statut | Dernière révision | Prochaine révision |
+|---|---|---|---|---|
+| M0 | Mental model : 1 exécution par pixel, pas d'état, sortie = couleur | en cours | — | — |
+| M1 | UV : repère 0..1, centrage, aspect ratio | en cours | — | — |
+| M2 | SDF du cercle (`discMask`, `smoothstep`) | à voir | — | — |
+| M3 | Segments (`segmentDistance`) | à voir | — | — |
+| M4 | Répétition de domaine (`fract`, `mod`) | à voir | — | — |
+| M5 | `remap` & easings GLSL | à voir | — | — |
+| M6 | Perlin sur GPU | à voir | — | — |
+| M7 | Palettes | à voir | — | — |
+| M8 | Composition & blending | à voir | — | — |
+| M9 | Vertex shader & matrices | à voir | — | — |
+| M10 | Raymarching | à voir | — | — |
+
+## Journal de session
+
+| Date | Ce qui a été fait | Prochaine étape |
+|---|---|---|
+| 2026-06-07 | Mise en place du cours. Démarrage M0–M1 (lecture + exercices à faire). | L'élève fait les exos M0–M1 dans le playground ; corriger, puis M2. |
+
+## Carnet d'erreurs récurrentes
+
+_(à remplir au fil de l'eau : confusions fréquentes, pièges à re-tester en révision)_

--- a/learning/shaders/PROGRESS.md
+++ b/learning/shaders/PROGRESS.md
@@ -35,6 +35,11 @@
 | Date | Ce qui a été fait | Prochaine étape |
 |---|---|---|
 | 2026-06-07 | Mise en place du cours. Démarrage M0–M1 (lecture + exercices à faire). | L'élève fait les exos M0–M1 dans le playground ; corriger, puis M2. |
+| 2026-06-14 | **Toutes** les leçons M2→M10 rédigées d'avance (lecture hors-ligne, corrigés inclus) avant un vol sans internet. | À son retour : corriger les exos faits hors-ligne (M0→…), valider la progression, caler la répétition espacée. |
+
+> Note : les fichiers de leçon existent tous, mais le **statut** ci-dessus reste « à voir » tant
+> que l'élève n'a pas fait les exos + memory checks de chaque module. Ne pas confondre « écrit »
+> et « acquis ».
 
 ## Carnet d'erreurs récurrentes
 

--- a/learning/shaders/README.md
+++ b/learning/shaders/README.md
@@ -39,19 +39,21 @@ ton repo. Garde ces fichiers ouverts pendant le cours :
 ## Le programme
 
 **Piste A — Fragment / 2D** (la majorité de tes sketchs)
-- **M0** Le mental model — chaque pixel se pose une question
-- **M1** L'espace du pixel — les UV (= l'équivalent de translate/scale)
-- **M2** Dessiner = SDF : le cercle (`discMask`)
-- **M3** Lignes & segments (`segmentDistance`)
-- **M4** Grilles & répétition SANS boucle (`fract`, `mod`)
-- **M5** map & easing en GLSL
-- **M6** Le bruit de Perlin sur GPU (cœur de `noise-grid`)
-- **M7** Couleur & palettes
-- **M8** Composition, ordre de dessin, blending
+- **M0–M1** [Le mental model & les UV](lessons/M0-M1-mental-model-and-uv.md) — chaque pixel se pose une question ; se repérer (= translate/scale)
+- **M2** [Dessiner = SDF : le cercle](lessons/M2-sdf-circle.md) (`discMask`)
+- **M3** [Lignes & segments](lessons/M3-lines-segments.md) (`segmentDistance`)
+- **M4** [Grilles & répétition SANS boucle](lessons/M4-grids-repetition.md) (`fract`, `mod`)
+- **M5** [map & easing en GLSL](lessons/M5-map-easing.md)
+- **M6** [Le bruit de Perlin sur GPU](lessons/M6-perlin-noise-gpu.md) (cœur de `noise-grid`)
+- **M7** [Couleur & palettes](lessons/M7-color-palettes.md)
+- **M8** [Composition, ordre de dessin, blending](lessons/M8-composition-blending.md)
 
 **Piste B — 3D / Vertex**
-- **M9** Vertex shader & matrices (dissection de `peaks-cone`)
-- **M10** Raymarching (avancé, optionnel)
+- **M9** [Vertex shader & matrices](lessons/M9-vertex-shader-3d.md) (dissection de `peaks-cone`)
+- **M10** [Raymarching](lessons/M10-raymarching.md) (avancé, optionnel)
+
+> **Toutes les leçons sont déjà écrites** (lecture hors-ligne possible), chacune avec ses
+> exercices et leurs **corrigés en `<details>`** pour t'auto-évaluer sans connexion.
 
 ## Le playground
 

--- a/learning/shaders/README.md
+++ b/learning/shaders/README.md
@@ -55,6 +55,11 @@ ton repo. Garde ces fichiers ouverts pendant le cours :
 > **Toutes les leçons sont déjà écrites** (lecture hors-ligne possible), chacune avec ses
 > exercices et leurs **corrigés en `<details>`** pour t'auto-évaluer sans connexion.
 
+**Transversal**
+- 📌 [Pièges, astuces, perf & bonus](REFERENCE-traps-tips-perf.md) — la fiche de référence à
+  garder sous la main : bugs sournois (NaN, types, précision), tweaks de perf (branches,
+  raymarch, full-screen vs instancing), boucles seamless pour les réseaux, et tours en bonus.
+
 ## Le playground
 
 `playground/index.html` — un éditeur de fragment shader **en direct**. Ouvre-le dans

--- a/learning/shaders/README.md
+++ b/learning/shaders/README.md
@@ -1,0 +1,69 @@
+# Apprendre les shaders — orienté p5-templates
+
+Un cours progressif pour passer du dessin 2D/3D en p5.js (CPU) aux **shaders** (GPU),
+construit autour de **ton propre code**. Le but final : pouvoir démarrer un sketch
+directement en shader.
+
+## Comment ça marche
+
+Chaque leçon suit toujours le même rituel — c'est lui qui crée la mémorisation :
+
+1. **Concept** — l'intuition, courte.
+2. **Lecture de ton code** — la version CPU que tu connais, puis sa version GPU
+   déjà présente dans le repo.
+3. **Exercice** — tu codes, dans le playground.
+4. **Memory check** — tu réécris de mémoire la fonction clé, ou un mini-quiz.
+5. **Révision espacée** — chaque session rejoue 1–2 notions passées avant d'avancer.
+
+> Mes sessions sont **éphémères** : rien n'est gardé entre deux discussions. C'est
+> pourquoi tout vit ici, dans le repo. `PROGRESS.md` est la mémoire du cours :
+> n'importe quelle future session le lit pour savoir où on en est et quoi te faire réviser.
+
+## La pierre de Rosette
+
+Pour presque chaque outil p5 que tu connais, il existe son jumeau GPU déjà écrit dans
+ton repo. Garde ces fichiers ouverts pendant le cours :
+
+| p5 (CPU) | Shader (GPU) | Fichier |
+|---|---|---|
+| `circle()` | `discMask()` (SDF) | `src/templates/p5/utils/noiseFieldGpu.js` |
+| stroke circle | `ringMask()` | idem |
+| `line()` | `segmentDistance()` (capsule SDF) | idem |
+| grille (`for`) | `fract(uv*N)` (répétition de domaine) | à comparer à `utils/grid.js` |
+| `map()` | `remap()` / `remapClamp()` | `utils/mappers.js` → MAPPERS_GLSL |
+| easings | `ease*` GLSL | `utils/easing.js` → MAPPERS_GLSL |
+| `noise()` | `perlinNoise()` | COMMON_GLSL dans noiseFieldGpu.js |
+| `rainbow()`… | `paletteRainbow()`… | `utils/colors.js` → PALETTES_GLSL |
+| sphère/cône 3D | vertex shader + `mat4` + instancing | `sketches/peaks/peaks-cone/index.js` |
+
+## Le programme
+
+**Piste A — Fragment / 2D** (la majorité de tes sketchs)
+- **M0** Le mental model — chaque pixel se pose une question
+- **M1** L'espace du pixel — les UV (= l'équivalent de translate/scale)
+- **M2** Dessiner = SDF : le cercle (`discMask`)
+- **M3** Lignes & segments (`segmentDistance`)
+- **M4** Grilles & répétition SANS boucle (`fract`, `mod`)
+- **M5** map & easing en GLSL
+- **M6** Le bruit de Perlin sur GPU (cœur de `noise-grid`)
+- **M7** Couleur & palettes
+- **M8** Composition, ordre de dessin, blending
+
+**Piste B — 3D / Vertex**
+- **M9** Vertex shader & matrices (dissection de `peaks-cone`)
+- **M10** Raymarching (avancé, optionnel)
+
+## Le playground
+
+`playground/index.html` — un éditeur de fragment shader **en direct**. Ouvre-le dans
+un navigateur (double-clic suffit, aucune dépendance, aucun serveur). Tu édites le
+shader à gauche, le résultat s'affiche à droite, les erreurs de compilation aussi.
+
+Uniforms disponibles dans tes shaders :
+- `vUv` — coordonnée du pixel, de `(0,0)` en bas-gauche à `(1,1)` en haut-droite
+- `uResolution` — taille du canvas en pixels (`vec2`)
+- `uTime` — secondes écoulées (`float`)
+- `uMouse` — position souris normalisée 0..1 (`vec2`)
+
+Le vertex shader est fixe et identique à celui de ton repo (`VERT_SRC` dans
+`noiseFieldGpu.js`), pour que ce que tu apprends ici se transpose tel quel.

--- a/learning/shaders/REFERENCE-traps-tips-perf.md
+++ b/learning/shaders/REFERENCE-traps-tips-perf.md
@@ -1,0 +1,237 @@
+# Référence — pièges, astuces, perf & bonus
+
+> À lire en transversal, pas d'un coup. C'est ton aide-mémoire pour écrire des shaders
+> **corrects** (sans bugs sournois), **rapides**, et avec quelques tours dans la manche.
+> Ancré sur ton contexte : **WebGL1 / GLSL ES 1.00** (`gl_FragColor`, `varying`), `noise-grid`,
+> raymarching, et tes exports en boucle pour les réseaux.
+
+---
+
+## 1. Pièges (les bugs qui ne préviennent pas)
+
+### Types : `float` ≠ `int`
+- `1` est un **int**, `1.0` un **float**. GLSL ES 1.00 ne convertit **pas** implicitement.
+  `float x = 1;` → **erreur**. `vec2(1, 0)` → erreur. Écris `vec2(1.0, 0.0)`.
+- Pas d'opérateur `%` sur les int, pas de bitwise (`&`, `|`, `<<`) en ES 1.00. Pour le modulo,
+  utilise `mod()` (sur des float).
+
+### `mod()` n'est pas le `%` de JS
+- `mod(x, y) = x - y*floor(x/y)` → le résultat a **le signe de `y`** (positif si `y>0`),
+  même pour `x` négatif. En JS, `%` garde le signe du **dividende**. Sur des coordonnées qui
+  passent en négatif (origine centrée), c'est une source de discontinuités. Pense-y pour la
+  répétition de domaine.
+
+### `pow(base_négative, n)` est **indéfini**
+- D'où le choix de ton repo d'écrire les easings polynomiaux en multiplications (`x*x*x`)
+  plutôt que `pow(x, 3.0)` : `mappers.fn` passe des entrées non bornées (donc parfois < 0).
+- Idem : `sqrt(négatif)`, `log(≤0)`, `pow(0.0, 0.0)` → NaN/indéfini.
+
+### NaN / Inf qui « mangent » l'écran
+- `normalize(vec3(0.0))` → **NaN** (division par 0). Garde-toi des vecteurs nuls (rayon de
+  caméra, normale d'un point pile au centre…).
+- Division par 0, `1.0/length` quand `length==0` → Inf. Un seul NaN se propage et peut noircir
+  tout un pixel. En cas d'écran noir/blanc inexpliqué, suspecte un NaN.
+- `dot(ba, ba)` vaut 0 si `a==b` dans `segmentDistance` → division par 0. (Au M3, `a==b` donnait
+  un disque « par chance » car `h=clamp(NaN)` ; en vrai, protège avec un `max(dot(ba,ba), 1e-6)`.)
+
+### `smoothstep(e0, e1, x)` avec `e0 >= e1`
+- Si `e0 == e1`, comportement indéfini (souvent un `step` dur). Garde `e1 > e0`. Pour un bord de
+  1px : `smoothstep(r-1.0, r+1.0, d)`.
+
+### Précision : `mediump` vs `highp`
+- Dans le **fragment**, `highp` n'est **pas garanti** sur tout GPU mobile (il l'est sur desktop).
+  `mediump` a une plage/précision réduite → **banding**, scintillement, bruit qui « bave » sur de
+  grandes coordonnées.
+- Ton moteur met `precision highp float; precision highp int;` exprès pour le Perlin (les indices
+  de table montent haut, cf. le clamp `MAX_OCTAVES = 12` : au-delà, les indices entiers perdent
+  la précision float). **Garde highp dès qu'il y a de grandes valeurs** (temps qui s'accumule,
+  indices, coordonnées monde). Le temps `uTime` qui grandit indéfiniment finit par saccader en
+  mediump → préfère `fract(uTime*...)` ou un temps qui boucle.
+
+### Géométrie / repère
+- **Aspect ratio oublié** → cercles ovales. `p.x *= uResolution.x/uResolution.y;` dès qu'il y a
+  une distance (M1).
+- **Y inversé** : `vUv` est origine **bas-gauche** (y monte) ; p5 2D est **haut-gauche** (y
+  descend). Ton moteur **flippe `vUv.y`** quand il passe en pixels pour coller à p5. Quand tu
+  transposes playground → repo (ou inverses une image), pense au flip.
+- **Couleurs en 0..1**, pas 0..255. Et **clampe** avant la sortie (`clamp(col, 0.0, 1.0)`) : tes
+  palettes le font déjà — sans ça, un canal > 1 peut donner des artefacts au blending/encodage.
+
+### WebGL1 : ce qui est interdit
+- **Boucles** : la borne doit être une **constante** (`for (int i=0;i<64;i++)`). Pas de borne
+  par uniform. Tu peux `break` tôt sous condition (c'est ce que fait le raymarch et le port Perlin
+  avec `if (o >= uOctaves) break;`).
+- **Indexation dynamique** d'`array`/`sampler` par une variable : très restreinte → évite.
+- **Dérivées** (`dFdx`, `fwidth`) : nécessitent `#extension GL_OES_standard_derivatives : enable`
+  en tête de fragment (sinon erreur de compilation).
+- `texture2DLod` seulement dans le **vertex** ; dans le fragment, pas de choix de mip explicite
+  sans extension.
+
+### Branches & dérivées
+- Échantillonner une texture (`texture2D`) sous un `if` qui diverge entre pixels voisins fausse
+  le calcul de mip (dérivées). Pour du bruit en texture comme le tien, ça compte si tu mets des
+  branches autour des lookups.
+
+---
+
+## 2. Astuces (écrire mieux, plus court)
+
+### Anti-aliasing indépendant de la résolution : `fwidth`
+Au lieu d'un `±1.0` fixe (qui suppose des pixels), la largeur du bord = la taille d'un pixel dans
+**ton** espace (UV, monde…) :
+```glsl
+#extension GL_OES_standard_derivatives : enable
+// ...
+float aa = fwidth(d);                  // ~1px exprimé dans l'unité de d
+float mask = 1.0 - smoothstep(r - aa, r + aa, d);
+```
+→ formes nettes quel que soit le zoom/la densité de la grille. Idéal pour M2–M4 en coords 0..1.
+
+### Compare des distances **au carré**
+`sqrt` coûte. Pour « est-ce que je suis à moins de r ? », compare `dot(p,p)` à `r*r` plutôt que
+`length(p)` à `r`. (Garde `length` quand tu as besoin de la vraie distance pour un bord doux.)
+
+### Remplace les `if` par `step`/`mix`/`clamp`
+```glsl
+// au lieu de : if (x > seuil) col = A; else col = B;
+col = mix(B, A, step(seuil, x));
+```
+Pas de divergence de branche (cf. perf §3), et souvent plus court.
+
+### Coordonnées polaires (radial, kaléidoscope, secteurs)
+```glsl
+float r = length(p);
+float a = atan(p.y, p.x);          // angle -PI..PI
+// répéter en N secteurs (mandala) :
+float N = 6.0;
+a = mod(a, TAU/N) - (TAU/N)*0.5;
+vec2 q = vec2(cos(a), sin(a)) * r;
+```
+
+### Rotation 2D propre
+```glsl
+vec2 rot(vec2 v, float a){ float c=cos(a), s=sin(a); return mat2(c,-s,s,c)*v; }
+```
+(Ton `rotateAroundCenter` fait ça autour de `uCenter`.)
+
+### Hash sans `sin` (plus stable d'un GPU à l'autre)
+`fract(sin(...)*43758.5)` varie selon le `sin` du driver. Plus robuste :
+```glsl
+float hash(vec2 p){ vec3 p3 = fract(vec3(p.xyx)*0.1031); p3 += dot(p3, p3.yzx+33.33); return fract((p3.x+p3.y)*p3.z); }
+```
+
+### Opérations SDF utiles (prolonge M2/M10)
+```glsl
+float opRound(float d, float r){ return d - r; }          // arrondit les angles
+float opAnnular(float d, float w){ return abs(d) - w; }    // creuse un anneau/coque
+// fusion douce (déjà au M10) :
+float smin(float a,float b,float k){ float h=clamp(0.5+0.5*(b-a)/k,0.0,1.0); return mix(b,a,h)-k*h*(1.0-h); }
+```
+
+### `sign`, `abs`, `step` pour la symétrie
+`abs(p)` replie l'espace → tu ne dessines qu'un quart et tu obtiens 4 symétries gratuites.
+
+---
+
+## 3. Perf (faire tenir le temps réel)
+
+### Le coût se mesure **par pixel × nombre de pixels**
+Un fragment full-screen en 1080p = ~2M exécutions/frame. Tout ce que tu ajoutes dans `main` est
+multiplié par ça. Les leviers, du plus rentable au moins :
+
+| Levier | Pourquoi | Comment |
+|---|---|---|
+| **Résolution / DPR** | coût ∝ nb de pixels | plafonne le devicePixelRatio (le playground le cap à 2) ; rends dans un buffer plus petit puis upscale |
+| **Moins de branches divergentes** | le GPU exécute par groupes (SIMD) : si des pixels voisins prennent des chemins différents, il fait **les deux** | `mix`/`step` au lieu de `if`; sors tôt **uniformément** |
+| **Moins de pas de raymarch** | la boucle domine | baisse le nb d'itérations, augmente l'epsilon de hit, borne la distance max, ajoute un *bounding* |
+| **Moins d'octaves de bruit** | chaque octave = un tour de boucle + lookups | `uOctaves` au minimum visuellement acceptable (ton moteur clampe à 12) |
+| **Moins de lookups texture** | la mémoire est lente | regroupe, évite les lookups sous branche, mets en cache dans une variable |
+| **Moins de `sin/cos/pow/exp`** | fonctions transcendantes coûteuses | sors-les des boucles, pré-calcule, ou approxime |
+| **Moins d'overdraw (instancing)** | redessiner le même pixel N fois | en mode quads, limite la taille des instances ; trie/évite les gros recouvrements |
+
+### Full-screen fragment vs instancing : choisir selon la densité
+Ton moteur a les deux (`createNoiseFieldRenderer` vs `createInstancedFieldRenderer`) :
+- **Full-screen** : coût ≈ constant = pixels × travail/pixel. Excellent si **dense** (champ qui
+  remplit l'écran). Le scan 3×3 de `v12` multiplie le travail/pixel par 9 → à réserver aux cas où
+  le débordement compte.
+- **Instanced** : coût ≈ cellules × (sommets + leur overdraw). Excellent si **épars** (peu de
+  formes, ou formes qui se chevauchent et qu'on veut blender dans l'ordre). Devient cher si la
+  grille est énorme (beaucoup de quads + overdraw).
+- Règle de poche : **champ plein → full-screen ; éléments comptés/chevauchants → instanced.**
+
+### Rendre plus petit, composer plus grand
+Tu rends déjà le champ dans un buffer WebGL off-screen puis tu le composites sur le canvas 2D.
+Tu peux **réduire la taille du buffer** (ex. 0.75×) pour les effets doux (bruit, halos) : le coût
+chute quadratiquement, et l'upscale se voit peu. Garde la pleine résolution pour les bords nets.
+
+### Évite `discard`
+`discard` (jeter un fragment) casse l'optimisation early-z du GPU. Pour de la transparence,
+préfère écrire un **alpha** et laisser le blending faire — comme tes masques `discMask`/`ringMask`
+qui renvoient une couverture.
+
+### `const` et hissage hors boucle
+Marque les constantes `const` (le compilateur les plie). Sors des boucles tout ce qui ne dépend
+pas de l'itération (un `cos(uTime)` calculé une fois, pas à chaque tour).
+
+### Minimise les `varying`
+Chaque `varying` est interpolé pour chaque fragment. Pour la 3D (M9), ne passe que le nécessaire
+(souvent une couleur et/ou une normale).
+
+### LUT (look-up table)
+Une palette/courbe coûteuse peut être pré-calculée dans une petite texture 1D et lue d'un
+`texture2D` — c'est exactement l'esprit de ta table de permutation Perlin packée en texture.
+
+---
+
+## 4. Bonus (les petits trucs qui en jettent)
+
+### Boucles **parfaitement** seamless (crucial pour tes exports réseaux)
+Pour qu'une animation boucle sans couture, **tout doit être périodique sur la durée**. Pilote
+l'animation par un angle qui fait un tour complet, pas par `uTime` brut :
+```glsl
+// progression 0..1 sur la durée du sketch  →  angle 0..TAU
+float a = TAU * uProgress;          // = ton animation.angle (utils/animation.js)
+float v = sin(a);                   // boucle parfaite
+float w = perlinNoise(vec3(p, cos(a)*R + sin(a)*R)); // bruit qui boucle via un CERCLE en Z
+```
+Le truc du bruit qui boucle : échantillonne la 3e dimension du bruit sur un **cercle**
+(`cos(a), sin(a)`) au lieu d'une ligne → la fin rejoint le début. Tes uniforms `uProgress`/angle
+existent déjà côté moteur.
+
+### Vignette / finition plein écran (post)
+```glsl
+col *= smoothstep(1.2, 0.3, length(vUv - 0.5));   // assombrit les bords
+```
+
+### Grain / dithering (casse le banding mediump)
+```glsl
+float n = (hash(gl_FragCoord.xy) - 0.5) / 255.0;
+col += n;   // bruit ±1 niveau : tue le banding des dégradés
+```
+
+### Aberration chromatique (échantillonne R/G/B décalés)
+Décale légèrement l'échantillonnage par canal autour du centre → effet « lentille » stylé sur les
+rendus à base de texture.
+
+### Palette cosinus paramétrique (rappel M7)
+`a + b*cos(TAU*(c*t + d))` : 4 `vec3` et tu as n'importe quel dégradé. Anime `d` avec l'angle de
+boucle pour un cycle de teinte seamless.
+
+### Kaléidoscope express
+Combine §2 (polaire + `mod` sur l'angle) avec un de tes champs → symétrie mandala instantanée.
+
+### Interactivité quasi gratuite
+`uMouse` (ou un uniform d'audio/temps) en entrée d'un `remap`/`fn` (M5) suffit à rendre un sketch
+réactif sans rien recoder de la structure. C'est là que les shaders battent ta 2D/3D CPU :
+l'interactivité temps réel ne coûte presque rien.
+
+---
+
+## Mini check-list « avant de publier »
+- [ ] Aspect ratio corrigé (pas d'ovales) ?
+- [ ] Couleurs clampées 0..1 ?
+- [ ] `highp` là où il y a de grandes valeurs (temps/indices) ?
+- [ ] Pas de `normalize`/division sur un vecteur potentiellement nul ?
+- [ ] La boucle (raymarch/octaves) a-t-elle une borne raisonnable ?
+- [ ] L'animation **boucle** proprement (pilotée par l'angle, pas `uTime` brut) ?
+- [ ] DPR plafonné / résolution adaptée à la cible ?

--- a/learning/shaders/lessons/M0-M1-mental-model-and-uv.md
+++ b/learning/shaders/lessons/M0-M1-mental-model-and-uv.md
@@ -1,0 +1,197 @@
+# M0 + M1 — Le mental model & l'espace du pixel (UV)
+
+> Objectif : acquérir le déclic mental des shaders, et savoir te repérer dans
+> l'espace du fragment shader (l'équivalent de `translate`/`scale` en p5).
+> Outil : `../playground/index.html` (ouvre-le dans un navigateur).
+
+---
+
+## M0 — Le mental model
+
+### Le déclic
+
+En p5 2D, tu es **impératif** : tu donnes des ordres, dans l'ordre.
+
+```js
+translate(width/2, height/2);
+fill(255, 0, 0);
+circle(0, 0, 200);   // « va là, et dessine un cercle »
+```
+
+Un **fragment shader**, c'est l'inverse. Le GPU prend ta fonction `main()` et
+l'exécute **une fois pour chaque pixel**, des millions de fois, **toutes en
+parallèle**. Ta fonction ne dessine rien : pour le pixel courant, elle doit
+**répondre à une seule question** — *« quelle est MA couleur ? »*.
+
+```glsl
+void main() {
+  gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0); // « moi, pixel, je suis rouge »
+}
+```
+
+Trois conséquences à graver :
+
+1. **Pas de boucle pour parcourir l'écran.** Le parcours de tous les pixels, c'est
+   le GPU qui le fait. Tu écris le corps de boucle, pas la boucle. (C'est aussi
+   pourquoi c'est si rapide.)
+2. **Pas d'état, pas de mémoire.** Un pixel ne peut PAS lire la couleur du pixel
+   voisin, ni savoir ce qui a été « dessiné avant ». Chaque exécution est isolée.
+   Ta fonction est **pure** : mêmes entrées → même sortie.
+3. **Tu ne dessines pas une forme, tu écris un test.** « Suis-je dans le cercle ? »
+   plutôt que « dessine un cercle ». On y revient au M2 — c'est exactement ce que
+   fait ton `discMask()`.
+
+### La syntaxe minimale (GLSL ES 1.00, comme ton repo)
+
+Ton repo utilise `gl_FragColor` et `varying` → c'est la version GLSL ES **1.00**.
+On apprend celle-là pour que tout se transpose directement.
+
+```glsl
+precision highp float;   // obligatoire : précision des float dans le fragment
+
+varying vec2 vUv;        // donnée venue du vertex shader (voir M1)
+
+void main() {
+  gl_FragColor = vec4(R, G, B, A);   // la sortie : la couleur du pixel
+}
+```
+
+- Les couleurs vont de **0.0 à 1.0** (pas 0–255 !). `vec4(1.0, 0.0, 0.0, 1.0)` = rouge opaque.
+- Types : `float`, `vec2` (x,y), `vec3` (r,g,b ou x,y,z), `vec4`.
+- `1.0` et `1` ne sont **pas** pareils : GLSL est strict, un `float` s'écrit avec un point.
+- Swizzle : `v.xy`, `v.rgb`, `v.x`, et `vec3(v.x)` = `vec3(v.x, v.x, v.x)`.
+
+### Lecture de ton code
+
+Ouvre `src/templates/p5/utils/noiseFieldGpu.js`, cherche `VERT_SRC` puis un des
+fragments. Tu reconnaîtras `precision highp float;`, des `varying`, et un `main()`
+qui finit par écrire une couleur. C'est exactement ce squelette, en plus gros.
+
+---
+
+## M1 — L'espace du pixel (les UV)
+
+Pour répondre « quelle est ma couleur ? », un pixel a besoin de savoir **où il est**.
+C'est le rôle de `vUv`.
+
+### Le repère
+
+Le vertex shader (fixe, identique à ton `VERT_SRC`) fournit à chaque pixel une
+coordonnée `vUv` :
+
+```
+(0,1) ┌───────────┐ (1,1)
+      │           │
+      │           │      vUv.x : 0 (gauche) → 1 (droite)
+      │           │      vUv.y : 0 (bas)    → 1 (haut)
+(0,0) └───────────┘ (1,0)
+```
+
+⚠️ Différence avec p5 : ici l'origine `(0,0)` est en **bas**-gauche et **y monte**.
+En p5 2D, `(0,0)` est en haut-gauche et y descend.
+
+### Premier shader : le dégradé (ton « hello world »)
+
+```glsl
+void main() {
+  gl_FragColor = vec4(vUv.x, vUv.y, 0.0, 1.0);
+}
+```
+
+Chaque pixel met du rouge proportionnel à sa position horizontale, du vert à sa
+verticale. Tu obtiens le dégradé bicolore classique. C'est le shader par défaut du
+playground.
+
+### Recentrer l'origine (≈ `translate(width/2, height/2)`)
+
+Souvent tu veux le `(0,0)` au centre. Deux gestes usuels :
+
+```glsl
+vec2 p = vUv - 0.5;        // centre en (0,0), bords à ±0.5
+// ou, plage -1..1 :
+vec2 p = vUv * 2.0 - 1.0;  // centre en (0,0), bords à ±1
+```
+
+### Corriger l'aspect ratio (sinon tes cercles seront des ovales)
+
+`vUv` va de 0 à 1 **dans les deux axes**, même si le canvas est plus large que haut.
+Donc une distance « ronde » apparaît ovale. On corrige en étirant x par le ratio :
+
+```glsl
+vec2 p = vUv - 0.5;
+p.x *= uResolution.x / uResolution.y;  // x à la même échelle que y
+```
+
+Retiens ce réflexe : **dès qu'il y a une notion de distance/forme, on corrige l'aspect.**
+Ça prépare directement le M2.
+
+### Passer en pixels
+
+Si tu veux raisonner en pixels (comme en p5) plutôt qu'en 0..1 :
+
+```glsl
+vec2 pix = vUv * uResolution;   // coordonnée en pixels
+```
+
+### Distance & dégradé radial
+
+`length(v)` donne la longueur d'un vecteur (= distance à l'origine). Premier pas vers
+les formes :
+
+```glsl
+vec2 p = vUv - 0.5;
+p.x *= uResolution.x / uResolution.y;
+float d = length(p);              // distance au centre
+gl_FragColor = vec4(vec3(d), 1.0); // dégradé radial : noir au centre, clair aux bords
+```
+
+---
+
+## Exercices (dans le playground)
+
+Fais-les dans l'ordre. Garde tes solutions dans `../solutions/` (un fichier `.frag`
+par exo, ex. `m1-e2.frag`).
+
+- **E0 — Couleur fixe.** Affiche un écran entièrement orange. *(But : la sortie est `gl_FragColor`, couleurs 0..1.)*
+- **E1 — Dégradés.** Reproduis le dégradé R/G. Puis : un dégradé **horizontal** en niveaux de gris (noir→blanc de gauche à droite). Puis **vertical**. *(But : lire `vUv.x` / `vUv.y`.)*
+- **E2 — Dégradé radial centré et rond.** Centre l'origine, corrige l'aspect ratio, affiche `length(p)`. Vérifie que le motif reste **rond** même si tu redimensionnes la fenêtre. *(But : centrage + aspect + `length`.)*
+- **E3 — Le pont vers le M2.** Reprends E2 et remplace l'affichage par un **disque dur** : blanc si `d < 0.3`, noir sinon. Indice : `step(0.3, d)` donne 0 ou 1. *(But : transformer une distance en forme — c'est l'idée de la SDF.)*
+- **E4 — Bonus animé.** Fais varier le rayon du disque avec `uTime` (ex. `0.3 + 0.1 * sin(uTime)`). *(But : un uniform qui change dans le temps.)*
+
+---
+
+## Memory checks
+
+Réponds **sans regarder** (puis vérifie) :
+
+1. Combien de fois s'exécute `main()` pour une image ?
+2. Un pixel peut-il connaître la couleur de son voisin ?
+3. Quelle est la plage des valeurs de couleur en GLSL ?
+4. En `vUv`, où se trouve l'origine `(0,0)` ? En quoi est-ce différent de p5 ?
+5. Pourquoi un cercle basé sur `length(vUv - 0.5)` apparaît-il ovale, et comment corriger ?
+6. **Recall** : réécris de mémoire, dans un éditeur vide, le shader complet du dégradé R/G
+   (avec `precision`, `varying`, `main`).
+
+<details>
+<summary>Réponses</summary>
+
+1. Une fois **par pixel/fragment**, en parallèle.
+2. **Non** — pas d'état partagé, exécution isolée.
+3. **0.0 à 1.0**.
+4. En **bas-gauche**, y monte. En p5 : haut-gauche, y descend.
+5. Parce que `vUv` va de 0 à 1 sur les deux axes quel que soit le format ; on
+   multiplie `p.x` par `uResolution.x / uResolution.y`.
+6. ```glsl
+   precision highp float;
+   varying vec2 vUv;
+   void main() {
+     gl_FragColor = vec4(vUv.x, vUv.y, 0.0, 1.0);
+   }
+   ```
+</details>
+
+---
+
+**Quand tu as fait E0→E3 (E4 bonus) et les memory checks**, dis-le moi (ou pousse tes
+`.frag` dans `solutions/`). Je corrige, on note la progression dans `PROGRESS.md`, et
+on passe au **M2 — la SDF du cercle**, où on disséquera ton `discMask()`.

--- a/learning/shaders/lessons/M10-raymarching.md
+++ b/learning/shaders/lessons/M10-raymarching.md
@@ -1,0 +1,146 @@
+# M10 — Raymarching (3D par distance) — avancé, optionnel
+
+> Pré-requis : M2 (SDF) surtout, + M5–M7. Notion clé : faire de la **vraie 3D dans un fragment
+> shader**, sans aucune géométrie, en prolongeant tes SDF 2D en 3D. **Ça tourne dans le playground.**
+
+---
+
+## L'idée
+
+Au M2, une forme 2D = une fonction de distance `length(p) - r`. En **3D**, c'est pareil mais
+`p` est un `vec3`. Pour afficher ça, on ne dessine pas de triangles : pour chaque pixel, on
+lance un **rayon** depuis la caméra et on **avance** le long du rayon jusqu'à toucher la surface.
+
+L'astuce (« sphere tracing ») : la SDF donne la **distance à la surface la plus proche** = la
+distance qu'on peut avancer **sans rien traverser**. On marche donc par bonds sûrs jusqu'à
+frôler la surface (distance ≈ 0).
+
+## Les SDF 3D de base
+
+```glsl
+float sdSphere(vec3 p, float r) { return length(p) - r; }
+float sdBox(vec3 p, vec3 b)     { vec3 q = abs(p) - b; return length(max(q,0.0)) + min(max(q.x,max(q.y,q.z)),0.0); }
+float sdTorus(vec3 p, vec2 t)   { vec2 q = vec2(length(p.xz) - t.x, p.y); return length(q) - t.y; }
+```
+
+Combinaisons (comme au M2, mais en **distances signées** : union = `min`) :
+- Union : `min(a, b)` · Intersection : `max(a, b)` · Soustraction : `max(a, -b)`
+- **Union douce** (fusion organique, très « toi ») :
+  ```glsl
+  float smin(float a, float b, float k){ float h = clamp(0.5 + 0.5*(b-a)/k, 0.0, 1.0); return mix(b, a, h) - k*h*(1.0-h); }
+  ```
+
+## La scène = une seule fonction `map`
+
+Tout ton monde 3D tient dans une fonction qui renvoie la distance au plus proche :
+
+```glsl
+float map(vec3 p) {
+  float s = sdSphere(p - vec3(0.0), 1.0);
+  // répétition de domaine en 3D (le M4 en 3D !) : des sphères à l'infini, gratuitement
+  // vec3 q = mod(p + 2.0, 4.0) - 2.0;  float s = sdSphere(q, 1.0);
+  return s;
+}
+```
+
+## La boucle de marche + l'éclairage
+
+```glsl
+vec3 calcNormal(vec3 p){               // normale = gradient de la SDF
+  vec2 e = vec2(0.001, 0.0);
+  return normalize(vec3(
+    map(p+e.xyy)-map(p-e.xyy),
+    map(p+e.yxy)-map(p-e.yxy),
+    map(p+e.yyx)-map(p-e.yyx)));
+}
+
+void main(){
+  vec2 uv = (vUv - 0.5);
+  uv.x *= uResolution.x / uResolution.y;        // aspect (M1)
+
+  vec3 ro = vec3(0.0, 0.0, 3.0);                 // origine du rayon (caméra)
+  vec3 rd = normalize(vec3(uv, -1.5));           // direction du rayon
+
+  float t = 0.0;                                  // distance parcourue
+  float hit = -1.0;
+  for (int i = 0; i < 80; i++) {                  // borne CONSTANTE (WebGL1)
+    vec3 p = ro + rd * t;
+    float d = map(p);                             // distance sûre
+    if (d < 0.001) { hit = t; break; }            // touché
+    if (t > 20.0) break;                          // trop loin → ciel
+    t += d;                                        // on avance du bond sûr
+  }
+
+  vec3 col = vec3(0.04);                           // fond
+  if (hit > 0.0) {
+    vec3 p = ro + rd * hit;
+    vec3 n = calcNormal(p);
+    vec3 lightDir = normalize(vec3(0.6, 0.7, 0.4));
+    float diff = max(dot(n, lightDir), 0.0);       // éclairage diffus (Lambert)
+    col = vec3(0.2, 0.5, 1.0) * (0.2 + diff);      // ambiant + diffus
+  }
+  gl_FragColor = vec4(col, 1.0);
+}
+```
+
+Colle-le dans le playground (avec les `sdSphere`/`calcNormal`/`map` au-dessus de `main`) : tu as
+une sphère 3D éclairée, **sans une seule triangle**. C'est la suite directe de tes SDF du M2.
+
+## Pourquoi ça t'intéresse
+
+- **Formes organiques** (fusion `smin`, déformations par bruit) bien plus souples qu'avec des maillages.
+- **Répétition infinie** quasi gratuite (`mod` en 3D = M4 en 3D).
+- Tout le coût est par pixel → idéal pour tes rendus plein écran et temps réel.
+- Contrepartie : ça peut devenir lourd (beaucoup de pas de marche, AO/ombres) → à doser.
+
+---
+
+## Exercices (playground)
+
+- **E1 — Sphère.** Fais tourner le template ci-dessus. Bouge la caméra (`ro`) et la lumière.
+- **E2 — Deux formes.** Ajoute un `sdBox`/`sdTorus` ; combine avec `min`, puis avec `smin` (compare).
+- **E3 — Animation.** Anime la position d'une sphère avec `uTime` (sin/cos) ; elle fusionne avec
+  une autre via `smin` → effet « blob ».
+- **E4 — Répétition 3D.** Active la ligne `mod` dans `map` → un champ infini de sphères. Fais
+  défiler avec `uTime` (`p.z += uTime`).
+- **E5 — Couleur.** Colore selon la normale (`col = n*0.5+0.5`) ou via une `palette()` (M7) sur
+  la distance/hauteur.
+- **E6 — Souris-caméra.** Fais tourner la scène avec `uMouse` (rotation de `ro`/`rd` autour de Y).
+
+<details>
+<summary>Indice E2 (smin) & E4 (répétition)</summary>
+
+```glsl
+float map(vec3 p){
+  vec3 q = mod(p + 2.0, 4.0) - 2.0;     // E4 : répétition de domaine
+  float s = sdSphere(q, 0.7);
+  float b = sdBox(p - vec3(0.0, sin(uTime), 0.0), vec3(0.6));
+  return smin(s, b, 0.5);               // E2 : fusion douce
+}
+```
+</details>
+
+## Memory checks
+
+1. Pourquoi peut-on « avancer de la distance renvoyée par la SDF » sans rien traverser ?
+2. Comment obtient-on la **normale** d'une surface définie par une SDF ?
+3. Union de deux SDF (distances signées) : `min` ou `max` ? Et au M2 (couvertures) ?
+4. Comment crée-t-on une **infinité** de copies sans boucle/géométrie ?
+5. Avantage clé du raymarching pour des formes organiques ?
+
+<details>
+<summary>Réponses</summary>
+
+1. Parce que la SDF donne la distance à la surface **la plus proche** : c'est la marge sûre. 2.
+Par le **gradient** de la SDF (différences finies sur x,y,z). 3. Ici `min` (distances) ; au M2
+c'était `max` (couvertures) — attention à la convention. 4. Répétition de domaine en 3D :
+`mod(p, taille)` (le M4 en 3D). 5. Fusion douce (`smin`) et déformations continues, impossibles/
+coûteuses avec des maillages.
+</details>
+
+---
+
+🎓 **Fin du parcours.** Tu as les briques : pixel→couleur (M0–M1), formes par SDF (M2–M3),
+répétition sans boucle (M4), animation (M5), bruit (M6), couleur (M7), composition (M8), 3D par
+géométrie (M9) et 3D par distance (M10). Le pas suivant : **démarrer un sketch neuf
+directement en shader** — reprends un de tes sketchs 2D/3D et reconstruis-le brique par brique.

--- a/learning/shaders/lessons/M2-sdf-circle.md
+++ b/learning/shaders/lessons/M2-sdf-circle.md
@@ -1,0 +1,158 @@
+# M2 — Dessiner = SDF : le cercle (`discMask`)
+
+> Pré-requis : M0–M1. Outil : `../playground/index.html`.
+> Notion clé : une forme = une **fonction de distance** transformée en **couverture** (alpha 0..1).
+
+---
+
+## Concept
+
+Souviens-toi du déclic (M0) : tu n'écris pas « dessine un cercle », tu écris un **test
+par pixel**. La brique de base de ce test, c'est la **distance**.
+
+- `length(v)` = distance du point `v` à l'origine.
+- Pour un cercle de rayon `r` centré à l'origine : un pixel est **dedans** si
+  `length(local) < r`, dehors sinon. (`local` = position du pixel par rapport au centre.)
+
+Une **SDF** (Signed Distance Field, champ de distance signé) est une fonction qui, pour
+une position, renvoie la distance au bord de la forme. Toute ta géométrie 2D peut s'exprimer
+comme ça. Ton repo l'utilise déjà.
+
+### Du « dedans/dehors » net au bord lissé
+
+Le seuil net `step(r, d)` crée un bord crénelé (aliasing). Pour lisser sur ~1 pixel, on
+utilise `smoothstep` :
+
+- `step(edge, x)` → 0 si `x < edge`, sinon 1. **Cassant**.
+- `smoothstep(e0, e1, x)` → transition douce de 0 à 1 entre `e0` et `e1`. **Anti-aliasé**.
+
+C'est **exactement** ce que fait ta fonction. Ouvre `src/templates/p5/utils/noiseFieldGpu.js`,
+section `SHAPES_GLSL` :
+
+```glsl
+// Disque plein (point p5 avec strokeWeight = 2*radius), bord anti-aliasé sur 1px.
+float discMask(vec2 local, float radius) {
+  return 1.0 - smoothstep(radius - 1.0, radius + 1.0, length(local));
+}
+
+// Anneau (circle(0,0,2*radius) avec strokeWeight) ; le trait chevauche le rayon.
+float ringMask(vec2 local, float radius, float halfStroke) {
+  float d = abs(length(local) - radius);
+  return 1.0 - smoothstep(halfStroke - 1.0, halfStroke + 1.0, d);
+}
+```
+
+Décortiquons `discMask` :
+- `length(local)` : distance au centre, en **pixels**.
+- `smoothstep(radius-1, radius+1, dist)` : vaut 0 à l'intérieur (dist < radius-1), 1 à
+  l'extérieur (dist > radius+1), et fait une rampe douce sur 2px autour du rayon.
+- `1.0 -` : on inverse, pour avoir **1 dedans, 0 dehors** → c'est la **couverture** (alpha).
+- Le `±1.0` est la largeur d'anti-aliasing en **pixels** (parce qu'ici `local` et `radius`
+  sont en pixels).
+
+`ringMask` est le même principe mais sur `abs(distance - radius)` : la couverture est forte
+**près du cercle de rayon r** (le contour) et nulle ailleurs → un anneau.
+
+> ⚠️ Échelle : `discMask` raisonne en **pixels**. Dans le playground, `vUv` est en 0..1.
+> Convertis : `vec2 local = (vUv - 0.5) * uResolution;` puis travaille en pixels. (Ou
+> reste en 0..1 et mets un `radius` petit avec une largeur d'AA genre `0.005`.)
+
+### Couverture ≠ distance signée
+
+Note la nuance : `discMask`/`ringMask` renvoient une **couverture** (0..1, prête à mixer),
+pas la distance signée brute. La SDF « pure » serait `length(local) - radius` (négatif
+dedans, positif dehors). Les deux vues sont utiles : la distance pour combiner des formes,
+la couverture pour colorer.
+
+### Colorer une forme
+
+Une couverture `mask` se compose avec `mix` (= lerp) :
+
+```glsl
+vec3 bg = vec3(0.05);
+vec3 fg = vec3(1.0, 0.4, 0.1);
+vec3 col = mix(bg, fg, mask);   // bg là où mask=0, fg là où mask=1
+gl_FragColor = vec4(col, 1.0);
+```
+
+### Combiner plusieurs formes
+
+Avec des **couvertures** (0..1) :
+- **Union** : `max(maskA, maskB)`
+- **Intersection** : `min(maskA, maskB)`
+- **Soustraction** : `maskA * (1.0 - maskB)`
+
+(Avec des **distances signées**, ce serait `min` pour l'union, `max` pour l'intersection —
+attention à ne pas confondre les deux conventions.)
+
+---
+
+## Exercices (playground)
+
+- **E1 — Disque.** Centre l'origine, passe en pixels (`local = (vUv-0.5)*uResolution`),
+  écris `discMask` **de mémoire**, dessine un disque blanc rayon 120px sur fond sombre.
+- **E2 — Anneau.** Ajoute un `ringMask` (rayon 200, halfStroke 6) par-dessus, en rouge.
+- **E3 — Union.** Deux disques côte à côte, fusionnés via `max`.
+- **E4 — Souris.** Un disque dont le centre suit la souris : `local = (vUv*uResolution) - uMouse*uResolution`.
+- **E5 — Glow.** Un halo doux : au lieu d'un bord net, `float glow = radius / length(local);`
+  (clampé). Observe la différence entre une *forme* et une *lueur*.
+
+<details>
+<summary>Corrigés</summary>
+
+```glsl
+// E1 + E2 + E3
+precision highp float;
+varying vec2 vUv;
+uniform vec2 uResolution;
+
+float discMask(vec2 local, float radius) {
+  return 1.0 - smoothstep(radius - 1.0, radius + 1.0, length(local));
+}
+float ringMask(vec2 local, float radius, float halfStroke) {
+  float d = abs(length(local) - radius);
+  return 1.0 - smoothstep(halfStroke - 1.0, halfStroke + 1.0, d);
+}
+
+void main() {
+  vec2 p = (vUv - 0.5) * uResolution;        // pixels, origine au centre
+  float disc = discMask(p, 120.0);
+  float ring = ringMask(p, 200.0, 6.0);
+
+  // union de deux disques (E3) :
+  float d2 = max(discMask(p - vec2(-150.0, 0.0), 80.0),
+                 discMask(p - vec2( 150.0, 0.0), 80.0));
+
+  vec3 col = vec3(0.05);
+  col = mix(col, vec3(1.0),            disc);
+  col = mix(col, vec3(1.0, 0.2, 0.2),  ring);
+  col = mix(col, vec3(0.2, 0.8, 1.0),  d2);   // remplace/retire selon l'exo
+  gl_FragColor = vec4(col, 1.0);
+}
+```
+```glsl
+// E4 — disque qui suit la souris
+vec2 p = vUv * uResolution - uMouse * uResolution;
+float disc = discMask(p, 90.0);
+```
+</details>
+
+## Memory checks
+
+1. Que renvoie `smoothstep(e0, e1, x)` quand `x < e0` ? quand `x > e1` ?
+2. Pourquoi le `1.0 -` dans `discMask` ?
+3. À quoi sert le `±1.0` et en quelle unité est-il ?
+4. Différence entre `discMask` et `ringMask` (un seul terme change) ?
+5. Couverture vs distance signée : laquelle vaut `length(local) - radius` ?
+6. Union de deux **couvertures** : `min` ou `max` ?
+
+<details>
+<summary>Réponses</summary>
+
+1. `0.0` puis `1.0`. 2. Pour inverser : avoir 1 **dedans**, 0 dehors (la couverture). 3. La
+largeur d'anti-aliasing, en **pixels**. 4. `ringMask` applique la distance à `abs(length - radius)`
+au lieu de `length`. 5. La **distance signée**. 6. `max`.
+</details>
+
+**Pont → M3** : un cercle, c'est `length(local)`. Une ligne, c'est la distance à un
+**segment**. Même logique, autre distance.

--- a/learning/shaders/lessons/M3-lines-segments.md
+++ b/learning/shaders/lessons/M3-lines-segments.md
@@ -1,0 +1,133 @@
+# M3 — Lignes & segments (`segmentDistance`)
+
+> Pré-requis : M2. Notion clé : une ligne = la **distance à un segment** (capsule SDF),
+> seuillée en couverture comme le disque.
+
+---
+
+## Concept
+
+En p5, `line(x1,y1, x2,y2)` trace un trait avec, par défaut, des bouts arrondis (ROUND cap).
+L'équivalent shader : pour chaque pixel, calculer **sa distance au segment** `a→b`, puis
+appliquer le même `smoothstep` qu'au M2.
+
+Ouvre `noiseFieldGpu.js`, section `SHAPES_GLSL` :
+
+```glsl
+// Distance du point p au segment a→b (bouts ronds = axe d'une capsule),
+// correspond au strokeCap ROUND par défaut de line() en p5.
+float segmentDistance(vec2 p, vec2 a, vec2 b) {
+  vec2 pa = p - a;
+  vec2 ba = b - a;
+  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+  return length(pa - ba * h);
+}
+```
+
+Comment ça marche, ligne par ligne :
+- `pa = p - a` : vecteur du début du segment vers le pixel.
+- `ba = b - a` : le segment lui-même (sa direction et sa longueur).
+- `dot(pa, ba) / dot(ba, ba)` : **projection** de `p` sur la droite `(a,b)`, exprimée en
+  fraction `h` de la longueur (0 = sur `a`, 1 = sur `b`, 0.5 = milieu).
+- `clamp(..., 0.0, 1.0)` : on **borne** `h` à `[0,1]` → au-delà des extrémités, le point
+  le plus proche redevient `a` ou `b`. C'est ce `clamp` qui crée les **bouts ronds**.
+- `length(pa - ba*h)` : distance du pixel au point le plus proche **sur** le segment.
+
+### Tracer la ligne
+
+`segmentDistance` donne une distance ; on la transforme en couverture comme le disque, avec
+la **demi-épaisseur** du trait (`halfWeight`) en seuil :
+
+```glsl
+float lineMask(vec2 p, vec2 a, vec2 b, float halfWeight) {
+  float d = segmentDistance(p, a, b);
+  return 1.0 - smoothstep(halfWeight - 1.0, halfWeight + 1.0, d);
+}
+```
+
+Une ligne, c'est donc « la zone à moins de `halfWeight` pixels du segment ». Un strokeWeight
+de 8px → `halfWeight = 4.0`.
+
+### Polylignes, croix, grilles de lignes
+
+- Une **polyligne** = plusieurs segments, unis par `max` de leurs masques (cf. M2).
+- Une **croix** = deux segments perpendiculaires (`utils/shapes.js` a une `cross()` en CPU —
+  voici son équivalent GPU).
+- Une **grille de lignes** = des segments verticaux et horizontaux répétés (on le fera sans
+  boucle au M4 avec `fract`).
+
+### Pointillés (aperçu M4)
+
+Pour des tirets, on coupe le trait le long du segment grâce au paramètre de projection `h`
+(ou à la distance le long de l'axe). En gros : on ne garde le trait que là où
+`fract(h * nbTirets) < 0.5`. Tu maîtriseras `fract` au M4 ; garde l'idée en tête.
+
+---
+
+## Exercices (playground)
+
+Travaille en pixels (`vec2 p = (vUv - 0.5) * uResolution;`).
+
+- **E1 — Segment.** Écris `segmentDistance` + `lineMask` **de mémoire**, trace un segment de
+  `a=(-200,-100)` à `b=(200,100)`, épaisseur 8px.
+- **E2 — Épaisseur animée.** Fais varier `halfWeight` avec `uTime` (`4.0 + 3.0*sin(uTime)`).
+- **E3 — Bouts ronds.** Mets `a == b` (segment de longueur nulle) : tu obtiens… un disque.
+  Comprends pourquoi (la capsule dégénère en cercle).
+- **E4 — Croix.** Deux segments perpendiculaires unis par `max`.
+- **E5 — Souris.** Un segment dont le point `b` suit la souris (`b = (uMouse-0.5)*uResolution`).
+
+<details>
+<summary>Corrigés</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform vec2  uResolution;
+uniform float uTime;
+uniform vec2  uMouse;
+
+float segmentDistance(vec2 p, vec2 a, vec2 b) {
+  vec2 pa = p - a, ba = b - a;
+  float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+  return length(pa - ba * h);
+}
+float lineMask(vec2 p, vec2 a, vec2 b, float hw) {
+  return 1.0 - smoothstep(hw - 1.0, hw + 1.0, segmentDistance(p, a, b));
+}
+
+void main() {
+  vec2 p = (vUv - 0.5) * uResolution;
+  float hw = 4.0 + 3.0 * sin(uTime);            // E2
+
+  float seg  = lineMask(p, vec2(-200.0,-100.0), vec2(200.0,100.0), hw);
+  float vert = lineMask(p, vec2(0.0,-150.0), vec2(0.0,150.0), 4.0); // E4
+  float hori = lineMask(p, vec2(-150.0,0.0), vec2(150.0,0.0), 4.0);
+  float cross = max(vert, hori);
+
+  vec3 col = vec3(0.05);
+  col = mix(col, vec3(1.0),           seg);
+  col = mix(col, vec3(0.3,1.0,0.6),   cross);
+  gl_FragColor = vec4(col, 1.0);
+}
+```
+</details>
+
+## Memory checks
+
+1. Que représente `h` dans `segmentDistance`, et pourquoi le `clamp(…,0,1)` ?
+2. Qu'est-ce qui crée les **bouts arrondis** d'une ligne ?
+3. Comment passe-t-on d'une distance à un trait visible d'épaisseur 8px ?
+4. Que se passe-t-il si `a == b` ?
+5. Comment unir deux segments en une seule forme ?
+
+<details>
+<summary>Réponses</summary>
+
+1. La position projetée du pixel le long du segment (0=a, 1=b) ; le `clamp` empêche de
+sortir du segment → c'est lui qui arrondit les extrémités. 2. Le `clamp` de `h`. 3. `1.0 -
+smoothstep(hw-1, hw+1, d)` avec `hw = 4.0`. 4. La capsule dégénère : on obtient un disque.
+5. `max` des deux masques.
+</details>
+
+**Pont → M4** : tu sais dessiner UNE forme. Maintenant, comment en faire **mille** (une
+grille) **sans aucune boucle** ? La réponse tient en un mot : `fract`.

--- a/learning/shaders/lessons/M4-grids-repetition.md
+++ b/learning/shaders/lessons/M4-grids-repetition.md
@@ -1,0 +1,155 @@
+# M4 — Grilles & répétition SANS boucle (`fract`, `mod`)
+
+> Pré-requis : M2–M3. **C'est la leçon qui remplace tes doubles `for`.** Notion clé :
+> la **répétition de domaine** — diviser l'espace en cellules identiques, gratuitement.
+
+---
+
+## Le superpouvoir
+
+En p5, pour faire une grille tu écris :
+
+```js
+for (let y = 0; y < rows; y++)
+  for (let x = 0; x < cols; x++)
+    circle(x * cell, y * cell, d);   // CPU : cols×rows itérations
+```
+
+En shader, **il n'y a pas de boucle** : chaque pixel sait déjà où il est. On lui demande
+juste « dans quelle cellule suis-je, et où **dans** cette cellule ? ». Deux fonctions suffisent :
+
+- `floor(x)` = partie entière → **l'identifiant** de la cellule.
+- `fract(x)` = `x - floor(x)` → partie fractionnaire, 0..1 → la **position locale** dans la cellule.
+
+```glsl
+vec2 g    = vUv * N;        // N = nombre de cellules par axe (ex. vec2(8.0, 6.0))
+vec2 id   = floor(g);       // indice entier de la cellule (0,0), (1,0), ...
+vec2 cell = fract(g);       // coord locale 0..1 dans la cellule
+```
+
+`cell` repart de 0 à 1 **dans chaque case** : un motif dessiné avec `cell` se répète
+automatiquement partout. C'est ça, la **répétition de domaine**.
+
+### Une grille de points (sans boucle)
+
+On recentre la cellule (`cell - 0.5`) et on dessine un disque dedans, comme au M2 :
+
+```glsl
+vec2 g    = vUv * vec2(uColumns, uRows);
+vec2 cell = fract(g) - 0.5;          // -0.5..0.5, origine au centre de la case
+float d   = length(cell);
+float dot = 1.0 - smoothstep(0.18, 0.20, d);  // rayon ~0.19 en unités de cellule
+```
+
+Tu viens de dessiner `uColumns × uRows` points d'un coup. **Zéro boucle.** C'est le squelette
+de ta famille `noise-grid` (il ne manque que le bruit, M6).
+
+### Varier chaque cellule avec `id`
+
+`id` est constant dans toute une cellule → parfait pour faire varier taille, couleur, phase
+**par case** :
+
+```glsl
+float r = 0.1 + 0.15 * fract(sin(dot(id, vec2(12.9, 78.2))) * 43758.5); // pseudo-aléa par case
+```
+
+(`id` sera bientôt l'entrée de `perlinNoise` au M6 : un angle/une couleur par cellule.)
+
+### `mod` : l'autre outil de répétition
+
+`mod(x, m)` ramène `x` dans `[0, m)`. Utile pour un damier :
+
+```glsl
+float checker = mod(id.x + id.y, 2.0);   // 0 ou 1 en damier
+```
+
+### Pointillés = répétition 1D
+
+Le long d'un axe (ou d'un segment via le `h` du M3) :
+
+```glsl
+float t = vUv.x * 20.0;        // 20 tirets
+float dash = step(0.5, fract(t)); // trait / vide alterné
+```
+
+### Le piège des bords (important)
+
+Une forme proche du bord d'une cellule est **coupée** : le pixel voisin appartient à la case
+d'à côté et ne « voit » pas ce qui déborde. Tant que tes formes tiennent dans leur cellule,
+tout va bien. Pour des formes qui débordent (gros points, halos), il faut **regarder les
+cellules voisines** — c'est le M8 (et c'est exactement pourquoi `noise-grid-v12` scanne un
+voisinage 3×3).
+
+### Aspect ratio
+
+`fract(vUv * N)` donne des cellules carrées en **UV**, donc rectangulaires à l'écran si le
+canvas n'est pas carré. Choisis `N = vec2(cols, rows)` proportionnel au format, ou corrige
+en pixels comme aux M2–M3.
+
+---
+
+## Exercices (playground)
+
+- **E1 — Grille de points.** 8×6 points (méthode ci-dessus), **de mémoire**.
+- **E2 — Taille par cellule.** Fais varier le rayon des points avec `id` (pseudo-aléa, ou
+  `0.1 + 0.1*sin(id.x + id.y)`).
+- **E3 — Damier.** Colore en damier avec `mod(id.x + id.y, 2.0)`.
+- **E4 — Pointillés.** Une ligne pointillée horizontale au centre de l'écran.
+- **E5 — Grille de cercles (anneaux).** Remplace le disque par un `ringMask` adapté en unités
+  de cellule (ou repasse en pixels).
+- **E6 — Vague.** Décale chaque point verticalement selon sa colonne : `cell.y += 0.2*sin(id.x + uTime)`.
+
+<details>
+<summary>Corrigés</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform float uTime;
+
+float rand(vec2 p){ return fract(sin(dot(p, vec2(12.9, 78.2))) * 43758.5); }
+
+void main() {
+  vec2 N    = vec2(8.0, 6.0);
+  vec2 g    = vUv * N;
+  vec2 id   = floor(g);
+  vec2 cell = fract(g) - 0.5;
+
+  cell.y += 0.2 * sin(id.x + uTime);          // E6 (retire pour E1)
+
+  float r   = 0.10 + 0.12 * rand(id);          // E2
+  float dot = 1.0 - smoothstep(r - 0.01, r + 0.01, length(cell));
+
+  float checker = mod(id.x + id.y, 2.0);       // E3
+  vec3 bg = mix(vec3(0.04), vec3(0.10), checker);
+
+  gl_FragColor = vec4(mix(bg, vec3(1.0), dot), 1.0);
+}
+```
+```glsl
+// E4 — pointillés
+float band = 1.0 - smoothstep(0.02, 0.03, abs(vUv.y - 0.5)); // bande centrale
+float dash = step(0.5, fract(vUv.x * 30.0));
+gl_FragColor = vec4(vec3(band * dash), 1.0);
+```
+</details>
+
+## Memory checks
+
+1. Que renvoient `floor(vUv*N)` et `fract(vUv*N)`, et à quoi sert chacun ?
+2. Combien de boucles écris-tu pour dessiner une grille 100×100 en shader ?
+3. Pourquoi `id` est-il idéal pour varier une propriété par cellule ?
+4. Quel est le piège quand une forme déborde de sa cellule, et quelle leçon le résout ?
+5. Comment ferais-tu un damier ?
+
+<details>
+<summary>Réponses</summary>
+
+1. `floor` = indice (entier) de la cellule ; `fract` = position locale 0..1 dedans. 2. **Zéro**.
+3. Il est constant dans toute la cellule → une valeur unique par case. 4. La forme est coupée
+au bord (le voisin ne la voit pas) ; résolu au M8 par l'échantillonnage des cellules voisines.
+5. `mod(id.x + id.y, 2.0)`.
+</details>
+
+**Pont → M5** : tu fais des grilles. Pour les **animer** proprement (tailles, opacités,
+courbes), il te faut `remap` et les easings — tes outils habituels, en GLSL.

--- a/learning/shaders/lessons/M5-map-easing.md
+++ b/learning/shaders/lessons/M5-map-easing.md
@@ -1,0 +1,143 @@
+# M5 — `map` & easing en GLSL (`mappers` + `easing`)
+
+> Pré-requis : M0–M4. Notion clé : remettre une valeur à l'échelle (`remap`) et lui donner
+> une **courbe** (easing) — l'idiome central de l'animation dans tes sketchs.
+
+---
+
+## `remap` = ton `map()`
+
+Ouvre `noiseFieldGpu.js`, section `MAPPERS_GLSL` :
+
+```glsl
+float remap(float v, float a, float b, float c, float d) {
+  return c + (v - a) / (b - a) * (d - c);
+}
+float remapClamp(float v, float a, float b, float c, float d) {
+  float t = clamp((v - a) / (b - a), 0.0, 1.0);
+  return c + t * (d - c);
+}
+```
+
+- `remap` = `p5.map(v, a, b, c, d)` **sans bornage**.
+- `remapClamp` = `p5.map(..., true)` : borné à `[c,d]`.
+
+Outils cousins, déjà natifs en GLSL :
+- `mix(a, b, t)` = **lerp** = `a + (b-a)*t` (interpolation linéaire). `remap(v,0,1,a,b)` ≡ `mix(a,b,v)`.
+- `clamp(x, lo, hi)` = borne.
+- `smoothstep(e0, e1, x)` = `remapClamp` + une courbe en S (du M2).
+
+## Les easings (= ton `easing.js`)
+
+Toujours dans `MAPPERS_GLSL`, les courbes que tu connais, portées en GLSL :
+
+```glsl
+float easeInSine(float x)    { return 1.0 - cos((x * PI) / 2.0); }
+float easeOutSine(float x)   { return sin((x * PI) / 2.0); }
+float easeInOutSine(float x) { return -(cos(PI * x) - 1.0) / 2.0; }
+
+float easeInQuad(float x)  { return x * x; }
+float easeOutQuad(float x) { float u = 1.0 - x; return 1.0 - u * u; }
+float easeInCubic(float x) { return x * x * x; }
+float easeInOutCubic(float x) {
+  if (x < 0.5) { return 4.0 * x * x * x; }
+  float u = -2.0 * x + 2.0;
+  return 1.0 - (u * u * u) / 2.0;
+}
+float easeInBack(float x) {  // léger dépassement avant d'arriver
+  float c1 = 1.70158, c3 = c1 + 1.0;
+  return c3 * x*x*x - c1 * x*x;
+}
+```
+
+Un détail de pro à retenir (c'est commenté dans ton repo) : les easings polynomiaux utilisent
+des **multiplications** (`x*x*x`) plutôt que `pow(x, 3.0)`. Raison : `pow(base_négative, n)`
+est **indéfini** en GLSL, alors que `Math.pow` côté JS l'accepte. La multiplication reproduit
+exactement le comportement JS, même quand l'entrée sort de `[0,1]`.
+
+## L'idiome central : `mappers.fn`
+
+Dans tes sketchs, l'animation type est : *prendre une valeur, la normaliser, lui appliquer une
+courbe, la remettre dans une plage cible*. C'est `mappers.fn(v, min, max, a, b, ease)`, soit :
+
+```glsl
+// remap(ease(remap(v, min, max, 0,1)), 0,1, a, b)
+float fn(float v, float mn, float mx, float a, float b) {
+  float t = remapClamp(v, mn, mx, 0.0, 1.0);  // 1) normaliser en 0..1
+  t = easeInOutCubic(t);                       // 2) courber
+  return mix(a, b, t);                          // 3) projeter dans [a,b]
+}
+```
+
+Mémorise ces **trois temps** : *normaliser → courber → projeter*. Presque toute ton animation
+en découle (rayon, opacité, déplacement, couleur…).
+
+## Animer avec le temps
+
+`uTime` est en secondes. Pour une boucle 0→1 qui se répète : `fract(uTime / duree)`. Pour un
+va-et-vient : `sin`/`cos` (déjà en 0-courbe), ou un easing sur un ping-pong.
+
+```glsl
+float t   = fract(uTime * 0.5);              // boucle de 2s
+float k   = easeInOutSine(t);                // courbe
+float r   = mix(40.0, 160.0, k);             // rayon qui respire
+```
+
+---
+
+## Exercices (playground)
+
+- **E1 — `remap` de mémoire.** Réécris `remap` et `remapClamp`. Vérifie : `remap(0.5,0,1,100,200)` doit valoir 150.
+- **E2 — Respiration.** Un disque (M2) dont le rayon respire entre 40 et 160px via `easeInOutSine(fract(uTime*0.5))`.
+- **E3 — Comparer les courbes.** Écran coupé en bandes verticales (M4) : dans chaque bande,
+  un point monte/descend avec un easing différent en fonction de `uTime`. Observe `linear` vs
+  `Quad` vs `Cubic` vs `Back`.
+- **E4 — `fn` de mémoire.** Implémente l'idiome *normaliser→courber→projeter* et anime
+  l'opacité d'une forme avec.
+- **E5 — Vague de grille.** Reprends la grille du M4 ; mappe le rayon de chaque point avec
+  `fn(sin(id.x*0.6 + uTime), -1, 1, 0.05, 0.25)`.
+
+<details>
+<summary>Corrigés</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform vec2  uResolution;
+uniform float uTime;
+const float PI = 3.14159265;
+
+float remapClamp(float v, float a, float b, float c, float d){
+  float t = clamp((v-a)/(b-a), 0.0, 1.0); return c + t*(d-c);
+}
+float easeInOutSine(float x){ return -(cos(PI*x)-1.0)/2.0; }
+
+void main(){
+  vec2 p = (vUv - 0.5) * uResolution;
+  float k = easeInOutSine(fract(uTime * 0.5));   // E2
+  float r = mix(40.0, 160.0, k);
+  float disc = 1.0 - smoothstep(r-1.0, r+1.0, length(p));
+  gl_FragColor = vec4(vec3(disc), 1.0);
+}
+```
+</details>
+
+## Memory checks
+
+1. `remap` vs `remapClamp` : la différence ?
+2. Écris `mix(a,b,t)` en clair (formule).
+3. Pourquoi les easings polynomiaux évitent-ils `pow()` ?
+4. Les **trois temps** de l'idiome `fn` ?
+5. Comment fais-tu une boucle temporelle de 3 secondes ?
+
+<details>
+<summary>Réponses</summary>
+
+1. `remapClamp` borne le résultat à `[c,d]` (clamp du facteur), `remap` non. 2. `a + (b-a)*t`.
+3. `pow(base négative, n)` est indéfini en GLSL ; la multiplication reproduit `Math.pow`. 4.
+normaliser (`remapClamp` en 0..1) → courber (easing) → projeter (`mix` dans `[a,b]`). 5.
+`fract(uTime / 3.0)`.
+</details>
+
+**Pont → M6** : tu sais mettre en forme et animer des valeurs. Reste la source de toute la
+richesse organique de tes sketchs : le **bruit de Perlin**.

--- a/learning/shaders/lessons/M6-perlin-noise-gpu.md
+++ b/learning/shaders/lessons/M6-perlin-noise-gpu.md
@@ -1,0 +1,176 @@
+# M6 — Le bruit de Perlin sur GPU (cœur de `noise-grid`)
+
+> Pré-requis : M0–M5. Notion clé : le **bruit** transforme une grille régulière en champ
+> organique. C'est l'âme de toute ta famille `noise-grid`.
+
+---
+
+## Pourquoi le bruit
+
+`noise()` en p5 te donne une valeur **lisse et pseudo-aléatoire** : proche dans l'espace =
+proche en valeur. C'est ce qui donne le côté « naturel » (flux, reliefs, fumée) plutôt que le
+bruit blanc cassant de `random()`.
+
+Le schéma de **tous** tes `noise-grid` est le même (lis le gros commentaire en tête de
+`noiseFieldGpu.js`) :
+
+> échantillonner Perlin sur une grille → en faire un **angle** → l'utiliser pour déplacer /
+> tourner / colorer une primitive par cellule.
+
+Sur CPU, faire ça par cellule à chaque frame était le goulot. Sur GPU, c'est gratuit.
+
+## Ton port de `noise()`
+
+Ton repo reproduit le Perlin de p5 **bit pour bit** : même graine (`noiseSeed`), même table de
+permutation de 4096 entrées (envoyée en texture `uPerlin`), mêmes octaves (`uOctaves`,
+`uFalloff`). Dans `COMMON_GLSL` :
+
+```glsl
+float perlinNoise(vec2 p);   // == p5 noise(x, y)
+float perlinNoise(vec3 p);   // == p5 noise(x, y, z)
+```
+
+Sortie ≈ `[0, 1]` centrée autour de 0.5, comme p5. **Mais** `perlinNoise` dépend de la texture
+`uPerlin` et des uniforms du moteur — donc **il ne tourne pas tel quel dans le playground**.
+
+### Un bruit autonome pour le playground (hors-ligne)
+
+Pour expérimenter sans le moteur, voici un **value noise** + **fbm** compacts à coller dans tes
+shaders. Ce n'est pas le Perlin exact de p5, mais le **comportement et les usages sont
+identiques** — c'est ce qui compte pour apprendre.
+
+```glsl
+float hash(vec2 p) {
+  p = fract(p * vec2(123.34, 345.45));
+  p += dot(p, p + 34.345);
+  return fract(p.x * p.y);
+}
+
+float valueNoise(vec2 p) {
+  vec2 i = floor(p), f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);            // lissage (smoothstep)
+  float a = hash(i),               b = hash(i + vec2(1.0, 0.0));
+  float c = hash(i + vec2(0.0,1.0)), d = hash(i + vec2(1.0, 1.0));
+  return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// fbm = somme d'octaves : l'équivalent de uOctaves / uFalloff de ton moteur.
+float fbm(vec2 p) {
+  float sum = 0.0, amp = 0.5;
+  for (int i = 0; i < 5; i++) {                // borne CONSTANTE (obligatoire en WebGL1)
+    sum += amp * valueNoise(p);
+    p *= 2.0;       // fréquence ×2 (lacunarity)
+    amp *= 0.5;     // amplitude ÷2 (= ton uFalloff)
+  }
+  return sum;
+}
+```
+
+> **fbm = octaves.** Chaque octave ajoute du détail à fréquence double et amplitude moitié.
+> C'est exactement le rôle de `uOctaves` (combien) et `uFalloff` (le ×0.5) dans ton moteur.
+
+## Le pattern noise-grid (reproduction conceptuelle)
+
+C'est la recette de `noise-grid-v1` / `v11`, version playground :
+
+```glsl
+vec2  N    = vec2(uColumnsEquivalent);     // densité de la grille
+vec2  g    = vUv * N;
+vec2  id   = floor(g);
+vec2  cell = fract(g) - 0.5;
+
+float n     = valueNoise(id * 0.15 + uTime * 0.1); // bruit par cellule (anime via le temps)
+float angle = n * 6.2831853 * 1.0;                  // → un angle (× nb de cycles)
+vec2  dir   = vec2(cos(angle), sin(angle));         // → une direction
+
+// déplacer le point de la cellule le long de cette direction (flow field) :
+cell -= dir * 0.25;
+float dot = 1.0 - smoothstep(0.08, 0.10, length(cell));
+```
+
+Tu retrouves la chaîne complète : **grille (M4) → bruit (M6) → angle → direction → forme (M2)**.
+Ajoute la couleur (M7) et tu as un vrai sketch.
+
+> Note coordonnées : ton moteur calcule la position en **pixels avec origine en haut-gauche**
+> (comme p5 2D), donc il **inverse `vUv.y`** au moment de passer en pixels. Le playground, lui,
+> garde `vUv` origine bas-gauche. Détail à connaître quand tu transposeras vers le repo.
+
+## Animer le bruit
+
+- 2D + décalage : `valueNoise(p + uTime)` fait défiler le champ.
+- 3D avec le temps en Z : `perlinNoise(vec3(p, uTime))` (dans le moteur) — le motif **évolue
+  sur place** au lieu de défiler. C'est souvent plus joli.
+
+## Domain warping (bonus, très « toi »)
+
+Échantillonner le bruit à une position elle-même perturbée par du bruit → textures fluides,
+marbrées :
+
+```glsl
+float w = fbm(p + fbm(p + uTime * 0.1));
+```
+
+---
+
+## Exercices (playground)
+
+- **E1 — Champ.** Affiche `fbm(vUv * 4.0)` en niveaux de gris. Fais-le défiler avec `uTime`.
+- **E2 — Seuil.** Seuille le champ avec `smoothstep` pour obtenir des « continents » noir/blanc.
+- **E3 — Flow field.** Grille de points (M4) déplacés par l'angle du bruit (pattern ci-dessus).
+  **C'est ta reproduction de `noise-grid-v1`.**
+- **E4 — Animation sur place.** Anime via un décalage temporel du bruit, pas via la position
+  des points.
+- **E5 — Octaves.** Compare `valueNoise(p)` seul vs `fbm(p)` : mesure ce qu'apportent les octaves.
+- **E6 — Warp.** Applique le domain warping et observe.
+
+<details>
+<summary>Corrigés (E1–E3)</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform float uTime;
+const float TAU = 6.2831853;
+
+float hash(vec2 p){ p=fract(p*vec2(123.34,345.45)); p+=dot(p,p+34.345); return fract(p.x*p.y); }
+float valueNoise(vec2 p){
+  vec2 i=floor(p), f=fract(p), u=f*f*(3.0-2.0*f);
+  float a=hash(i), b=hash(i+vec2(1,0)), c=hash(i+vec2(0,1)), d=hash(i+vec2(1,1));
+  return mix(mix(a,b,u.x), mix(c,d,u.x), u.y);
+}
+float fbm(vec2 p){ float s=0.0,a=0.5; for(int i=0;i<5;i++){ s+=a*valueNoise(p); p*=2.0; a*=0.5;} return s; }
+
+void main(){
+  // E1 : gl_FragColor = vec4(vec3(fbm(vUv*4.0 + uTime*0.2)), 1.0);
+
+  // E3 : flow field
+  vec2 N=vec2(24.0,16.0), g=vUv*N, id=floor(g), cell=fract(g)-0.5;
+  float n=valueNoise(id*0.15 + uTime*0.1);
+  float ang=n*TAU;
+  cell -= vec2(cos(ang),sin(ang))*0.25;
+  float dot=1.0-smoothstep(0.08,0.10,length(cell));
+  gl_FragColor=vec4(vec3(dot),1.0);
+}
+```
+</details>
+
+## Memory checks
+
+1. Différence entre `noise()` et `random()` ?
+2. Que veulent dire « octaves » et « falloff » (fbm) ?
+3. La chaîne complète d'un sketch noise-grid (4–5 maillons) ?
+4. Pourquoi `perlinNoise` du repo ne tourne pas tel quel dans le playground ?
+5. Comment animer un champ « sur place » plutôt qu'en le faisant défiler ?
+
+<details>
+<summary>Réponses</summary>
+
+1. `noise` est lisse et corrélé spatialement (organique) ; `random` est non corrélé (cassant).
+2. octaves = nb de couches de bruit superposées (fréq ×2 à chaque fois) ; falloff = facteur
+d'amplitude (×0.5) entre couches. 3. grille (`fract`) → bruit par cellule → angle → direction →
+forme (déplacée/colorée). 4. Il dépend de la texture `uPerlin` et des uniforms du moteur,
+absents du playground. 5. Bruit 3D avec le temps en Z (`perlinNoise(vec3(p, uTime))`).
+</details>
+
+**Pont → M7** : ton champ est en niveaux de gris. Donne-lui les couleurs de tes sketchs avec
+les **palettes**.

--- a/learning/shaders/lessons/M7-color-palettes.md
+++ b/learning/shaders/lessons/M7-color-palettes.md
@@ -1,0 +1,134 @@
+# M7 — Couleur & palettes
+
+> Pré-requis : M0–M6. Notion clé : transformer un scalaire (angle, bruit, temps) en **couleur**,
+> avec tes palettes existantes et la formule cosinus universelle.
+
+---
+
+## Le principe
+
+Une palette = une fonction `float → vec3` : tu lui donnes un paramètre (souvent un angle, une
+valeur de bruit, une position) et elle renvoie une couleur RGB (0..1). Tu en as déjà plusieurs.
+
+## Tes palettes (`PALETTES_GLSL`)
+
+Ouvre `noiseFieldGpu.js`. Tes palettes construisent chaque canal avec des `sin`/`cos`, façon
+roue chromatique, puis divisent par `opacityFactor` (héritage du code p5 en espace 0..255) :
+
+```glsl
+vec3 paletteRainbow(float hueOffset, float hueIndex, float opacityFactor) {
+  float a = hueOffset + hueIndex;
+  float b = hueOffset - hueIndex;
+  float red   = (sin(a) * 0.5 + 0.5) * 360.0 / opacityFactor;
+  float green = (1.0 - cos(b)) * 0.5 * 360.0 / opacityFactor;
+  float blue  = (1.0 - sin(a)) * 0.5 * 360.0 / opacityFactor;
+  return clamp(vec3(red, green, blue) / 255.0, 0.0, 1.0);
+}
+```
+
+Et un sélecteur runtime (comme l'option « palette » de tes sketchs) :
+
+```glsl
+vec3 paletteColor(int id, float hueOffset, float hueIndex, float opacityFactor);
+// 0 = rainbow, 1 = purple, 2 = darkBlueYellow
+```
+
+Idée à retenir : chaque canal est une **onde** (`sin`/`cos`) du paramètre. Décaler les phases
+des trois canaux donne tout le spectre.
+
+## La formule universelle : palette cosinus (Inigo Quilez)
+
+Au-delà de tes palettes, mémorise **celle-ci** — elle génère n'importe quel dégradé doux avec 4
+vecteurs de contrôle :
+
+```glsl
+// t : 0..1   →   couleur
+vec3 palette(float t) {
+  vec3 a = vec3(0.5, 0.5, 0.5);  // moyenne (offset)
+  vec3 b = vec3(0.5, 0.5, 0.5);  // amplitude
+  vec3 c = vec3(1.0, 1.0, 1.0);  // fréquence par canal
+  vec3 d = vec3(0.00, 0.33, 0.67); // phase par canal
+  return a + b * cos(6.28318 * (c * t + d));
+}
+```
+
+- `a` = couleur moyenne, `b` = contraste, `c` = combien de cycles, `d` = décalage de teinte
+  par canal (c'est `d` qui « écarte » R, G, B pour créer l'arc-en-ciel).
+- Change `d` pour explorer : `(0.0, 0.1, 0.2)` = chaud, `(0.3, 0.2, 0.2)` = pastel…
+
+## Mélanger deux couleurs
+
+Le plus simple des dégradés, c'est `mix` (M5) :
+
+```glsl
+vec3 col = mix(colA, colB, t);   // t de 0..1
+```
+
+## Brancher la couleur sur le reste
+
+- Sur le **bruit** (M6) : `vec3 col = palette(fbm(vUv*4.0));`
+- Sur l'**angle** d'un flow field : `palette(angle / TAU)`
+- Sur le **temps** : `palette(fract(uTime*0.1))` pour un cycle de teinte
+- Sur la **distance** (M2) : `palette(length(p)/maxR)` pour un dégradé radial coloré
+
+> Note perceptuelle (bonus) : le mélange linéaire de couleurs en sRGB peut « ternir » au
+> milieu. Pour des dégradés très propres, certains travaillent en espace linéaire
+> (`pow(col, 2.2)` avant, `pow(col, 1.0/2.2)` après). Optionnel pour tes usages.
+
+---
+
+## Exercices (playground)
+
+- **E1 — Palette cosinus.** Colorie l'écran avec `palette(vUv.x)`. Joue avec `d` pour 3 ambiances.
+- **E2 — Champ coloré.** Reprends `fbm` (M6) et colorie-le avec `palette(fbm(...))`.
+- **E3 — Flow coloré.** Reprends le flow field E3 du M6 ; colore chaque point selon son angle
+  (`palette(angle/TAU)`).
+- **E4 — Rainbow de mémoire.** Réécris `paletteRainbow` ; vérifie que des `hueIndex` croissants
+  parcourent bien le spectre.
+- **E5 — Cycle temporel.** Fais tourner la teinte de tout l'écran avec `uTime`.
+
+<details>
+<summary>Corrigés (E1–E2)</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform float uTime;
+
+vec3 palette(float t){
+  vec3 a=vec3(0.5), b=vec3(0.5), c=vec3(1.0), d=vec3(0.0,0.33,0.67);
+  return a + b * cos(6.28318 * (c*t + d));
+}
+float hash(vec2 p){ p=fract(p*vec2(123.34,345.45)); p+=dot(p,p+34.345); return fract(p.x*p.y); }
+float valueNoise(vec2 p){
+  vec2 i=floor(p), f=fract(p), u=f*f*(3.0-2.0*f);
+  float a=hash(i),b=hash(i+vec2(1,0)),c=hash(i+vec2(0,1)),d=hash(i+vec2(1,1));
+  return mix(mix(a,b,u.x),mix(c,d,u.x),u.y);
+}
+float fbm(vec2 p){ float s=0.0,a=0.5; for(int i=0;i<5;i++){s+=a*valueNoise(p);p*=2.0;a*=0.5;} return s; }
+
+void main(){
+  float n = fbm(vUv*4.0 + uTime*0.15);
+  gl_FragColor = vec4(palette(n + uTime*0.05), 1.0);  // E2 + E5
+}
+```
+</details>
+
+## Memory checks
+
+1. Une palette, c'est une fonction de quel type vers quel type ?
+2. Dans la palette cosinus `a + b*cos(TAU*(c*t+d))`, que contrôle `d` ?
+3. Comment colorer un point d'un flow field selon sa direction ?
+4. Quel outil pour un simple dégradé entre deux couleurs ?
+5. Idée commune à toutes tes palettes (rainbow, purple…) ?
+
+<details>
+<summary>Réponses</summary>
+
+1. `float → vec3` (scalaire → RGB). 2. La **phase par canal** → l'écart de teinte entre R/G/B.
+3. `palette(angle / TAU)`. 4. `mix(colA, colB, t)`. 5. Chaque canal RGB est une onde sin/cos du
+paramètre, avec des phases décalées.
+</details>
+
+**Pont → M8** : tu sais dessiner et colorer des formes. Quand elles se **superposent** (grilles
+denses, calques), il faut maîtriser l'**ordre** et le **blending**.

--- a/learning/shaders/lessons/M8-composition-blending.md
+++ b/learning/shaders/lessons/M8-composition-blending.md
@@ -1,0 +1,141 @@
+# M8 — Composition, ordre de dessin & blending
+
+> Pré-requis : M0–M7. Notion clé : dans un fragment full-screen il n'y a **pas** d'ordre de
+> dessin — tu composes toi-même la couleur finale. Et la gestion du débordement entre cellules.
+
+---
+
+## Il n'y a pas de « dessine par-dessus »
+
+En p5, l'ordre des appels crée la profondeur (ce qui est dessiné après recouvre). Dans un
+fragment shader full-screen, **chaque pixel calcule directement sa couleur finale** : pas de
+« couche au-dessus ». Tu simules l'empilement avec des `mix` successifs (peintre) :
+
+```glsl
+vec3 col = bg;                       // fond
+col = mix(col, colA, maskA);         // forme A par-dessus le fond
+col = mix(col, colB, maskB);         // forme B par-dessus A
+col = mix(col, colC, maskC);         // etc.
+```
+
+L'**ordre des `mix`** = l'ordre de dessin. La dernière forme dont le masque vaut 1 gagne.
+
+Opérateurs utiles (rappel M2) :
+- **Union** de masques : `max(mA, mB)` · **Intersection** : `min` · **Soustraction** : `mA*(1.0-mB)`
+- Bord doux : `smoothstep` · Mélange de couleurs : `mix`
+
+## Le problème du débordement (et `noise-grid-v12`)
+
+Au M4 on a vu : une forme qui **déborde** de sa cellule est coupée, car le pixel voisin
+appartient à une autre cellule et ne « voit » pas ce débordement. Pour des points qui se
+chevauchent, il faut, depuis le pixel courant, **regarder aussi les cellules voisines** et
+prendre en compte leurs formes.
+
+C'est précisément ce que fait `noise-grid-v12-field-on-fire` : un **scan 3×3** autour de la
+cellule courante. Le squelette :
+
+```glsl
+vec2 g  = vUv * N;
+vec2 id = floor(g);
+vec3 col = bg;
+
+for (int dy = -1; dy <= 1; dy++) {        // bornes CONSTANTES (WebGL1)
+  for (int dx = -1; dx <= 1; dx++) {
+    vec2 nid    = id + vec2(float(dx), float(dy));   // cellule voisine
+    vec2 center = (nid + 0.5) / N;                   // son centre en UV
+    // ... calcule la forme/couleur de CETTE cellule (bruit, angle, rayon)
+    // ... position du pixel courant par rapport à ce centre
+    float m = /* masque de la forme de la cellule voisine au pixel courant */;
+    col = mix(col, cellColor, m);                     // composition (ordre = front/back)
+  }
+}
+gl_FragColor = vec4(col, 1.0);
+```
+
+Chaque pixel évalue donc jusqu'à 9 formes et les compose dans l'ordre voulu — ce qui résout
+proprement les chevauchements et l'ordre d'empilement. C'est plus de calcul par pixel, mais
+toujours massivement parallèle, donc rapide.
+
+## L'alternative : l'instancing (`createInstancedFieldRenderer`)
+
+Ton moteur a **deux** stratégies pour la même famille :
+
+| | Fragment full-screen | Instanced (1 quad/cellule) |
+|---|---|---|
+| Idée | chaque pixel calcule tout | on dessine N petits quads, blending GPU |
+| Ordre / chevauchement | scan voisinage (3×3) à la main | **ordre de dessin** natif + alpha blending |
+| Coût | par pixel (×9 si scan) | par cellule (geometry) + overdraw |
+| Quand | champs denses, plein écran | formes éparses, gros points qui se chevauchent |
+
+L'instancing **active le blending GPU** (`gl.enable(BLEND)`, `blendFunc`), dessine une instance
+par cellule et laisse le pipeline gérer la transparence dans l'ordre d'émission. C'est l'autre
+façon, complémentaire, de régler l'ordre/chevauchement — voir `noise-grid-v1/v2/v8`.
+
+> **Alpha blending en bref** : `couleur_finale = src.rgb*src.a + dst.rgb*(1-src.a)` (mode
+> « over »). En fragment full-screen tu fais ça à la main avec `mix(dst, src, src_a)`. En
+> instanced, le GPU le fait pour toi entre les quads.
+
+## Vignette, fond, post-traitement
+
+Comme tout finit dans une couleur, tu peux ajouter des effets « plein écran » en dernier :
+vignette (`col *= smoothstep(1.2, 0.3, length(vUv-0.5))`), grain, teinte globale, etc.
+
+---
+
+## Exercices (playground)
+
+- **E1 — Empilement.** Trois disques de couleurs différentes qui se chevauchent ; change
+  l'ordre des `mix` et observe qui passe devant.
+- **E2 — Union vs empilement.** Compare `max(mA,mB)` (fusion) et deux `mix` successifs (recouvrement).
+- **E3 — Scan 3×3.** Grille de gros points (rayon > taille de cellule) ; d'abord **sans** scan
+  (observe les coupures aux bords), puis **avec** le scan 3×3 (débordement propre).
+- **E4 — Front/back par le bruit.** Dans le scan, choisis l'ordre de composition selon une
+  valeur de bruit par cellule (certaines passent devant).
+- **E5 — Vignette.** Ajoute une vignette en post pour finir une compo.
+
+<details>
+<summary>Corrigé (E3, scan 3×3 minimal)</summary>
+
+```glsl
+precision highp float;
+varying vec2 vUv;
+uniform vec2 uResolution;
+
+void main(){
+  vec2 N = vec2(10.0, 6.0);
+  vec2 g = vUv * N, id = floor(g);
+  vec3 col = vec3(0.05);
+  for (int dy=-1; dy<=1; dy++){
+    for (int dx=-1; dx<=1; dx++){
+      vec2 nid = id + vec2(float(dx), float(dy));
+      vec2 center = (nid + 0.5) / N;        // UV du centre de la cellule voisine
+      vec2 d = (vUv - center) * N;          // distance en unités de cellule
+      float m = 1.0 - smoothstep(0.55, 0.6, length(d));  // rayon > 0.5 -> déborde
+      col = mix(col, vec3(1.0, 0.5, 0.2), m);
+    }
+  }
+  gl_FragColor = vec4(col, 1.0);
+}
+```
+</details>
+
+## Memory checks
+
+1. Pourquoi n'y a-t-il pas d'« ordre de dessin » dans un fragment full-screen ?
+2. Comment simules-tu l'empilement « peintre » ?
+3. Pourquoi `noise-grid-v12` scanne-t-il un voisinage 3×3 ?
+4. Les deux stratégies de ton moteur pour gérer chevauchement/ordre ?
+5. Formule du blending « over » ?
+
+<details>
+<summary>Réponses</summary>
+
+1. Chaque pixel calcule directement sa couleur finale, isolément ; rien n'est « au-dessus ».
+2. Des `mix(col, forme, masque)` successifs ; l'ordre des `mix` = l'ordre d'empilement. 3. Pour
+que les formes qui débordent d'une cellule soient vues par les pixels des cellules voisines
+(sinon coupures). 4. Fragment full-screen avec scan 3×3 **ou** instancing + alpha blending GPU.
+5. `src.rgb*src.a + dst.rgb*(1 - src.a)`.
+</details>
+
+**Pont → M9** : fin de la piste 2D (fragment). On passe à la 3D : le **vertex shader** et les
+**matrices**, avec ton `peaks-cone`.

--- a/learning/shaders/lessons/M9-vertex-shader-3d.md
+++ b/learning/shaders/lessons/M9-vertex-shader-3d.md
@@ -1,0 +1,180 @@
+# M9 — Vertex shader & matrices (3D, `peaks-cone`)
+
+> Pré-requis : M0–M8. Notion clé : jusqu'ici le vertex shader était figé (un quad). Pour la
+> 3D, c'est **lui** qui place la géométrie. Tes sphères/cônes/peaks vivent ici.
+
+> ⚠️ Le playground est **fragment-only** (un quad plein écran). M9 est surtout une leçon de
+> **lecture/compréhension** + des exercices papier. Un mini-template p5 est fourni en bas pour
+> expérimenter quand tu auras internet.
+
+---
+
+## Les deux étages du pipeline
+
+1. **Vertex shader** : s'exécute une fois **par sommet**. Son job : produire `gl_Position`, la
+   position du sommet à l'écran (en clip space). C'est là qu'on applique les transformations 3D.
+2. **Fragment shader** : une fois **par pixel** (ce que tu connais). Il colore.
+
+Entre les deux, les `varying` interpolent des valeurs (couleur, normale, UV) du sommet vers le pixel.
+
+## Les matrices : l'équivalent de `translate/rotate/scale`
+
+En p5 3D tu fais `translate()`, `rotateY()`, `scale()`, puis `sphere()`. Sous le capot, ces
+opérations sont des **matrices 4×4** (`mat4`) que le GPU multiplie au sommet :
+
+```glsl
+gl_Position = uP * uMV * vec4(position, 1.0);
+```
+
+- `uMV` (**model-view**) : place l'objet dans le monde **et** par rapport à la caméra
+  (= tes `translate`/`rotate`/`scale` cumulés).
+- `uP` (**projection**) : applique la perspective (objets lointains plus petits).
+- L'ordre se lit **de droite à gauche** : le sommet est d'abord transformé par `uMV`, puis projeté par `uP`.
+- `vec4(pos, 1.0)` : le `1.0` (coordonnée homogène `w`) permet à la matrice d'encoder une
+  **translation** (avec `0.0`, ce serait une direction, non translatée).
+
+## Lecture : ton `peaks-cone`
+
+Ouvre `src/templates/p5/sketches/peaks/peaks-cone/index.js`. Le vertex shader **construit
+chaque cône sur le GPU** à partir d'un cercle unité, puis le pose sur la sphère :
+
+```glsl
+attribute vec2 aUnit;   // (theta, layer_t) : par sommet du cône unité
+attribute vec4 aPos;    // (x,y,z, longueur) : par instance (un spike)
+attribute vec4 aNrm;    // normale (direction du spike) : par instance
+attribute vec4 aCol;    // couleur : par instance
+
+uniform mat4 uMV, uP;
+uniform float uProfile, uTaper, uTwist, uPtBase, uPtTip;
+varying vec4 vCol;
+
+void main() {
+  float theta  = aUnit.x;             // angle autour de l'axe du cône
+  float layerT = aUnit.y;             // 0 = base, 1 = pointe
+  vec3  pos    = aPos.xyz;            // position du spike sur la sphère
+  float slen   = aPos.w;             // longueur du spike
+  vec3  normal = normalize(aNrm.xyz); // axe du spike
+
+  float h   = (1.0 - layerT) * slen;            // hauteur le long de l'axe
+  float rad = profileRadius(layerT) * slen * uTaper; // rayon (selon le profil)
+  float tw  = theta + uTwist * h;               // torsion (effet ADN)
+
+  // repère local autour de la normale : (tan, bitan) ⟂ normal
+  vec3 up    = abs(normal.y) < 0.9 ? vec3(0,1,0) : vec3(1,0,0);
+  vec3 tan   = normalize(cross(normal, up));
+  vec3 bitan = cross(normal, tan);
+
+  // point 3D final = base + le long de l'axe + autour de l'axe
+  vec3 wp = pos + normal*h + tan*cos(tw)*rad + bitan*sin(tw)*rad;
+
+  gl_Position  = uP * uMV * vec4(wp, 1.0);
+  gl_PointSize = mix(uPtTip, uPtBase, layerT);
+  vCol         = aCol;
+}
+```
+
+À comprendre :
+- **Cône paramétrique** : un point du cône = `centre + axe*h + (autour de l'axe)*rayon`. Le
+  « autour » se fait avec deux vecteurs perpendiculaires (`tan`, `bitan`) et `cos/sin(theta)`.
+- **`profileRadius(layerT)`** mélange 4 profils (cône, goutte, tube, bulbe) selon `uProfile` —
+  c'est ton morphing, fait **sur le GPU**.
+- **`cross(normal, up)`** construit un repère orienté le long de chaque spike (base orthonormée).
+- Le fragment shader est trivial : `gl_FragColor = vCol;` (il ne fait que ressortir la couleur interpolée).
+
+## L'instancing (le « pour tous les spikes d'un coup »)
+
+C'est la version 3D du M4 : au lieu d'une boucle CPU « pour chaque spike, push/sphere/pop », on
+dessine **une seule géométrie de base** (le cône unité, `aUnit`) répétée N fois, chaque copie
+recevant ses propres **données par instance** (`aPos`, `aNrm`, `aCol`) :
+
+- `aUnit` : attribut **par sommet** (divisor 0) — la forme du cône, partagée.
+- `aPos/aNrm/aCol` : attributs **par instance** (divisor 1) — un jeu par spike.
+- Un seul `drawArraysInstanced(...)` dessine tous les spikes. Voir `gl.vertexAttribDivisor`.
+
+C'est la même idée que « grille sans boucle » : on décrit **un** élément + **les données qui
+changent**, et le GPU multiplie.
+
+## Le passage mental depuis p5 3D
+
+| p5 3D | Vertex shader |
+|---|---|
+| `translate/rotate/scale` | matrice `uMV` |
+| perspective de la caméra | matrice `uP` |
+| `sphere()`, `cone()` | géométrie construite/fournie en `attribute` |
+| boucle `for` + `push/pop` | **instancing** (attributs par instance) |
+| `fill(c)` | `varying` couleur vers le fragment |
+
+---
+
+## Exercices
+
+Surtout **papier/lecture** (le playground ne fait pas de 3D) :
+
+- **E1 — Lis `gl_Position`.** Explique avec tes mots ce que `uP * uMV * vec4(wp,1.0)` calcule,
+  et pourquoi de droite à gauche.
+- **E2 — Le `1.0`.** Pourquoi `vec4(wp, 1.0)` et pas `0.0` ? Qu'est-ce que ça change pour la translation ?
+- **E3 — Repère local.** Pourquoi a-t-on besoin de `tan` et `bitan` perpendiculaires à `normal` ?
+- **E4 — Données d'instance.** Liste ce qui est « par sommet » vs « par instance » dans `peaks-cone`, et pourquoi.
+- **E5 — Nouveau profil.** Écris une expression `profileRadius` pour un profil « sablier »
+  (fin au milieu, large aux bouts). Indice : l'inverse du `bulge` `4t(1-t)`.
+- **E6 (avec internet) — Mini p5.** Avec le template ci-dessous, fais tourner un cube/sphère et
+  déplace ses sommets avec du bruit dans le vertex shader.
+
+<details>
+<summary>Mini-template p5 (createShader) — pour quand tu auras internet</summary>
+
+```js
+// p5 (WEBGL). Vertex shader qui déforme une sphère ; fragment trivial.
+let prog;
+const VERT = `
+precision highp float;
+attribute vec3 aPosition;
+uniform mat4 uModelViewMatrix;   // p5 fournit ces uniforms automatiquement
+uniform mat4 uProjectionMatrix;
+uniform float uTime;
+varying float vH;
+void main(){
+  vec3 p = aPosition;
+  float bump = sin(p.x*4.0 + uTime) * cos(p.y*4.0 + uTime) * 0.15;
+  p += normalize(aPosition) * bump;   // pousse le sommet le long de sa normale
+  vH = bump;
+  gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(p, 1.0);
+}`;
+const FRAG = `
+precision highp float;
+varying float vH;
+void main(){ gl_FragColor = vec4(0.5 + vH*2.0, 0.6, 1.0 - vH*2.0, 1.0); }`;
+
+function setup(){ createCanvas(600,600, WEBGL); prog = createShader(VERT, FRAG); }
+function draw(){
+  background(10);
+  shader(prog);
+  prog.setUniform('uTime', millis()/1000);
+  rotateY(millis()/2000);
+  noStroke();
+  sphere(150, 64, 64);   // p5 fournit aPosition + les matrices au shader
+}
+```
+</details>
+
+## Memory checks
+
+1. Que produit le vertex shader, et à quelle fréquence s'exécute-t-il ?
+2. Rôles de `uMV` et `uP` ?
+3. Pourquoi lit-on `uP * uMV * v` de droite à gauche ?
+4. À quoi sert le `1.0` dans `vec4(pos, 1.0)` ?
+5. Différence « par sommet » vs « par instance » dans l'instancing ?
+
+<details>
+<summary>Réponses</summary>
+
+1. La position écran (`gl_Position`) de chaque sommet ; une fois **par sommet**. 2. `uMV` = modèle
++ caméra (translate/rotate/scale) ; `uP` = projection/perspective. 3. Le sommet est transformé
+par `uMV` d'abord (le plus à droite), puis projeté par `uP`. 4. La coordonnée homogène `w=1`
+permet d'encoder une **translation** dans la matrice. 5. « Par sommet » = la géométrie de base
+partagée (divisor 0) ; « par instance » = les données propres à chaque copie (divisor 1).
+</details>
+
+**Pont → M10** : tu sais faire de la 3D **par géométrie** (sommets + matrices). Le M10 montre
+l'autre voie — la 3D **par distance** (raymarching) — qui prolonge directement tes SDF du M2…
+et qui, elle, tourne dans le playground.

--- a/learning/shaders/playground/index.html
+++ b/learning/shaders/playground/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Shader Playground — p5-templates</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #0e0f13; color: #d7dae0; }
+  #app { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr auto; height: 100%; gap: 1px; background: #23262e; }
+  #editorPane { grid-row: 1 / 3; display: flex; flex-direction: column; background: #14161b; }
+  #editorPane header, #viewPane header { padding: 8px 12px; font-size: 12px; letter-spacing: .04em; color: #8b94a3; background: #14161b; border-bottom: 1px solid #23262e; display: flex; justify-content: space-between; align-items: center; }
+  #code { flex: 1; width: 100%; border: 0; resize: none; padding: 12px; font: 13px/1.5 ui-monospace, monospace; color: #d7dae0; background: #14161b; tab-size: 2; outline: none; }
+  #viewPane { display: flex; flex-direction: column; background: #000; }
+  #canvasWrap { flex: 1; position: relative; }
+  canvas { width: 100%; height: 100%; display: block; }
+  #log { grid-column: 2; background: #14161b; border-top: 1px solid #23262e; padding: 8px 12px; font-size: 12px; min-height: 38px; max-height: 160px; overflow: auto; white-space: pre-wrap; color: #9fb0c3; }
+  #log.error { color: #ff8a8a; }
+  #log.ok { color: #7fd49a; }
+  .pill { font-size: 11px; color: #6b7280; }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="editorPane">
+    <header>
+      <span>fragment shader — édite ici</span>
+      <span class="pill">recompile auto · Ctrl/Cmd+S pour forcer</span>
+    </header>
+    <textarea id="code" spellcheck="false"></textarea>
+  </div>
+  <div id="viewPane">
+    <header>
+      <span>rendu</span>
+      <span class="pill" id="fps"></span>
+    </header>
+    <div id="canvasWrap"><canvas id="gl"></canvas></div>
+  </div>
+  <div id="log"></div>
+</div>
+
+<script>
+// --- Vertex shader : identique à VERT_SRC de src/.../utils/noiseFieldGpu.js ---
+const VERT_SRC = `
+precision highp float;
+attribute vec2 aPos;   // quad plein écran en clip space (-1..1)
+varying vec2 vUv;      // 0..1 sur le quad
+void main() {
+  vUv = aPos * 0.5 + 0.5;
+  gl_Position = vec4(aPos, 0.0, 1.0);
+}`;
+
+// --- Fragment shader de départ : ton premier shader, le dégradé R/G ---
+const DEFAULT_FRAG = `precision highp float;
+
+varying vec2 vUv;           // position du pixel, 0..1
+uniform vec2  uResolution;  // taille du canvas en pixels
+uniform float uTime;        // secondes
+uniform vec2  uMouse;       // souris 0..1
+
+void main() {
+  // Chaque pixel répond : "quelle est MA couleur ?"
+  // vUv.x va de 0 (gauche) à 1 (droite)  -> canal rouge
+  // vUv.y va de 0 (bas)    à 1 (haut)     -> canal vert
+  vec3 col = vec3(vUv.x, vUv.y, 0.0);
+  gl_FragColor = vec4(col, 1.0);
+}`;
+
+const canvas = document.getElementById("gl");
+const gl = canvas.getContext("webgl");
+const codeEl = document.getElementById("code");
+const logEl = document.getElementById("log");
+const fpsEl = document.getElementById("fps");
+
+if (!gl) { logEl.textContent = "WebGL indisponible dans ce navigateur."; logEl.className = "error"; }
+
+// quad plein écran (2 triangles)
+const quad = new Float32Array([-1,-1, 1,-1, -1,1,  -1,1, 1,-1, 1,1]);
+const buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, quad, gl.STATIC_DRAW);
+
+function compile(type, src) {
+  const sh = gl.createShader(type);
+  gl.shaderSource(sh, src);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    const err = gl.getShaderInfoLog(sh);
+    gl.deleteShader(sh);
+    throw new Error(err);
+  }
+  return sh;
+}
+
+let program = null;
+let loc = {};
+
+function build(fragSrc) {
+  try {
+    const vs = compile(gl.VERTEX_SHADER, VERT_SRC);
+    const fs = compile(gl.FRAGMENT_SHADER, fragSrc);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs); gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(p));
+    if (program) gl.deleteProgram(program);
+    program = p;
+    loc = {
+      aPos: gl.getAttribLocation(p, "aPos"),
+      uResolution: gl.getUniformLocation(p, "uResolution"),
+      uTime: gl.getUniformLocation(p, "uTime"),
+      uMouse: gl.getUniformLocation(p, "uMouse"),
+    };
+    logEl.textContent = "✓ compilé"; logEl.className = "ok";
+  } catch (e) {
+    logEl.textContent = String(e.message || e); logEl.className = "error";
+  }
+}
+
+let mouse = [0.5, 0.5];
+canvas.addEventListener("pointermove", (e) => {
+  const r = canvas.getBoundingClientRect();
+  mouse = [(e.clientX - r.left) / r.width, 1 - (e.clientY - r.top) / r.height];
+});
+
+function resize() {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const w = canvas.clientWidth * dpr, h = canvas.clientHeight * dpr;
+  if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h; }
+}
+
+let frames = 0, lastFps = performance.now();
+const start = performance.now();
+function render(now) {
+  resize();
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  if (program) {
+    gl.useProgram(program);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.enableVertexAttribArray(loc.aPos);
+    gl.vertexAttribPointer(loc.aPos, 2, gl.FLOAT, false, 0, 0);
+    if (loc.uResolution) gl.uniform2f(loc.uResolution, canvas.width, canvas.height);
+    if (loc.uTime) gl.uniform1f(loc.uTime, (now - start) / 1000);
+    if (loc.uMouse) gl.uniform2f(loc.uMouse, mouse[0], mouse[1]);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  }
+  frames++;
+  if (now - lastFps > 500) { fpsEl.textContent = Math.round(frames * 1000 / (now - lastFps)) + " fps"; frames = 0; lastFps = now; }
+  requestAnimationFrame(render);
+}
+
+// recompile auto (débounce léger) + Ctrl/Cmd+S
+let t = null;
+function scheduleBuild() { clearTimeout(t); t = setTimeout(() => build(codeEl.value), 250); }
+codeEl.addEventListener("input", scheduleBuild);
+codeEl.addEventListener("keydown", (e) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === "s") { e.preventDefault(); build(codeEl.value); }
+  if (e.key === "Tab") { e.preventDefault(); const s = codeEl.selectionStart; codeEl.value = codeEl.value.slice(0,s) + "  " + codeEl.value.slice(codeEl.selectionEnd); codeEl.selectionStart = codeEl.selectionEnd = s + 2; }
+});
+
+codeEl.value = DEFAULT_FRAG;
+build(DEFAULT_FRAG);
+requestAnimationFrame(render);
+</script>
+</body>
+</html>

--- a/learning/shaders/solutions/README.md
+++ b/learning/shaders/solutions/README.md
@@ -1,0 +1,4 @@
+# Tes solutions d'exercices
+
+Un fichier `.frag` par exercice (ex. `m1-e2.frag`). Tu peux y copier le contenu
+depuis le playground. Je relis et corrige depuis ici.


### PR DESCRIPTION
## Cours de shaders, résident dans le repo

Met en place un programme progressif pour apprendre les shaders GLSL, orienté autour des sketchs p5.js 2D/3D existants. Le but : pouvoir un jour démarrer un sketch directement en shader.

### Contenu (`learning/shaders/`)
- **`README.md`** — le déroulé du cours, ses rituels, et une table « pierre de Rosette » qui relie chaque outil p5 (CPU) à son jumeau GPU déjà présent dans le repo (`discMask`/`circle`, `segmentDistance`/`line`, `perlinNoise`/`noise`, etc.).
- **`PROGRESS.md`** — la mémoire du cours : un registre de répétition espacée + un journal de session. Comme les sessions sont éphémères, c'est ce fichier qui permet à une future session (ou un rappel programmé) de savoir quoi réviser.
- **`lessons/M0-M1-mental-model-and-uv.md`** — première leçon : le mental model (« chaque pixel se pose une question ») et l'espace des UV (l'équivalent de `translate`/`scale`), avec exercices et *memory checks*.
- **`playground/index.html`** — un éditeur de fragment shader **en direct**, sans dépendance ni serveur (double-clic pour ouvrir). Vertex shader identique au `VERT_SRC` du repo ; uniforms `vUv`, `uResolution`, `uTime`, `uMouse`.

### Notes
- Aucune modification du code applicatif : tout est isolé sous `learning/`.
- Les modules suivants (SDF, lignes, grilles sans boucle, Perlin GPU, palettes, 3D/vertex, raymarching) viendront s'ajouter au fil des sessions.

🤖 Brouillon ouvert pour suivre l'avancée du cours.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ukQxUvEkX7FdLdABEkfEG)_