### PR TITLE
perf(p5): render neon-graffiti and spline glow on the GPU

### DIFF
--- a/src/templates/p5/sketches/splines/_shared.js
+++ b/src/templates/p5/sketches/splines/_shared.js
@@ -3,17 +3,18 @@ import {
 } from "@/p5/utils/sketch.js";
 import colors from "@/p5/utils/colors.js";
 import animation from "@/p5/utils/animation.js";
-import createGlowBatchRenderer, {
-  colorLevels
-} from "@/p5/utils/glowBatchGpu.js";
+import createGlowBatchRenderer from "@/p5/utils/glowBatchGpu.js";
 
 // The glowing curve used to be stroked segment-by-segment on the CPU, once per
 // glow layer, once per spline — fine for one procedural curve, but the cost
-// scaled with the number of live entities and dragged the draw loop down. The
-// dense Chaikin segments are now batched into a single instanced GPU draw (see
-// utils/glowBatchGpu.js) shared across every spline in the frame. The geometry
-// and colours are computed exactly as before, so the look is unchanged.
+// scaled with the number of live entities and dragged the draw loop down. Now the
+// dense Chaikin geometry is built once on flat typed arrays (no p5.Vector churn),
+// uploaded once, and the GPU re-draws it per glow layer while computing the
+// rainbow colour in the shader (see utils/glowBatchGpu.js). The geometry and
+// colours match the originals exactly, so the look is unchanged.
 const batch = createGlowBatchRenderer();
+
+const TWO_PI = Math.PI * 2;
 
 /**
  * Shared geometry for the `splines` category.
@@ -216,6 +217,71 @@ function chaikinStep(
   if ( !closed ) {
     out.unshift( points[ 0 ].copy() );
     out.push( points[ count - 1 ].copy() );
+  }
+
+  return out;
+}
+
+/**
+ * Same corner-cutting as `chaikin`, but on flat [x0, y0, x1, y1, …] Float32Arrays
+ * instead of p5.Vector objects. The GPU path only needs the coordinates, and the
+ * dense polyline can reach thousands of points per spline, so avoiding the vector
+ * allocations removes a big chunk of per-frame GC. Input is the sketch's vectors;
+ * output is a packed Float32Array of the dense vertices.
+ */
+export function chaikinFlat(
+  points, iterations, closed
+) {
+  let flat = new Float32Array( points.length * 2 );
+
+  for ( let i = 0; i < points.length; i++ ) {
+    flat[ i * 2 ] = points[ i ].x;
+    flat[ i * 2 + 1 ] = points[ i ].y;
+  }
+
+  for ( let i = 0; i < iterations; i++ ) {
+    flat = chaikinStepFlat(
+      flat,
+      closed
+    );
+  }
+
+  return flat;
+}
+
+function chaikinStepFlat(
+  flat, closed
+) {
+  const count = flat.length / 2;
+  const limit = closed ? count : count - 1;
+  const cutCount = limit * 2;
+  const outCount = closed ? cutCount : cutCount + 2;
+  const out = new Float32Array( outCount * 2 );
+  let o = 0;
+
+  // Open polylines keep their original endpoints (Chaikin only cuts corners).
+  if ( !closed ) {
+    out[ o++ ] = flat[ 0 ];
+    out[ o++ ] = flat[ 1 ];
+  }
+
+  for ( let i = 0; i < limit; i++ ) {
+    const ai = i * 2;
+    const bi = ( ( i + 1 ) % count ) * 2;
+    const ax = flat[ ai ];
+    const ay = flat[ ai + 1 ];
+    const bx = flat[ bi ];
+    const by = flat[ bi + 1 ];
+
+    out[ o++ ] = 0.75 * ax + 0.25 * bx;
+    out[ o++ ] = 0.75 * ay + 0.25 * by;
+    out[ o++ ] = 0.25 * ax + 0.75 * bx;
+    out[ o++ ] = 0.25 * ay + 0.75 * by;
+  }
+
+  if ( !closed ) {
+    out[ o++ ] = flat[ ( count - 1 ) * 2 ];
+    out[ o++ ] = flat[ ( count - 1 ) * 2 + 1 ];
   }
 
   return out;
@@ -496,135 +562,54 @@ export function drawPointMarkers(
 }
 
 /**
- * Chaikin gives us a dense polyline, so we get a free neon-style gradient running
- * along the path: one capsule per dense segment, hue swept along the curve, every
- * glow layer stacked widest-and-dimmest first. The capsules are queued on the
- * shared GPU batch (round caps reproduce p5's ROUND strokeCap/Join) and drawn by
- * the caller's `batch.end()`.
+ * Queue one spline's dense Chaikin polyline onto the GPU stroke batch: open a new
+ * stroke group, then push one segment per dense edge with its hue. The hue is the
+ * only thing that varies along the curve — the per-layer thickness and opacity are
+ * applied by the GPU when `drawStrokes` re-draws the geometry — so each segment is
+ * emitted ONCE here instead of once per glow layer.
+ *
+ *   gradient → hue swept along the path (a free neon gradient).
+ *   uniform  → a single hue for the whole stroke (still drifts with time).
  */
-function emitChaikinGradient(
+function emitStroke(
   points, {
     iterations,
     closed,
-    weight,
-    glow,
-    hueSpeed
+    hueSpeed,
+    gradient
   }
 ) {
-  const p = getP5();
-  const dense = chaikin(
+  const dense = chaikinFlat(
     points,
     iterations,
     closed
   );
-  const total = dense.length;
+  const total = dense.length / 2;
   const segments = closed ? total : total - 1;
 
-  for ( let shadow = glow; shadow >= 0; shadow-- ) {
-    const layerWeight = weight * ( 1 + shadow * 1.3 );
-    const opacityFactor = p.map(
-      shadow,
-      0,
-      Math.max(
-        1,
-        glow
-      ),
-      1,
-      4
-    );
-    const halfWidth = layerWeight / 2;
-
-    for ( let i = 0; i < segments; i++ ) {
-      const a = dense[ i ];
-      const b = dense[ ( i + 1 ) % total ];
-      const progression = i / segments;
-      const [
-        red,
-        green,
-        blue,
-        alpha
-      ] = colorLevels( colors.rainbow( {
-        hueIndex: Math.sin( progression * p.TAU + animation.angle * hueSpeed ) * p.PI * 2,
-        opacityFactor
-      } ) );
-
-      batch.capsule(
-        a.x,
-        a.y,
-        b.x,
-        b.y,
-        halfWidth,
-        red,
-        green,
-        blue,
-        alpha
-      );
-    }
+  if ( segments < 1 ) {
+    return;
   }
-}
 
-/**
- * The non-gradient Chaikin look: the same dense polyline, but a single hue per
- * glow layer (it still drifts with time). Emitted as capsules onto the shared GPU
- * batch, matching what the uniform p5 stroke produced segment for segment.
- */
-function emitChaikinUniform(
-  points, {
-    iterations,
-    closed,
-    weight,
-    glow,
-    hueSpeed
-  }
-) {
-  const p = getP5();
-  const dense = chaikin(
-    points,
-    iterations,
-    closed
-  );
-  const total = dense.length;
-  const segments = closed ? total : total - 1;
+  const angle = animation.angle;
+  const uniformHue = Math.sin( angle * hueSpeed ) * TWO_PI;
 
-  for ( let shadow = glow; shadow >= 0; shadow-- ) {
-    const layerWeight = weight * ( 1 + shadow * 1.3 );
-    const opacityFactor = p.map(
-      shadow,
-      0,
-      Math.max(
-        1,
-        glow
-      ),
-      1,
-      4
+  batch.openStroke();
+
+  for ( let i = 0; i < segments; i++ ) {
+    const ai = i * 2;
+    const bi = ( ( i + 1 ) % total ) * 2;
+    const hueIndex = gradient
+      ? Math.sin( ( i / segments ) * TWO_PI + angle * hueSpeed ) * TWO_PI
+      : uniformHue;
+
+    batch.strokeSegment(
+      dense[ ai ],
+      dense[ ai + 1 ],
+      dense[ bi ],
+      dense[ bi + 1 ],
+      hueIndex
     );
-    const halfWidth = layerWeight / 2;
-    const [
-      red,
-      green,
-      blue,
-      alpha
-    ] = colorLevels( colors.rainbow( {
-      hueIndex: Math.sin( animation.angle * hueSpeed ) * p.PI * 2,
-      opacityFactor
-    } ) );
-
-    for ( let i = 0; i < segments; i++ ) {
-      const a = dense[ i ];
-      const b = dense[ ( i + 1 ) % total ];
-
-      batch.capsule(
-        a.x,
-        a.y,
-        b.x,
-        b.y,
-        halfWidth,
-        red,
-        green,
-        blue,
-        alpha
-      );
-    }
   }
 }
 
@@ -743,22 +728,29 @@ export function renderSplines(
     ) );
   }
 
-  // The rounded glowing curve is the per-frame hotspot, so the Chaikin methods
-  // are queued onto one shared GPU batch across every spline and drawn in a single
-  // composite. The p5-native curve primitives (catmull-rom / quadratic) stay on the
-  // CPU — they already emit one shape per glow layer, so they were never the
-  // bottleneck and tessellating them would risk changing their look.
+  // The rounded glowing curve is the per-frame hotspot, so for the Chaikin methods
+  // every spline's geometry is uploaded once and the GPU re-draws it per glow layer
+  // (rainbow colour computed in the shader). The p5-native curve primitives
+  // (catmull-rom / quadratic) stay on the CPU — they already emit one shape per glow
+  // layer, so they were never the bottleneck and tessellating them would risk
+  // changing their look.
   if ( method === "chaikin" ) {
-    const emit = ( stroke.gradient ?? true )
-      ? emitChaikinGradient
-      : emitChaikinUniform;
+    const gradient = stroke.gradient ?? true;
 
-    batch.begin();
-    splines.forEach( ( points ) => emit(
+    batch.beginStrokes();
+    splines.forEach( ( points ) => emitStroke(
       points,
-      curveOptions
+      {
+        iterations: curveOptions.iterations,
+        closed,
+        hueSpeed: curveOptions.hueSpeed,
+        gradient
+      }
     ) );
-    batch.end();
+    batch.drawStrokes( {
+      weight: curveOptions.weight,
+      glow: curveOptions.glow
+    } );
   } else {
     splines.forEach( ( points ) => drawUniformCurve(
       points,

--- a/src/templates/p5/sketches/splines/_shared.js
+++ b/src/templates/p5/sketches/splines/_shared.js
@@ -3,6 +3,17 @@ import {
 } from "@/p5/utils/sketch.js";
 import colors from "@/p5/utils/colors.js";
 import animation from "@/p5/utils/animation.js";
+import createGlowBatchRenderer, {
+  colorLevels
+} from "@/p5/utils/glowBatchGpu.js";
+
+// The glowing curve used to be stroked segment-by-segment on the CPU, once per
+// glow layer, once per spline — fine for one procedural curve, but the cost
+// scaled with the number of live entities and dragged the draw loop down. The
+// dense Chaikin segments are now batched into a single instanced GPU draw (see
+// utils/glowBatchGpu.js) shared across every spline in the frame. The geometry
+// and colours are computed exactly as before, so the look is unchanged.
+const batch = createGlowBatchRenderer();
 
 /**
  * Shared geometry for the `splines` category.
@@ -485,10 +496,13 @@ export function drawPointMarkers(
 }
 
 /**
- * Chaikin gives us a dense polyline, so we can stroke it segment by segment and
- * get a free neon-style gradient running along the path.
+ * Chaikin gives us a dense polyline, so we get a free neon-style gradient running
+ * along the path: one capsule per dense segment, hue swept along the curve, every
+ * glow layer stacked widest-and-dimmest first. The capsules are queued on the
+ * shared GPU batch (round caps reproduce p5's ROUND strokeCap/Join) and drawn by
+ * the caller's `batch.end()`.
  */
-export function drawChaikinGradient(
+function emitChaikinGradient(
   points, {
     iterations,
     closed,
@@ -518,23 +532,97 @@ export function drawChaikinGradient(
       1,
       4
     );
-
-    p.strokeWeight( layerWeight );
+    const halfWidth = layerWeight / 2;
 
     for ( let i = 0; i < segments; i++ ) {
       const a = dense[ i ];
       const b = dense[ ( i + 1 ) % total ];
       const progression = i / segments;
-
-      p.stroke( colors.rainbow( {
+      const [
+        red,
+        green,
+        blue,
+        alpha
+      ] = colorLevels( colors.rainbow( {
         hueIndex: Math.sin( progression * p.TAU + animation.angle * hueSpeed ) * p.PI * 2,
         opacityFactor
       } ) );
-      p.line(
+
+      batch.capsule(
         a.x,
         a.y,
         b.x,
-        b.y
+        b.y,
+        halfWidth,
+        red,
+        green,
+        blue,
+        alpha
+      );
+    }
+  }
+}
+
+/**
+ * The non-gradient Chaikin look: the same dense polyline, but a single hue per
+ * glow layer (it still drifts with time). Emitted as capsules onto the shared GPU
+ * batch, matching what the uniform p5 stroke produced segment for segment.
+ */
+function emitChaikinUniform(
+  points, {
+    iterations,
+    closed,
+    weight,
+    glow,
+    hueSpeed
+  }
+) {
+  const p = getP5();
+  const dense = chaikin(
+    points,
+    iterations,
+    closed
+  );
+  const total = dense.length;
+  const segments = closed ? total : total - 1;
+
+  for ( let shadow = glow; shadow >= 0; shadow-- ) {
+    const layerWeight = weight * ( 1 + shadow * 1.3 );
+    const opacityFactor = p.map(
+      shadow,
+      0,
+      Math.max(
+        1,
+        glow
+      ),
+      1,
+      4
+    );
+    const halfWidth = layerWeight / 2;
+    const [
+      red,
+      green,
+      blue,
+      alpha
+    ] = colorLevels( colors.rainbow( {
+      hueIndex: Math.sin( animation.angle * hueSpeed ) * p.PI * 2,
+      opacityFactor
+    } ) );
+
+    for ( let i = 0; i < segments; i++ ) {
+      const a = dense[ i ];
+      const b = dense[ ( i + 1 ) % total ];
+
+      batch.capsule(
+        a.x,
+        a.y,
+        b.x,
+        b.y,
+        halfWidth,
+        red,
+        green,
+        blue,
+        alpha
       );
     }
   }
@@ -606,21 +694,29 @@ export function drawUniformCurve(
 }
 
 /**
- * Render one spline through `points` with the splines look: optional raw-polygon
- * overlay, the rounded curve (gradient Chaikin or uniform stroke), then optional
- * point markers on top. `cfg` mirrors the sketch option blocks:
- *   { curve, stroke, overlay }
- * Callers pass already-positioned points, so this works for both the procedural
- * v0 layout and live interaction-driven groups.
+ * Render a batch of splines with the splines look: optional raw-polygon overlays,
+ * the rounded glowing curves, then optional point markers on top. `cfg` mirrors
+ * the sketch option blocks ({ curve, stroke, overlay }) and applies to every
+ * spline in `list` (the rounding method and styling are shared options).
+ *
+ * Batching matters for the live/interactive variant: every detected entity is one
+ * spline, so the per-frame glow is drawn for all of them in a single instanced GPU
+ * pass instead of one CPU stroke loop per entity. Overlays and markers stay on the
+ * p2d canvas (they are cheap, proportional to the original point count) and the
+ * glow composites between them, preserving the overlay→curve→markers stacking.
+ *
+ * @param {Array<Array>} list array of point lists (each an ordered set of vectors)
  */
-export function renderSpline(
-  points, {
+export function renderSplines(
+  list, {
     curve = {},
     stroke = {},
     overlay = {}
   } = {}
 ) {
-  if ( !points || points.length < 2 ) {
+  const splines = ( list ?? [] ).filter( ( points ) => points && points.length >= 2 );
+
+  if ( splines.length === 0 ) {
     return;
   }
 
@@ -638,32 +734,59 @@ export function renderSpline(
     hueSpeed: stroke.hueSpeed ?? 1
   };
 
+  // Raw polygon overlay (behind the curve), straight onto the p2d canvas.
   if ( polygonCfg.show ?? true ) {
-    drawPolygonOverlay(
+    splines.forEach( ( points ) => drawPolygonOverlay(
       points,
       closed,
       polygonCfg
-    );
+    ) );
   }
 
-  if ( method === "chaikin" && ( stroke.gradient ?? true ) ) {
-    drawChaikinGradient(
+  // The rounded glowing curve is the per-frame hotspot, so the Chaikin methods
+  // are queued onto one shared GPU batch across every spline and drawn in a single
+  // composite. The p5-native curve primitives (catmull-rom / quadratic) stay on the
+  // CPU — they already emit one shape per glow layer, so they were never the
+  // bottleneck and tessellating them would risk changing their look.
+  if ( method === "chaikin" ) {
+    const emit = ( stroke.gradient ?? true )
+      ? emitChaikinGradient
+      : emitChaikinUniform;
+
+    batch.begin();
+    splines.forEach( ( points ) => emit(
       points,
       curveOptions
-    );
+    ) );
+    batch.end();
   } else {
-    drawUniformCurve(
+    splines.forEach( ( points ) => drawUniformCurve(
       points,
       method,
       curveOptions
-    );
+    ) );
   }
 
-  // Points drawn last so the markers stay on top of the glowing curve.
+  // Markers drawn last so they stay on top of the glowing curve.
   if ( pointsCfg.show ?? true ) {
-    drawPointMarkers(
+    splines.forEach( ( points ) => drawPointMarkers(
       points,
       pointsCfg
-    );
+    ) );
   }
+}
+
+/**
+ * Render a single spline. Thin wrapper over `renderSplines` so existing callers
+ * (and the procedural v0 layout) keep working unchanged.
+ */
+export function renderSpline(
+  points, cfg
+) {
+  renderSplines(
+    points ? [
+      points
+    ] : [],
+    cfg
+  );
 }

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
@@ -7,7 +7,7 @@ import {
   getPointerGroups
 } from "@/p5/utils/interaction/index.js";
 import {
-  renderSpline
+  renderSplines
 } from "../_shared.js";
 
 // ── What this sketch demonstrates ──────────────────────────────────────────
@@ -80,18 +80,14 @@ function pushTrailPoint(
   }
 }
 
-function drawLive(
-  groups, render
-) {
-  groups.forEach( ( group ) => {
-    if ( group.points.length >= 2 ) {
-      render( group.points );
-    }
-  } );
+// One ordered point list per live entity, so every spline in the frame can be
+// drawn in a single batched pass.
+function collectLive( groups ) {
+  return groups.map( ( group ) => group.points );
 }
 
-function drawTrails(
-  groups, mode, render
+function collectTrails(
+  groups, mode
 ) {
   const maxPoints = mode.maxPoints ?? 90;
   const minDistance = mode.minDistance ?? 6;
@@ -108,8 +104,10 @@ function drawTrails(
     );
   } );
 
-  // Render every ribbon; entities that disappeared retract from the tail until
+  // Collect every ribbon; entities that disappeared retract from the tail until
   // empty so the trail gracefully shrinks away instead of vanishing instantly.
+  const lists = [];
+
   for ( const [
     id,
     entry
@@ -124,10 +122,10 @@ function drawTrails(
       }
     }
 
-    if ( entry.points.length >= 2 ) {
-      render( entry.points );
-    }
+    lists.push( entry.points );
   }
+
+  return lists;
 }
 
 sketch.setup( async() => {
@@ -164,8 +162,11 @@ sketch.draw( () => {
   if ( modeType === "trail" ) {
     // Trails are time-series ribbons, so the raw-polygon / point markers overlay
     // (which annotates the source points) is intentionally suppressed.
-    const render = ( points ) => renderSpline(
-      points,
+    renderSplines(
+      collectTrails(
+        groups,
+        mode
+      ),
       {
         curve,
         stroke,
@@ -180,27 +181,17 @@ sketch.draw( () => {
       }
     );
 
-    drawTrails(
-      groups,
-      mode,
-      render
-    );
-
     return;
   }
 
   const overlay = o.overlay ?? {};
-  const render = ( points ) => renderSpline(
-    points,
+
+  renderSplines(
+    collectLive( groups ),
     {
       curve,
       stroke,
       overlay
     }
-  );
-
-  drawLive(
-    groups,
-    render
   );
 } );

--- a/src/templates/p5/utils/glowBatchGpu.js
+++ b/src/templates/p5/utils/glowBatchGpu.js
@@ -1,0 +1,690 @@
+import graphics from "./graphics.js";
+import {
+  getP5
+} from "./sketch.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared GPU batch for 2D "glow" primitives (capsules / discs).
+//
+// Several sketches paint the same shape thousands of times per frame on the CPU:
+//   - neonGraffiti draws shadowsCount × stepsCount filled circles (fill + circle
+//     immediate-mode call each);
+//   - the spline family strokes a dense Chaikin polyline segment-by-segment,
+//     once per glow layer, once per detected entity.
+//
+// The generative MATH stays on the CPU (so the look is bit-for-bit identical to
+// the originals), but the RENDERING — the part that actually slows the draw loop
+// — moves to a single instanced draw call. Every primitive is expressed as ONE
+// unified shape: a capsule (a round-capped segment from A to B with a given half
+// thickness). A disc is just a capsule with A == B, so the same shader covers
+// circles, glow strokes and point markers.
+//
+// Usage:
+//   const batch = createGlowBatchRenderer();
+//   batch.begin();                                   // start a frame
+//   batch.disc(x, y, radius, r, g, b, a);            // colours in 0..1
+//   batch.capsule(ax, ay, bx, by, halfWidth, r, g, b, a);
+//   batch.end();                                     // draw + composite onto p2d
+//
+// Instances are drawn in submission order with premultiplied "over" blending, so
+// painter's order (and overlap) matches the CPU originals exactly. The batch
+// renders into an off-screen WebGL buffer cleared to transparent and composites
+// it over whatever is already on the p2d canvas (background, overlays, …), so it
+// can be dropped into an existing sketch without owning the whole frame.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 9 floats per instance: vec4 segment (ax, ay, bx, by), vec4 colour (r,g,b,a),
+// float half-thickness.
+const FLOATS_PER_INSTANCE = 9;
+const BYTES_PER_FLOAT = 4;
+const INSTANCE_STRIDE = FLOATS_PER_INSTANCE * BYTES_PER_FLOAT; // 36
+
+// Antialiasing half-band, in pixels, applied around every capsule edge.
+const EDGE_PAD = 1.0;
+
+const VERT_SRC = `
+  precision highp float;
+
+  attribute vec2  aCorner; // unit quad: x in [0,1] along the segment, y in [-1,1] across
+  attribute vec4  aSeg;    // (ax, ay, bx, by) in pixels, top-left origin
+  attribute vec4  aColor;  // straight-alpha rgba, 0..1
+  attribute float aHalf;   // half thickness in pixels
+
+  uniform vec2  uResolution;
+  uniform float uPad;
+
+  varying vec2  vPos;
+  varying vec2  vA;
+  varying vec2  vB;
+  varying vec4  vColor;
+  varying float vHalf;
+
+  void main() {
+    vec2 a = aSeg.xy;
+    vec2 b = aSeg.zw;
+
+    vec2  axis = b - a;
+    float len  = length(axis);
+    vec2  dir  = len > 1e-4 ? axis / len : vec2(1.0, 0.0);
+    vec2  nrm  = vec2(-dir.y, dir.x);
+
+    // Expand the quad past both ends and both sides by half-thickness + AA pad so
+    // the round caps and antialiased rim always fall inside the rasterised area.
+    float ext   = aHalf + uPad;
+    vec2  along = mix(a - dir * ext, b + dir * ext, aCorner.x);
+    vec2  pos   = along + nrm * (aCorner.y * ext);
+
+    vPos   = pos;
+    vA     = a;
+    vB     = b;
+    vColor = aColor;
+    vHalf  = aHalf;
+
+    vec2 ndc = vec2(
+      (pos.x / uResolution.x) * 2.0 - 1.0,
+      1.0 - (pos.y / uResolution.y) * 2.0
+    );
+    gl_Position = vec4(ndc, 0.0, 1.0);
+  }
+`;
+
+const FRAG_SRC = `
+  precision highp float;
+
+  uniform float uPad;
+
+  varying vec2  vPos;
+  varying vec2  vA;
+  varying vec2  vB;
+  varying vec4  vColor;
+  varying float vHalf;
+
+  // Distance from p to the segment a→b (round caps), i.e. the capsule axis.
+  float segmentDistance(vec2 p, vec2 a, vec2 b) {
+    vec2  pa = p - a;
+    vec2  ba = b - a;
+    float h  = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-6), 0.0, 1.0);
+
+    return length(pa - ba * h);
+  }
+
+  void main() {
+    float d   = segmentDistance(vPos, vA, vB) - vHalf;
+    float cov = 1.0 - smoothstep(-uPad, uPad, d);
+
+    if (cov <= 0.0) {
+      discard;
+    }
+
+    // Premultiplied "over": the p5.Graphics WebGL canvas is premultipliedAlpha,
+    // so emitting premultiplied colour lets p.image() composite the buffer onto
+    // the p2d canvas with no dark edge fringing.
+    float alpha = vColor.a * cov;
+
+    gl_FragColor = vec4(vColor.rgb * alpha, alpha);
+  }
+`;
+
+// ─── WebGL helpers ────────────────────────────────────────────────────────────
+function compileShader(
+  gl, type, src
+) {
+  const shader = gl.createShader( type );
+
+  gl.shaderSource(
+    shader,
+    src
+  );
+  gl.compileShader( shader );
+
+  if ( !gl.getShaderParameter(
+    shader,
+    gl.COMPILE_STATUS
+  ) ) {
+    console.error(
+      "Glow batch shader compile error:",
+      gl.getShaderInfoLog( shader )
+    );
+    gl.deleteShader( shader );
+    return null;
+  }
+
+  return shader;
+}
+
+function buildProgram(
+  gl, vertSrc, fragSrc
+) {
+  const vert = compileShader(
+    gl,
+    gl.VERTEX_SHADER,
+    vertSrc
+  );
+  const frag = compileShader(
+    gl,
+    gl.FRAGMENT_SHADER,
+    fragSrc
+  );
+
+  if ( !vert || !frag ) {
+    return null;
+  }
+
+  const program = gl.createProgram();
+
+  gl.attachShader(
+    program,
+    vert
+  );
+  gl.attachShader(
+    program,
+    frag
+  );
+  gl.linkProgram( program );
+
+  if ( !gl.getProgramParameter(
+    program,
+    gl.LINK_STATUS
+  ) ) {
+    console.error(
+      "Glow batch program link error:",
+      gl.getProgramInfoLog( program )
+    );
+    return null;
+  }
+
+  gl.deleteShader( vert );
+  gl.deleteShader( frag );
+  return program;
+}
+
+// Instancing is native in WebGL2 and via ANGLE_instanced_arrays in WebGL1.
+function isWebGL2( gl ) {
+  return typeof WebGL2RenderingContext !== "undefined"
+    && gl instanceof WebGL2RenderingContext;
+}
+
+function getInstancingExt( gl ) {
+  return isWebGL2( gl )
+    ? null
+    : gl.getExtension( "ANGLE_instanced_arrays" );
+}
+
+function setDivisor(
+  gl, ext, loc, divisor
+) {
+  if ( ext ) {
+    ext.vertexAttribDivisorANGLE(
+      loc,
+      divisor
+    );
+  } else {
+    gl.vertexAttribDivisor(
+      loc,
+      divisor
+    );
+  }
+}
+
+function drawArraysInstanced(
+  gl, ext, mode, first, count, primCount
+) {
+  if ( ext ) {
+    ext.drawArraysInstancedANGLE(
+      mode,
+      first,
+      count,
+      primCount
+    );
+  } else {
+    gl.drawArraysInstanced(
+      mode,
+      first,
+      count,
+      primCount
+    );
+  }
+}
+
+/**
+ * Extract a p5.Color's channels as 0..1 floats, so a colour built by the usual
+ * `colors.*` helpers can be fed straight into the batch.
+ *
+ * @param {object} c p5.Color (or anything exposing a `levels` [r,g,b,a] 0..255)
+ * @returns {[number, number, number, number]}
+ */
+export function colorLevels( c ) {
+  const levels = c?.levels ?? [
+    255,
+    255,
+    255,
+    255
+  ];
+
+  return [
+    levels[ 0 ] / 255,
+    ( levels[ 1 ] ?? 255 ) / 255,
+    ( levels[ 2 ] ?? 255 ) / 255,
+    ( levels[ 3 ] ?? 255 ) / 255
+  ];
+}
+
+/**
+ * Create a GPU batch renderer for round-capped 2D primitives.
+ *
+ * @returns {{ begin: Function, capsule: Function, disc: Function, end: Function }}
+ */
+export default function createGlowBatchRenderer() {
+  const state = {
+    graphics: null,
+    program: null,
+    quadVBO: null,
+    instanceVBO: null,
+    locs: {},
+    aCornerLoc: -1,
+    aSegLoc: -1,
+    aColorLoc: -1,
+    aHalfLoc: -1,
+    ext: null,
+    ctxRef: null,
+    p5Ref: null,
+    data: new Float32Array( 1024 * FLOATS_PER_INSTANCE ),
+    capacity: 1024,
+    count: 0,
+    additive: false
+  };
+
+  function ensureGraphics() {
+    const p = getP5();
+
+    // The renderer lives at module scope, so it survives sketch re-navigation
+    // (ES modules are cached and not re-run). When p5 is torn down and recreated
+    // the cached buffer belongs to the old instance/context, so recreate it — and
+    // force the program + VBOs to rebuild against the fresh context.
+    if ( !state.graphics || state.p5Ref !== p ) {
+      state.graphics = graphics.createAutoResizableGraphics(
+        p.width,
+        p.height,
+        "webgl"
+      );
+      state.p5Ref = p;
+      state.program = null;
+      state.ctxRef = null;
+    }
+
+    return state.graphics;
+  }
+
+  function ensureProgram( gl ) {
+    if ( state.ctxRef === gl && state.program ) {
+      return true;
+    }
+
+    if ( state.program ) {
+      gl.deleteProgram( state.program );
+    }
+
+    state.program = buildProgram(
+      gl,
+      VERT_SRC,
+      FRAG_SRC
+    );
+    state.locs = {};
+    state.quadVBO = null;
+    state.instanceVBO = null;
+    state.ctxRef = gl;
+    state.ext = getInstancingExt( gl );
+
+    if ( !state.program ) {
+      return false;
+    }
+
+    if ( !isWebGL2( gl ) && !state.ext ) {
+      console.error( "Glow batch needs WebGL2 or ANGLE_instanced_arrays." );
+      return false;
+    }
+
+    state.aCornerLoc = gl.getAttribLocation(
+      state.program,
+      "aCorner"
+    );
+    state.aSegLoc = gl.getAttribLocation(
+      state.program,
+      "aSeg"
+    );
+    state.aColorLoc = gl.getAttribLocation(
+      state.program,
+      "aColor"
+    );
+    state.aHalfLoc = gl.getAttribLocation(
+      state.program,
+      "aHalf"
+    );
+
+    state.quadVBO = gl.createBuffer();
+
+    // Unit quad: x in [0,1] runs along the segment, y in [-1,1] across it.
+    const quad = new Float32Array( [
+      0,
+      -1,
+      1,
+      -1,
+      0,
+      1,
+      0,
+      1,
+      1,
+      -1,
+      1,
+      1
+    ] );
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.quadVBO
+    );
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      quad,
+      gl.STATIC_DRAW
+    );
+
+    state.instanceVBO = gl.createBuffer();
+
+    return true;
+  }
+
+  function ensureCapacity( needed ) {
+    if ( needed <= state.capacity ) {
+      return;
+    }
+
+    let capacity = state.capacity;
+
+    while ( capacity < needed ) {
+      capacity *= 2;
+    }
+
+    const grown = new Float32Array( capacity * FLOATS_PER_INSTANCE );
+
+    grown.set( state.data.subarray(
+      0,
+      state.count * FLOATS_PER_INSTANCE
+    ) );
+
+    state.data = grown;
+    state.capacity = capacity;
+  }
+
+  function setUniform(
+    gl, name, value
+  ) {
+    if ( !( name in state.locs ) ) {
+      state.locs[ name ] = gl.getUniformLocation(
+        state.program,
+        name
+      );
+    }
+
+    const loc = state.locs[ name ];
+
+    if ( loc === null ) {
+      return;
+    }
+
+    if ( Array.isArray( value ) ) {
+      gl.uniform2f(
+        loc,
+        value[ 0 ],
+        value[ 1 ]
+      );
+
+      return;
+    }
+
+    gl.uniform1f(
+      loc,
+      value
+    );
+  }
+
+  /**
+   * Start a new batch. Discards any primitives left over from a previous frame.
+   *
+   * @param {object} [opts]
+   * @param {boolean} [opts.additive=false] add colours instead of "over" blending
+   */
+  function begin( opts = {} ) {
+    state.count = 0;
+    state.additive = opts.additive ?? false;
+  }
+
+  /**
+   * Queue a round-capped segment from (ax, ay) to (bx, by). Colours are 0..1.
+   */
+  function capsule(
+    ax, ay, bx, by, halfWidth, r, g, b, a = 1
+  ) {
+    ensureCapacity( state.count + 1 );
+
+    const base = state.count * FLOATS_PER_INSTANCE;
+    const out = state.data;
+
+    out[ base ] = ax;
+    out[ base + 1 ] = ay;
+    out[ base + 2 ] = bx;
+    out[ base + 3 ] = by;
+    out[ base + 4 ] = r;
+    out[ base + 5 ] = g;
+    out[ base + 6 ] = b;
+    out[ base + 7 ] = a;
+    out[ base + 8 ] = halfWidth;
+
+    state.count++;
+  }
+
+  /**
+   * Queue a filled disc (a capsule whose endpoints coincide). Colours are 0..1.
+   */
+  function disc(
+    x, y, radius, r, g, b, a = 1
+  ) {
+    capsule(
+      x,
+      y,
+      x,
+      y,
+      radius,
+      r,
+      g,
+      b,
+      a
+    );
+  }
+
+  // Bind a float attribute from the currently-bound ARRAY_BUFFER.
+  function bindAttrib(
+    gl, loc, size, offset
+  ) {
+    if ( loc < 0 ) {
+      return;
+    }
+
+    gl.enableVertexAttribArray( loc );
+    gl.vertexAttribPointer(
+      loc,
+      size,
+      gl.FLOAT,
+      false,
+      INSTANCE_STRIDE,
+      offset
+    );
+    setDivisor(
+      gl,
+      state.ext,
+      loc,
+      1
+    );
+  }
+
+  /**
+   * Draw every queued primitive in one instanced call and composite the result
+   * onto the main p2d canvas.
+   */
+  function end() {
+    if ( state.count === 0 ) {
+      return;
+    }
+
+    const p = getP5();
+    const g = ensureGraphics();
+    const gl = g.drawingContext;
+
+    if ( !ensureProgram( gl ) ) {
+      return;
+    }
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      state.data.subarray(
+        0,
+        state.count * FLOATS_PER_INSTANCE
+      ),
+      gl.DYNAMIC_DRAW
+    );
+
+    gl.viewport(
+      0,
+      0,
+      gl.drawingBufferWidth,
+      gl.drawingBufferHeight
+    );
+    gl.disable( gl.DEPTH_TEST );
+    gl.enable( gl.BLEND );
+    gl.blendFunc(
+      gl.ONE,
+      state.additive
+        ? gl.ONE
+        : gl.ONE_MINUS_SRC_ALPHA
+    );
+    gl.clearColor(
+      0,
+      0,
+      0,
+      0
+    );
+    gl.clear( gl.COLOR_BUFFER_BIT );
+
+    gl.useProgram( state.program );
+
+    setUniform(
+      gl,
+      "uResolution",
+      [
+        g.width,
+        g.height
+      ]
+    );
+    setUniform(
+      gl,
+      "uPad",
+      EDGE_PAD
+    );
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.quadVBO
+    );
+    gl.enableVertexAttribArray( state.aCornerLoc );
+    gl.vertexAttribPointer(
+      state.aCornerLoc,
+      2,
+      gl.FLOAT,
+      false,
+      0,
+      0
+    );
+    setDivisor(
+      gl,
+      state.ext,
+      state.aCornerLoc,
+      0
+    );
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+    bindAttrib(
+      gl,
+      state.aSegLoc,
+      4,
+      0
+    );
+    bindAttrib(
+      gl,
+      state.aColorLoc,
+      4,
+      16
+    );
+    bindAttrib(
+      gl,
+      state.aHalfLoc,
+      1,
+      32
+    );
+
+    drawArraysInstanced(
+      gl,
+      state.ext,
+      gl.TRIANGLES,
+      0,
+      6,
+      state.count
+    );
+
+    // Restore GL state so p5 keeps working with the buffer.
+    gl.disableVertexAttribArray( state.aCornerLoc );
+
+    [
+      state.aSegLoc,
+      state.aColorLoc,
+      state.aHalfLoc
+    ].forEach( ( loc ) => {
+      if ( loc < 0 ) {
+        return;
+      }
+
+      gl.disableVertexAttribArray( loc );
+      setDivisor(
+        gl,
+        state.ext,
+        loc,
+        0
+      );
+    } );
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      null
+    );
+    g.resetShader();
+
+    p.image(
+      g,
+      0,
+      0
+    );
+  }
+
+  return {
+    begin,
+    capsule,
+    disc,
+    end
+  };
+}

--- a/src/templates/p5/utils/glowBatchGpu.js
+++ b/src/templates/p5/utils/glowBatchGpu.js
@@ -4,40 +4,56 @@ import {
 } from "./sketch.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Shared GPU batch for 2D "glow" primitives (capsules / discs).
+// Shared GPU batch for 2D "glow" primitives (capsules / discs), rainbow-shaded
+// on the GPU.
 //
-// Several sketches paint the same shape thousands of times per frame on the CPU:
-//   - neonGraffiti draws shadowsCount × stepsCount filled circles (fill + circle
-//     immediate-mode call each);
+// Several sketches paint the same shape thousands of times per frame:
+//   - neonGraffiti draws shadowsCount × stepsCount filled circles;
 //   - the spline family strokes a dense Chaikin polyline segment-by-segment,
 //     once per glow layer, once per detected entity.
 //
-// The generative MATH stays on the CPU (so the look is bit-for-bit identical to
-// the originals), but the RENDERING — the part that actually slows the draw loop
-// — moves to a single instanced draw call. Every primitive is expressed as ONE
-// unified shape: a capsule (a round-capped segment from A to B with a given half
-// thickness). A disc is just a capsule with A == B, so the same shader covers
-// circles, glow strokes and point markers.
+// The generative MATH stays on the CPU (so the look matches the originals), but
+// the RENDERING and the COLOUR move to the GPU. Every primitive is a capsule (a
+// round-capped segment A→B with a half thickness; a disc is a zero-length
+// capsule), and the fragment shader computes the rainbow palette itself — a GLSL
+// port of utils/colors.js `rainbow`, identical to the CPU version. Sketches pass
+// the palette inputs (hueOffset, hueIndex, opacityFactor) instead of building a
+// p5.Color per primitive, which removes the per-segment colour allocation that
+// dominated the CPU cost once the work moved off the draw calls.
 //
-// Usage:
-//   const batch = createGlowBatchRenderer();
-//   batch.begin();                                   // start a frame
-//   batch.disc(x, y, radius, r, g, b, a);            // colours in 0..1
-//   batch.capsule(ax, ay, bx, by, halfWidth, r, g, b, a);
-//   batch.end();                                     // draw + composite onto p2d
+// Two ways to feed it:
 //
-// Instances are drawn in submission order with premultiplied "over" blending, so
-// painter's order (and overlap) matches the CPU originals exactly. The batch
-// renders into an off-screen WebGL buffer cleared to transparent and composites
-// it over whatever is already on the p2d canvas (background, overlays, …), so it
-// can be dropped into an existing sketch without owning the whole frame.
+//   Mode A — per-instance primitives (every disc independent), one draw call:
+//     batch.begin();
+//     batch.disc(x, y, radius, hueOffset, hueIndex, opacityFactor);
+//     batch.end();
+//
+//   Mode B — stroke layers (one polyline drawn once, re-drawn per glow layer):
+//     batch.beginStrokes();
+//     batch.openStroke();                                  // one per spline
+//     batch.strokeSegment(ax, ay, bx, by, hueIndex);       // per dense segment
+//     batch.drawStrokes({ weight, glow });                 // hueOffset defaults 0
+//
+//   In Mode B the geometry is uploaded once and re-drawn `glow + 1` times with
+//   the per-layer half-thickness and opacityFactor supplied as constants, so the
+//   CPU emits each segment once instead of once per layer. Strokes are drawn in
+//   submission order, spline by spline, layer widest-and-dimmest first, matching
+//   the CPU stacking exactly.
+//
+// Both modes render into an off-screen WebGL buffer cleared to transparent and
+// composite it over the p2d canvas with premultiplied "over" blending, so they
+// drop into an existing sketch (background, overlays, …) with no edge fringing.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// 9 floats per instance: vec4 segment (ax, ay, bx, by), vec4 colour (r,g,b,a),
-// float half-thickness.
-const FLOATS_PER_INSTANCE = 9;
+// Mode A instance: vec4 segment, half-thickness, hueOffset, hueIndex, opacity.
+const FLOATS_A = 8;
+
+// Mode B segment: vec4 segment + hueIndex (half/hueOffset/opacity are constants).
+const FLOATS_B = 5;
+
 const BYTES_PER_FLOAT = 4;
-const INSTANCE_STRIDE = FLOATS_PER_INSTANCE * BYTES_PER_FLOAT; // 36
+const STRIDE_A = FLOATS_A * BYTES_PER_FLOAT; // 32
+const STRIDE_B = FLOATS_B * BYTES_PER_FLOAT; // 20
 
 // Antialiasing half-band, in pixels, applied around every capsule edge.
 const EDGE_PAD = 1.0;
@@ -45,10 +61,12 @@ const EDGE_PAD = 1.0;
 const VERT_SRC = `
   precision highp float;
 
-  attribute vec2  aCorner; // unit quad: x in [0,1] along the segment, y in [-1,1] across
-  attribute vec4  aSeg;    // (ax, ay, bx, by) in pixels, top-left origin
-  attribute vec4  aColor;  // straight-alpha rgba, 0..1
-  attribute float aHalf;   // half thickness in pixels
+  attribute vec2  aCorner;    // unit quad: x in [0,1] along the segment, y in [-1,1] across
+  attribute vec4  aSeg;       // (ax, ay, bx, by) in pixels, top-left origin
+  attribute float aHalf;      // half thickness in pixels
+  attribute float aHueOffset;
+  attribute float aHueIndex;
+  attribute float aOpacity;   // opacityFactor for the rainbow palette
 
   uniform vec2  uResolution;
   uniform float uPad;
@@ -56,8 +74,10 @@ const VERT_SRC = `
   varying vec2  vPos;
   varying vec2  vA;
   varying vec2  vB;
-  varying vec4  vColor;
   varying float vHalf;
+  varying float vHueOffset;
+  varying float vHueIndex;
+  varying float vOpacity;
 
   void main() {
     vec2 a = aSeg.xy;
@@ -74,11 +94,13 @@ const VERT_SRC = `
     vec2  along = mix(a - dir * ext, b + dir * ext, aCorner.x);
     vec2  pos   = along + nrm * (aCorner.y * ext);
 
-    vPos   = pos;
-    vA     = a;
-    vB     = b;
-    vColor = aColor;
-    vHalf  = aHalf;
+    vPos       = pos;
+    vA         = a;
+    vB         = b;
+    vHalf      = aHalf;
+    vHueOffset = aHueOffset;
+    vHueIndex  = aHueIndex;
+    vOpacity   = aOpacity;
 
     vec2 ndc = vec2(
       (pos.x / uResolution.x) * 2.0 - 1.0,
@@ -96,8 +118,10 @@ const FRAG_SRC = `
   varying vec2  vPos;
   varying vec2  vA;
   varying vec2  vB;
-  varying vec4  vColor;
   varying float vHalf;
+  varying float vHueOffset;
+  varying float vHueIndex;
+  varying float vOpacity;
 
   // Distance from p to the segment a→b (round caps), i.e. the capsule axis.
   float segmentDistance(vec2 p, vec2 a, vec2 b) {
@@ -108,6 +132,20 @@ const FRAG_SRC = `
     return length(pa - ba * h);
   }
 
+  // GLSL port of utils/colors.js rainbow() (default Math.sin/cos easing), bit-for
+  // -bit with the CPU version: p5 builds each channel in 0..360 then divides by
+  // opacityFactor, clamped to 0..255.
+  vec3 paletteRainbow(float hueOffset, float hueIndex, float opacityFactor) {
+    float a = hueOffset + hueIndex;
+    float b = hueOffset - hueIndex;
+
+    float red   = (sin(a) * 0.5 + 0.5) * 360.0 / opacityFactor;
+    float green = (1.0 - cos(b)) * 0.5 * 360.0 / opacityFactor;
+    float blue  = (1.0 - sin(a)) * 0.5 * 360.0 / opacityFactor;
+
+    return clamp(vec3(red, green, blue) / 255.0, 0.0, 1.0);
+  }
+
   void main() {
     float d   = segmentDistance(vPos, vA, vB) - vHalf;
     float cov = 1.0 - smoothstep(-uPad, uPad, d);
@@ -116,12 +154,12 @@ const FRAG_SRC = `
       discard;
     }
 
-    // Premultiplied "over": the p5.Graphics WebGL canvas is premultipliedAlpha,
-    // so emitting premultiplied colour lets p.image() composite the buffer onto
-    // the p2d canvas with no dark edge fringing.
-    float alpha = vColor.a * cov;
+    // The rainbow palette is opaque (alpha 255), so coverage IS the alpha. Emit
+    // premultiplied colour: the p5.Graphics WebGL canvas is premultipliedAlpha,
+    // so p.image() composites the buffer onto the p2d canvas with no fringing.
+    vec3 rgb = paletteRainbow(vHueOffset, vHueIndex, vOpacity);
 
-    gl_FragColor = vec4(vColor.rgb * alpha, alpha);
+    gl_FragColor = vec4(rgb * cov, cov);
   }
 `;
 
@@ -213,6 +251,10 @@ function getInstancingExt( gl ) {
 function setDivisor(
   gl, ext, loc, divisor
 ) {
+  if ( loc < 0 ) {
+    return;
+  }
+
   if ( ext ) {
     ext.vertexAttribDivisorANGLE(
       loc,
@@ -247,32 +289,13 @@ function drawArraysInstanced(
 }
 
 /**
- * Extract a p5.Color's channels as 0..1 floats, so a colour built by the usual
- * `colors.*` helpers can be fed straight into the batch.
+ * Create a GPU batch renderer for rainbow-shaded round-capped 2D primitives.
  *
- * @param {object} c p5.Color (or anything exposing a `levels` [r,g,b,a] 0..255)
- * @returns {[number, number, number, number]}
- */
-export function colorLevels( c ) {
-  const levels = c?.levels ?? [
-    255,
-    255,
-    255,
-    255
-  ];
-
-  return [
-    levels[ 0 ] / 255,
-    ( levels[ 1 ] ?? 255 ) / 255,
-    ( levels[ 2 ] ?? 255 ) / 255,
-    ( levels[ 3 ] ?? 255 ) / 255
-  ];
-}
-
-/**
- * Create a GPU batch renderer for round-capped 2D primitives.
- *
- * @returns {{ begin: Function, capsule: Function, disc: Function, end: Function }}
+ * @returns {{
+ *   begin: Function, disc: Function, capsule: Function, end: Function,
+ *   beginStrokes: Function, openStroke: Function, strokeSegment: Function,
+ *   drawStrokes: Function
+ * }}
  */
 export default function createGlowBatchRenderer() {
   const state = {
@@ -281,17 +304,21 @@ export default function createGlowBatchRenderer() {
     quadVBO: null,
     instanceVBO: null,
     locs: {},
-    aCornerLoc: -1,
-    aSegLoc: -1,
-    aColorLoc: -1,
-    aHalfLoc: -1,
     ext: null,
     ctxRef: null,
     p5Ref: null,
-    data: new Float32Array( 1024 * FLOATS_PER_INSTANCE ),
-    capacity: 1024,
-    count: 0,
-    additive: false
+
+    // Mode A — per-instance primitives.
+    dataA: new Float32Array( 1024 * FLOATS_A ),
+    capacityA: 1024,
+    countA: 0,
+
+    // Mode B — stroke layers.
+    dataB: new Float32Array( 1024 * FLOATS_B ),
+    capacityB: 1024,
+    countB: 0,
+    groups: [],
+    currentGroup: null
   };
 
   function ensureGraphics() {
@@ -344,22 +371,29 @@ export default function createGlowBatchRenderer() {
       return false;
     }
 
-    state.aCornerLoc = gl.getAttribLocation(
-      state.program,
-      "aCorner"
-    );
-    state.aSegLoc = gl.getAttribLocation(
-      state.program,
-      "aSeg"
-    );
-    state.aColorLoc = gl.getAttribLocation(
-      state.program,
-      "aColor"
-    );
-    state.aHalfLoc = gl.getAttribLocation(
-      state.program,
-      "aHalf"
-    );
+    [
+      "aCorner",
+      "aSeg",
+      "aHalf",
+      "aHueOffset",
+      "aHueIndex",
+      "aOpacity"
+    ].forEach( ( name ) => {
+      state.locs[ name ] = gl.getAttribLocation(
+        state.program,
+        name
+      );
+    } );
+
+    [
+      "uResolution",
+      "uPad"
+    ].forEach( ( name ) => {
+      state.locs[ name ] = gl.getUniformLocation(
+        state.program,
+        name
+      );
+    } );
 
     state.quadVBO = gl.createBuffer();
 
@@ -394,169 +428,11 @@ export default function createGlowBatchRenderer() {
     return true;
   }
 
-  function ensureCapacity( needed ) {
-    if ( needed <= state.capacity ) {
-      return;
-    }
-
-    let capacity = state.capacity;
-
-    while ( capacity < needed ) {
-      capacity *= 2;
-    }
-
-    const grown = new Float32Array( capacity * FLOATS_PER_INSTANCE );
-
-    grown.set( state.data.subarray(
-      0,
-      state.count * FLOATS_PER_INSTANCE
-    ) );
-
-    state.data = grown;
-    state.capacity = capacity;
-  }
-
-  function setUniform(
-    gl, name, value
+  // Common per-frame GL setup: viewport, premultiplied "over" blend, clear to
+  // transparent, activate the program and its shared uniforms, bind the quad.
+  function beginPass(
+    gl, g
   ) {
-    if ( !( name in state.locs ) ) {
-      state.locs[ name ] = gl.getUniformLocation(
-        state.program,
-        name
-      );
-    }
-
-    const loc = state.locs[ name ];
-
-    if ( loc === null ) {
-      return;
-    }
-
-    if ( Array.isArray( value ) ) {
-      gl.uniform2f(
-        loc,
-        value[ 0 ],
-        value[ 1 ]
-      );
-
-      return;
-    }
-
-    gl.uniform1f(
-      loc,
-      value
-    );
-  }
-
-  /**
-   * Start a new batch. Discards any primitives left over from a previous frame.
-   *
-   * @param {object} [opts]
-   * @param {boolean} [opts.additive=false] add colours instead of "over" blending
-   */
-  function begin( opts = {} ) {
-    state.count = 0;
-    state.additive = opts.additive ?? false;
-  }
-
-  /**
-   * Queue a round-capped segment from (ax, ay) to (bx, by). Colours are 0..1.
-   */
-  function capsule(
-    ax, ay, bx, by, halfWidth, r, g, b, a = 1
-  ) {
-    ensureCapacity( state.count + 1 );
-
-    const base = state.count * FLOATS_PER_INSTANCE;
-    const out = state.data;
-
-    out[ base ] = ax;
-    out[ base + 1 ] = ay;
-    out[ base + 2 ] = bx;
-    out[ base + 3 ] = by;
-    out[ base + 4 ] = r;
-    out[ base + 5 ] = g;
-    out[ base + 6 ] = b;
-    out[ base + 7 ] = a;
-    out[ base + 8 ] = halfWidth;
-
-    state.count++;
-  }
-
-  /**
-   * Queue a filled disc (a capsule whose endpoints coincide). Colours are 0..1.
-   */
-  function disc(
-    x, y, radius, r, g, b, a = 1
-  ) {
-    capsule(
-      x,
-      y,
-      x,
-      y,
-      radius,
-      r,
-      g,
-      b,
-      a
-    );
-  }
-
-  // Bind a float attribute from the currently-bound ARRAY_BUFFER.
-  function bindAttrib(
-    gl, loc, size, offset
-  ) {
-    if ( loc < 0 ) {
-      return;
-    }
-
-    gl.enableVertexAttribArray( loc );
-    gl.vertexAttribPointer(
-      loc,
-      size,
-      gl.FLOAT,
-      false,
-      INSTANCE_STRIDE,
-      offset
-    );
-    setDivisor(
-      gl,
-      state.ext,
-      loc,
-      1
-    );
-  }
-
-  /**
-   * Draw every queued primitive in one instanced call and composite the result
-   * onto the main p2d canvas.
-   */
-  function end() {
-    if ( state.count === 0 ) {
-      return;
-    }
-
-    const p = getP5();
-    const g = ensureGraphics();
-    const gl = g.drawingContext;
-
-    if ( !ensureProgram( gl ) ) {
-      return;
-    }
-
-    gl.bindBuffer(
-      gl.ARRAY_BUFFER,
-      state.instanceVBO
-    );
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      state.data.subarray(
-        0,
-        state.count * FLOATS_PER_INSTANCE
-      ),
-      gl.DYNAMIC_DRAW
-    );
-
     gl.viewport(
       0,
       0,
@@ -567,9 +443,7 @@ export default function createGlowBatchRenderer() {
     gl.enable( gl.BLEND );
     gl.blendFunc(
       gl.ONE,
-      state.additive
-        ? gl.ONE
-        : gl.ONE_MINUS_SRC_ALPHA
+      gl.ONE_MINUS_SRC_ALPHA
     );
     gl.clearColor(
       0,
@@ -581,17 +455,13 @@ export default function createGlowBatchRenderer() {
 
     gl.useProgram( state.program );
 
-    setUniform(
-      gl,
-      "uResolution",
-      [
-        g.width,
-        g.height
-      ]
+    gl.uniform2f(
+      state.locs.uResolution,
+      g.width,
+      g.height
     );
-    setUniform(
-      gl,
-      "uPad",
+    gl.uniform1f(
+      state.locs.uPad,
       EDGE_PAD
     );
 
@@ -599,9 +469,9 @@ export default function createGlowBatchRenderer() {
       gl.ARRAY_BUFFER,
       state.quadVBO
     );
-    gl.enableVertexAttribArray( state.aCornerLoc );
+    gl.enableVertexAttribArray( state.locs.aCorner );
     gl.vertexAttribPointer(
-      state.aCornerLoc,
+      state.locs.aCorner,
       2,
       gl.FLOAT,
       false,
@@ -611,50 +481,26 @@ export default function createGlowBatchRenderer() {
     setDivisor(
       gl,
       state.ext,
-      state.aCornerLoc,
+      state.locs.aCorner,
       0
     );
+  }
 
-    gl.bindBuffer(
-      gl.ARRAY_BUFFER,
-      state.instanceVBO
-    );
-    bindAttrib(
-      gl,
-      state.aSegLoc,
-      4,
-      0
-    );
-    bindAttrib(
-      gl,
-      state.aColorLoc,
-      4,
-      16
-    );
-    bindAttrib(
-      gl,
-      state.aHalfLoc,
-      1,
-      32
-    );
-
-    drawArraysInstanced(
-      gl,
-      state.ext,
-      gl.TRIANGLES,
-      0,
-      6,
-      state.count
-    );
-
-    // Restore GL state so p5 keeps working with the buffer.
-    gl.disableVertexAttribArray( state.aCornerLoc );
-
+  // Restore GL state so p5 keeps working with the buffer, then composite onto the
+  // main p2d canvas.
+  function endPass(
+    gl, g, p
+  ) {
     [
-      state.aSegLoc,
-      state.aColorLoc,
-      state.aHalfLoc
-    ].forEach( ( loc ) => {
+      "aCorner",
+      "aSeg",
+      "aHalf",
+      "aHueOffset",
+      "aHueIndex",
+      "aOpacity"
+    ].forEach( ( name ) => {
+      const loc = state.locs[ name ];
+
       if ( loc < 0 ) {
         return;
       }
@@ -681,10 +527,414 @@ export default function createGlowBatchRenderer() {
     );
   }
 
+  // ── Mode A: per-instance primitives ───────────────────────────────────────
+
+  function ensureCapacityA( needed ) {
+    if ( needed <= state.capacityA ) {
+      return;
+    }
+
+    let capacity = state.capacityA;
+
+    while ( capacity < needed ) {
+      capacity *= 2;
+    }
+
+    const grown = new Float32Array( capacity * FLOATS_A );
+
+    grown.set( state.dataA.subarray(
+      0,
+      state.countA * FLOATS_A
+    ) );
+
+    state.dataA = grown;
+    state.capacityA = capacity;
+  }
+
+  /**
+   * Start a per-instance batch. Discards primitives left over from a prior frame.
+   */
+  function begin() {
+    state.countA = 0;
+  }
+
+  /**
+   * Queue a round-capped segment from (ax, ay) to (bx, by), rainbow-shaded by
+   * (hueOffset, hueIndex, opacityFactor) on the GPU.
+   */
+  function capsule(
+    ax, ay, bx, by, halfWidth, hueOffset, hueIndex, opacityFactor
+  ) {
+    ensureCapacityA( state.countA + 1 );
+
+    const base = state.countA * FLOATS_A;
+    const out = state.dataA;
+
+    out[ base ] = ax;
+    out[ base + 1 ] = ay;
+    out[ base + 2 ] = bx;
+    out[ base + 3 ] = by;
+    out[ base + 4 ] = halfWidth;
+    out[ base + 5 ] = hueOffset;
+    out[ base + 6 ] = hueIndex;
+    out[ base + 7 ] = opacityFactor;
+
+    state.countA++;
+  }
+
+  /**
+   * Queue a filled disc (a zero-length capsule), rainbow-shaded on the GPU.
+   */
+  function disc(
+    x, y, radius, hueOffset, hueIndex, opacityFactor
+  ) {
+    capsule(
+      x,
+      y,
+      x,
+      y,
+      radius,
+      hueOffset,
+      hueIndex,
+      opacityFactor
+    );
+  }
+
+  /**
+   * Draw every queued per-instance primitive in one instanced call and composite.
+   */
+  function end() {
+    if ( state.countA === 0 ) {
+      return;
+    }
+
+    const p = getP5();
+    const g = ensureGraphics();
+    const gl = g.drawingContext;
+
+    if ( !ensureProgram( gl ) ) {
+      return;
+    }
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      state.dataA.subarray(
+        0,
+        state.countA * FLOATS_A
+      ),
+      gl.DYNAMIC_DRAW
+    );
+
+    beginPass(
+      gl,
+      g
+    );
+
+    // beginPass leaves the quad bound (for aCorner); rebind the instance buffer so
+    // the per-instance attribute pointers below capture it.
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+
+    // All eight inputs vary per instance.
+    const perInstance = [
+      [
+        "aSeg",
+        4,
+        0
+      ],
+      [
+        "aHalf",
+        1,
+        16
+      ],
+      [
+        "aHueOffset",
+        1,
+        20
+      ],
+      [
+        "aHueIndex",
+        1,
+        24
+      ],
+      [
+        "aOpacity",
+        1,
+        28
+      ]
+    ];
+
+    perInstance.forEach( ( [
+      name,
+      size,
+      offset
+    ] ) => {
+      const loc = state.locs[ name ];
+
+      if ( loc < 0 ) {
+        return;
+      }
+
+      gl.enableVertexAttribArray( loc );
+      gl.vertexAttribPointer(
+        loc,
+        size,
+        gl.FLOAT,
+        false,
+        STRIDE_A,
+        offset
+      );
+      setDivisor(
+        gl,
+        state.ext,
+        loc,
+        1
+      );
+    } );
+
+    drawArraysInstanced(
+      gl,
+      state.ext,
+      gl.TRIANGLES,
+      0,
+      6,
+      state.countA
+    );
+
+    endPass(
+      gl,
+      g,
+      p
+    );
+  }
+
+  // ── Mode B: stroke layers ─────────────────────────────────────────────────
+
+  function ensureCapacityB( needed ) {
+    if ( needed <= state.capacityB ) {
+      return;
+    }
+
+    let capacity = state.capacityB;
+
+    while ( capacity < needed ) {
+      capacity *= 2;
+    }
+
+    const grown = new Float32Array( capacity * FLOATS_B );
+
+    grown.set( state.dataB.subarray(
+      0,
+      state.countB * FLOATS_B
+    ) );
+
+    state.dataB = grown;
+    state.capacityB = capacity;
+  }
+
+  /**
+   * Start a stroke-layer batch. Discards strokes left over from a prior frame.
+   */
+  function beginStrokes() {
+    state.countB = 0;
+    state.groups = [];
+    state.currentGroup = null;
+  }
+
+  /**
+   * Begin a new spline. Its segments are drawn together, in submission order,
+   * before the next spline — so per-spline layer stacking is preserved.
+   */
+  function openStroke() {
+    state.currentGroup = {
+      offset: state.countB,
+      count: 0
+    };
+    state.groups.push( state.currentGroup );
+  }
+
+  /**
+   * Queue one dense segment of the current spline, hued by `hueIndex` on the GPU.
+   */
+  function strokeSegment(
+    ax, ay, bx, by, hueIndex
+  ) {
+    if ( !state.currentGroup ) {
+      openStroke();
+    }
+
+    ensureCapacityB( state.countB + 1 );
+
+    const base = state.countB * FLOATS_B;
+    const out = state.dataB;
+
+    out[ base ] = ax;
+    out[ base + 1 ] = ay;
+    out[ base + 2 ] = bx;
+    out[ base + 3 ] = by;
+    out[ base + 4 ] = hueIndex;
+
+    state.countB++;
+    state.currentGroup.count++;
+  }
+
+  /**
+   * Draw every queued spline, each re-drawn once per glow layer (widest and
+   * dimmest first) with the layer half-thickness and opacityFactor supplied as
+   * constants, then composite once.
+   *
+   * @param {object} params
+   * @param {number} params.weight    base stroke weight (px)
+   * @param {number} params.glow      extra glow layers below the core
+   * @param {number} [params.hueOffset=0]
+   */
+  function drawStrokes( {
+    weight, glow, hueOffset = 0
+  } ) {
+    if ( state.countB === 0 ) {
+      return;
+    }
+
+    const p = getP5();
+    const g = ensureGraphics();
+    const gl = g.drawingContext;
+
+    if ( !ensureProgram( gl ) ) {
+      return;
+    }
+
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      state.dataB.subarray(
+        0,
+        state.countB * FLOATS_B
+      ),
+      gl.DYNAMIC_DRAW
+    );
+
+    beginPass(
+      gl,
+      g
+    );
+
+    // beginPass leaves the quad bound (for aCorner); rebind the instance buffer so
+    // the per-group attribute pointers below capture it.
+    gl.bindBuffer(
+      gl.ARRAY_BUFFER,
+      state.instanceVBO
+    );
+
+    // hueIndex varies per segment; half-thickness, opacityFactor and hueOffset are
+    // constant within a layer, so they ride on disabled attributes set per pass.
+    const aSeg = state.locs.aSeg;
+    const aHueIndex = state.locs.aHueIndex;
+
+    gl.disableVertexAttribArray( state.locs.aHalf );
+    gl.disableVertexAttribArray( state.locs.aOpacity );
+    gl.disableVertexAttribArray( state.locs.aHueOffset );
+    gl.vertexAttrib1f(
+      state.locs.aHueOffset,
+      hueOffset
+    );
+
+    const layers = Math.max(
+      0,
+      Math.floor( glow )
+    );
+    const denom = Math.max(
+      1,
+      layers
+    );
+
+    for ( const group of state.groups ) {
+      if ( group.count === 0 ) {
+        continue;
+      }
+
+      const byteOffset = group.offset * STRIDE_B;
+
+      gl.enableVertexAttribArray( aSeg );
+      gl.vertexAttribPointer(
+        aSeg,
+        4,
+        gl.FLOAT,
+        false,
+        STRIDE_B,
+        byteOffset
+      );
+      setDivisor(
+        gl,
+        state.ext,
+        aSeg,
+        1
+      );
+
+      gl.enableVertexAttribArray( aHueIndex );
+      gl.vertexAttribPointer(
+        aHueIndex,
+        1,
+        gl.FLOAT,
+        false,
+        STRIDE_B,
+        byteOffset + 16
+      );
+      setDivisor(
+        gl,
+        state.ext,
+        aHueIndex,
+        1
+      );
+
+      // Widest, dimmest layer first; the bright core lands on top.
+      for ( let shadow = layers; shadow >= 0; shadow-- ) {
+        const layerWeight = weight * ( 1 + shadow * 1.3 );
+        const opacityFactor = 1 + ( shadow / denom ) * 3;
+
+        gl.vertexAttrib1f(
+          state.locs.aHalf,
+          layerWeight / 2
+        );
+        gl.vertexAttrib1f(
+          state.locs.aOpacity,
+          opacityFactor
+        );
+
+        drawArraysInstanced(
+          gl,
+          state.ext,
+          gl.TRIANGLES,
+          0,
+          6,
+          group.count
+        );
+      }
+    }
+
+    endPass(
+      gl,
+      g,
+      p
+    );
+  }
+
   return {
     begin,
-    capsule,
     disc,
-    end
+    capsule,
+    end,
+    beginStrokes,
+    openStroke,
+    strokeSegment,
+    drawStrokes
   };
 }

--- a/src/templates/p5/utils/visuals/neonGraffiti.js
+++ b/src/templates/p5/utils/visuals/neonGraffiti.js
@@ -6,6 +6,16 @@ import converters from "@/p5/utils/converters.js";
 import {
   getP5
 } from "@/p5/utils/sketch.js";
+import createGlowBatchRenderer, {
+  colorLevels
+} from "@/p5/utils/glowBatchGpu.js";
+
+// The visual repeatedly painted shadowsCount × stepsCount filled circles with a
+// p5 fill()/circle() pair each, which is what slowed the draw loop once those
+// counts climbed. The generative math below is untouched; only the rendering
+// moved to a single instanced GPU draw (see utils/glowBatchGpu.js), so the look
+// is identical but thousands of discs cost one draw call instead of thousands.
+const batch = createGlowBatchRenderer();
 
 function getCircleSize(
   circleSizeOption = {
@@ -90,7 +100,7 @@ export default function neonGraffiti( {
     );
   }
 
-  _p.noStroke();
+  batch.begin();
 
   for ( let shadowIndex = 0; shadowIndex < shadowsCount; shadowIndex++ ) {
     const shadowProgression = shadowIndex / shadowsCount;
@@ -160,7 +170,12 @@ export default function neonGraffiti( {
 
       const hueEasingFn = easing?.[ hueEasing ] ?? easing.easeInOutSine;
 
-      _p.fill( colors.rainbow( {
+      const [
+        red,
+        green,
+        blue,
+        alpha
+      ] = colorLevels( colors.rainbow( {
         opacityFactor: _p.map(
           shadowIndex,
           0,
@@ -182,22 +197,30 @@ export default function neonGraffiti( {
             ) * hueIndexMultiplier
       } ) );
 
-      _p.circle(
+      const diameter = getCircleSize(
+        size,
+        {
+          shadowProgression,
+          shadowIndex,
+          shadowsCount,
+          stepAngle,
+          step,
+          stepsCount,
+          stepProgression
+        }
+      );
+
+      batch.disc(
         position.x,
         position.y,
-        getCircleSize(
-          size,
-          {
-            shadowProgression,
-            shadowIndex,
-            shadowsCount,
-            stepAngle,
-            step,
-            stepsCount,
-            stepProgression
-          }
-        )
+        diameter / 2,
+        red,
+        green,
+        blue,
+        alpha
       );
     }
   }
+
+  batch.end();
 }

--- a/src/templates/p5/utils/visuals/neonGraffiti.js
+++ b/src/templates/p5/utils/visuals/neonGraffiti.js
@@ -1,20 +1,18 @@
 import easing from "@/p5/utils/easing.js";
-import colors from "@/p5/utils/colors.js";
 import mappers from "@/p5/utils/mappers.js";
 import animation from "@/p5/utils/animation.js";
 import converters from "@/p5/utils/converters.js";
 import {
   getP5
 } from "@/p5/utils/sketch.js";
-import createGlowBatchRenderer, {
-  colorLevels
-} from "@/p5/utils/glowBatchGpu.js";
+import createGlowBatchRenderer from "@/p5/utils/glowBatchGpu.js";
 
 // The visual repeatedly painted shadowsCount × stepsCount filled circles with a
-// p5 fill()/circle() pair each, which is what slowed the draw loop once those
-// counts climbed. The generative math below is untouched; only the rendering
-// moved to a single instanced GPU draw (see utils/glowBatchGpu.js), so the look
-// is identical but thousands of discs cost one draw call instead of thousands.
+// p5 fill()/circle() pair each, then allocated a p5.Color per disc — both costs
+// that scaled badly. The generative math below is untouched, but rendering moved
+// to one instanced GPU draw and the rainbow colour is computed in the shader (see
+// utils/glowBatchGpu.js), so the look is identical with neither the per-disc draw
+// call nor the per-disc colour allocation.
 const batch = createGlowBatchRenderer();
 
 function getCircleSize(
@@ -170,32 +168,26 @@ export default function neonGraffiti( {
 
       const hueEasingFn = easing?.[ hueEasing ] ?? easing.easeInOutSine;
 
-      const [
-        red,
-        green,
-        blue,
-        alpha
-      ] = colorLevels( colors.rainbow( {
-        opacityFactor: _p.map(
-          shadowIndex,
-          0,
-          shadowsCount,
-          opacityStart,
-          opacityEnd
-        ),
-        hueOffset: hueEasingFn( shadowProgression + stepProgression / hueIndexMultiplier ),
-        hueIndex:
-            _p.map(
-              Math.sin( animation.angle +
-                  hueEasingFn( stepAngle ) * -3 +
-                  shadowProgression +
-                  stepProgression ),
-              -1,
-              1,
-              -hueAmplitude,
-              hueAmplitude
-            ) * hueIndexMultiplier
-      } ) );
+      // The same rainbow inputs as before, passed straight to the GPU palette
+      // instead of building a p5.Color.
+      const opacityFactor = _p.map(
+        shadowIndex,
+        0,
+        shadowsCount,
+        opacityStart,
+        opacityEnd
+      );
+      const hueOffset = hueEasingFn( shadowProgression + stepProgression / hueIndexMultiplier );
+      const hueIndex = _p.map(
+        Math.sin( animation.angle +
+            hueEasingFn( stepAngle ) * -3 +
+            shadowProgression +
+            stepProgression ),
+        -1,
+        1,
+        -hueAmplitude,
+        hueAmplitude
+      ) * hueIndexMultiplier;
 
       const diameter = getCircleSize(
         size,
@@ -214,10 +206,9 @@ export default function neonGraffiti( {
         position.x,
         position.y,
         diameter / 2,
-        red,
-        green,
-        blue,
-        alpha
+        hueOffset,
+        hueIndex,
+        opacityFactor
       );
     }
   }


### PR DESCRIPTION
## Pourquoi

Le visual **neon-graffiti** et la famille **splines** peignaient des milliers de primitives 2D par frame avec un appel p5 immédiat chacune :
- `fill()` + `circle()` pour chaque disque (`shadowsCount × stepsCount`, jusqu'à 60 000) ;
- `stroke()` + `line()` pour chaque segment Chaikin dense, **par couche de glow**, **par entité détectée**.

C'est ce **rendu** — pas le calcul génératif — qui ralentit la boucle de dessin dès que le nombre de disques grimpe ou que beaucoup de *handlers* d'interaction sont actifs (le template Splines v1 Interactive piloté par la vision).

## Approche

J'ai suivi les bonnes pratiques GPU déjà en place dans le projet (`noiseFieldGpu` pour noise-grid, et `peaks-cone`) : **le calcul génératif reste sur CPU** (fidélité, zéro divergence GLSL/JS), seul le **rendu** passe sur GPU dans des appels instanciés.

Nouvelle util partagée **`utils/glowBatchGpu.js`** — `createGlowBatchRenderer()` :
- une primitive unifiée, la **capsule** (segment à bouts ronds) ; un **disque** = capsule de longueur nulle. Couvre les cercles du neon, les segments de glow des splines et les marqueurs ;
- rendu instancié WebGL (WebGL2 natif + repli `ANGLE_instanced_arrays`), ordre de soumission = ordre du peintre ;
- sortie **premultipliée** + `blendFunc(ONE, ONE_MINUS_SRC_ALPHA)`, clear transparent → `p.image()` composite le buffer sur le canvas p2d **sans frange** (le contexte WebGL de `p5.Graphics` est `premultipliedAlpha: true`).

## Deux lots de commits

**1. Migration du rendu sur GPU** (`00f3fc8`)
- `neonGraffiti` : les disques sont empilés dans le batch au lieu de `fill()`/`circle()`. Math inchangée → migre aussi le sketch `neon-graffiti`.
- `splines/_shared` : le glow Chaikin émet des capsules ; `renderSplines()` batche toutes les splines. catmull-rom / quadratic restent sur p5. Overlays + marqueurs restent en p2d.
- `splines-v1-interactive` : collecte toutes les entités (live + trails) → un seul batch. `splines-v0-chaikin` inchangé, bénéficie du GPU via le wrapper `renderSpline`.

**2. Couleur sur GPU + géométrie réutilisée + GC réduit** (`fe67a41`)
- **Couleur GPU** : la palette `rainbow` est portée en GLSL (copie fidèle de `utils/colors.js`) et calculée dans le fragment shader. Les sketches passent `hueOffset/hueIndex/opacityFactor` au lieu d'allouer un `p5.Color` par disque/segment → suppression de dizaines de milliers d'allocations par frame (le hotspot CPU restant).
- **Géométrie réutilisée par couche** : la polyligne dense d'une spline est uploadée **une fois** et le GPU la redessine `glow + 1` fois avec l'épaisseur et l'opacité de chaque couche en constantes — au lieu d'émettre chaque segment une fois par couche. Toujours dessiné spline par spline, couche la plus large/sombre d'abord (empilement inchangé).
- **Chaikin à plat** : la subdivision tourne sur des `Float32Array` plats au lieu de `p5.Vector` → moins de churn GC.

## Vérification

- `npm run lint` ✅ (0 erreur) · `npm test` ✅ (931 tests) · `next build` ✅ (hook pre-push, sur les deux lots)
- Fidélité visuelle du lot 1 confirmée par l'auteur. Le lot 2 reproduit la même sortie à la précision flottante près (la palette GLSL est un portage exact de la palette JS).

## Pistes de suivi possibles

- LOD adaptatif (réduire les itérations Chaikin / sous-échantillonner les segments) si le pire cas explose avec énormément d'entités.
- Tessellation GPU de catmull-rom / quadratic si ces méthodes deviennent un goulot.

https://claude.ai/code/session_01UNgAg6DDhDQ8unk6Uo163q