### PR TITLE
perf(templates): read engine labels from a static catalog, not the runtime

### DIFF
--- a/src/app/templates/[engine]/page.tsx
+++ b/src/app/templates/[engine]/page.tsx
@@ -8,11 +8,9 @@ import {
   Suspense
 } from "react";
 
-import "@/engines/index";
-
 import {
-  hasEngine
-} from "@/engines/registry";
+  isKnownEngine
+} from "@/engines/engineCatalog";
 import {
   buildOgTitle, getBaseUrl, SITE_NAME
 } from "@/lib/seo";
@@ -34,7 +32,7 @@ export async function generateMetadata( {
     engine
   } = await params;
 
-  if ( !hasEngine( engine ) ) {
+  if ( !isKnownEngine( engine ) ) {
     return {};
   }
 
@@ -67,7 +65,7 @@ export default async function EngineTemplatesPage( {
     engine
   } = await params;
 
-  if ( !hasEngine( engine ) ) {
+  if ( !isKnownEngine( engine ) ) {
     notFound();
   }
 

--- a/src/app/templates/getTemplatesData.ts
+++ b/src/app/templates/getTemplatesData.ts
@@ -1,6 +1,6 @@
 import {
-  listEngines
-} from "@/engines/index";
+  ENGINE_LABELS
+} from "@/engines/engineCatalog";
 import getSketchThumbnailURL from "@/utils/getSketchThumbnailURL";
 import getSketchPreviewURL from "@/utils/getSketchPreviewURL";
 import getSketchList from "@/utils/getSketchList";
@@ -63,16 +63,12 @@ export async function getTemplatesData() {
       } );
     } );
 
-  const engines = listEngines();
-  const engineLabels: Record<string, string> = {};
-
-  engines.forEach( ( e ) => {
-    engineLabels[ e.id ] = e.label;
-  } );
-
+  // Labels come from the static catalogue rather than the engine runtime, so
+  // the gallery/home/listing pages don't compile the whole engine graph (and
+  // the generated sketch registry) just to render "p5.js" / "GSAP".
   return {
     templatesByEngine,
-    engineLabels
+    engineLabels: ENGINE_LABELS
   };
 }
 

--- a/src/engines/engineCatalog.ts
+++ b/src/engines/engineCatalog.ts
@@ -1,0 +1,49 @@
+/**
+ * Static engine catalogue — id + display label only, with **zero runtime
+ * dependencies**.
+ *
+ * Why this exists separately from `@/engines/index` / the registrations:
+ * importing `@/engines/index` pulls every engine *class* (P5Engine, GsapEngine)
+ * and their transitive graph (recording adapters, the generated 219-thunk
+ * sketch registry, …). The gallery, home and engine-listing pages only need the
+ * human label for an engine id — they should not drag the whole engine runtime
+ * into their compile graph. They read from this module instead.
+ *
+ * This is the single source of truth for engine labels: the engine
+ * registrations derive their `label` from here too (see `engines/p5/index.ts`
+ * and `engines/gsap/index.ts`).
+ */
+
+export type EngineCatalogEntry = {
+  id: string;
+  label: string;
+};
+
+export const ENGINE_CATALOG: readonly EngineCatalogEntry[] = [
+  {
+    id: "p5",
+    label: "p5.js"
+  },
+  {
+    id: "gsap",
+    label: "GSAP"
+  }
+];
+
+export const ENGINE_LABELS: Record<string, string> = Object.fromEntries( ENGINE_CATALOG.map( ( entry ) => [
+  entry.id,
+  entry.label
+] ) );
+
+/** Display label for an engine id, falling back to the id itself. */
+export function getEngineLabel( id: string ): string {
+  return ENGINE_LABELS[ id ] ?? id;
+}
+
+/**
+ * Whether `id` is a known engine — a static equivalent of the registry's
+ * `hasEngine()` that doesn't require the engine runtime to be loaded.
+ */
+export function isKnownEngine( id: string ): boolean {
+  return id in ENGINE_LABELS;
+}

