### PR TITLE
perf(sketch): code-split the collapsed option sections (content, slides)

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/OptionsPanel.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/OptionsPanel.tsx
@@ -1,6 +1,7 @@
 import React, {
   Fragment
 } from "react";
+import dynamic from "next/dynamic";
 import {
   UseFormReturn, useWatch
 } from "react-hook-form";
@@ -16,10 +17,19 @@ import {
 } from "@/types/recording.types";
 import CollapsibleItem from "@/components/CollapsibleItem";
 import RootSettings from "./RootSettings/RootSettings";
-import ContentItems from "./ContentItems/ContentItems";
-import SlideCarousel from "./SlideCarousel";
-import SlideEditor from "./SlideEditor";
 import TemplateAssetsProvider from "./TemplateAssetsProvider/TemplateAssetsProvider";
+
+// The "global content" and "slides" sections start collapsed (see
+// useCollapsibleStates DEFAULT_STATES), so CollapsibleItem never mounts their
+// content until the user expands them. Loading them as separate chunks means
+// the dev server doesn't compile this whole subtree — the recursive content
+// editor and its dnd-kit deps (~2.6k LOC) — just to open a sketch page; it
+// compiles only when a section is actually opened. The collapsible headers live
+// here in OptionsPanel and stay static, so there is no loading flash.
+const ContentItems = dynamic( () => import( "./ContentItems/ContentItems" ) );
+const SlideCarousel = dynamic( () => import( "./SlideCarousel" ) );
+const SlideEditor = dynamic( () => import( "./SlideEditor" ) );
+
 import ContentArrayProvider from "./ContentArrayProvider/ContentArrayProvider";
 import OptionsImportExport from "./CaptureActions/components/OptionsImportExport";
 import initOptions from "@/utils/initOptions";


### PR DESCRIPTION
## Contexte

Étape 3 de l'optimisation du temps de chargement de la **page sketch**. Hypothèse de départ : `TemplateOptions` (panneau d'options, ~93 fichiers) ralentit la page.

## Ce que fait ce PR

Les sections les plus lourdes du panneau (`ContentItems` ≈ 2,6k LOC + l'éditeur de contenu récursif et ses deps `@dnd-kit`, ainsi que la section `slides`) démarrent **repliées** (`DEFAULT_STATES` dans `useCollapsibleStates`) et `CollapsibleItem` ne monte leur contenu (`{render ? children : null}`) qu'à l'ouverture. Mais elles étaient importées **statiquement** dans `OptionsPanel`, donc incluses dans le chunk `TemplateOptions`.

Ce PR les charge via `next/dynamic` (`ContentItems`, `SlideCarousel`, `SlideEditor`). Leurs **headers restent dans `OptionsPanel`** (statiques) → aucun flash ; le contenu (et son compile) n'est tiré que quand l'utilisateur ouvre la section.

## ⚠️ Honnêteté sur la mesure

J'ai mesuré le compile dev **avant/après sur la même machine** :

| | `main` | cette branche |
|---|---|---|
| `Compiled /…[...sketch]` | **19,8 s** | **19,9 s** |

→ **Aucun effet sur ce nombre.** Raison : `TemplateOptions` est **déjà** un chunk `dynamic()` (chargé côté navigateur quand la sketch est prête), donc il n'apparaît pas dans le compile de route que mesure une requête SSR. Ce nombre est dominé par le graphe **moteur + p5 + providers + foundation**, pas par les options.

Ce PR agit sur le **chunk navigateur de `TemplateOptions`** : il en sort ContentItems/slides au profit de sous-chunks chargés à l'ouverture. Ça allège le 1er chargement du panneau d'options **dans le navigateur** (ce qui est plus proche du temps réellement ressenti). Je **n'ai pas pu chiffrer** ce gain ici : le téléchargement de Chromium (playwright) est bloqué par la politique réseau du bac à sable.

## Statut

Changement **sûr et sans régression** (comportement identique, sections repliées non montées de toute façon), mais **bénéfice non chiffré** dans ce contexte. À garder si le ressenti navigateur s'améliore, ou à fermer sinon. Le vrai levier du *nombre* de compile de route serait le graphe moteur/p5/foundation — investigation séparée.

## Vérifications

- ✅ `eslint`, ✅ `npm test` (**913** tests), ✅ `next build` complet
- ⚠️ `tsc` : 6 erreurs **pré-existantes** dans `traceLetters.test.ts` (fichier non touché)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry5CC7dukpyWwbA1oD3om1)_