### PR TITLE
fix(video): make S3-backed videos render on iOS/WebKit

### DIFF
--- a/src/app/api/s3/[...key]/route.ts
+++ b/src/app/api/s3/[...key]/route.ts
@@ -1,12 +1,24 @@
 import {
-  NextResponse
-} from "next/server";
-import {
-  getDownloadUrlFromS3Url
+  getObjectStream,
+  getObjectSize
 } from "@/lib/connections/s3";
 
+/**
+ * Same-origin streaming proxy for S3-backed assets.
+ *
+ * This used to be a 307 redirect to a presigned S3 URL, which broke `<video>`
+ * on WebKit (iOS/iPadOS Safari): media elements created with
+ * `crossOrigin="anonymous"` fail when the media URL redirects cross-origin
+ * (WebKit drops the CORS context on redirect), and WebKit additionally
+ * requires the final server to answer `Range` requests with
+ * `206 Partial Content` before it will decode anything at all.
+ *
+ * Streaming the bytes from this route keeps every asset same-origin (no CORS,
+ * no canvas tainting) and forwards `Range` end-to-end, which satisfies both
+ * WebKit constraints while staying transparent for every other browser.
+ */
 export async function GET(
-  _request: Request,
+  request: Request,
   {
     params
   }: {
@@ -16,10 +28,58 @@ export async function GET(
   }
 ) {
   const objectKey = ( await params ).key.join( "/" );
-  const signedUrl = await getDownloadUrlFromS3Url( objectKey );
+  const range = request.headers.get( "range" );
 
-  return NextResponse.redirect(
-    signedUrl,
-    307
-  );
+  try {
+    const object = await getObjectStream(
+      objectKey,
+      range
+    );
+
+    return new Response(
+      object.body,
+      {
+        status: object.status,
+        headers: {
+          ...object.headers,
+          "cache-control": "private, max-age=3600"
+        }
+      }
+    );
+  } catch( error ) {
+    const status = ( error as {
+      $metadata?: {
+        httpStatusCode?: number;
+      };
+      name?: string;
+    } );
+
+    if ( status.$metadata?.httpStatusCode === 416 ) {
+      const size = await getObjectSize( objectKey );
+
+      return new Response(
+        null,
+        {
+          status: 416,
+          headers: size === null ? {} : {
+            "content-range": `bytes */${ size }`
+          }
+        }
+      );
+    }
+
+    if (
+      status.name === "NoSuchKey" ||
+      status.$metadata?.httpStatusCode === 404
+    ) {
+      return new Response(
+        null,
+        {
+          status: 404
+        }
+      );
+    }
+
+    throw error;
+  }
 }

--- a/src/lib/assets/kinds/videos/loadVideoAsset.ts
+++ b/src/lib/assets/kinds/videos/loadVideoAsset.ts
@@ -130,10 +130,35 @@ export function loadVideoAsset(
   const element = document.createElement( "video" );
 
   element.muted = true;
+  // WebKit checks the *attribute* (and `defaultMuted`) when deciding whether
+  // a programmatic play() counts as muted autoplay — the property alone is
+  // not enough on iOS.
+  element.defaultMuted = true;
+  element.setAttribute(
+    "muted",
+    ""
+  );
   element.playsInline = true;
+  element.setAttribute(
+    "webkit-playsinline",
+    ""
+  );
   element.preload = "auto";
   element.crossOrigin = "anonymous";
-  element.style.display = options.hidden === false ? "" : "none";
+
+  if ( options.hidden === false ) {
+    element.style.display = "";
+  } else {
+    // Hide off-screen instead of `display: none`: WebKit stops decoding (and
+    // never presents frames to canvas drawImage) for display:none videos.
+    element.style.position = "fixed";
+    element.style.left = "-99999px";
+    element.style.top = "0";
+    element.style.width = "2px";
+    element.style.height = "2px";
+    element.style.opacity = "0";
+    element.style.pointerEvents = "none";
+  }
 
   document.body.appendChild( element );
 
@@ -215,11 +240,52 @@ export function loadVideoAsset(
       );
     } );
 
