### PR TITLE
Déploiement événementiel : Watchtower HTTP API + GHCR + image standalone

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,18 +9,38 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      # Optional: set this repo secret to trigger an instant redeploy on your
+      # NAS. Leave it unset and the build still publishes — only the redeploy
+      # step is skipped.
+      PORTAINER_WEBHOOK_URL: ${{ secrets.PORTAINER_WEBHOOK_URL }}
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Docker metadata (tags & labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # `main` + `latest` are moving tags (what Portainer re-pulls);
+          # `sha-<short>` is immutable and what you pin to for a rollback.
+          tags: |
+            type=raw,value=main
+            type=raw,value=latest
+            type=sha,format=short
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -28,10 +48,22 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
-          tags: containeurrouge/social-templates-renderer:amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Registry-side layer cache keyed on the workflow run, so unchanged
+          # layers (base image, deps) aren't rebuilt every push.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BACKEND_RECORDING=true
             NOTIFICATIONS=false
             LIVE_THUMBNAIL=true
             NEXT_PUBLIC_GITHUB_REPO_URL=${{ vars['NEXT_PUBLIC_GITHUB_REPO_URL'] }}
+
+      - name: Trigger Portainer redeploy
+        if: env.PORTAINER_WEBHOOK_URL != ''
+        run: |
+          echo "Triggering Portainer stack redeploy…"
+          curl -fsS -X POST "$PORTAINER_WEBHOOK_URL"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,10 +14,13 @@ jobs:
       packages: write
 
     env:
-      # Optional: set this repo secret to trigger an instant redeploy on your
-      # NAS. Leave it unset and the build still publishes — only the redeploy
-      # step is skipped.
-      PORTAINER_WEBHOOK_URL: ${{ secrets.PORTAINER_WEBHOOK_URL }}
+      # Optional: point this at the Watchtower HTTP API on your NAS to trigger an
+      # instant redeploy after each push (see deploy/README.md). Leave the secret
+      # unset and the build still publishes — only the redeploy step is skipped.
+      #   DEPLOY_WEBHOOK_URL   e.g. https://watchtower.example.com/v1/update?image=ghcr.io/costardrouge/p5-templates
+      #   DEPLOY_WEBHOOK_TOKEN matches WATCHTOWER_HTTP_API_TOKEN on the NAS
+      DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+      DEPLOY_WEBHOOK_TOKEN: ${{ secrets.DEPLOY_WEBHOOK_TOKEN }}
 
     steps:
       - name: Checkout Code
@@ -35,7 +38,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-          # `main` + `latest` are moving tags (what Portainer re-pulls);
+          # `main` + `latest` are moving tags (what Watchtower re-pulls);
           # `sha-<short>` is immutable and what you pin to for a rollback.
           tags: |
             type=raw,value=main
@@ -62,8 +65,10 @@ jobs:
             LIVE_THUMBNAIL=true
             NEXT_PUBLIC_GITHUB_REPO_URL=${{ vars['NEXT_PUBLIC_GITHUB_REPO_URL'] }}
 
-      - name: Trigger Portainer redeploy
-        if: env.PORTAINER_WEBHOOK_URL != ''
+      - name: Trigger redeploy (Watchtower HTTP API)
+        if: env.DEPLOY_WEBHOOK_URL != ''
         run: |
-          echo "Triggering Portainer stack redeploy…"
-          curl -fsS -X POST "$PORTAINER_WEBHOOK_URL"
+          echo "Triggering Watchtower update…"
+          curl -fsS --retry 3 --retry-delay 5 -X POST \
+            -H "Authorization: Bearer ${DEPLOY_WEBHOOK_TOKEN}" \
+            "${DEPLOY_WEBHOOK_URL}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+# syntax=docker/dockerfile:1
+
+# ─── Stage 1: build ──────────────────────────────────────────────────────────
+# Full toolchain (dev deps included) to compile the Next.js standalone bundle.
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS builder
 
 WORKDIR /app
 
@@ -17,38 +21,62 @@ ENV NEXT_PUBLIC_GITHUB_REPO_URL=${NEXT_PUBLIC_GITHUB_REPO_URL}
 ENV NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}
 ENV NEXT_PUBLIC_VAPID_PUBLIC_KEY=${NEXT_PUBLIC_VAPID_PUBLIC_KEY}
 
