### PR TITLE
feat(video): vector2d position pad in video modal; text position + blur in video-text

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/ControlledVector2DInput.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/ControlledVector2DInput.tsx
@@ -1,85 +1,29 @@
 "use client";
 
 import {
-  useRef
-} from "react";
-import {
   useController, useFormContext
 } from "react-hook-form";
 
-import clamp from "@/utils/clamp";
-import {
-  fractionToValue,
-  stepDecimals,
-  valueToFraction,
-  type AxisRange
-} from "./utils/vector2dMath";
+import Vector2DPad, {
+  type Vector2DInputConfig, type Vector2DValue
+} from "./Vector2DPad";
 
-/**
- * Subset of the field config understood by the pad. Kept independent from
- * `FieldConfig` so the component stays reusable outside the form renderer.
- */
-export interface Vector2DInputConfig {
-  /**
-   * When false, both axes are constrained to non-negative values ([0, max]) so
-   * the vector can only point up/right — handy for scaling a vector's strength
-   * down to 0 without flipping its direction. Defaults to true, which yields a
-   * centered pad spanning [min, max] on both axes.
-   */
-  allowNegative?: boolean;
-  /** Shared lower bound. Defaults to -1 (or 0 when `allowNegative` is false). */
-  min?: number;
-  /** Shared upper bound. Defaults to 1. */
-  max?: number;
-  /** Shared snapping increment. Defaults to 0.01. */
-  step?: number;
-  /** Per-axis overrides, merged over the shared min/max/step. */
-  xAxis?: Partial<AxisRange>;
-  yAxis?: Partial<AxisRange>;
-  /**
-   * Invert the vertical axis so the top of the pad maps to the *minimum* value.
-   * Use it for screen-space positions (where y grows downward): dragging the
-   * handle up then moves the point toward the top of the canvas. Defaults to
-   * false (top = max), matching the "Y points up" convention used for vectors.
-   */
-  yDown?: boolean;
-}
-
-type Vector2DValue = {
-  x: number;
-  y: number;
-};
+export type {
+  Vector2DInputConfig, Vector2DValue
+} from "./Vector2DPad";
 
 type Props = {
   name: string;
   config?: Vector2DInputConfig;
 };
 