+    // iOS ignores `preload="auto"` in several situations (Low Power Mode,
+    // cellular); an explicit load() reliably kicks off the metadata fetch.
+    element.load();
+
     // Surface load failures without leaving an unhandled rejection.
     ready.catch( ( error ) => {
       console.warn(
         "[loadVideoAsset]",
         error
+      );
+    } );
+
+    const expectedPath = currentPath;
+
+    ready.then( () => {
+      if ( expectedPath === currentPath ) {
+        primeDecode();
+      }
+    } ).catch( () => {} );
+  }
+
+  /**
+   * WebKit won't decode frames for a video that has never played:
+   * `drawImage(video)` silently paints nothing, and seeks alone don't start
+   * the decoder. A muted inline play() — allowed without a user gesture —
+   * followed by a pause on the first `timeupdate` (first decoded frame)
+   * spins the decoder up so subsequent seeked frames reach the canvas.
+   */
+  function primeDecode(): void {
+    const stop = () => {
+      element.removeEventListener(
+        "timeupdate",
+        stop
+      );
+      element.pause();
+    };
+
+    element.addEventListener(
+      "timeupdate",
+      stop
+    );
+
+    element.play().catch( () => {
+      element.removeEventListener(
+        "timeupdate",
+        stop
       );
     } );
   }
@@ -280,29 +346,67 @@ export function loadVideoAsset(
     }
 
     activeSeek = trackPendingMedia( new Promise<void>( ( resolve ) => {
-      const onSeeked = () => {
+      let pollId: ReturnType<typeof setInterval> | null = null;
+
+      const settle = () => {
         element.removeEventListener(
           "seeked",
-          onSeeked
+          settle
         );
+        element.removeEventListener(
+          "error",
+          settle
+        );
+        if ( pollId !== null ) {
+          clearInterval( pollId );
+        }
         activeSeek = null;
         resolve();
       };
 
       element.addEventListener(
         "seeked",
-        onSeeked
+        settle
       );
+      element.addEventListener(
+        "error",
+        settle
+      );
+
+      // WebKit occasionally drops the `seeked` event for hidden videos /
+      // sub-frame deltas, which would leave this promise (and every
+      // coalesced caller) hanging forever. Poll `seeking` as a fallback:
+      // while it's `true` the seek is genuinely in flight and waiting is
+      // correct; once it's `false` the seek finished even if no event fired.
+      pollId = setInterval(
+        () => {
+          if ( !element.seeking ) {
+            settle();
+          }
+        },
+        500
+      );
+
       element.currentTime = lastTarget;
     } ) );
 
     await activeSeek;
 
     // `requestVideoFrameCallback` is frame-accurate; await one tick so the
-    // pixels visible to p5 actually match the seeked time.
+    // pixels visible to p5 actually match the seeked time. WebKit only fires
+    // it when a frame is *composited*, which never happens for off-screen
+    // videos — race a short timeout so iOS doesn't hang here.
     if ( typeof ( element as any ).requestVideoFrameCallback === "function" ) {
       await trackPendingMedia( new Promise<void>( ( resolve ) => {
-        ( element as any ).requestVideoFrameCallback( () => resolve() );
+        const timeoutId = setTimeout(
+          resolve,
+          250
+        );
+
+        ( element as any ).requestVideoFrameCallback( () => {
+          clearTimeout( timeoutId );
+          resolve();
+        } );
       } ) );
     }
   }

--- a/src/lib/connections/s3.ts
+++ b/src/lib/connections/s3.ts
@@ -72,6 +72,70 @@ export async function getDownloadUrlFromS3Url(
   return signedUrl;
 }
 