-# Install system dependencies
+# Copy dependency files first for better layer caching.
+COPY package.json package-lock.json ./
+COPY prisma ./prisma
+
+# Install dependencies (runs postinstall → prisma generate).
+RUN npm ci
+
+# Copy configuration files.
+COPY next.config.ts tsconfig.json tailwind.config.ts postcss.config.mjs ./
+
+# Copy application code.
+COPY src ./src
+COPY public ./public
+COPY scripts ./scripts
+
+# Build the Next.js project (emits .next/standalone + .next/static).
+ENV NODE_ENV=production
+RUN npm run build
+
+# ─── Stage 2: runtime ────────────────────────────────────────────────────────
+# Slim runtime: Playwright base (browsers + Node already present) + ffmpeg.
+# Only the standalone server, static assets, public files and the Prisma CLI
+# (needed for `migrate deploy` on startup) are copied over — no dev deps.
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Standalone server honours these; bind to all interfaces inside the container.
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# Runtime system dependencies.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     ffmpeg \
     curl \
  && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency files first for better layer caching
-COPY package.json package-lock.json ./
-COPY prisma ./prisma
+# Application: standalone server, static chunks and public assets.
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
 
-# Install dependencies (runs postinstall → prisma generate)
-RUN npm ci && npm cache clean --force
+# Prisma: schema + migrations for `migrate deploy`, the generated client (with
+# its native query engine) and the CLI used by the entrypoint at startup.
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/src/generated/prisma ./src/generated/prisma
+COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
 
-# Copy configuration files
-COPY next.config.ts tsconfig.json tailwind.config.ts postcss.config.mjs ./
-
-# Copy application code
-COPY src ./src
-COPY public ./public
-COPY scripts ./scripts
-
-# Build the Next.js project
-ENV NODE_ENV=production
-RUN npm run build
-
-# Copy and setup entrypoint
+# Entrypoint: runs migrations then starts the standalone server.
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
-# Expose port
 EXPOSE 3000
 
-# Run migrations and start the app
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,112 @@
+# Deploy — event-driven redeploy
+
+How a push to `main` ends up running on the NAS, instantly and without polling
+Docker Hub.
+
+```
+push main ─▶ GitHub Actions ─▶ build + push image to GHCR
+                             └▶ POST /v1/update ─▶ Watchtower (on the NAS)
+                                                   └▶ re-pull image + recreate app
+```
+
+Two moving parts replace the old "Watchtower polls Docker Hub every minute":
+
+- **Registry:** images are published to **GHCR** (`ghcr.io/costardrouge/p5-templates`)
+  with a moving `:main` tag plus an immutable `:sha-<short>` tag for rollbacks.
+  No Docker Hub pull rate-limit.
+- **Trigger:** **Watchtower in HTTP API mode** — it waits for an authenticated
+  POST instead of polling. The build calls it the moment the image is pushed.
+
+> The original `containrrr/watchtower` image was archived in Dec 2025. Use the
+> maintained `nickfedor/watchtower` fork (already set in
+> [`watchtower.compose.yml`](./watchtower.compose.yml)).
+
+---
+
+## 1. Make the GHCR image pullable from the NAS
+
+Pick one:
+
+- **Public package (simplest):** GitHub → your profile → **Packages** →
+  `p5-templates` → **Package settings** → **Change visibility** → **Public**.
+- **Private package:** on the NAS, `docker login ghcr.io -u CostardRouge`
+  (paste a PAT with `read:packages`), then uncomment the `config.json` volume in
+  `watchtower.compose.yml`.
+
+Point the app stack at the published image:
+
+```yaml
+# in the app stack's docker-compose.yml
+image: ghcr.io/costardrouge/p5-templates:main
+```
+
+(`APP_IMAGE` can override this to pin a `sha-<short>` tag for a rollback.)
+
+## 2. Deploy Watchtower as its own stack on the NAS
+
+```sh
+# pick a long random token
+export WATCHTOWER_TOKEN=$(openssl rand -hex 32)
+
+docker compose -f deploy/watchtower.compose.yml up -d
+```
+
+(In Portainer: new stack, paste `watchtower.compose.yml`, set `WATCHTOWER_TOKEN`
+as a stack environment variable.)
+
+## 3. Make the API reachable from GitHub Actions
+
+GitHub's runners are on the public internet and need to reach Watchtower's
+`:8080` on your NAS. **Never expose `:8080` raw to the internet** — the bearer
+token is the only auth, so wrap it. Options, best first:
+
+| Option | How | Open ports? |
+|---|---|---|
+| **Cloudflare Tunnel** | `cloudflared` on the NAS → `https://watchtower.yourdomain.com` → `localhost:8080` | None |
+| **Tailscale** | Runner joins your tailnet (`tailscale/github-action`), hits the NAS's tailnet IP | None (private) |
+| **Reverse proxy + DDNS** | Traefik/Caddy/NPM terminates TLS in front of `:8080` | 443 |
+
+For Tailscale, the workflow needs an extra step to join the tailnet before the
+curl — ask and it can be added.
+
+## 4. Wire the secrets in GitHub
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret | Value |
+|---|---|
+| `DEPLOY_WEBHOOK_URL` | `https://watchtower.yourdomain.com/v1/update?image=ghcr.io/costardrouge/p5-templates` |
+| `DEPLOY_WEBHOOK_TOKEN` | the same `WATCHTOWER_TOKEN` as on the NAS |
+
+Until `DEPLOY_WEBHOOK_URL` is set, the build still publishes the image — only
+the redeploy step is skipped (so nothing breaks while you wire this up).
+
+The `?image=...` filter makes the trigger touch only the app, never the other
+services.
+
+## 5. Test
+
+```sh
+# from anywhere with the token — should return 200 and recreate the app
+curl -fsS -X POST \
+  -H "Authorization: Bearer $WATCHTOWER_TOKEN" \
+  "https://watchtower.yourdomain.com/v1/update?image=ghcr.io/costardrouge/p5-templates"
+
+# watch it work
+docker logs -f watchtower
+```
+
+Then push a trivial change to `main` and confirm the app container is recreated
+within a minute of the build finishing.
+
+---
+
+## Why not …?
+
+- **Portainer stack webhooks** — a Portainer **Business** feature, not in CE.
+- **A hand-rolled webhook receiver** (a container with the docker socket that
+  re-pulls on POST) — that is exactly what Watchtower's HTTP API already is, with
+  cleanup, label-scoping and a polling fallback included. No custom code to keep
+  alive.
+- **Polling Docker Hub** (the old setup) — laggy, and the free tier's
+  100–200 pulls/6h rate-limit silently throttles frequent polls.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,8 +66,42 @@ token is the only auth, so wrap it. Options, best first:
 | **Tailscale** | Runner joins your tailnet (`tailscale/github-action`), hits the NAS's tailnet IP | None (private) |
 | **Reverse proxy + DDNS** | Traefik/Caddy/NPM terminates TLS in front of `:8080` | 443 |
 
