### PR TITLE
ci: move CI off the deprecated Node 20 runtime and onto Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Acknowledge command
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -41,7 +41,7 @@ jobs:
 
       - name: Resolve PR head ref
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -62,7 +62,7 @@ jobs:
           exit 1
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.ref }}
           # Need a token that can push back to the PR branch.
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -109,7 +109,7 @@ jobs:
 
       - name: React to comment with result
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const ok = '${{ job.status }}' === 'success';

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Two related changes, both about getting CI off Node 20.

## 1. Action runtimes: bump first-party `actions/*` off Node 20

GitHub forces Actions onto the Node 24 runner from 2026-06-16 and warns on every run that `actions/checkout@v4` / `actions/setup-node@v4` run on the deprecated Node 20 runtime. Bumped all first-party actions to their Node 24 majors:

| Action | From → To | Where |
|---|---|---|
| `actions/checkout` | v4 → **v5** | `ci.yml` (×3 jobs), `docker-build.yml`, `lint-fix.yml` |
| `actions/setup-node` | v4 → **v5** | `ci.yml` (×3 jobs), `lint-fix.yml` |
| `actions/github-script` | v7 → **v8** | `lint-fix.yml` (×3) |

`github-script@v8`'s `github`/`context`/`core` API is unchanged from v7, so the inline scripts need no edits.

## 2. Project runtime: `node-version` 20 → 24 (match production)

The CI `setup-node` input that runs `npm ci` / lint / test / build was pinned to Node 20, which:
- is **EOL since 2026-04-30**, and
- differs from what production actually runs — the Docker image (`mcr.microsoft.com/playwright:v1.59.1-jammy`) **ships Node 24**.

Bumped `node-version: 20 → 24` in `ci.yml` (×3) and `lint-fix.yml` so CI validates on the same Node major as production. There's no `engines`/`.nvmrc` pin elsewhere, so these workflow inputs were the only places hardcoding Node 20.

## Notes
- Third-party `docker/*` actions weren't part of the deprecation warning and are left untouched.
- The `videos.js` anonymous-default-export lint warning from the original run is handled separately by the author.

https://claude.ai/code/session_01YUZyYpjZLWoyehgKyMGpsk