### PR TITLE
ci: parallelize lint/test/build, cancel stale runs, skip docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,26 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+
+# Cancel an in-progress run when a new commit lands on the same PR. On `main`,
+# head_ref is empty -> fallback to run_id (unique) -> main runs are never
+# cancelled, so every commit pushed to main is validated end-to-end.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-  test:
-    name: Lint, test & build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -23,12 +38,52 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          HUSKY: 0
 
       - name: Lint
         run: npm run lint
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          HUSKY: 0
+
       - name: Unit + regression tests
         run: npm test -- --ci
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          HUSKY: 0
 
       - name: Production build smoke test
         run: npm run build


### PR DESCRIPTION
## Pourquoi

La CI prend du temps, surtout sur le **lint** et le **build**. On garde ces étapes (elles prennent le temps qu'il faut), mais on supprime le gaspillage.

## Ce que fait cette PR (`ci.yml` uniquement)

1. **Parallélisation** — le job unique `lint → test → build` (séquentiel) devient **trois jobs parallèles** (`Lint`, `Test`, `Build`). Le temps total d'une PR passe de la *somme* des trois à ≈ la durée du **build** seul.
2. **Annulation des runs obsolètes** — ajout d'un bloc `concurrency`. Pousser plusieurs commits d'affilée sur une PR annule le run précédent au lieu de tout faire tourner en parallèle. Le fallback `head_ref || run_id` garantit que **`main` n'est jamais annulé** (chaque commit sur main reste validé entièrement — comportement conservé volontairement).
3. **Skip docs-only** — `paths-ignore` sur `**/*.md`, `docs/**`, `LICENSE` : un changement purement documentation ne déclenche plus la CI.
4. **`HUSKY=0`** sur `npm ci` pour éviter l'install des hooks en CI (cohérent avec `lint-fix.yml`).

`docker-build.yml` et `lint-fix.yml` ne sont **pas** touchés.

## Compromis

Chaque job refait `npm ci` (+ `prisma generate` via `postinstall`) → un peu plus de minutes runner, mais moins de temps réel. Le cache `setup-node` (`cache: npm`) accélère chaque install.

## ⚠️ À vérifier après merge

Les noms des status checks changent : `CI / Lint, test & build` devient **trois** checks `CI / Lint`, `CI / Test`, `CI / Build`. Si une **branch protection** exige l'ancien check par son nom, mettre à jour la liste des checks requis (Settings → Branches).

## Vérification

- [ ] Les 3 jobs `Lint` / `Test` / `Build` apparaissent et tournent **en parallèle** sur cette PR.
- [ ] Le temps total ≈ durée du build seul (plus la somme).
- [ ] Pousser un 2ᵉ commit rapidement → le run précédent passe en *Cancelled*.
- [ ] Un commit ne touchant qu'un `.md` ne déclenche **pas** la CI.

https://claude.ai/code/session_013t98kPMFLZ9Yh1s7oeuCSB

---
_Generated by [Claude Code](https://claude.ai/code/session_013t98kPMFLZ9Yh1s7oeuCSB)_