### PR TITLE
fix(docker): full dependency closure for prisma migrate deploy (Cannot find module 'effect')

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,26 @@ COPY scripts ./scripts
 ENV NODE_ENV=production
 RUN npm run build
 
-# ─── Stage 2: runtime ────────────────────────────────────────────────────────
+# ─── Stage 2: prisma CLI ─────────────────────────────────────────────────────
+# A clean, isolated install of the Prisma CLI pinned to the lockfile version,
+# with its FULL dependency closure (@prisma/*, effect, c12, deepmerge-ts, …).
+# The runtime runs `migrate deploy` on startup; cherry-picking node_modules
+# subtrees misses transitive deps, so install the CLI properly instead.
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS prisma-deps
+
+WORKDIR /prisma-cli
+
+COPY package-lock.json ./lock.json
+RUN PRISMA_VERSION="$(node -p "require('./lock.json').packages['node_modules/prisma'].version")" \
+ && rm -f lock.json \
+ && npm init -y >/dev/null 2>&1 \
+ && npm install "prisma@${PRISMA_VERSION}" \
+ && npm cache clean --force
+
+# ─── Stage 3: runtime ────────────────────────────────────────────────────────
 # Slim runtime: Playwright base (browsers + Node already present) + ffmpeg.
-# Only the standalone server, static assets, public files and the Prisma CLI
-# (needed for `migrate deploy` on startup) are copied over — no dev deps.
+# Only the standalone server, static assets, public files and an isolated Prisma
+# CLI (for `migrate deploy` on startup) are copied over — no dev deps.
 FROM mcr.microsoft.com/playwright:v1.59.1-jammy AS runner
 
 WORKDIR /app
@@ -69,15 +85,14 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
-# Prisma: schema + migrations for `migrate deploy`, the generated client (with
-# its native query engine) and the CLI used by the entrypoint at startup. The
-# whole prisma/ + @prisma/ trees are copied so the CLI finds its bundled WASM
-# (build/*.wasm) and engines; it is invoked via build/index.js directly — NOT
-# via .bin/prisma, whose symlink Docker dereferences, breaking __dirname.
+# Prisma schema + migrations (read by `migrate deploy`) and the generated client
+# with its native query engine (used by the app server).
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/src/generated/prisma ./src/generated/prisma
-COPY --from=builder /app/node_modules/prisma ./node_modules/prisma
-COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
+
+# The isolated Prisma CLI + its full dependency closure, kept out of the app's
+# own node_modules to avoid version clashes. Invoked from here by the entrypoint.
+COPY --from=prisma-deps /prisma-cli/node_modules ./prisma-cli/node_modules
 
 # Entrypoint: runs migrations then starts the standalone server.
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,10 +13,10 @@ else
 fi
 
 echo "Running database migrations..."
-# Invoke the CLI's real entrypoint (not node_modules/.bin/prisma): Docker
-# dereferences that symlink into a plain file, which puts __dirname in .bin/ and
-# the bundled WASM (prisma_schema_build_bg.wasm, schema_engine_bg.wasm) out of reach.
-node /app/node_modules/prisma/build/index.js migrate deploy
+# Run the isolated Prisma CLI (full dependency closure under prisma-cli/) via its
+# real entrypoint — not node_modules/.bin/prisma, whose symlink Docker
+# dereferences, which breaks __dirname-relative WASM loading.
+node /app/prisma-cli/node_modules/prisma/build/index.js migrate deploy --schema /app/prisma/schema.prisma
 
 echo "Starting application..."
 exec node server.js


### PR DESCRIPTION
Suite de #99. Après le fix WASM (#99), le conteneur démarre, charge le moteur Prisma… puis crashe une étape plus loin sur :

```
Error: Cannot find module 'effect'
Require stack:
- /app/node_modules/@prisma/config/dist/index.js
- /app/node_modules/prisma/build/index.js
```

## Cause

Copier `node_modules/prisma` + `@prisma` à la main rate les deps transitives du CLI **hors scope `@prisma/`** : `@prisma/config` dépend de `effect`, `c12`, `deepmerge-ts`, `empathic`. Le cherry-pick de sous-arbres `node_modules` ne sera jamais complet.

## Correctif (robuste, on arrête le whack-a-mole)

- Nouveau stage `prisma-deps` : `npm install` propre du CLI Prisma **épinglé à la version du lockfile** (`6.19.3`), donc **fermeture de dépendances complète** (`@prisma/*` + `effect` + `c12` + …).
- Copié dans `/app/prisma-cli/node_modules`, **isolé** du `node_modules` de l'app (pas de conflit de versions), et invoqué de là par l'entrypoint :
  `node /app/prisma-cli/node_modules/prisma/build/index.js migrate deploy --schema /app/prisma/schema.prisma`

## Validation locale (layout identique au conteneur)

Reproduit `app/prisma-cli/node_modules` + `app/prisma/` et lancé l'invocation **exacte** de l'entrypoint contre une DB injoignable :

```
Prisma schema loaded from prisma/schema.prisma
Error: P1001: Can't reach database server at `127.0.0.1:1`
```

→ tous les modules résolvent (plus de `MODULE_NOT_FOUND`), le WASM/engine se charge, seule la connexion DB manque. Sur le NAS (Postgres joignable via le réseau compose), la migration passera.

Diff : 2 fichiers (`Dockerfile`, `docker-entrypoint.sh`).

https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5thiCXTcz82XHYQYZMtHp)_