### PR TITLE
Add QR code content item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "next-themes": "^0.4.6",
         "p5": "^1.9.4",
         "playwright": "^1.50.1",
+        "qrcode": "^1.5.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.61.1",
@@ -6893,7 +6894,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7458,6 +7458,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -7601,6 +7610,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -8881,7 +8896,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -12606,7 +12620,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12673,7 +12686,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12927,6 +12939,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13251,6 +13272,173 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13535,11 +13723,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -13801,6 +13994,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -15542,6 +15741,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "next-themes": "^0.4.6",
     "p5": "^1.9.4",
     "playwright": "^1.50.1",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.61.1",

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
@@ -5,7 +5,8 @@ import {
   Layers as StackIcon,
   PaintBucket as BgIcon,
   Sparkles as VisualIcon,
-  Terminal as SpecsIcon
+  Terminal as SpecsIcon,
+  QrCode as QrCodeIcon
 } from "lucide-react";
 import {
   ItemKind,
@@ -19,7 +20,8 @@ export const ITEM_ORDER: ItemKind[] = [
   "images-stack",
   "meta",
   "specs",
-  "background"
+  "background",
+  "qrcode"
 ];
 
 export const ITEM_META: Record<ItemKind, ItemKindMeta> = {
@@ -57,5 +59,10 @@ export const ITEM_META: Record<ItemKind, ItemKindMeta> = {
     label: "Visual",
     Icon: VisualIcon,
     description: "2D/3D visual"
+  },
+  qrcode: {
+    label: "QR code",
+    Icon: QrCodeIcon,
+    description: "Scannable link to the current URL"
   }
 };

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
@@ -5,7 +5,8 @@ export type ItemKind =
   | "specs"
   | "image"
   | "images-stack"
-  | "background";
+  | "background"
+  | "qrcode";
 
 export type ItemKindMeta = {
   label: string;

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
@@ -6,7 +6,8 @@ import {
   SpecsItemSchema,
   TextItemSchema,
   ContentItem,
-  VisualItemSchema
+  VisualItemSchema,
+  QrCodeItemSchema
 } from "@/types/sketch.types";
 
 import {
@@ -42,6 +43,10 @@ export default function makeDefaultItem( type: ItemKind ): ContentItem {
       } );
     case "visual":
       return VisualItemSchema.parse( {
+        type
+      } );
+    case "qrcode":
+      return QrCodeItemSchema.parse( {
         type
       } );
     default:

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -809,5 +809,101 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       // @ts-expect-error
       schema: VisualOptions
     }
+  },
+  qrcode: {
+    url: {
+      label: "URL",
+      component: "text",
+      placeholder: "Leave empty to use the current page URL"
+    },
+    size: {
+      label: "Size",
+      component: "slider",
+      min: 0.02,
+      max: 1,
+      step: 0.01
+    },
+    position: {
+      label: "Position",
+      component: "nested-object",
+      fields: {
+        x: {
+          label: "x",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.01
+        },
+        y: {
+          label: "y",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.01
+        }
+      }
+    },
+    errorCorrection: {
+      label: "Error correction",
+      component: "select",
+      options: [
+        {
+          value: "L",
+          label: "L — Low (7%)"
+        },
+        {
+          value: "M",
+          label: "M — Medium (15%)"
+        },
+        {
+          value: "Q",
+          label: "Q — Quartile (25%)"
+        },
+        {
+          value: "H",
+          label: "H — High (30%)"
+        }
+      ]
+    },
+    quietZone: {
+      label: "Quiet zone",
+      component: "slider",
+      min: 0,
+      max: 8,
+      step: 1
+    },
+    foreground: {
+      label: "Foreground",
+      component: "color"
+    },
+    background: {
+      label: "Background",
+      component: "color"
+    },
+    blend: {
+      label: "Blend",
+      component: "select",
+      options: blendSelectOptions
+    },
+    showUrl: {
+      label: "Show URL caption",
+      component: "checkbox"
+    },
+    urlFont: {
+      label: "URL font",
+      component: "select",
+      options: fontSelectOptions
+    },
+    urlSize: {
+      label: "URL size",
+      component: "slider",
+      min: 6,
+      max: 96,
+      step: 1
+    },
+    urlFill: {
+      label: "URL color",
+      component: "color"
+    }
   }
 };

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -811,10 +811,10 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   qrcode: {
-    url: {
-      label: "URL",
+    domainOverride: {
+      label: "Domain override",
       component: "text",
-      placeholder: "Leave empty to use the current page URL"
+      placeholder: "e.g. mysite.com — empty uses NEXT_PUBLIC_SITE_URL"
     },
     size: {
       label: "Size",

--- a/src/templates/p5/utils/slides/common/__tests__/qrCodeUrl.test.ts
+++ b/src/templates/p5/utils/slides/common/__tests__/qrCodeUrl.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Covers the QR code URL resolution rules:
+ *   - origin priority: domain override -> NEXT_PUBLIC_SITE_URL -> live origin
+ *   - bare hosts default to https; an explicit scheme wins
+ *   - the path comes from the live page, minus the headless-capture params
+ *   - the displayed caption drops the scheme
+ */
+
+import {
+  buildQrUrl, normaliseBase, stripScheme
+} from "../qrCodeUrl.js";
+
+describe(
+  "normaliseBase",
+  () => {
+    it(
+      "assumes https for a bare host",
+      () => {
+        expect( normaliseBase( "mysite.com" ) ).toBe( "https://mysite.com" );
+      }
+    );
+
+    it(
+      "keeps an explicit scheme (including http)",
+      () => {
+        expect( normaliseBase( "http://localhost:3000" ) ).toBe( "http://localhost:3000" );
+        expect( normaliseBase( "https://x.dev" ) ).toBe( "https://x.dev" );
+      }
+    );
+
+    it(
+      "trims whitespace and trailing slashes, and maps empty to ''",
+      () => {
+        expect( normaliseBase( "  mysite.com/  " ) ).toBe( "https://mysite.com" );
+        expect( normaliseBase( "" ) ).toBe( "" );
+        expect( normaliseBase( undefined ) ).toBe( "" );
+      }
+    );
+  }
+);
+
+describe(
+  "stripScheme",
+  () => {
+    it(
+      "removes http(s):// for display",
+      () => {
+        expect( stripScheme( "https://p5.example.com/a/b" ) ).toBe( "p5.example.com/a/b" );
+        expect( stripScheme( "http://localhost:3000/x" ) ).toBe( "localhost:3000/x" );
+      }
+    );
+
+    it(
+      "leaves scheme-less strings untouched",
+      () => {
+        expect( stripScheme( "example.com/x" ) ).toBe( "example.com/x" );
+        expect( stripScheme( "" ) ).toBe( "" );
+      }
+    );
+  }
+);
+
+describe(
+  "buildQrUrl",
+  () => {
+    const href = "http://localhost:3000/templates/p5/photo/photo-3d-sphere?id=abc&capturing=&previewFramerate=20&previewDuration=3#frag";
+
+    it(
+      "uses the domain override (bare host -> https) with the live path",
+      () => {
+        expect( buildQrUrl( {
+          domainOverride: "p5.costardrouge.com",
+          siteUrl: "https://ignored.example",
+          href
+        } ) ).toBe( "https://p5.costardrouge.com/templates/p5/photo/photo-3d-sphere?id=abc#frag" );
+      }
+    );
+
+    it(
+      "honours an explicit scheme in the override",
+      () => {
+        expect( buildQrUrl( {
+          domainOverride: "http://192.168.1.10:3000",
+          href
+        } ) ).toBe( "http://192.168.1.10:3000/templates/p5/photo/photo-3d-sphere?id=abc#frag" );
+      }
+    );
+
+    it(
+      "falls back to NEXT_PUBLIC_SITE_URL when no override is set",
+      () => {
+        expect( buildQrUrl( {
+          siteUrl: "https://p5.costardrouge.com",
+          href
+        } ) ).toBe( "https://p5.costardrouge.com/templates/p5/photo/photo-3d-sphere?id=abc#frag" );
+      }
+    );
+
+    it(
+      "falls back to the live origin when no override and no site URL",
+      () => {
+        expect( buildQrUrl( {
+          href
+        } ) ).toBe( "http://localhost:3000/templates/p5/photo/photo-3d-sphere?id=abc#frag" );
+      }
+    );
+
+    it(
+      "strips only the capture params and keeps other query params",
+      () => {
+        const result = buildQrUrl( {
+          siteUrl: "https://x.dev",
+          href
+        } );
+
+        expect( result ).toContain( "?id=abc" );
+        expect( result ).not.toContain( "capturing" );
+        expect( result ).not.toContain( "previewFramerate" );
+        expect( result ).not.toContain( "previewDuration" );
+      }
+    );
+
+    it(
+      "returns '' when no origin can be determined",
+      () => {
+        expect( buildQrUrl( {} ) ).toBe( "" );
+        expect( buildQrUrl( {
+          href: "not a url"
+        } ) ).toBe( "" );
+      }
+    );
+
+    it(
+      "uses the override origin even when the page has no path",
+      () => {
+        expect( buildQrUrl( {
+          domainOverride: "mysite.com",
+          href: "https://localhost/"
+        } ) ).toBe( "https://mysite.com/" );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/slides/common/drawSlideQrCode.js
+++ b/src/templates/p5/utils/slides/common/drawSlideQrCode.js
@@ -1,0 +1,196 @@
+import QRCode from "qrcode";
+
+import string from "../../string.js";
+import sketch, {
+  getP5
+} from "../../sketch.js";
+
+// Query params injected by the headless capture pipeline (see the studio
+// route). They are stripped from the auto-detected URL so a recorded or
+// thumbnailed QR still points at the real experience, not the capture URL.
+const CAPTURE_PARAMS = [
+  "capturing",
+  "previewFramerate",
+  "previewDuration"
+];
+
+function resolveUrl( explicit ) {
+  if ( typeof explicit === "string" && explicit.trim() ) {
+    return explicit.trim();
+  }
+
+  if ( typeof window === "undefined" || !window?.location?.href ) {
+    return "";
+  }
+
+  try {
+    const url = new URL( window.location.href );
+
+    CAPTURE_PARAMS.forEach( ( param ) => url.searchParams.delete( param ) );
+
+    return url.toString();
+  } catch {
+    return window.location.href;
+  }
+}
+
+// Encoding a QR matrix is comparatively expensive, so memoise the last few
+// (url + error-correction) combinations instead of rebuilding every frame.
+const matrixCache = new Map();
+
+function getMatrix(
+  text, errorCorrectionLevel
+) {
+  const key = `${ errorCorrectionLevel }::${ text }`;
+
+  if ( !matrixCache.has( key ) ) {
+    if ( matrixCache.size > 16 ) {
+      matrixCache.clear();
+    }
+
+    try {
+      matrixCache.set(
+        key,
+        QRCode.create(
+          text,
+          {
+            errorCorrectionLevel
+          }
+        )
+      );
+    } catch {
+      // Text too long for a QR symbol, or any other encoder error: cache the
+      // failure so we don't retry it every frame.
+      matrixCache.set(
+        key,
+        null
+      );
+    }
+  }
+
+  return matrixCache.get( key );
+}
+
+export default function drawSlideQrCode( qrCodeOption ) {
+  const p = getP5();
+  const text = resolveUrl( qrCodeOption.url );
+
+  if ( !text ) {
+    return;
+  }
+
+  const qr = getMatrix(
+    text,
+    qrCodeOption.errorCorrection || "M"
+  );
+
+  if ( !qr ) {
+    return;
+  }
+
+  const moduleCount = qr.modules.size;
+  const moduleData = qr.modules.data;
+  const quietZone = qrCodeOption.quietZone ?? 4;
+  const totalModules = moduleCount + quietZone * 2;
+
+  const side =
+    Math.max(
+      qrCodeOption.size ?? 0.22,
+      0
+    ) * Math.min(
+      p.width,
+      p.height
+    );
+
+  if ( side <= 0 ) {
+    return;
+  }
+
+  const moduleSize = side / totalModules;
+  const centerX = ( qrCodeOption.position?.x ?? 0.5 ) * p.width;
+  const centerY = ( qrCodeOption.position?.y ?? 0.82 ) * p.height;
+  const left = centerX - side / 2;
+  const top = centerY - side / 2;
+
+  p.push();
+
+  if ( sketch.sketchOptions?.type === "webgl" ) {
+    p.translate(
+      -p.width / 2,
+      -p.height / 2
+    );
+  }
+
+  if ( qrCodeOption.blend ) {
+    p.blendMode( qrCodeOption.blend );
+  }
+
+  p.noStroke();
+
+  // Backdrop, including the quiet zone. A transparent alpha keeps it
+  // see-through, but scanning still needs enough contrast behind the code.
+  p.fill( ...qrCodeOption.background );
+  p.rect(
+    Math.round( left ),
+    Math.round( top ),
+    Math.round( left + side ) - Math.round( left ),
+    Math.round( top + side ) - Math.round( top )
+  );
+
+  // Dark modules. Edges are snapped to integer pixels so adjacent modules
+  // share an exact boundary (no anti-aliasing seams, no double-blended
+  // overlap with translucent foregrounds).
+  p.fill( ...qrCodeOption.foreground );
+
+  for ( let row = 0; row < moduleCount; row++ ) {
+    for ( let col = 0; col < moduleCount; col++ ) {
+      if ( !moduleData[ row * moduleCount + col ] ) {
+        continue;
+      }
+
+      const x0 = Math.round( left + ( quietZone + col ) * moduleSize );
+      const y0 = Math.round( top + ( quietZone + row ) * moduleSize );
+      const x1 = Math.round( left + ( quietZone + col + 1 ) * moduleSize );
+      const y1 = Math.round( top + ( quietZone + row + 1 ) * moduleSize );
+
+      p.rect(
+        x0,
+        y0,
+        x1 - x0,
+        y1 - y0
+      );
+    }
+  }
+
+  // URL caption under the code.
+  if ( qrCodeOption.showUrl ) {
+    const captionWidth = Math.min(
+      p.width * 0.92,
+      Math.max(
+        side * 1.5,
+        side
+      )
+    );
+    const urlSize = Number( qrCodeOption.urlSize ?? 20 );
+
+    string.write(
+      text,
+      centerX - captionWidth / 2,
+      top + side + urlSize,
+      {
+        size: urlSize,
+        font: string.fonts?.[ qrCodeOption.urlFont ] ?? string.fonts.spaceMonoRegular,
+        fill: p.color( ...qrCodeOption.urlFill ),
+        stroke: false,
+        strokeWeight: 0,
+        textWidth: captionWidth,
+        textAlign: [
+          p.CENTER,
+          p.TOP
+        ]
+      }
+    );
+  }
+
+  p.pop();
+}

--- a/src/templates/p5/utils/slides/common/drawSlideQrCode.js
+++ b/src/templates/p5/utils/slides/common/drawSlideQrCode.js
@@ -4,34 +4,24 @@ import string from "../../string.js";
 import sketch, {
   getP5
 } from "../../sketch.js";
+import {
+  buildQrUrl, stripScheme
+} from "./qrCodeUrl.js";
 
-// Query params injected by the headless capture pipeline (see the studio
-// route). They are stripped from the auto-detected URL so a recorded or
-// thumbnailed QR still points at the real experience, not the capture URL.
-const CAPTURE_PARAMS = [
-  "capturing",
-  "previewFramerate",
-  "previewDuration"
-];
+// Inlined at build time by Next for NEXT_PUBLIC_* vars, so it is readable in
+// the client/headless sketch bundle. Lets a localhost dev machine encode the
+// production domain instead of "localhost".
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "";
 
-function resolveUrl( explicit ) {
-  if ( typeof explicit === "string" && explicit.trim() ) {
-    return explicit.trim();
-  }
-
-  if ( typeof window === "undefined" || !window?.location?.href ) {
-    return "";
-  }
-
-  try {
-    const url = new URL( window.location.href );
-
-    CAPTURE_PARAMS.forEach( ( param ) => url.searchParams.delete( param ) );
-
-    return url.toString();
-  } catch {
-    return window.location.href;
-  }
+function resolveUrl( domainOverride ) {
+  return buildQrUrl( {
+    domainOverride,
+    siteUrl: SITE_URL,
+    href:
+      typeof window !== "undefined" && window.location
+        ? window.location.href
+        : ""
+  } );
 }
 
 // Encoding a QR matrix is comparatively expensive, so memoise the last few
@@ -73,7 +63,7 @@ function getMatrix(
 
 export default function drawSlideQrCode( qrCodeOption ) {
   const p = getP5();
-  const text = resolveUrl( qrCodeOption.url );
+  const text = resolveUrl( qrCodeOption.domainOverride );
 
   if ( !text ) {
     return;
@@ -174,7 +164,7 @@ export default function drawSlideQrCode( qrCodeOption ) {
     const urlSize = Number( qrCodeOption.urlSize ?? 20 );
 
     string.write(
-      text,
+      stripScheme( text ),
       centerX - captionWidth / 2,
       top + side + urlSize,
       {

--- a/src/templates/p5/utils/slides/common/qrCodeUrl.js
+++ b/src/templates/p5/utils/slides/common/qrCodeUrl.js
@@ -1,0 +1,86 @@
+/**
+ * URL resolution for the QR code content item, kept dependency-free (no p5,
+ * no window, no qrcode) so it can be unit-tested in isolation. The renderer
+ * (drawSlideQrCode.js) feeds it the runtime values.
+ *
+ * The encoded URL is built from two parts:
+ *   - origin: domain override -> NEXT_PUBLIC_SITE_URL -> the live page origin.
+ *     This lets a localhost dev machine generate content that still points at
+ *     the production domain.
+ *   - path: always the live page's path (+ query + hash), with the headless
+ *     capture params stripped so a recorded/thumbnailed QR points at the real
+ *     experience, not the internal capture URL.
+ */
+
+// Query params injected by the headless capture pipeline (see the studio route).
+const CAPTURE_PARAMS = [
+  "capturing",
+  "previewFramerate",
+  "previewDuration"
+];
+
+/**
+ * Normalise an origin: trim, drop trailing slashes, and assume https when no
+ * scheme is given (production is https). Returns "" for empty input.
+ */
+export function normaliseBase( base ) {
+  const trimmed = ( base || "" ).trim()
+    .replace(
+      /\/+$/,
+      ""
+    );
+
+  if ( !trimmed ) {
+    return "";
+  }
+
+  return /^https?:\/\//i.test( trimmed ) ? trimmed : `https://${ trimmed }`;
+}
+
+/** Drop the scheme for display — "https://" adds nothing to a printed URL. */
+export function stripScheme( url ) {
+  return ( url || "" ).replace(
+    /^https?:\/\//i,
+    ""
+  );
+}
+
+/**
+ * Build the absolute URL to encode.
+ * @param {object}  args
+ * @param {string} [args.domainOverride] per-item origin override
+ * @param {string} [args.siteUrl]        NEXT_PUBLIC_SITE_URL value
+ * @param {string} [args.href]           live page href (window.location.href)
+ * @returns {string} absolute URL, or "" when no origin can be determined
+ */
+export function buildQrUrl( {
+  domainOverride = "",
+  siteUrl = "",
+  href = ""
+} = {} ) {
+  let parsed = null;
+
+  try {
+    parsed = href ? new URL( href ) : null;
+  } catch {
+    parsed = null;
+  }
+
+  const base =
+    normaliseBase( domainOverride ) ||
+    normaliseBase( siteUrl ) ||
+    ( parsed ? parsed.origin : "" );
+
+  if ( !base ) {
+    return "";
+  }
+
+  let path = "";
+
+  if ( parsed ) {
+    CAPTURE_PARAMS.forEach( ( param ) => parsed.searchParams.delete( param ) );
+    path = `${ parsed.pathname }${ parsed.search }${ parsed.hash }`;
+  }
+
+  return `${ base }${ path }`;
+}

--- a/src/templates/p5/utils/slides/layouts/freeLayout.js
+++ b/src/templates/p5/utils/slides/layouts/freeLayout.js
@@ -6,6 +6,7 @@ import drawSlideImage from "../common/drawSlideImage.js";
 import drawSlideImages from "../common/drawSlideImages.js";
 import drawSlideBackground from "../common/drawSlideBackground.js";
 import drawSlideImagesStack from "../common/drawSlideImagesStack.js";
+import drawSlideQrCode from "../common/drawSlideQrCode.js";
 
 export default function freeLayout( options ) {
   options?.content?.forEach( ( item ) => {
@@ -42,6 +43,12 @@ export default function freeLayout( options ) {
         break;
       case "visual":
         drawSlideVisual(
+          item,
+          options
+        );
+        break;
+      case "qrcode":
+        drawSlideQrCode(
           item,
           options
         );

--- a/src/types/__tests__/qrCodeItem.test.ts
+++ b/src/types/__tests__/qrCodeItem.test.ts
@@ -30,7 +30,7 @@ describe(
 
         expect( item ).toMatchObject( {
           type: "qrcode",
-          url: "",
+          domainOverride: "",
           size: 0.22,
           quietZone: 4,
           errorCorrection: "M",
@@ -60,13 +60,13 @@ describe(
       () => {
         const parsed = ContentItemSchema.parse( {
           type: "qrcode",
-          url: "https://example.com"
+          domainOverride: "https://example.com"
         } );
 
         expect( parsed.type ).toBe( "qrcode" );
 
         if ( parsed.type === "qrcode" ) {
-          expect( parsed.url ).toBe( "https://example.com" );
+          expect( parsed.domainOverride ).toBe( "https://example.com" );
         }
       }
     );

--- a/src/types/__tests__/qrCodeItem.test.ts
+++ b/src/types/__tests__/qrCodeItem.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Guards the "qrcode" content item wiring.
+ *
+ * A QR item, like every other content item, is spread across four places that
+ * must stay in agreement: the Zod schema (source of truth), the discriminated
+ * union, the makeDefaultItem factory, and the form field-config. If any of
+ * them drifts the item either fails to parse, can't be added from the palette,
+ * or renders a form with missing/orphan fields (GenericItemForm warns at
+ * runtime). These tests catch that drift at build time instead.
+ */
+
+import {
+  ContentItemSchema, QrCodeItemSchema
+} from "@/types/sketch.types";
+import makeDefaultItem
+  from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem";
+import {
+  formConfig
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
+
+describe(
+  "qrcode content item",
+  () => {
+    it(
+      "applies sensible defaults",
+      () => {
+        const item = QrCodeItemSchema.parse( {
+          type: "qrcode"
+        } );
+
+        expect( item ).toMatchObject( {
+          type: "qrcode",
+          url: "",
+          size: 0.22,
+          quietZone: 4,
+          errorCorrection: "M",
+          showUrl: true,
+          urlFont: "spaceMonoRegular"
+        } );
+        expect( item.position ).toEqual( {
+          x: 0.5,
+          y: 0.82
+        } );
+        expect( item.foreground ).toEqual( [
+          0,
+          0,
+          0
+        ] );
+        expect( item.background ).toEqual( [
+          255,
+          255,
+          255,
+          255
+        ] );
+      }
+    );
+
+    it(
+      "is accepted by the ContentItem discriminated union",
+      () => {
+        const parsed = ContentItemSchema.parse( {
+          type: "qrcode",
+          url: "https://example.com"
+        } );
+
+        expect( parsed.type ).toBe( "qrcode" );
+
+        if ( parsed.type === "qrcode" ) {
+          expect( parsed.url ).toBe( "https://example.com" );
+        }
+      }
+    );
+
+    it(
+      "makeDefaultItem('qrcode') round-trips through the schema",
+      () => {
+        const item = makeDefaultItem( "qrcode" );
+
+        expect( item.type ).toBe( "qrcode" );
+        expect( () => ContentItemSchema.parse( item ) ).not.toThrow();
+      }
+    );
+
+    it(
+      "has a form-config entry for every schema field (no orphan fields)",
+      () => {
+        const schemaFields = Object.keys( QrCodeItemSchema.shape ).filter( ( field ) => field !== "type" );
+        const configFields = Object.keys( formConfig.qrcode );
+
+        for ( const field of schemaFields ) {
+          expect( configFields ).toContain( field );
+        }
+      }
+    );
+
+    it(
+      "rejects error-correction levels outside L/M/Q/H",
+      () => {
+        expect( () =>
+          QrCodeItemSchema.parse( {
+            type: "qrcode",
+            errorCorrection: "Z"
+          } ) ).toThrow();
+      }
+    );
+  }
+);

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -375,10 +375,12 @@ export const VisualItemSchema = z.object( {
 
 export const QrCodeItemSchema = z.object( {
   type: z.literal( "qrcode" ),
-  // Empty -> encode the current page URL (auto-detected at draw time).
-  // Non-empty -> encode this value verbatim. Use it to point at the public
-  // URL when the live page URL is a localhost / headless-capture URL.
-  url: z.string().default( "" ),
+  // Origin to encode. Empty -> NEXT_PUBLIC_SITE_URL (the production domain),
+  // falling back to the live page origin. Set it to point at the public
+  // domain when generating content from a localhost / capture URL. A bare
+  // host ("mysite.com") is assumed https; include a scheme to override that.
+  // The path is always taken from the live page.
+  domainOverride: z.string().default( "" ),
   position: Vec2.default( {
     x: 0.5,
     y: 0.82

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -373,6 +373,55 @@ export const VisualItemSchema = z.object( {
   rotation: z.number().default( 0 )
 } );
 
+export const QrCodeItemSchema = z.object( {
+  type: z.literal( "qrcode" ),
+  // Empty -> encode the current page URL (auto-detected at draw time).
+  // Non-empty -> encode this value verbatim. Use it to point at the public
+  // URL when the live page URL is a localhost / headless-capture URL.
+  url: z.string().default( "" ),
+  position: Vec2.default( {
+    x: 0.5,
+    y: 0.82
+  } ),
+  // QR side length as a fraction of min( canvas width, canvas height ).
+  size: z.number().min( 0.02 )
+    .max( 1 )
+    .default( 0.22 ),
+  // Quiet-zone border thickness, in modules (the spec recommends >= 4).
+  quietZone: z.number().int()
+    .min( 0 )
+    .max( 8 )
+    .default( 4 ),
+  errorCorrection: z.enum( [
+    "L",
+    "M",
+    "Q",
+    "H"
+  ] ).default( "M" ),
+  foreground: RGBA.default( [
+    0,
+    0,
+    0
+  ] ),
+  background: RGBA.default( [
+    255,
+    255,
+    255,
+    255
+  ] ),
+  blend: Blend.default( "source-over" ),
+  // Caption: print the encoded URL underneath the code.
+  showUrl: z.boolean().default( true ),
+  urlFont: z.string().default( "spaceMonoRegular" ),
+  urlSize: z.number().positive()
+    .default( 20 ),
+  urlFill: RGBA.default( [
+    0,
+    0,
+    0
+  ] )
+} );
+
 export const ContentItemSchema = z.discriminatedUnion(
   "type",
   [
@@ -382,7 +431,8 @@ export const ContentItemSchema = z.discriminatedUnion(
     TextItemSchema,
     ImagesStackItemSchema,
     ImageItemSchema,
-    VisualItemSchema
+    VisualItemSchema,
+    QrCodeItemSchema
   ]
 );
 


### PR DESCRIPTION
## Pourquoi

Pouvoir poser un **QR code** sur un sketch (en global ou sur un slide précis), comme les autres items de contenu (text, meta, specs, visual, image, background). L'idée : sur les sketches « à valeur ajoutée », un visiteur devant l'écran scanne le code et rouvre l'expérience sur son téléphone.

Comme discuté, le QR seul n'a pas grand intérêt sur un feed Instagram consulté au téléphone — d'où l'option d'afficher **l'URL en toutes lettres sous le code** (activée par défaut), qui reste lisible même sans scan.

## Ce que ça fait

Nouveau type d'item `qrcode`, disponible dans la palette d'ajout. Champs configurables : override de domaine, position, taille, quiet zone, niveau de correction d'erreur, couleurs avant/arrière-plan, blend, et la légende URL (affichage on/off, police, taille, couleur).

### URL encodée (origine + chemin)
L'URL est composée d'une **origine** et du **chemin de la page courante**.

- **Origine**, par ordre de priorité :
  1. `domainOverride` (champ de l'item) — un hôte nu (`mysite.com`) est supposé `https://` ; un scheme explicite (`http://…`) l'emporte.
  2. `NEXT_PUBLIC_SITE_URL` — le domaine de prod (variable `NEXT_PUBLIC_`, donc lisible côté navigateur). Permet de générer du contenu depuis une machine de dev sans encoder `localhost`.
  3. l'origine de la page en dernier recours.
- **Chemin** : toujours celui de la page courante. Les query params propres à la capture headless (`capturing`, `previewFramerate`, `previewDuration`) sont retirés ; `?id=` et le reste (query/hash) sont conservés, pour qu'un enregistrement encode l'expérience réelle.
- **Caption** : le `https://` est retiré à l'affichage (il n'apporte rien sur une URL imprimée). Le QR, lui, encode bien l'URL absolue complète.

La logique d'URL est isolée dans un module sans dépendances (`qrCodeUrl.js`) et couverte par des tests unitaires (priorité d'origine, gestion du scheme, strip des params de capture, affichage caption).

### Rendu
- Matrice dessinée en `rect` p5, **bords alignés au pixel** pour que les modules adjacents partagent une arête exacte (pas de coutures d'anti-aliasing, pas de double-blend avec un avant-plan translucide).
- Matrice générée via `qrcode` (`QRCode.create`, build *browser*, sans `fs`) et mémoïsée — pas de ré-encodage à chaque frame.
- Légende URL optionnelle sous le code.

## Fichiers

- `src/types/sketch.types.ts` — `QrCodeItemSchema` + ajout à l'union discriminée
- `…/ItemPalette/types/item-kinds.ts` & `…/constants/item-kinds.ts` — entrée palette (icône `QrCode`)
- `…/AddItemControls/utils/makeDefaultItem.ts` — factory
- `…/ContentItems/constants/field-config.ts` — config du formulaire
- `src/templates/p5/utils/slides/common/qrCodeUrl.js` — **résolution d'URL** (pur, testé) (nouveau)
- `src/templates/p5/utils/slides/common/drawSlideQrCode.js` — **renderer** (nouveau)
- `src/templates/p5/utils/slides/layouts/freeLayout.js` — branchement
- `package.json` — dépendance `qrcode`

## Tests

- `npx tsc --noEmit` ✅
- `npx eslint` sur les fichiers touchés ✅
- `npx jest` — **904 tests** ✅, dont :
  - `qrCodeUrl.test.ts` — origine/scheme/chemin/caption (12 cas)
  - `qrCodeItem.test.ts` — défauts du schéma, acceptation par l'union, round-trip `makeDefaultItem`, garde anti-drift schéma ↔ form-config
- Correction de la matrice vérifiée end-to-end vs l'API officielle `BitMatrix.get(row, col)` de `qrcode`, finder pattern bien orienté.

## À essayer

1. Régler `NEXT_PUBLIC_SITE_URL` sur le domaine de prod (sinon fallback sur l'origine de la page).
2. Ouvrir un sketch → panneau Options → ajouter un item **QR code** depuis la palette → ajuster position/taille.
3. Laisser l'override vide pour `NEXT_PUBLIC_SITE_URL` + chemin courant, ou saisir un domaine.

## Points ouverts / à challenger

- Pas de modules arrondis / logo central — volontairement carré pour maximiser la scannabilité. À ajouter si on veut « plus joli ».

https://claude.ai/code/session_011bqfGWjjY3tkS4m6SKidcN