### PR TITLE
Fix gyroscope handler runtime wiring and use vector2d offsets

### DIFF
--- a/src/templates/p5/utils/interaction/defaults.js
+++ b/src/templates/p5/utils/interaction/defaults.js
@@ -9,8 +9,10 @@ export const interactionFormValues = {
   mouse: {
     enabled: false,
     smoothing: 0,
-    offsetX: 0,
-    offsetY: 0
+    offset: {
+      x: 0,
+      y: 0
+    }
   },
 
   touch: {
@@ -93,7 +95,11 @@ export const interactionFormValues = {
 
   gyroscope: {
     enabled: false,
-    clampAngle: 45
+    clampAngle: 45,
+    offset: {
+      x: 0,
+      y: 0
+    }
   },
 
   midi: {
@@ -155,19 +161,13 @@ export const interactionFormConfiguration = {
           max: 0.99,
           step: 0.01
         },
-        offsetX: {
-          component: "slider",
-          label: "Offset X",
+        offset: {
+          component: "vector2d",
+          label: "Offset",
           min: -500,
           max: 500,
-          step: 1
-        },
-        offsetY: {
-          component: "slider",
-          label: "Offset Y",
-          min: -500,
-          max: 500,
-          step: 1
+          step: 1,
+          yDown: true
         }
       }
     },
@@ -574,6 +574,14 @@ export const interactionFormConfiguration = {
           min: 5,
           max: 90,
           step: 5
+        },
+        offset: {
+          component: "vector2d",
+          label: "Offset",
+          min: -500,
+          max: 500,
+          step: 1,
+          yDown: true
         }
       }
     },

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -142,7 +142,9 @@ const _gyro = {
 };
 
 // Listeners
+let _gyroInitialized = false;
 let _gyroListener = null;
+let _gyroPermissionListener = null;
 let _pointerMoveListener = null;
 let _touchListeners = null;
 
@@ -226,6 +228,99 @@ function _clientToCanvas(
     x: ( clientX - rect.left ) * ( p.width / rect.width ),
     y: ( clientY - rect.top ) * ( p.height / rect.height )
   };
+}
+
+// ── Gyroscope helpers ──────────────────────────────────────────────────────
+
+function _wireGyroListener() {
+  _gyroListener = ( e ) => {
+    _gyro.beta = e.beta ?? 0;
+    _gyro.gamma = e.gamma ?? 0;
+  };
+  window.addEventListener(
+    "deviceorientation",
+    _gyroListener
+  );
+}
+
+function _removeGyroPermissionListener() {
+  if ( !_gyroPermissionListener ) {
+    return;
+  }
+
+  window.removeEventListener(
+    "click",
+    _gyroPermissionListener
+  );
+  window.removeEventListener(
+    "touchend",
+    _gyroPermissionListener
+  );
+  _gyroPermissionListener = null;
+}
+
+// Lazily wire the deviceorientation listener the first time the gyroscope
+// collector runs. The listener used to be wired only from initInteraction()
+// when gyroscope.enabled was already true at setup, so toggling it on at
+// runtime never attached anything and the pointer stayed glued to the canvas
+// centre (beta/gamma stuck at 0). iOS 13+ additionally gates the events behind
+// DeviceOrientationEvent.requestPermission(), which must be called from a user
+// gesture — so there we arm a one-shot tap/click handler that requests it.
+function _initGyro() {
+  if ( _gyroInitialized || typeof window === "undefined" ) {
+    return;
+  }
+
+  _gyroInitialized = true;
+
+  const OrientationEvent = window.DeviceOrientationEvent;
+
+  if ( OrientationEvent && typeof OrientationEvent.requestPermission === "function" ) {
+    const requestOnGesture = () => {
+      _removeGyroPermissionListener();
+      OrientationEvent.requestPermission()
+        .then( ( state ) => {
+          if ( state === "granted" ) {
+            _wireGyroListener();
+          }
+        } )
+        .catch( () => {
+          // Permission denied — leave beta/gamma at 0
+        } );
+    };
+
+    _gyroPermissionListener = requestOnGesture;
+    window.addEventListener(
+      "click",
+      requestOnGesture
+    );
+    window.addEventListener(
+      "touchend",
+      requestOnGesture
+    );
+  } else {
+    _wireGyroListener();
+  }
+}
+
+function _disposeGyro() {
+  if ( typeof window === "undefined" ) {
+    return;
+  }
+
+  _removeGyroPermissionListener();
+
+  if ( _gyroListener ) {
+    window.removeEventListener(
+      "deviceorientation",
+      _gyroListener
+    );
+    _gyroListener = null;
+  }
+
+  _gyroInitialized = false;
+  _gyro.beta = 0;
+  _gyro.gamma = 0;
 }
 
 // ── MIDI helpers ───────────────────────────────────────────────────────────
@@ -321,25 +416,8 @@ async function _initAudio( opts ) {
 export async function initInteraction( opts = {} ) {
   _noiseOffset = opts.perlinNoise?.seed ?? 0;
 
-  // ── Gyroscope ────────────────────────────────────────────────────────────
-  if ( _gyroListener && typeof window !== "undefined" ) {
-    window.removeEventListener(
-      "deviceorientation",
-      _gyroListener
-    );
-    _gyroListener = null;
-  }
-
-  if ( opts.gyroscope?.enabled && typeof window !== "undefined" ) {
-    _gyroListener = ( e ) => {
-      _gyro.beta = e.beta ?? 0;
-      _gyro.gamma = e.gamma ?? 0;
-    };
-    window.addEventListener(
-      "deviceorientation",
-      _gyroListener
-    );
-  }
+  // ── Gyroscope reset (lazy init triggered by _collectGyroscope) ───────────
+  _disposeGyro();
 
   // ── Raw mouse / touch tracking ───────────────────────────────────────────
   // We track raw clientX/Y ourselves so _clientToCanvas() can give correct
@@ -455,13 +533,7 @@ export function disposeInteraction() {
   }
 
   // Gyroscope
-  if ( _gyroListener ) {
-    window.removeEventListener(
-      "deviceorientation",
-      _gyroListener
-    );
-    _gyroListener = null;
-  }
+  _disposeGyro();
 
   // Mouse
   if ( _pointerMoveListener ) {
@@ -773,8 +845,10 @@ function _collectMouse(
     return;
   }
 
-  const ox = mouse.offsetX ?? 0;
-  const oy = mouse.offsetY ?? 0;
+  // `offset` is the vector2d pad value; offsetX/offsetY are kept as a fallback
+  // for options saved before the two sliders were merged into one pad.
+  const ox = mouse.offset?.x ?? mouse.offsetX ?? 0;
+  const oy = mouse.offset?.y ?? mouse.offsetY ?? 0;
   const smoothing = mouse.smoothing ?? 0;
 
   // Use raw client coordinates converted through getBoundingClientRect() so
@@ -1599,7 +1673,14 @@ function _collectGyroscope(
     return;
   }
 
+  // Trigger lazy listener wiring on first call (see _initGyro)
+  if ( !_gyroInitialized ) {
+    _initGyro();
+  }
+
   const clamp = gyro.clampAngle ?? 45;
+  const ox = gyro.offset?.x ?? 0;
+  const oy = gyro.offset?.y ?? 0;
 
   out.push( p.createVector(
     p.constrain(
@@ -1612,7 +1693,7 @@ function _collectGyroscope(
       ),
       0,
       p.width
-    ),
+    ) + ox,
     p.constrain(
       p.map(
         _gyro.beta,
@@ -1623,7 +1704,7 @@ function _collectGyroscope(
       ),
       0,
       p.height
-    )
+    ) + oy
   ) );
 }
 


### PR DESCRIPTION
## Problem

In the interaction-test sketch, the gyroscope handler always returned a vector at the centre of the canvas.

**Root cause:** the `deviceorientation` listener was only wired from `initInteraction()` when `gyroscope.enabled` was already `true` at setup time. Since the gyroscope starts disabled in the defaults and is toggled on at runtime through the options form, no listener was ever attached — `_gyro.beta`/`_gyro.gamma` stayed at `0`, and `map(0, -clamp, clamp, 0, width/height)` lands exactly at the canvas centre. This is the same class of bug previously fixed for the vision trackers with `_ensureVision()`.

On iOS 13+ there was a second blocker: `DeviceOrientationEvent.requestPermission()` must be called from a user gesture, so even a listener wired at setup would never receive events.

## Fix

- The gyroscope listener is now lazily wired from `_collectGyroscope()` on first use (same lazy-init pattern as MIDI and audio), so toggling it on at runtime works without a reload.
- On iOS, a one-shot tap/click handler requests the device-orientation permission from the required user gesture, then wires the listener once granted.
- `initInteraction()` / `disposeInteraction()` fully reset the gyroscope state (listener, pending permission handler, beta/gamma).

## Vector2D offsets

- The mouse handler's two `offsetX` / `offsetY` sliders are replaced by a single `offset: { x, y }` field using the `vector2d` pad component (`yDown: true` for screen-space dragging). Saved options using the legacy `offsetX`/`offsetY` keys still work via a fallback.
- The gyroscope handler gains the same `offset: { x, y }` vector2d field.

## Testing

- `eslint` passes on both modified files.
- `npm test`: 940/940 tests pass.

https://claude.ai/code/session_01RGiUqHcxSqfZiab1y5NzAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGiUqHcxSqfZiab1y5NzAJ)_