### PR TITLE
fix(docker): run prisma migrate deploy via build/index.js (WASM ENOENT au boot)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,12 +70,14 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
 # Prisma: schema + migrations for `migrate deploy`, the generated client (with
-# its native query engine) and the CLI used by the entrypoint at startup.
+# its native query engine) and the CLI used by the entrypoint at startup. The
+# whole prisma/ + @prisma/ trees are copied so the CLI finds its bundled WASM
+# (build/*.wasm) and engines; it is invoked via build/index.js directly — NOT
+# via .bin/prisma, whose symlink Docker dereferences, breaking __dirname.
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/src/generated/prisma ./src/generated/prisma
 COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
-COPY --from=builder /app/node_modules/.bin/prisma ./node_modules/.bin/prisma
 
 # Entrypoint: runs migrations then starts the standalone server.
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,10 @@ else
 fi
 
 echo "Running database migrations..."
-npx prisma migrate deploy
+# Invoke the CLI's real entrypoint (not node_modules/.bin/prisma): Docker
+# dereferences that symlink into a plain file, which puts __dirname in .bin/ and
+# the bundled WASM (prisma_schema_build_bg.wasm, schema_engine_bg.wasm) out of reach.
+node /app/node_modules/prisma/build/index.js migrate deploy
 
 echo "Starting application..."
 exec node server.js


### PR DESCRIPTION
## Problème

Depuis le merge de #92/#96, l'image se build et se déploie sur le NAS, mais le conteneur **crashe au démarrage** sur `prisma migrate deploy` :

```
Error: ENOENT: no such file or directory,
open '/app/node_modules/.bin/prisma_schema_build_bg.wasm'
```

## Cause

Le runtime stage copiait `node_modules/.bin/prisma`. Or **Docker déréférence ce symlink** lors du `COPY --from`, le transformant en fichier réel sous `.bin/`. Le `__dirname` du CLI pointe alors sur `.bin/` et il cherche son WASM bundlé (`prisma_schema_build_bg.wasm`, `schema_engine_bg.wasm`) au mauvais endroit — alors qu'il vit dans `node_modules/prisma/build/`.

## Correctif

- Suppression du `COPY .bin/prisma`.
- L'entrypoint invoque le vrai point d'entrée : `node /app/node_modules/prisma/build/index.js migrate deploy`, donc `__dirname = prisma/build/` où se trouvent les WASM.

Les arbres `node_modules/prisma` et `node_modules/@prisma` sont déjà copiés en entier ; les seules deps runtime du CLI (`@prisma/engines`, `@prisma/config`) sont sous `@prisma/`, donc rien d'autre n'est requis.

## Validation

- `node node_modules/prisma/build/index.js --version` : ✅ résout WASM + engines.
- `migrate deploy` contre une **DB injoignable** : renvoie `P1001: Can't reach database server` (et **plus aucun `ENOENT`**) → le WASM/engine se charge bien, seule la connexion DB manque. Sur le NAS, Postgres étant joignable, la migration passera.

Diff : 2 fichiers (`Dockerfile`, `docker-entrypoint.sh`).

https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp)_