--- a/src/engines/gsap/index.ts
+++ b/src/engines/gsap/index.ts
@@ -5,12 +5,15 @@ import {
   GsapEngine
 } from "./GsapEngine";
 import {
+  getEngineLabel
+} from "@/engines/engineCatalog";
+import {
   findSketchMeta, listTemplatesForEngine
 } from "@/engines/metadata";
 
 export const gsapRegistration: EngineRegistration = {
   id: "gsap",
-  label: "GSAP",
+  label: getEngineLabel( "gsap" ),
 
   createEngine: () => new GsapEngine(),
 

--- a/src/engines/p5/index.ts
+++ b/src/engines/p5/index.ts
@@ -5,12 +5,15 @@ import {
   P5Engine
 } from "./P5Engine";
 import {
+  getEngineLabel
+} from "@/engines/engineCatalog";
+import {
   findSketchMeta, listTemplatesForEngine
 } from "@/engines/metadata";
 
 export const p5Registration: EngineRegistration = {
   id: "p5",
-  label: "p5.js",
+  label: getEngineLabel( "p5" ),
 
   createEngine: () => new P5Engine(),
 


### PR DESCRIPTION
## Contexte

Suite de l'optimisation du temps de compile dev (la PR #82 — registre d'imports littéraux — est **déjà mergée** ; elle a supprimé le *context module* des 219 sketches de chaque page). Ce PR s'attaque à un coût résiduel identifié en mesurant les compiles à froid sur `main`.

## Problème

Les pages **home**, **/templates** et **/templates/[engine]** importaient `@/engines/index` uniquement pour :
- lire le label d'affichage d'un moteur (`"p5.js"` / `"GSAP"`), et
- valider l'id de moteur (`hasEngine`).

Or cet import à effet de bord tire **tout le runtime moteur** dans le graphe de compilation de ces routes : les classes `P5Engine` / `GsapEngine`, leurs adaptateurs `recording`, et le **registre généré de 219 thunks** — alors que la gallery n'exécute aucun de ces modules.

## Solution

Nouveau `src/engines/engineCatalog.ts` : un catalogue `{ id, label }` **sans aucune dépendance** (`ENGINE_LABELS`, `getEngineLabel`, `isKnownEngine`).

- `getTemplatesData` lit les labels depuis le catalogue (plus de `listEngines()`).
- `/templates/[engine]/page.tsx` valide l'id via `isKnownEngine` (plus de `import "@/engines/index"`).
- Les registrations moteur (`engines/p5/index.ts`, `engines/gsap/index.ts`) dérivent leur `label` du même catalogue → **source unique de vérité**.

La route **sketch** (et `EngineSketchRenderer`) importent toujours le runtime — elles en ont besoin pour exécuter une sketch.

## Effet

- Home / `/templates` / `/templates/[engine]` ne compilent plus le runtime moteur ni le registre généré → moins de modules dans leur graphe Turbopack en dev.
- Effet de bord agréable au build : la First Load JS des routes gallery baisse (`/` ≈ 118 kB, `/templates` ≈ 113 kB).

C'est un gain **incrémental** : le gros levier (registre) était déjà en place. Le reste de la lenteur résiduelle est le coût incompressible du compile à froid des gros arbres client (notamment l'UI d'options de la page sketch, ~93 fichiers).

## Vérifications

- ✅ `eslint`
- ✅ `npm test` — **896** tests passants
- ✅ `next build` complet (compilé, 28/28 pages statiques)
- ⚠️ `tsc --noEmit` remonte 6 erreurs, **toutes** dans `src/templates/p5/utils/__tests__/traceLetters.test.ts` — un fichier **non touché** par ce PR, donc **pré-existant sur `main`** (hors scope).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry5CC7dukpyWwbA1oD3om1)_