-For Tailscale, the workflow needs an extra step to join the tailnet before the
-curl — ask and it can be added.
+### Cloudflare Tunnel (chosen)
+
+Prereq: a domain on Cloudflare (the free plan is enough).
+
+**Already running `cloudflared`** for other services? Just add one Public
+Hostname route to your existing tunnel (step 2 below) — nothing else to deploy.
+
+**Otherwise, run it next to Watchtower** so it reaches the API over the internal
+compose network — then you can even drop the host `8080` mapping from
+`watchtower.compose.yml` entirely. Add to that stack:
+
+```yaml
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel run
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:?set from the Cloudflare dashboard}
+```
+
+In the **Cloudflare Zero Trust dashboard → Networks → Tunnels**:
+
+1. **Create a tunnel** → copy its token into `CF_TUNNEL_TOKEN`.
+2. Add a **Public Hostname**: `watchtower.yourdomain.com` → service
+   `http://watchtower:8080` (same compose network; use `http://localhost:8080`
+   if `cloudflared` runs directly on the host). Cloudflare creates the DNS record
+   and terminates TLS automatically.
+
+`DEPLOY_WEBHOOK_URL` is then
+`https://watchtower.yourdomain.com/v1/update?image=ghcr.io/costardrouge/p5-templates`.
+
+Optional extra hardening: put a Zero Trust **Access** service-token policy in
+front of the hostname — though the bearer token already gates `/v1/update`.
+
+> For Tailscale instead, the workflow needs an extra step to join the tailnet
+> before the curl — ask and it can be added.
 
 ## 4. Wire the secrets in GitHub
 

