### PR TITLE
Ignore viewport touch pan/zoom while the sketch consumes touch input

### DIFF
--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -24,6 +24,7 @@ export default function ScalableViewport( {
   resolutionKey,
   isReady = true,
   disable = false,
+  disableTouchGestures = false,
   onInteractionStart,
   onInteractionEnd
 }: {
@@ -32,6 +33,9 @@ export default function ScalableViewport( {
   resolutionKey?: string;
   showZoomControls?: boolean;
   disable?: boolean;
+  // Ignore touchscreen pan/pinch so fingers reach the content instead of
+  // moving the viewport (mouse drag, wheel and zoom controls still work).
+  disableTouchGestures?: boolean;
   isReady?: boolean;
   onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
@@ -66,6 +70,7 @@ export default function ScalableViewport( {
     transform,
     setTransform,
     cancelAnimation,
+    disableTouchGestures,
     onInteractionStart,
     onInteractionEnd
   } );

--- a/src/components/ScalableViewport/hooks/useViewportGestures.ts
+++ b/src/components/ScalableViewport/hooks/useViewportGestures.ts
@@ -19,8 +19,23 @@ interface UseViewportGesturesProps {
     contentElement: HTMLDivElement | null
   ) => void;
   cancelAnimation: () => void;
+  disableTouchGestures?: boolean;
   onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
+}
+
+// True when the gesture originates from a touchscreen (finger on the canvas),
+// as opposed to a mouse drag or a trackpad wheel/pinch.
+function isTouchGesture( event: Event | undefined ): boolean {
+  if ( !event ) {
+    return false;
+  }
+
+  if ( "pointerType" in event ) {
+    return ( event as PointerEvent ).pointerType === "touch";
+  }
+
+  return event.type.startsWith( "touch" );
 }
 
 export function useViewportGestures( {
@@ -29,6 +44,7 @@ export function useViewportGestures( {
   transform,
   setTransform,
   cancelAnimation,
+  disableTouchGestures = false,
   onInteractionStart,
   onInteractionEnd
 }: UseViewportGesturesProps ) {
@@ -42,11 +58,26 @@ export function useViewportGestures( {
           return;
         }
 
+        // Fingers belong to the sketch (touch interaction source) — leave
+        // panning to the mouse / zoom controls so touching never moves the
+        // canvas nor pauses the loop.
+        if ( disableTouchGestures && isTouchGesture( event ) ) {
+          cancel();
+          return;
+        }
+
         cancelAnimation();
         onInteractionStart?.( "panning" );
       },
       onDragEnd: () => onInteractionEnd?.(),
-      onPinchStart: () => {
+      onPinchStart: ( {
+        event, cancel
+      } ) => {
+        if ( disableTouchGestures && isTouchGesture( event ) ) {
+          cancel();
+          return;
+        }
+
         cancelAnimation();
         onInteractionStart?.( "zooming" );
       },
@@ -84,6 +115,7 @@ export function useViewportGestures( {
 
       // Two-finger Pinch (Zoom + Pan)
       onPinch: ( {
+        event,
         origin: [
           originX,
           originY
@@ -92,11 +124,12 @@ export function useViewportGestures( {
           scale
         ],
         first,
-        memo
+        memo,
+        canceled
       } ) => {
         const container = containerRef.current;
 
-        if ( !container ) {
+        if ( !container || canceled || ( disableTouchGestures && isTouchGesture( event ) ) ) {
           return;
         }
 

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -198,6 +198,30 @@ export default function TemplateSketchPage() {
     ]
   );
 
+  // When the sketch consumes touch input (interaction.touch source), hand the
+  // touchscreen over to it: the viewport must not pan/zoom — nor pause the
+  // loop — on finger gestures. The options store is the only bridge needed;
+  // the sketch itself stays unaware of the UI. Mirrors the runtime merge in
+  // slides.getSketchSettings(): a slide-level `sketch` shallowly overrides
+  // the global one, so its `interaction` block wins when present.
+  const disableTouchGestures = useMemo(
+    () => {
+      const slideSketch = activeSlideIndex !== undefined
+        ? options?.slides?.[ activeSlideIndex ]?.sketch
+        : undefined;
+      const interaction = ( slideSketch?.interaction ?? options?.sketch?.interaction ) as
+        | { enabled?: boolean;
+          touch?: { enabled?: boolean } }
+        | undefined;
+
+      return interaction?.enabled !== false && interaction?.touch?.enabled === true;
+    },
+    [
+      options,
+      activeSlideIndex
+    ]
+  );
+
   return (
     <>
       {/* Loading placeholder */}
@@ -238,6 +262,7 @@ export default function TemplateSketchPage() {
           showZoomControls={ !capturing && sketchLoaded }
           resolutionKey={ `${ effectiveSettings.size.width }x${ effectiveSettings.size.height }` }
           isReady={ sketchLoaded }
+          disableTouchGestures={ disableTouchGestures }
           onInteractionStart={ handleInteractionStart }
           onInteractionEnd={ handleInteractionEnd }
         >


### PR DESCRIPTION
## Problem

When a sketch enables the `interaction.touch` source (e.g. the kinetic **interaction-test** sketch), finger gestures on the canvas are hijacked by `ScalableViewport`:

- a one-finger drag **pans** the viewport instead of feeding the sketch,
- a two-finger gesture **pinch-zooms** it,
- and both fire `onInteractionStart`, which **pauses the running loop** for the whole gesture.

Multitouch interaction with the sketch is therefore impossible.

## Solution

No new signal/event bus is needed: the **options store is already the bridge** between the UI and the sketch (the sketch reads `options.sketch.interaction`, and `TemplateSketchPage` owns the same options object).

- `TemplateSketchPage` derives a `disableTouchGestures` flag from `interaction.enabled !== false && interaction.touch.enabled === true`, honouring the per-slide `sketch` override exactly like the runtime's `slides.getSketchSettings()` (shallow spread — a slide-level `interaction` block wins when present).
- The flag is threaded through a new `ScalableViewport` prop down to `useViewportGestures`.
- The gesture hook **cancels drags and pinches whose `pointerType` is `touch`** before they start, so they never pan/zoom nor trigger the pause. The decision is made per gesture, live: toggling the Touch checkbox in the options panel takes effect immediately.

## What still works

- Mouse drag pan, wheel zoom, and trackpad pinch (ctrl+wheel — not a touch pointer).
- The zoom-control buttons (+ / − / fit / reset), so you can still frame the canvas on a touch device.
- The sketch's window-level `touchstart/move/end` listeners receive the touches untouched (`touch-action: none` on the container is unchanged, so the page never scrolls either).
- With Touch disabled (the default for all sketches), behaviour is strictly identical to before.

## Verification

- `eslint` clean on the three touched files.
- `npm test`: 940/940 pass.
- `next build` passes (pre-push hook).

https://claude.ai/code/session_01ErsRHa1G8jb3EfR2KNiws1

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErsRHa1G8jb3EfR2KNiws1)_