-function resolveAxes( config: Vector2DInputConfig ): {
-  xAxis: AxisRange;
-  yAxis: AxisRange;
-} {
-  const allowNegative = config.allowNegative ?? true;
-  const min = config.min ?? ( allowNegative ? -1 : 0 );
-  const max = config.max ?? 1;
-  const step = config.step ?? 0.01;
-
-  return {
-    xAxis: {
-      min: config.xAxis?.min ?? min,
-      max: config.xAxis?.max ?? max,
-      step: config.xAxis?.step ?? step
-    },
-    yAxis: {
-      min: config.yAxis?.min ?? min,
-      max: config.yAxis?.max ?? max,
-      step: config.yAxis?.step ?? step
-    }
-  };
-}
-
+/**
+ * Binds the presentational {@link Vector2DPad} to react-hook-form. Reads/writes
+ * `{ x, y }` on the field while preserving any sibling keys stored alongside
+ * them, so the pad can edit a position nested inside a larger value object.
+ */
 export default function ControlledVector2DInput( {
-  name, config = {}
+  name, config
 }: Props ) {
   const {
     control
@@ -92,286 +36,20 @@ export default function ControlledVector2DInput( {
     control
   } );
 
-  const padRef = useRef<HTMLDivElement>( null );
-
-  const {
-    xAxis, yAxis
-  } = resolveAxes( config );
-
-  const yDown = config.yDown ?? false;
-
-  // Convert between a Y value and its vertical position in the pad (a 0..1
-  // fraction where 0 is the top). Unless yDown is set, the axis is flipped so
-  // the top of the pad represents the maximum value.
-  const valueYToFraction = ( y: number ) => {
-    const fraction = valueToFraction(
-      y,
-      yAxis
-    );
-
-    return yDown ? fraction : 1 - fraction;
-  };
-
-  const fractionToValueY = ( fraction: number ) => fractionToValue(
-    yDown ? fraction : 1 - fraction,
-    yAxis
-  );
-
   const raw = field.value as Partial<Vector2DValue> | undefined;
-  const value: Vector2DValue = {
-    x: typeof raw?.x === "number" ? raw.x : xAxis.min,
-    y: typeof raw?.y === "number" ? raw.y : yAxis.min
-  };
-
-  // Preserve any sibling keys on the stored object while updating x/y.
-  const commit = ( next: Vector2DValue ) => {
-    field.onChange( {
-      ...( raw && typeof raw === "object" ? raw : {} ),
-      x: next.x,
-      y: next.y
-    } );
-  };
-
-  const updateFromPointer = (
-    clientX: number, clientY: number
-  ) => {
-    const pad = padRef.current;
-
-    if ( !pad ) {
-      return;
-    }
-
-    const rect = pad.getBoundingClientRect();
-    const fractionX = ( clientX - rect.left ) / rect.width;
-    const fractionY = ( clientY - rect.top ) / rect.height;
-
-    commit( {
-      x: fractionToValue(
-        fractionX,
-        xAxis
-      ),
-      y: fractionToValueY( fractionY )
-    } );
-  };
-
-  const handlePointerDown = ( event: React.PointerEvent<HTMLDivElement> ) => {
-    event.currentTarget.setPointerCapture( event.pointerId );
-    updateFromPointer(
-      event.clientX,
-      event.clientY
-    );
-  };
-
-  const handlePointerMove = ( event: React.PointerEvent<HTMLDivElement> ) => {
-    if ( !event.currentTarget.hasPointerCapture( event.pointerId ) ) {
-      return;
-    }
-
-    updateFromPointer(
-      event.clientX,
-      event.clientY
-    );
-  };
-
-  const nudge = (
-    dx: number, dy: number
-  ) => {
-    const round = (
-      v: number, step: number | undefined
-    ) => Number( v.toFixed( stepDecimals( step ) ) );
-
-    // `dy` is expressed in screen terms (+1 = up). Flip it for a non-inverted
-    // axis so pressing "up" increases the value.
-    const valueDy = yDown ? -dy : dy;
-
-    commit( {
-      x: clamp(
-        round(
-          value.x + dx * ( xAxis.step ?? 0.01 ),
-          xAxis.step
-        ),
-        xAxis.min,
-        xAxis.max
-      ),
-      y: clamp(
-        round(
-          value.y + valueDy * ( yAxis.step ?? 0.01 ),
-          yAxis.step
-        ),
-        yAxis.min,
-        yAxis.max
-      )
-    } );
-  };
-
-  const handleKeyDown = ( event: React.KeyboardEvent<HTMLDivElement> ) => {
-    const moves: Record<string, [number, number]> = {
-      ArrowLeft: [
-        -1,
-        0
-      ],
-      ArrowRight: [
-        1,
-        0
-      ],
-      ArrowUp: [
-        0,
-        1
-      ],
-      ArrowDown: [
-        0,
-        -1
-      ]
-    };
-
-    const move = moves[ event.key ];
-
-    if ( move ) {
-      event.preventDefault();
-      nudge(
-        move[ 0 ],
-        move[ 1 ]
-      );
-    }
-  };
-
-  const handleAxisInput = (
-    axis: "x" | "y", rawValue: string
-  ) => {
-    const parsed = parseFloat( rawValue );
-
-    if ( Number.isNaN( parsed ) ) {
-      return;
-    }
-
-    const range = axis === "x" ? xAxis : yAxis;
-    const clamped = clamp(
-      parsed,
-      range.min,
-      range.max
-    );
-
-    commit( axis === "x"
-      ? {
-        ...value,
-        x: clamped
-      }
-      : {
-        ...value,
-        y: clamped
-      } );
-  };
-
-  // Handle position as a percentage within the pad (top-left origin). The
-  // guide line always emanates from the geometric centre so the pad reads
-  // like a small graph, whatever the axis ranges.
-  const pointLeft = valueToFraction(
-    value.x,
-    xAxis
-  ) * 100;
-  const pointTop = valueYToFraction( value.y ) * 100;
-
-  const numberInputClassName =
-    "w-full text-center text-xs font-mono px-1 py-0.5 rounded border border-theme/30 bg-theme/20 focus:outline-none focus:ring-1 focus:ring-theme";
 
   return (
-    <div className="flex w-full max-w-[100px] flex-col gap-1">
-      <div className="flex items-center gap-1">
-        <input
-          type="number"
-          aria-label={ `${ name } x` }
-          className={ numberInputClassName }
-          value={ value.x }
-          min={ xAxis.min }
-          max={ xAxis.max }
-          step={ xAxis.step }
-          onChange={ ( event ) => handleAxisInput(
-            "x",
-            event.target.value
-          ) }
-        />
-        <input
-          type="number"
-          aria-label={ `${ name } y` }
-          className={ numberInputClassName }
-          value={ value.y }
-          min={ yAxis.min }
-          max={ yAxis.max }
-          step={ yAxis.step }
-          onChange={ ( event ) => handleAxisInput(
-            "y",
-            event.target.value
-          ) }
-        />
-      </div>
-
-      <div
-        ref={ padRef }
-        role="application"
-        tabIndex={ 0 }
-        aria-label="2D vector pad"
-        onPointerDown={ handlePointerDown }
-        onPointerMove={ handlePointerMove }
-        onKeyDown={ handleKeyDown }
-        className="relative aspect-square w-full cursor-crosshair touch-none select-none overflow-hidden rounded-lg border border-theme bg-background/50 focus:outline-none focus:ring-1 focus:ring-theme"
-      >
-        <svg
-          className="absolute inset-0 h-full w-full"
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          aria-hidden="true"
-        >
-          {/* Static grid through the geometric centre. */}
-          <line
-            x1="50"
-            y1="0"
-            x2="50"
-            y2="100"
-            className="stroke-theme/40"
-            strokeWidth={ 0.5 }
-            strokeDasharray="2 2"
-            vectorEffect="non-scaling-stroke"
-          />
-          <line
-            x1="0"
-            y1="50"
-            x2="100"
-            y2="50"
-            className="stroke-theme/40"
-            strokeWidth={ 0.5 }
-            strokeDasharray="2 2"
-            vectorEffect="non-scaling-stroke"
-          />
-
-          {/* Guide line from the centre of the pad to the current value. */}
-          <line
-            x1={ 50 }
-            y1={ 50 }
-            x2={ pointLeft }
-            y2={ pointTop }
-            className="stroke-foreground/60"
-            strokeWidth={ 1 }
-            strokeDasharray="2 2"
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
-
-        {/* Tiny axis labels so the active axis stays obvious. */}
-        <span className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 bg-background/70 px-px font-mono text-[7px] leading-none text-gray-400">
-          x
-        </span>
-        <span className="pointer-events-none absolute left-1/2 top-0.5 -translate-x-1/2 bg-background/70 px-px font-mono text-[7px] leading-none text-gray-400">
-          y
-        </span>
-
-        <span
-          className="pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-background bg-foreground shadow"
-          style={ {
-            left: `${ pointLeft }%`,
-            top: `${ pointTop }%`
-          } }
-        />
-      </div>
-    </div>
+    <Vector2DPad
+      value={ raw }
+      onChange={ ( next ) =>
+        field.onChange( {
+          ...( raw && typeof raw === "object" ? raw : {} ),
+          x: next.x,
+          y: next.y
+        } )
+      }
+      config={ config }
+      ariaLabel={ name }
+    />
   );
 }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/Vector2DPad.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/Vector2DPad.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import {
+  useRef
+} from "react";
+
+import clamp from "@/utils/clamp";
+import {
+  fractionToValue,
+  stepDecimals,
+  valueToFraction,
+  type AxisRange
+} from "./utils/vector2dMath";
+
+/**
+ * Subset of the field config understood by the pad. Kept independent from
+ * `FieldConfig` so the component stays reusable outside the form renderer
+ * (e.g. the video asset params editor, which drives it from plain state).
+ */
+export interface Vector2DInputConfig {
+  /**
+   * When false, both axes are constrained to non-negative values ([0, max]) so
+   * the vector can only point up/right — handy for scaling a vector's strength
+   * down to 0 without flipping its direction. Defaults to true, which yields a
+   * centered pad spanning [min, max] on both axes.
+   */
+  allowNegative?: boolean;
+  /** Shared lower bound. Defaults to -1 (or 0 when `allowNegative` is false). */
+  min?: number;
+  /** Shared upper bound. Defaults to 1. */
+  max?: number;
+  /** Shared snapping increment. Defaults to 0.01. */
+  step?: number;
+  /** Per-axis overrides, merged over the shared min/max/step. */
+  xAxis?: Partial<AxisRange>;
+  yAxis?: Partial<AxisRange>;
+  /**
+   * Invert the vertical axis so the top of the pad maps to the *minimum* value.
+   * Use it for screen-space positions (where y grows downward): dragging the
+   * handle up then moves the point toward the top of the canvas. Defaults to
+   * false (top = max), matching the "Y points up" convention used for vectors.
+   */
+  yDown?: boolean;
+}
+
+export type Vector2DValue = {
+  x: number;
+  y: number;
+};
+
+type Props = {
+  /**
+   * Current value. Partial / undefined values fall back to each axis minimum so
+   * the pad still renders for half-initialized form state.
+   */
+  value: Partial<Vector2DValue> | undefined;
+  /** Always emits a complete `{ x, y }`; callers merge it back as they see fit. */
+  onChange: ( value: Vector2DValue ) => void;
+  config?: Vector2DInputConfig;
+  /** Accessible name prefix for the x / y number inputs. Defaults to "vector". */
+  ariaLabel?: string;
+  /** Overrides the wrapper sizing. Defaults to a compact 100px-wide column. */
+  className?: string;
+};
+
+function resolveAxes( config: Vector2DInputConfig ): {
+  xAxis: AxisRange;
+  yAxis: AxisRange;
+} {
+  const allowNegative = config.allowNegative ?? true;
+  const min = config.min ?? ( allowNegative ? -1 : 0 );
+  const max = config.max ?? 1;
+  const step = config.step ?? 0.01;
+
+  return {
+    xAxis: {
+      min: config.xAxis?.min ?? min,
+      max: config.xAxis?.max ?? max,
+      step: config.xAxis?.step ?? step
+    },
+    yAxis: {
+      min: config.yAxis?.min ?? min,
+      max: config.yAxis?.max ?? max,
+      step: config.yAxis?.step ?? step
+    }
+  };
+}
+
+/**
+ * Presentational 2D vector pad: two number inputs plus a draggable square that
+ * edits an `{ x, y }` pair at once. It is fully controlled and form-agnostic —
+ * {@link ControlledVector2DInput} wires it to react-hook-form, while other
+ * callers (e.g. the video params editor) drive it from local state.
+ */
+export default function Vector2DPad( {
+  value, onChange, config = {}, ariaLabel = "vector", className
+}: Props ) {
+  const padRef = useRef<HTMLDivElement>( null );
+
+  const {
+    xAxis, yAxis
+  } = resolveAxes( config );
+
+  const yDown = config.yDown ?? false;
+
+  // Convert between a Y value and its vertical position in the pad (a 0..1
+  // fraction where 0 is the top). Unless yDown is set, the axis is flipped so
+  // the top of the pad represents the maximum value.
+  const valueYToFraction = ( y: number ) => {
+    const fraction = valueToFraction(
+      y,
+      yAxis
+    );
+
+    return yDown ? fraction : 1 - fraction;
+  };
+
+  const fractionToValueY = ( fraction: number ) => fractionToValue(
+    yDown ? fraction : 1 - fraction,
+    yAxis
+  );
+
+  const current: Vector2DValue = {
+    x: typeof value?.x === "number" ? value.x : xAxis.min,
+    y: typeof value?.y === "number" ? value.y : yAxis.min
+  };
+
+  const updateFromPointer = (
+    clientX: number, clientY: number
+  ) => {
+    const pad = padRef.current;
+
+    if ( !pad ) {
+      return;
+    }
+
+    const rect = pad.getBoundingClientRect();
+    const fractionX = ( clientX - rect.left ) / rect.width;
+    const fractionY = ( clientY - rect.top ) / rect.height;
+
+    onChange( {
+      x: fractionToValue(
+        fractionX,
+        xAxis
+      ),
+      y: fractionToValueY( fractionY )
+    } );
+  };
+
+  const handlePointerDown = ( event: React.PointerEvent<HTMLDivElement> ) => {
+    event.currentTarget.setPointerCapture( event.pointerId );
+    updateFromPointer(
+      event.clientX,
+      event.clientY
+    );
+  };
+
+  const handlePointerMove = ( event: React.PointerEvent<HTMLDivElement> ) => {
+    if ( !event.currentTarget.hasPointerCapture( event.pointerId ) ) {
+      return;
+    }
+
+    updateFromPointer(
+      event.clientX,
+      event.clientY
+    );
+  };
+
+  const nudge = (
+    dx: number, dy: number
+  ) => {
+    const round = (
+      v: number, step: number | undefined
+    ) => Number( v.toFixed( stepDecimals( step ) ) );
+
+    // `dy` is expressed in screen terms (+1 = up). Flip it for a non-inverted
+    // axis so pressing "up" increases the value.
+    const valueDy = yDown ? -dy : dy;
+
+    onChange( {
+      x: clamp(
+        round(
+          current.x + dx * ( xAxis.step ?? 0.01 ),
+          xAxis.step
+        ),
+        xAxis.min,
+        xAxis.max
+      ),
+      y: clamp(
+        round(
+          current.y + valueDy * ( yAxis.step ?? 0.01 ),
+          yAxis.step
+        ),
+        yAxis.min,
+        yAxis.max
+      )
+    } );
+  };
+
+  const handleKeyDown = ( event: React.KeyboardEvent<HTMLDivElement> ) => {
+    const moves: Record<string, [number, number]> = {
+      ArrowLeft: [
+        -1,
+        0
+      ],
+      ArrowRight: [
+        1,
+        0
+      ],
+      ArrowUp: [
+        0,
+        1
+      ],
+      ArrowDown: [
+        0,
+        -1
+      ]
+    };
+
+    const move = moves[ event.key ];
+
+    if ( move ) {
+      event.preventDefault();
+      nudge(
+        move[ 0 ],
+        move[ 1 ]
+      );
+    }
+  };
+
+  const handleAxisInput = (
+    axis: "x" | "y", rawValue: string
+  ) => {
+    const parsed = parseFloat( rawValue );
+
+    if ( Number.isNaN( parsed ) ) {
+      return;
+    }
+
+    const range = axis === "x" ? xAxis : yAxis;
+    const clamped = clamp(
+      parsed,
+      range.min,
+      range.max
+    );
+
+    onChange( axis === "x"
+      ? {
+        ...current,
+        x: clamped
+      }
+      : {
+        ...current,
+        y: clamped
+      } );
+  };
+
+  // Handle position as a percentage within the pad (top-left origin). The
+  // guide line always emanates from the geometric centre so the pad reads
+  // like a small graph, whatever the axis ranges.
+  const pointLeft = valueToFraction(
+    current.x,
+    xAxis
+  ) * 100;
+  const pointTop = valueYToFraction( current.y ) * 100;
+
+  const numberInputClassName =
+    "w-full text-center text-xs font-mono px-1 py-0.5 rounded border border-theme/30 bg-theme/20 focus:outline-none focus:ring-1 focus:ring-theme";
+
+  return (
+    <div className={ className ?? "flex w-full max-w-[100px] flex-col gap-1" }>
+      <div className="flex items-center gap-1">
+        <input
+          type="number"
+          aria-label={ `${ ariaLabel } x` }
+          className={ numberInputClassName }
+          value={ current.x }
+          min={ xAxis.min }
+          max={ xAxis.max }
+          step={ xAxis.step }
+          onChange={ ( event ) => handleAxisInput(
+            "x",
+            event.target.value
+          ) }
+        />
+        <input
+          type="number"
+          aria-label={ `${ ariaLabel } y` }
+          className={ numberInputClassName }
+          value={ current.y }
+          min={ yAxis.min }
+          max={ yAxis.max }
+          step={ yAxis.step }
+          onChange={ ( event ) => handleAxisInput(
+            "y",
+            event.target.value
+          ) }
+        />
+      </div>
+
+      <div
+        ref={ padRef }
+        role="application"
+        tabIndex={ 0 }
+        aria-label="2D vector pad"
+        onPointerDown={ handlePointerDown }
+        onPointerMove={ handlePointerMove }
+        onKeyDown={ handleKeyDown }
+        className="relative aspect-square w-full cursor-crosshair touch-none select-none overflow-hidden rounded-lg border border-theme bg-background/50 focus:outline-none focus:ring-1 focus:ring-theme"
+      >
+        <svg
+          className="absolute inset-0 h-full w-full"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          {/* Static grid through the geometric centre. */}
+          <line
+            x1="50"
+            y1="0"
+            x2="50"
+            y2="100"
+            className="stroke-theme/40"
+            strokeWidth={ 0.5 }
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+          />
+          <line
+            x1="0"
+            y1="50"
+            x2="100"
+            y2="50"
+            className="stroke-theme/40"
+            strokeWidth={ 0.5 }
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+          />
+
+          {/* Guide line from the centre of the pad to the current value. */}
+          <line
+            x1={ 50 }
+            y1={ 50 }
+            x2={ pointLeft }
+            y2={ pointTop }
+            className="stroke-foreground/60"
+            strokeWidth={ 1 }
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+
+        {/* Tiny axis labels so the active axis stays obvious. */}
+        <span className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 bg-background/70 px-px font-mono text-[7px] leading-none text-gray-400">
+          x
+        </span>
+        <span className="pointer-events-none absolute left-1/2 top-0.5 -translate-x-1/2 bg-background/70 px-px font-mono text-[7px] leading-none text-gray-400">
+          y
+        </span>
+
+        <span
+          className="pointer-events-none absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-background bg-foreground shadow"
+          style={ {
+            left: `${ pointLeft }%`,
+            top: `${ pointTop }%`
+          } }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/assets/kinds/videos/VideoParamsEditor.tsx
+++ b/src/lib/assets/kinds/videos/VideoParamsEditor.tsx
@@ -6,6 +6,19 @@ import type {
 import type {
   AssetParamsEditorProps
 } from "../../types";
+import Vector2DPad, {
+  type Vector2DInputConfig
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/Vector2DPad";
+
+// Screen-space position pad: centered [-1, 1] on both axes (0 = centered in the
+// draw box), with the Y axis pointing down so dragging the handle up moves the
+// video toward the top of the frame, matching `computeVideoLayout`'s offsets.
+const POSITION_PAD_CONFIG: Vector2DInputConfig = {
+  min: -1,
+  max: 1,
+  step: 0.01,
+  yDown: true
+};
 
 const SPEED_MIN = 0.1;
 const SPEED_MAX = 4;
@@ -122,37 +135,32 @@ export default function VideoParamsEditor( {
         />
       </Row>
 
-      <Row label="Position X" hint={ value.posX.toFixed( 2 ) }>
-        <input
-          type="range"
-          min={ -1 }
-          max={ 1 }
-          step={ 0.01 }
-          value={ value.posX }
-          onChange={ ( e ) =>
+      {/* Position is a single { x, y } pad rather than two sliders: the
+          AssetDialog's layout preview can be dragged for coarse placement, and
+          this pad gives precise numeric control over the same posX/posY. Not
+          wrapped in a `Row` <label> since the pad is a composite widget. */}
+      <div className="flex flex-col gap-0.5">
+        <span className="flex justify-between text-gray-500">
+          <span>Position</span>
+          <span className="font-mono text-foreground/80">
+            {value.posX.toFixed( 2 )}, {value.posY.toFixed( 2 )}
+          </span>
+        </span>
+        <Vector2DPad
+          ariaLabel="Position"
+          config={ POSITION_PAD_CONFIG }
+          value={ {
+            x: value.posX,
+            y: value.posY
+          } }
+          onChange={ ( next ) =>
             update( {
-              posX: parseFloat( e.target.value )
+              posX: next.x,
+              posY: next.y
             } )
           }
-          className="w-full"
         />
-      </Row>
-
-      <Row label="Position Y" hint={ value.posY.toFixed( 2 ) }>
-        <input
-          type="range"
-          min={ -1 }
-          max={ 1 }
-          step={ 0.01 }
-          value={ value.posY }
-          onChange={ ( e ) =>
-            update( {
-              posY: parseFloat( e.target.value )
-            } )
-          }
-          className="w-full"
-        />
-      </Row>
+      </div>
 
       <Row label="Aspect ratio">
         <select

--- a/src/templates/p5/sketches/video/video-text/index.js
+++ b/src/templates/p5/sketches/video/video-text/index.js
@@ -97,6 +97,18 @@ sketch.draw( () => {
     cfg.outlineWeight ?? 8
   );
   const invert = Boolean( cfg.invert );
+  const blur = Math.max(
+    0,
+    cfg.blur ?? 0
+  );
+
+  // Where the masking text sits, as a fraction of the canvas (0.5 = centered,
+  // matching the previous always-centered behaviour). Y points down.
+  const textPosition = cfg.textPosition ?? {};
+  const textPosX =
+    typeof textPosition.x === "number" ? textPosition.x : 0.5;
+  const textPosY =
+    typeof textPosition.y === "number" ? textPosition.y : 0.5;
 
   const mask = ensure(
     p,
@@ -122,6 +134,13 @@ sketch.draw( () => {
       g.CENTER
     );
     g.textLeading( fontSize * lineHeight );
+
+    // Shift the whole (centered) text block by the configured position. At
+    // 0.5/0.5 the offset is zero, preserving the original centered layout.
+    g.translate(
+      ( textPosX - 0.5 ) * ( g.width - margin * 2 ),
+      ( textPosY - 0.5 ) * ( g.height - margin * 2 )
+    );
 
     if ( style === "outline" ) {
       g.noFill();
@@ -192,6 +211,15 @@ sketch.draw( () => {
       layout.height
     );
   } );
+
+  // Blur the composited video layer; the text mask stays sharp so the video
+  // shows softly through crisp glyphs.
+  if ( blur > 0 ) {
+    frame.filter(
+      p.BLUR,
+      blur
+    );
+  }
 
   // Keep the video only where the mask is opaque.
   const masked = frame.get();

--- a/src/templates/p5/sketches/video/video-text/options.ts
+++ b/src/templates/p5/sketches/video/video-text/options.ts
@@ -5,6 +5,7 @@ import {
 // Default values only
 export const formValues = {
   videos: [],
+  blur: 0,
 
   text: "VIDEO",
   font: "martian",
@@ -12,6 +13,10 @@ export const formValues = {
   align: "center",
   lineHeight: 1,
   margin: 0,
+  textPosition: {
+    x: 0.5,
+    y: 0.5
+  },
   style: "fill",
   outlineWeight: 8,
   invert: false,
@@ -29,6 +34,14 @@ export const formConfiguration: Record<string, any> = {
     component: "asset-stack",
     kind: "videos",
     label: "Videos"
+  },
+
+  blur: {
+    component: "slider",
+    label: "Video blur",
+    min: 0,
+    max: 20,
+    step: 1
   },
 
   text: {
@@ -83,6 +96,16 @@ export const formConfiguration: Record<string, any> = {
     min: 0,
     max: 400,
     step: 1
+  },
+
+  textPosition: {
+    component: "vector2d",
+    label: "Text position",
+    allowNegative: false,
+    min: 0,
+    max: 1,
+    step: 0.01,
+    yDown: true
   },
 
   style: {


### PR DESCRIPTION
## What & why

Two requests, both around using the existing 2D vector pad for video positioning.

### 1. Reusable `Vector2DPad`
The draggable pad lived entirely inside `ControlledVector2DInput`, which is bound to react-hook-form (`useFormContext` / `useController`) and so could not be reused anywhere else. Extracted the presentational pad into a form-agnostic **`Vector2DPad`** (plain `value` / `onChange`). `ControlledVector2DInput` is now a thin wrapper that reads/writes the field and preserves any sibling keys on the value object. No behaviour change for existing `vector2d` form fields (aria-labels and sibling-key preservation kept identical).

### 2. Video asset modal — single position pad
`VideoParamsEditor` (the per-video settings in the asset dialog) replaced its separate **Position X** / **Position Y** sliders with one `Vector2DPad`, centered `[-1, 1]` with `yDown` so dragging the handle up moves the video toward the top — consistent with `computeVideoLayout`'s offsets. Editing still writes the same `posX` / `posY` params, so this benefits every video sketch that uses the modal (video-text, video-grid, …). The dialog's draggable layout preview is unchanged.

### 3. video-text sketch — text position + video blur
- **Text position**: new `textPosition` `vector2d` field (`0..1`, `yDown`, default `0.5/0.5`). Offsets the masking text block; `0.5/0.5` reproduces the previous always-centered layout, so existing presets render identically.
- **Video blur**: new `blur` slider (`0–20`, default `0`). Blurs the composited video layer before masking, so video shows softly through crisp glyphs. Matches the `frame.filter(p.BLUR, …)` pattern already used in `video-echo`. Default `0` = no cost.

## Testing
- `jest` vector2d math/render suite — 11 passed
- `eslint` on all changed files — clean
- `tsc --noEmit` — no errors in changed files (only pre-existing, unrelated `traceLetters.test.ts` failures)

https://claude.ai/code/session_01XYLGDxAUXyhM1WtsxnhckM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYLGDxAUXyhM1WtsxnhckM)_