--- a/deploy/watchtower.compose.yml
+++ b/deploy/watchtower.compose.yml
@@ -1,0 +1,49 @@
+# Watchtower — event-driven redeploy for the social-templates app.
+#
+# Deploy this as its OWN stack on the NAS (separate from the app stack): it is
+# infrastructure that watches the app container and re-pulls its image on demand.
+#
+#   docker compose -f watchtower.compose.yml up -d
+#
+# Flow:
+#   push main
+#     → GitHub Actions builds & pushes ghcr.io/costardrouge/p5-templates:main
+#     → Actions POSTs /v1/update  (Authorization: Bearer $WATCHTOWER_TOKEN)
+#     → Watchtower re-pulls the image and recreates ONLY the app container
+#
+# Note: the original containrrr/watchtower was archived in Dec 2025 and is
+# unmaintained; this uses the maintained nickfedor fork (drop-in compatible).
+
+services:
+  watchtower:
+    image: nickfedor/watchtower:latest
+    restart: unless-stopped
+    ports:
+      # HTTP API. Do NOT expose this raw to the internet — front it with a
+      # Cloudflare Tunnel / reverse proxy (TLS), or reach it over Tailscale.
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # If the GHCR package is PRIVATE, `docker login ghcr.io` on the host first,
+      # then uncomment so Watchtower can authenticate the pull:
+      # - /root/.docker/config.json:/config.json:ro
+    environment:
+      # ── Event-driven trigger ────────────────────────────────────────────────
+      # Enable the HTTP API and require this bearer token on every request.
+      WATCHTOWER_HTTP_API_UPDATE: "true"
+      WATCHTOWER_HTTP_API_TOKEN: ${WATCHTOWER_TOKEN:?set WATCHTOWER_TOKEN in this stack's env}
+
+      # ── Safety net ──────────────────────────────────────────────────────────
+      # Also poll on a slow interval so a missed webhook self-heals (without this,
+      # enabling the API disables polling entirely).
+      WATCHTOWER_HTTP_API_PERIODIC_POLLS: "true"
+      WATCHTOWER_POLL_INTERVAL: "1800" # 30 min
+
+      # ── Scope & hygiene ─────────────────────────────────────────────────────
+      # Only touch containers carrying com.centurylinklabs.watchtower.enable=true
+      # (i.e. the app) — never redis / postgres / minio.
+      WATCHTOWER_LABEL_ENABLE: "true"
+      # Delete the previous image after a successful update so disk stays lean.
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_INCLUDE_RESTARTING: "true"
+      TZ: ${TZ:-Europe/Paris}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
 services:
   app:
+    # Prod (Portainer) pulls this published image; the moving `:main` tag lets
+    # the Portainer webhook re-pull the latest build. Override APP_IMAGE to pin
+    # an immutable `sha-<short>` tag for rollbacks. Local dev still uses `build`.
+    image: ${APP_IMAGE:-ghcr.io/costardrouge/p5-templates:main}
     build:
       context: .
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       postgres:
         condition: service_healthy
     restart: unless-stopped
+    labels:
+      # Opt this container in to Watchtower updates (see deploy/watchtower.compose.yml).
+      # With WATCHTOWER_LABEL_ENABLE=true only labelled containers are touched, so
+      # redis / postgres / minio are never auto-updated.
+      com.centurylinklabs.watchtower.enable: "true"
     networks:
       - pipeline
     env_file:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,40 +1,19 @@
 #!/bin/sh
 set -e
 
-echo "Checking VAPID keys for push notifications..."
+# VAPID keys are required for web-push notifications. They MUST be provided via
+# the environment (.env / compose) and kept stable — generating a fresh pair on
+# every container start would silently invalidate every existing subscription.
 if [ -z "$NEXT_PUBLIC_VAPID_PUBLIC_KEY" ] || [ -z "$VAPID_PRIVATE_KEY" ]; then
-  echo "⚠️  VAPID keys not found in environment. Generating new keys..."
-  
-  # Generate VAPID keys using web-push
-  VAPID_OUTPUT=$(node -e "
-    const webpush = require('web-push');
-    const keys = webpush.generateVAPIDKeys();
-    console.log(JSON.stringify(keys));
-  ")
-  
-  export NEXT_PUBLIC_VAPID_PUBLIC_KEY=$(echo $VAPID_OUTPUT | node -e "
-    const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
-    console.log(data.publicKey);
-  ")
-  
-  export VAPID_PRIVATE_KEY=$(echo $VAPID_OUTPUT | node -e "
-    const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
-    console.log(data.privateKey);
-  ")
-  
-  echo "✅ Generated new VAPID keys:"
-  echo "   Public: $NEXT_PUBLIC_VAPID_PUBLIC_KEY"
-  echo "   Private: $VAPID_PRIVATE_KEY"
-  echo ""
-  echo "⚠️  IMPORTANT: Save these keys to your .env file or docker-compose.yml"
-  echo "   to persist them across container restarts!"
+  echo "⚠️  VAPID keys not set — push notifications are disabled."
+  echo "    Generate a persistent pair once and store it in your .env:"
+  echo "      npx web-push generate-vapid-keys"
 else
   echo "✅ VAPID keys found in environment"
 fi
 
 echo "Running database migrations..."
-npx prisma generate
 npx prisma migrate deploy
 
 echo "Starting application..."
-exec npm run start
+exec node server.js

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import type {
 } from "next";
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (.next/standalone) so the runtime
+  // image only ships the modules actually traced by the build instead of the
+  // whole node_modules tree. Started with `node server.js`.
+  output: "standalone",
   distDir: process.env.NEXT_BUILD_DIR || ".next",
   poweredByHeader: false,
   devIndicators: false,


### PR DESCRIPTION
## Pourquoi

Le déploiement reposait sur **Watchtower en polling** d'un tag mutable unique (`:amd64`) sur Docker Hub. Plusieurs causes cumulées expliquaient les déploiements en retard / parfois absents :

- **Rate-limit Docker Hub** : le polling (~toutes les minutes) dépasse les 100–200 pulls/6h du tier gratuit → `429` → Watchtower échoue silencieusement.
- **`containrrr/watchtower` archivé en déc. 2025** (cassé sous Docker 29) — si c'est l'image en place, ça suffit à expliquer « parfois ça ne marche pas ».
- **Tag mutable unique** : aucun versionnage, aucun rollback, et une image cassée se déploie quand même.
- **Image lourde** (base Playwright + 286 Mo d'assets + tout `node_modules`) → pulls lents/fragiles.
- Latence **structurelle** : CI + attente du prochain cycle de poll + pull.

## Ce que fait cette PR

Passage d'un modèle **pull/polling** à **push/événementiel**, sans dépendre de Portainer Business (dont les webhooks de stack sont payants), + allègement de l'image.

Le déclencheur est **Watchtower en mode HTTP API** : Watchtower *est* déjà « le conteneur qui attend un webhook, monte le socket Docker et re-pull l'image » — avec en plus le cleanup, le scope par label et un poll de secours. Aucun receiver custom à maintenir.

| Fichier | Changement |
|---|---|
| `.github/workflows/docker-build.yml` | Docker Hub → **GHCR** ; tags `main`/`latest` + `sha-<court>` (rollback) via `metadata-action` ; cache GHA ; étape `POST /v1/update` avec bearer token (`DEPLOY_WEBHOOK_URL` / `DEPLOY_WEBHOOK_TOKEN`, + retries) |
| `Dockerfile` | **Multi-stage** : `builder` → `runner` mince (standalone + Playwright/ffmpeg + CLI Prisma uniquement) |
| `next.config.ts` | `output: "standalone"` |
| `docker-entrypoint.sh` | `node server.js` ; suppression de la régénération de clés VAPID éphémères à chaque boot (cassait les abonnements push) |
| `docker-compose.yml` | Image GHCR `:main` (`APP_IMAGE` surchargeable pour rollback) + label `watchtower.enable` sur l'app uniquement |
| `deploy/watchtower.compose.yml` | Stack Watchtower (**fork maintenu `nickfedor`**) en HTTP API : token, scope par label, `CLEANUP`, et poll lent (30 min) de secours |
| `deploy/README.md` | Guide complet : GHCR (public/PAT), joignabilité (Cloudflare Tunnel / Tailscale / reverse proxy), secrets, tests |

## Validation

- Build de fumée `next build` standalone : ✅ exit 0, `.next/standalone/server.js` émis, `.next/static` présent.
- Les 4 chemins copiés par le Dockerfile existent dans le contexte builder.
- YAML des 3 fichiers (workflow + 2 compose) : ✅ valides.
- Le build d'image multi-stage complet sera validé par le 1er run `docker-build` sur `main` ; il **échoue de façon sûre** (build raté ⇒ aucune image publiée ⇒ le conteneur en place continue de tourner).

## À configurer côté NAS (hors repo — voir `deploy/README.md`)

1. Rendre le package GHCR pullable (public, ou `docker login ghcr.io` + PAT `read:packages`).
2. Déployer la stack `deploy/watchtower.compose.yml` avec un `WATCHTOWER_TOKEN`.
3. Rendre l'API `:8080` joignable depuis GitHub (Cloudflare Tunnel recommandé — pas de port ouvert).
4. Secrets GitHub `DEPLOY_WEBHOOK_URL` + `DEPLOY_WEBHOOK_TOKEN`.

Tant que `DEPLOY_WEBHOOK_URL` n'est pas posé, le build publie l'image mais saute l'étape de redeploy → mergeable sans rien casser.

## Non inclus (volontairement)

- Sortie des 286 Mo d'assets vers MinIO — écartée pour cette itération.

https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp