### PR TITLE
feat(ui): prefix engine to canvas title, drop label from controls

### DIFF
--- a/src/components/TemplateSketchPage/EngineControls.tsx
+++ b/src/components/TemplateSketchPage/EngineControls.tsx
@@ -244,8 +244,6 @@ export function EngineControls( ) {
           )}
         </button>
       </div>
-
-      <span className="text-xs text-foreground/50 font-mono">{engineId}</span>
     </div>
   );
 }

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -256,6 +256,13 @@ export default function TemplateSketchPage() {
             >
               <p className="truncate">
                 <Link
+                  href={ `/templates/${ engineId }` }
+                  target="_blank"
+                >
+                  {engineId}
+                </Link>
+                <span className="text-xs">{" · "}</span>
+                <Link
                   href={ `/templates/${ engineId }/${ name }` }
                   target="_blank"
                 >


### PR DESCRIPTION
## Summary
- Drops the `engineId` label that sat next to the engine controls bar — it crowded the mobile toolbar.
- Adds an `<engine> / <name>` breadcrumb to the canvas title above the viewport, where the engine half links to `/templates/<engine>` (target _blank), matching the existing template-name link behavior.

## Test plan
- [ ] On desktop, confirm the title above the canvas reads `p5 / <template>` and that clicking `p5` opens `/templates/p5` in a new tab.
- [ ] Confirm the `engineId` label no longer appears beside the play/capture controls.
- [ ] On mobile width, confirm the controls bar (github, play/pause, capture) no longer overflows.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FFMNkCsiTiFzQ7h453i45S)_