### PR TITLE
fix(docker): drop dev-only prepare script so npm ci succeeds in the i…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,12 @@ ENV NEXT_PUBLIC_VAPID_PUBLIC_KEY=${NEXT_PUBLIC_VAPID_PUBLIC_KEY}
 COPY package.json package-lock.json ./
 COPY prisma ./prisma
 
-# Install dependencies (runs postinstall → prisma generate).
-RUN npm ci
+# Strip the dev-only `prepare` script (husky hooks + git merge-driver setup): it
+# needs a .git work tree and scripts/ that aren't in the build context, and has
+# no purpose in an image. postinstall (prisma generate) and dependency lifecycle
+# scripts still run.
+RUN npm pkg delete scripts.prepare \
+ && npm ci
 
 # Copy configuration files.
 COPY next.config.ts tsconfig.json tailwind.config.ts postcss.config.mjs ./


### PR DESCRIPTION
The prepare lifecycle script (husky hooks + git merge-driver setup) runs during npm ci but needs a .git work tree and scripts/ that aren't in the build context, breaking the image build (Cannot find module scripts/setup-git-merge-drivers.mjs). This has been failing every docker-build on main since the script was added.

Strip scripts.prepare before npm ci; postinstall (prisma generate) and all dependency lifecycle scripts still run.

https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp