### PR TITLE
feat(interaction): per-finger hand detection + finger line tracing in splines-v1-interactive

### DIFF
--- a/src/templates/p5/sketches/kinetic/interaction-test/index.js
+++ b/src/templates/p5/sketches/kinetic/interaction-test/index.js
@@ -8,7 +8,8 @@ import {
 import {
   initInteraction,
   disposeInteraction,
-  getPointersDebug
+  getPointersDebug,
+  getPointerGroups
 } from "@/p5/utils/interaction/index.js";
 
 // Color palette per source (RGB)
@@ -28,6 +29,11 @@ const SOURCE_COLORS = {
     109,
     0
   ], // orange
+  fingers: [
+    139,
+    195,
+    74
+  ], // light green
   face: [
     233,
     30,
@@ -74,6 +80,7 @@ const SOURCE_LABELS = {
   mouse: "Mouse",
   touch: "Touch",
   hands: "Hands (MediaPipe)",
+  fingers: "Fingers (MediaPipe)",
   face: "Face (MediaPipe)",
   body: "Body (MediaPipe)",
   orbit: "Orbit",
@@ -126,6 +133,28 @@ sketch.draw( () => {
     } );
   }
 
+  // ── Draw finger chains ─────────────────────────────────────────────────
+  // Each detected finger is one ordered group (base → tip); draw it as a
+  // polyline so the per-finger ordering is visible, not just the joints.
+  if ( interaction.vision?.enabled !== false && interaction.vision?.fingers?.enabled ) {
+    getPointerGroups( interaction )
+      .filter( ( group ) => group.source === "fingers" )
+      .forEach( ( group ) => {
+        p.noFill();
+        p.stroke(
+          ...SOURCE_COLORS.fingers,
+          160
+        );
+        p.strokeWeight( 3 );
+        p.beginShape();
+        group.points.forEach( ( v ) => p.vertex(
+          v.x,
+          v.y
+        ) );
+        p.endShape();
+      } );
+  }
+
   // ── Draw pointer circles ───────────────────────────────────────────────
   pointers.forEach( ( {
     vector, source
@@ -138,6 +167,10 @@ sketch.draw( () => {
     const x = vector.x;
     const y = vector.y;
 
+    // Finger joints come 21 per hand — draw them smaller to stay readable.
+    const ringSize = source === "fingers" ? 22 : 56;
+    const dotSize = source === "fingers" ? 5 : 12;
+
     // Outer ring
     p.noFill();
     p.stroke(
@@ -148,7 +181,7 @@ sketch.draw( () => {
     p.circle(
       x,
       y,
-      56
+      ringSize
     );
 
     // Center dot
@@ -157,7 +190,7 @@ sketch.draw( () => {
     p.circle(
       x,
       y,
-      12
+      dotSize
     );
   } );
 
@@ -270,7 +303,7 @@ function _drawLegend(
 
   // Camera hint when vision enabled but mediapipe not yet running
   const vision = interaction.vision;
-  const needsCamera = vision?.hands?.enabled || vision?.face?.enabled || vision?.body?.enabled;
+  const needsCamera = vision?.hands?.enabled || vision?.fingers?.enabled || vision?.face?.enabled || vision?.body?.enabled;
   const cameraRunning = !!mediapipe.capture?.element;
 
   if ( needsCamera && !cameraRunning && vision?.enabled !== false ) {

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
@@ -18,9 +18,12 @@ import {
 //
 // Two modes:
 //   - live  → re-fit a spline through each group's current points every frame
-//             (e.g. a fan across the fingertips, an arc across the body).
-//   - trail → track each group's centroid over time and spline that history,
-//             so moving a hand/pointer draws a ribbon in the air.
+//             (e.g. a fan across the fingertips, an arc across the body, or —
+//             with Vision → Fingers — one spline along each finger's joints).
+//   - trail → track each group's anchor over time and spline that history,
+//             so moving a hand/pointer draws a ribbon in the air. Most groups
+//             anchor at their centroid; finger groups anchor at the FINGERTIP,
+//             so each finger acts as a pen and traces its own line.
 //
 // It works with no webcam out of the box because the orbit source is enabled by
 // default; turn on Vision → Hands / Body / Face to drive it with the camera.
@@ -97,12 +100,19 @@ function drawTrails(
   const minDistance = mode.minDistance ?? 6;
   const present = new Set();
 
-  // Grow the history of every entity present this frame.
+  // Grow the history of every entity present this frame. Finger groups are
+  // ordered base → tip, so their last point is the fingertip — the natural
+  // pen point — while other groups trail their centroid.
   groups.forEach( ( group ) => {
     present.add( group.id );
+
+    const anchor = group.source === "fingers"
+      ? group.points[ group.points.length - 1 ]
+      : centroid( group.points );
+
     pushTrailPoint(
       group.id,
-      centroid( group.points ),
+      anchor,
       maxPoints,
       minDistance
     );

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
@@ -13,8 +13,10 @@ export const formValues = {
 
   // A virtual orbit source is on by default so the sketch animates immediately
   // (and previews) without a webcam or a camera-permission prompt. Vision is
-  // armed but its trackers start OFF — flip Vision → Hands / Body / Face on to
-  // drive the splines live; the hand landmarks are pre-set for a fingertip fan.
+  // armed but starts OFF — the Fingers tracker is pre-enabled, so flipping
+  // Vision → Enabled immediately lets each finger trace its own line (use
+  // trail mode to draw in the air with your fingertips). Hands / Body / Face
+  // can be toggled too; the hand landmarks are pre-set for a fingertip fan.
   interaction: {
     ...interactionFormValues,
     vision: {
@@ -26,6 +28,10 @@ export const formValues = {
           fingertips: true,
           palm: true
         }
+      },
+      fingers: {
+        ...interactionFormValues.vision.fingers,
+        enabled: true
       }
     },
     orbit: {

--- a/src/templates/p5/utils/interaction/defaults.js
+++ b/src/templates/p5/utils/interaction/defaults.js
@@ -36,6 +36,15 @@ export const interactionFormValues = {
       confidence: 0.5,
       drawOverlay: false
     },
+    fingers: {
+      enabled: false,
+      maxHands: 2,
+      thumb: true,
+      index: true,
+      middle: true,
+      ring: true,
+      pinky: true
+    },
     face: {
       enabled: false,
       maxFaces: 1,
@@ -275,6 +284,44 @@ export const interactionFormConfiguration = {
             drawOverlay: {
               component: "checkbox",
               label: "Draw skeleton"
+            }
+          }
+        },
+
+        fingers: {
+          component: "nested-object",
+          label: "Fingers (per-finger joint chains)",
+          fields: {
+            enabled: {
+              component: "checkbox",
+              label: "Enabled"
+            },
+            maxHands: {
+              component: "slider",
+              label: "Max hands",
+              min: 1,
+              max: 2,
+              step: 1
+            },
+            thumb: {
+              component: "checkbox",
+              label: "Thumb"
+            },
+            index: {
+              component: "checkbox",
+              label: "Index"
+            },
+            middle: {
+              component: "checkbox",
+              label: "Middle"
+            },
+            ring: {
+              component: "checkbox",
+              label: "Ring"
+            },
+            pinky: {
+              component: "checkbox",
+              label: "Pinky"
             }
           }
         },

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -19,6 +19,51 @@ export const HAND_FINGERTIP_INDICES = [
 ];
 export const HAND_PALM_INDEX = 0;
 
+// Per-finger joint chains (base → tip), as traced in the hand-capture series
+// (hand-tracking v0..v4 via drawHands.js). The thumb is "extended": it is
+// rooted at the wrist so its stroke sweeps across the palm like in those
+// sketches instead of floating from the thumb base.
+export const HAND_FINGER_NAMES = [
+  "thumb",
+  "index",
+  "middle",
+  "ring",
+  "pinky"
+];
+export const HAND_FINGER_JOINT_INDICES = {
+  thumb: [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  index: [
+    5,
+    6,
+    7,
+    8
+  ],
+  middle: [
+    9,
+    10,
+    11,
+    12
+  ],
+  ring: [
+    13,
+    14,
+    15,
+    16
+  ],
+  pinky: [
+    17,
+    18,
+    19,
+    20
+  ]
+};
+
 // ── Body pose landmark indices (MediaPipe Pose) ────────────────────────────
 export const BODY_WRIST_INDICES = [
   15,
@@ -485,6 +530,11 @@ export function getPointers( opts ) {
     p,
     vectors
   );
+  _collectFingers(
+    opts,
+    p,
+    vectors
+  );
   _collectFace(
     opts,
     p,
@@ -588,6 +638,17 @@ export function getPointersDebug( opts ) {
     h
   );
 
+  const fi = [];
+
+  _collectFingers(
+    opts,
+    p,
+    fi
+  ); push(
+    "fingers",
+    fi
+  );
+
   const f = [];
 
   _collectFace(
@@ -684,6 +745,7 @@ export function getPointersDebug( opts ) {
  * list — each group is meant to become a single continuous stroke/spline.
  *
  *   - hands  → one group per detected hand  (palm → fingertips, thumb→pinky)
+ *   - fingers→ one group per detected finger (joint chain, base → fingertip)
  *   - body   → one group per detected pose  (wrist→elbow→shoulder→…→wrist)
  *   - face   → one group per detected face  (ear→eye→nose→mouth→eye→ear arc)
  *   - orbit / perlinNoise / audio / touch / midi / joypad / mouse / gyroscope
@@ -737,6 +799,11 @@ export function getPointerGroups( opts ) {
 
   // Vision: one ordered group per detected entity.
   _collectHandGroups(
+    opts,
+    p,
+    groups
+  );
+  _collectFingerGroups(
     opts,
     p,
     groups
@@ -882,7 +949,7 @@ function _desiredVisionTasks( opts ) {
 
   const tasks = [];
 
-  if ( vision.hands?.enabled ) {
+  if ( vision.hands?.enabled || vision.fingers?.enabled ) {
     tasks.push( "hands" );
   }
 
@@ -1041,6 +1108,92 @@ function _collectHands(
       }
     }
   } );
+}
+
+// Iterate every enabled finger of every detected hand, invoking
+// cb( points, handIndex, fingerName ) with the finger's joint chain converted
+// to canvas space (base → tip). Shared by the flat and grouped finger collectors.
+function _eachDetectedFinger(
+  opts, p, cb
+) {
+  const vision = opts.vision;
+  const fingers = vision?.fingers;
+
+  if ( vision?.enabled === false || !fingers?.enabled ) {
+    return;
+  }
+
+  const flip = vision?.camera?.flip ?? true;
+  const maxHands = fingers.maxHands ?? 2;
+  const results = mediapipe.tasks?.hands?.result?.landmarks ?? [];
+
+  results.slice(
+    0,
+    maxHands
+  ).forEach( (
+    hand, handIndex
+  ) => {
+    HAND_FINGER_NAMES.forEach( ( fingerName ) => {
+      if ( fingers[ fingerName ] === false ) {
+        return;
+      }
+
+      const points = [];
+
+      HAND_FINGER_JOINT_INDICES[ fingerName ].forEach( ( i ) => {
+        const pt = hand[ i ];
+
+        if ( pt ) {
+          points.push( _normToCanvas(
+            pt,
+            flip,
+            p
+          ) );
+        }
+      } );
+
+      if ( points.length > 0 ) {
+        cb(
+          points,
+          handIndex,
+          fingerName
+        );
+      }
+    } );
+  } );
+}
+
+function _collectFingers(
+  opts, p, out
+) {
+  _eachDetectedFinger(
+    opts,
+    p,
+    ( points ) => {
+      out.push( ...points );
+    }
+  );
+}
+
+// One ordered group per detected finger (per hand), so each finger strokes as
+// its own continuous line — like the per-finger neon traces of the
+// hand-capture series.
+function _collectFingerGroups(
+  opts, p, groups
+) {
+  _eachDetectedFinger(
+    opts,
+    p,
+    (
+      points, handIndex, fingerName
+    ) => {
+      groups.push( {
+        source: "fingers",
+        id: `hand-${ handIndex }-${ fingerName }`,
+        points
+      } );
+    }
+  );
 }
 
 function _collectFace(


### PR DESCRIPTION
## Summary

Ports the per-finger joint chains from the hand-capture series (`drawHands.js` used by hand-tracking v0–v4: extended thumb rooted at the wrist, then index / middle / ring / pinky) into the reusable interaction layer, as a new **Vision → Fingers** source.

### Interaction layer (`utils/interaction`)

- New exports `HAND_FINGER_NAMES` and `HAND_FINGER_JOINT_INDICES` (thumb `[0..4]`, index `[5..8]`, middle `[9..12]`, ring `[13..16]`, pinky `[17..20]`).
- New `vision.fingers` options block: `enabled`, `maxHands`, and per-finger toggles (thumb / index / middle / ring / pinky), with matching form configuration in `defaults.js`.
- `getPointers()` / `getPointersDebug()` collect every joint of each enabled finger (debug source: `"fingers"`).
- `getPointerGroups()` emits **one ordered group per finger per hand** (`source: "fingers"`, `id: hand-N-<finger>`, points base → tip), so each finger can stroke as its own continuous line — temporal smoothing works per finger out of the box.
- Enabling the fingers tracker boots the MediaPipe `hands` task (lazy init / re-init / webcam release handled like the existing hands tracker).

### `kinetic/interaction-test`

- New `fingers` source color + legend label.
- Draws each detected finger chain as a polyline (base → tip) on top of the joint markers, so ordering is verifiable.
- Smaller markers for finger joints (21 per hand) to stay readable; the "reload to start camera" hint now also accounts for the fingers tracker.

### `splines/splines-v1-interactive`

- **Live mode**: each finger group renders as its own spline along the finger's joints.
- **Trail mode**: finger groups anchor at the **fingertip** instead of the group centroid, so each finger acts as a pen and traces its own line in the air.
- The fingers tracker is pre-enabled in the sketch defaults: flipping Vision → Enabled immediately lets you draw with your fingers.

## Testing

- `npm test` — 931/931 pass
- ESLint clean on all touched files
- `next build` passes (via pre-commit hook)
- Manual webcam verification still needed in-browser (`interaction-test` and `splines-v1-interactive` with Vision enabled)

https://claude.ai/code/session_01XnVQc1vtazSbJRNPUop7Wt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnVQc1vtazSbJRNPUop7Wt)_