### PR TITLE
Improve zoom controls: live percentage indicator and multiplicative steps

### DIFF
--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -40,7 +40,7 @@ export default function ScalableViewport( {
   const contentRef = useRef<HTMLDivElement | null>( null );
 
   const {
-    transform, setTransform
+    transform, displayScale, setTransform
   } = useTransformState( initialScale || 1 );
 
   const handleAnimationStart = useCallback(
@@ -180,6 +180,7 @@ export default function ScalableViewport( {
     >
       {showZoomControls && (
         <ZoomControls
+          scale={ displayScale }
           onPlus={ zoomIn }
           onMinus={ zoomOut }
           onFit={ () => fitToViewport( true ) }

--- a/src/components/ScalableViewport/components/ZoomControls.tsx
+++ b/src/components/ScalableViewport/components/ZoomControls.tsx
@@ -1,61 +1,69 @@
 "use client";
 
 import {
-  Maximize2, Minus, Plus
+  Minus, Plus, Scan
 } from "lucide-react";
 
+const buttonClassName = "h-full px-3 hover:bg-hover transition-colors group inline-flex items-center justify-center";
+const iconClassName = "w-4 h-4 text-foreground/70 group-hover:text-foreground transition-colors";
+
 const ZoomControls = ( {
+  scale,
   onPlus,
   onMinus,
   onFit,
   onReset
 }: {
+  scale: number;
   onPlus: () => void;
   onMinus: () => void;
   onReset: () => void;
   onFit: () => void;
 } ) => {
   return (
-    <div className="absolute top-2 right-2 md:top-4 md:right-4 flex items-center gap-2 z-50">
-      <div className="flex items-center h-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md overflow-hidden">
+    <div
+      className="absolute top-2 right-2 md:top-4 md:right-4 z-50"
+      data-no-drag="true"
+    >
+      <div className="flex items-center h-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md overflow-hidden divide-x divide-border">
         <button
           onClick={ onMinus }
-          className="h-full px-3 hover:bg-hover transition-colors border-r border-border group inline-flex items-center justify-center"
+          className={ buttonClassName }
           title="Zoom out"
           aria-label="Zoom out"
         >
-          <Minus className="w-4 h-4 text-foreground/70 group-hover:text-foreground transition-colors" />
+          <Minus className={ iconClassName } />
         </button>
 
         <button
           onClick={ onReset }
-          className="h-full px-3 hover:bg-hover transition-colors border-r border-border group inline-flex items-center justify-center min-w-[3rem]"
-          title="Reset to 100%"
-          aria-label="Reset zoom to 100%"
+          className={ `${ buttonClassName } min-w-[3.5rem]` }
+          title="Zoom to 100% (actual size)"
+          aria-label="Zoom to 100% (actual size)"
         >
-          <span className="text-xs font-semibold text-foreground/70 group-hover:text-foreground transition-colors leading-none">
-            100%
+          <span className="text-xs font-semibold tabular-nums text-foreground/70 group-hover:text-foreground transition-colors leading-none">
+            {Math.round( scale * 100 )}%
           </span>
         </button>
 
         <button
           onClick={ onPlus }
-          className="h-full px-3 hover:bg-hover transition-colors group inline-flex items-center justify-center"
+          className={ buttonClassName }
           title="Zoom in"
           aria-label="Zoom in"
         >
-          <Plus className="w-4 h-4 text-foreground/70 group-hover:text-foreground transition-colors" />
+          <Plus className={ iconClassName } />
+        </button>
+
+        <button
+          onClick={ onFit }
+          className={ buttonClassName }
+          title="Fit to viewport"
+          aria-label="Fit to viewport"
+        >
+          <Scan className={ iconClassName } />
         </button>
       </div>
-
-      <button
-        onClick={ onFit }
-        className="h-9 px-3 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md hover:bg-hover transition-colors group inline-flex items-center justify-center"
-        title="Fit to viewport"
-        aria-label="Fit to viewport"
-      >
-        <Maximize2 className="w-4 h-4 text-foreground/70 group-hover:text-foreground transition-colors" />
-      </button>
     </div>
   );
 };

--- a/src/components/ScalableViewport/hooks/useTransformState.ts
+++ b/src/components/ScalableViewport/hooks/useTransformState.ts
@@ -48,7 +48,9 @@ export function useTransformState( initialScale: number = 1 ) {
       };
       updateDom( contentElement );
       if ( newValues.scale !== undefined ) {
-        setDisplayScale( newValues.scale );
+        // Quantize to whole percents so consumers only re-render when the
+        // displayed zoom level changes, not on every animation frame.
+        setDisplayScale( Math.round( newValues.scale * 100 ) / 100 );
       }
     },
     [

--- a/src/components/ScalableViewport/hooks/useViewportActions.ts
+++ b/src/components/ScalableViewport/hooks/useViewportActions.ts
@@ -8,8 +8,15 @@ import {
   calculateFitToViewport,
   calculateActualPixels,
   calculateZoomTarget,
-  ZOOM_STEP
+  ZOOM_STEP_FACTOR
 } from "../utils/zoomCalculations";
+
+type LayoutCalculation = (
+  contentWidth: number,
+  contentHeight: number,
+  viewportWidth: number,
+  viewportHeight: number
+) => TransformState;
 
 interface UseViewportActionsProps {
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -29,8 +36,10 @@ export function useViewportActions( {
   setTransform,
   animateTo
 }: UseViewportActionsProps ) {
-  const fitToViewport = useCallback(
-    ( animate = false ) => {
+  const applyLayout = useCallback(
+    (
+      calculate: LayoutCalculation, animate: boolean
+    ) => {
       const viewport = containerRef.current;
       const canvas = contentRef.current;
 
@@ -38,18 +47,13 @@ export function useViewportActions( {
         return;
       }
 
-      const contentWidth = canvas.offsetWidth;
-      const contentHeight = canvas.offsetHeight;
-      const viewportWidth = viewport.clientWidth;
-      const viewportHeight = viewport.clientHeight;
-
       const {
         x, y, scale
-      } = calculateFitToViewport(
-        contentWidth,
-        contentHeight,
-        viewportWidth,
-        viewportHeight
+      } = calculate(
+        canvas.offsetWidth,
+        canvas.offsetHeight,
+        viewport.clientWidth,
+        viewport.clientHeight
       );
 
       if ( animate ) {
@@ -65,7 +69,7 @@ export function useViewportActions( {
             y,
             scale
           },
-          contentRef.current
+          canvas
         );
       }
     },
@@ -77,113 +81,67 @@ export function useViewportActions( {
     ]
   );
 
-  const resetToActualPixels = useCallback(
-    ( animate = false ) => {
-      const viewport = containerRef.current;
-      const canvas = contentRef.current;
+  const fitToViewport = useCallback(
+    ( animate = false ) => applyLayout(
+      calculateFitToViewport,
+      animate
+    ),
+    [
+      applyLayout
+    ]
+  );
 
-      if ( !viewport || !canvas ) {
+  const resetToActualPixels = useCallback(
+    ( animate = false ) => applyLayout(
+      calculateActualPixels,
+      animate
+    ),
+    [
+      applyLayout
+    ]
+  );
+
+  const zoomBy = useCallback(
+    ( factor: number ) => {
+      const container = containerRef.current;
+
+      if ( !container ) {
         return;
       }
 
-      const contentWidth = canvas.offsetWidth;
-      const contentHeight = canvas.offsetHeight;
-      const viewportWidth = viewport.clientWidth;
-      const viewportHeight = viewport.clientHeight;
-
-      const {
-        x, y, scale
-      } = calculateActualPixels(
-        contentWidth,
-        contentHeight,
-        viewportWidth,
-        viewportHeight
+      const rect = container.getBoundingClientRect();
+      const target = calculateZoomTarget(
+        transform.current.scale * factor,
+        rect.left + rect.width / 2,
+        rect.top + rect.height / 2,
+        rect,
+        transform.current
       );
 
-      if ( animate ) {
-        animateTo(
-          x,
-          y,
-          scale
-        );
-      } else {
-        setTransform(
-          {
-            x,
-            y,
-            scale
-          },
-          contentRef.current
-        );
-      }
+      animateTo(
+        target.x,
+        target.y,
+        target.scale
+      );
     },
     [
       containerRef,
-      contentRef,
-      setTransform,
+      transform,
       animateTo
     ]
   );
 
   const zoomIn = useCallback(
-    () => {
-      const {
-        scale
-      } = transform.current;
-      const container = containerRef.current;
-
-      if ( container ) {
-        const rect = container.getBoundingClientRect();
-        const target = calculateZoomTarget(
-          scale + ZOOM_STEP,
-          rect.left + rect.width / 2,
-          rect.top + rect.height / 2,
-          rect,
-          transform.current
-        );
-
-        animateTo(
-          target.x,
-          target.y,
-          target.scale
-        );
-      }
-    },
+    () => zoomBy( ZOOM_STEP_FACTOR ),
     [
-      containerRef,
-      transform,
-      animateTo
+      zoomBy
     ]
   );
 
   const zoomOut = useCallback(
-    () => {
-      const {
-        scale
-      } = transform.current;
-      const container = containerRef.current;
-
-      if ( container ) {
-        const rect = container.getBoundingClientRect();
-        const target = calculateZoomTarget(
-          scale - ZOOM_STEP,
-          rect.left + rect.width / 2,
-          rect.top + rect.height / 2,
-          rect,
-          transform.current
-        );
-
-        animateTo(
-          target.x,
-          target.y,
-          target.scale
-        );
-      }
-    },
+    () => zoomBy( 1 / ZOOM_STEP_FACTOR ),
     [
-      containerRef,
-      transform,
-      animateTo
+      zoomBy
     ]
   );
 

--- a/src/components/ScalableViewport/utils/__tests__/zoomCalculations.test.ts
+++ b/src/components/ScalableViewport/utils/__tests__/zoomCalculations.test.ts
@@ -1,0 +1,126 @@
+import {
+  calculateZoomTarget,
+  calculateFitToViewport,
+  calculateActualPixels,
+  MIN_SCALE,
+  MAX_SCALE
+} from "../zoomCalculations";
+
+const containerRect = {
+  left: 0,
+  top: 0
+} as DOMRect;
+
+describe(
+  "calculateZoomTarget",
+  () => {
+    it(
+      "keeps the point under the cursor stationary while zooming",
+      () => {
+        const result = calculateZoomTarget(
+          2,
+          100,
+          100,
+          containerRect,
+          {
+            x: 0,
+            y: 0,
+            scale: 1
+          }
+        );
+
+        // The content coordinate under the cursor was (100 - 0) / 1 = 100;
+        // after zooming, its screen position must still be 100.
+        expect( result.scale ).toBe( 2 );
+        expect( result.x + 100 * result.scale ).toBeCloseTo( 100 );
+        expect( result.y + 100 * result.scale ).toBeCloseTo( 100 );
+      }
+    );
+
+    it(
+      "clamps the requested scale into [MIN_SCALE, MAX_SCALE]",
+      () => {
+        const transform = {
+          x: 0,
+          y: 0,
+          scale: 1
+        };
+
+        expect( calculateZoomTarget(
+          0,
+          0,
+          0,
+          containerRect,
+          transform
+        ).scale ).toBe( MIN_SCALE );
+
+        expect( calculateZoomTarget(
+          100,
+          0,
+          0,
+          containerRect,
+          transform
+        ).scale ).toBe( MAX_SCALE );
+      }
+    );
+  }
+);
+
+describe(
+  "calculateFitToViewport",
+  () => {
+    it(
+      "scales to 90% of the limiting dimension and centers the content",
+      () => {
+        const result = calculateFitToViewport(
+          200,
+          100,
+          1000,
+          1000
+        );
+
+        // Width is the limiting dimension: ( 1000 / 200 ) * 0.9 = 4.5.
+        expect( result.scale ).toBeCloseTo( 4.5 );
+        expect( result.x ).toBeCloseTo( ( 1000 - 200 * 4.5 ) / 2 );
+        expect( result.y ).toBeCloseTo( ( 1000 - 100 * 4.5 ) / 2 );
+      }
+    );
+
+    it(
+      "returns the identity transform for empty content",
+      () => {
+        expect( calculateFitToViewport(
+          0,
+          0,
+          1000,
+          1000
+        ) ).toEqual( {
+          x: 0,
+          y: 0,
+          scale: 1
+        } );
+      }
+    );
+  }
+);
+
+describe(
+  "calculateActualPixels",
+  () => {
+    it(
+      "centers the content at scale 1",
+      () => {
+        expect( calculateActualPixels(
+          400,
+          200,
+          1000,
+          800
+        ) ).toEqual( {
+          x: 300,
+          y: 300,
+          scale: 1
+        } );
+      }
+    );
+  }
+);

--- a/src/components/ScalableViewport/utils/zoomCalculations.ts
+++ b/src/components/ScalableViewport/utils/zoomCalculations.ts
@@ -5,7 +5,10 @@ import type {
 
 export const MIN_SCALE = 0.1;
 export const MAX_SCALE = 6;
-export const ZOOM_STEP = 0.2;
+
+// Multiplicative step so +/- buttons feel uniform at every zoom level,
+// matching the exponential factor used by wheel zoom.
+export const ZOOM_STEP_FACTOR = 1.25;
 
 export function calculateZoomTarget(
   newScale: number,


### PR DESCRIPTION
## Summary

Revamps the floating zoom controls on the sketch page, following the standard pattern used by canvas editors (Excalidraw, Figma, Miro):

- **Live zoom percentage**: the static "100%" button is now a live indicator of the current zoom level (updates during wheel, pinch, buttons and animations). Clicking it still resets to 100% (actual size). `tabular-nums` + fixed min-width keep the pill from shifting as digits change.
- **Single grouped pill**: the separate fit-to-viewport button is merged into the main control group: `[ − | 73% | + | fit ]`.
- **Icon reassignment**: fit-to-viewport now uses the `Scan` icon instead of `Maximize2`, which is universally associated with fullscreen — freeing it for the upcoming fullscreen toggle (TODO.md, intentionally not part of this PR).
- **Multiplicative zoom steps**: `+`/`−` buttons now scale by ×1.25 / ÷1.25 instead of adding ±0.2, so a click feels the same at 20% as at 500% — consistent with the exponential factor already used by wheel zoom.

## Code quality

- `useViewportActions`: factored the duplicated measure-then-apply logic (`fitToViewport`/`resetToActualPixels`) into `applyLayout`, and `zoomIn`/`zoomOut` into a shared `zoomBy` (~200 → ~150 lines).
- `useTransformState`: `displayScale` (previously unused) is quantized to whole percents, so subscribers only re-render when the displayed value changes instead of every animation frame.
- `ZoomControls`: added `data-no-drag` so drags starting on the controls no longer pan the canvas.
- Added unit tests for the pure `zoomCalculations` module (point-zoom invariant, clamping, fit/center math) — first step of the "Unit tests" TODO item.

## Testing

- `npm run lint` — clean (one pre-existing warning in `videos.js`, untouched)
- `npm test` — 936 tests pass, including 5 new ones
- `tsc --noEmit` — same 6 pre-existing errors before/after (all in `traceLetters.test.ts`, unrelated)

https://claude.ai/code/session_01XcRsuwfTETY9M1FyBN3G3m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcRsuwfTETY9M1FyBN3G3m)_