+export type S3ObjectStream = {
+  body: ReadableStream | null;
+  /** 206 when S3 answered a byte-range request, 200 otherwise. */
+  status: 200 | 206;
+  headers: Record<string, string>;
+};
+
+/**
+ * Open a streaming read of an S3 object, optionally limited to a byte range
+ * (the raw `Range` request header value, e.g. `bytes=0-1`).
+ *
+ * Range support is what lets media elements progressively fetch and seek:
+ * WebKit (iOS Safari) refuses to play a `<video>` whose server cannot answer
+ * `Range` requests with `206 Partial Content`.
+ */
+export async function getObjectStream(
+  objectKey: string,
+  range?: string | null
+): Promise<S3ObjectStream> {
+  const response = await s3client.send( new GetObjectCommand( {
+    Bucket: process.env.S3_BUCKET!,
+    Key: objectKey,
+    ...( range ? {
+      Range: range
+    } : {} )
+  } ) );
+
+  const headers: Record<string, string> = {
+    "accept-ranges": "bytes"
+  };
+
+  if ( response.ContentType ) {
+    headers[ "content-type" ] = response.ContentType;
+  }
+
+  if ( typeof response.ContentLength === "number" ) {
+    headers[ "content-length" ] = String( response.ContentLength );
+  }
+
+  if ( response.ContentRange ) {
+    headers[ "content-range" ] = response.ContentRange;
+  }
+
+  if ( response.ETag ) {
+    headers.etag = response.ETag;
+  }
+
+  if ( response.LastModified ) {
+    headers[ "last-modified" ] = response.LastModified.toUTCString();
+  }
+
+  const body = response.Body
+    ? ( response.Body as unknown as {
+      transformToWebStream: () => ReadableStream;
+    } ).transformToWebStream()
+    : null;
+
+  return {
+    body,
+    status: response.ContentRange ? 206 : 200,
+    headers
+  };
+}
+
 /**
  * Download an object from S3 and return its contents as a Node.js Buffer.
  *


### PR DESCRIPTION
## Problème

Sur iPhone (Safari/WebKit), les sketchs vidéo (`video-player`, `video-text`, …) n'affichent **aucune** vidéo, alors que tout fonctionne sur desktop.

## Causes identifiées

1. **Redirect 307 + CORS** — `/api/s3/[...key]` redirigeait vers une URL S3 présignée (cross-origin). Le `<video>` est créé avec `crossOrigin="anonymous"` (nécessaire pour dessiner dans le canvas sans le « tainter »), et WebKit ne suit pas correctement les redirections cross-origin pour les médias en mode CORS : le chargement échoue silencieusement.
2. **Range/206 obligatoire** — WebKit refuse de décoder une vidéo si le serveur ne répond pas aux requêtes `Range` par du `206 Partial Content`.
3. **`display:none`** — WebKit ne décode pas (et ne présente pas de frames à `drawImage`) pour une vidéo masquée par `display:none`.
4. **Décodeur jamais démarré** — sur iOS, une vidéo qui n'a jamais été jouée ne décode pas de frames : les seeks seuls ne suffisent pas, `drawImage(video)` ne peint rien.
5. **Risques de blocage** — `seeked` parfois non émis par WebKit (la coalescence des seeks restait suspendue pour toujours) et `requestVideoFrameCallback` jamais déclenché pour une vidéo non composée (hors écran).

## Correctifs

### `src/app/api/s3/[...key]/route.ts` + `src/lib/connections/s3.ts`
La route streame désormais les octets **same-origin** (plus de CORS du tout) avec support complet de `Range` : transfert du header vers S3, réponse `206` avec `Content-Range`/`Accept-Ranges`, gestion `416` et `404`, passthrough `ETag`/`Last-Modified`.

### `src/lib/assets/kinds/videos/loadVideoAsset.ts`
- élément masqué hors écran (`position:fixed` + `opacity:0`) au lieu de `display:none` ;
- `defaultMuted` + attributs `muted`/`webkit-playsinline` (WebKit vérifie l'attribut, pas seulement la propriété, pour autoriser l'autoplay muet inline) ;
- `load()` explicite après `src` (iOS ignore `preload="auto"` en mode économie d'énergie / cellulaire) ;
- amorçage du décodeur : `play()` muet puis `pause()` au premier `timeupdate` ;
- fallback anti-blocage sur `seeked` (poll de `element.seeking`) et timeout de 250 ms sur `requestVideoFrameCallback`.

## Vérifications

- `npm test` : 931 tests, 13 suites ✅
- `npm run lint` ✅ (seul un warning préexistant subsiste)
- `npx tsc --noEmit` : aucune nouvelle erreur (6 erreurs préexistantes dans `traceLetters.test.ts`, identiques avant/après)
- `next build` ✅ (via le hook pre-push)

⚠️ À valider sur un vrai iPhone : ouvrir un job avec une vidéo S3 et vérifier l'affichage dans `video-player`.

## Note sur le « tremblotement » d'`animated-text-points` sur mobile

Diagnostic (pas de changement de code ici) : l'animation est bien basée sur le temps, mais le canvas 1080×1350 WEBGL + des centaines de points avec 7 cercles chacun par frame saturent le GPU mobile → cadence irrégulière. S'ajoutent le mode économie d'énergie d'iOS (rAF plafonné à 30 Hz) et le shimmer dû au downscale CSS (~×2,8) de traits de 1–2 px. Pistes de suivi : réduire `sampleFactor` / la résolution de rendu sur petits écrans, ou plafonner `framerate` à 30 sur mobile.

https://claude.ai/code/session_013fQXHDJyhinQZAdws6x3YE

---
_Generated by [Claude Code](https://claude.ai/code/session_013fQXHDJyhinQZAdws6x3YE)_