### PR TITLE
feat(ui): sketch breadcrumb with category link + clearable templates filters

### DIFF
--- a/src/app/templates/[engine]/[...sketch]/page.tsx
+++ b/src/app/templates/[engine]/[...sketch]/page.tsx
@@ -298,6 +298,7 @@ export default async function StudioPage( {
       <SketchContextProvider
         name={ sketchName }
         engineId={ engineId }
+        category={ sketchMeta.category }
         options={ sketchOptions }
         persistedJob={ persistedJob }
         sketchFormValues={ formValues }

--- a/src/components/ClientProcessingSketch/components/SketchProvider/types/SketchContextType.ts
+++ b/src/components/ClientProcessingSketch/components/SketchProvider/types/SketchContextType.ts
@@ -14,6 +14,7 @@ import type {
 export type SketchState = {
   name: string;
   engineId: string;
+  category?: string | null;
   capturing: boolean;
   options: SketchOption;
   persistedJob?: JobModel;
@@ -57,6 +58,7 @@ export type SketchAction =
 export type SketchContextProviderProps = {
   name: string;
   engineId: string;
+  category?: string | null;
   capturing: boolean;
   options: SketchOption;
   persistedJob?: JobModel;

--- a/src/components/TemplateSketchPage/SketchBreadcrumb.tsx
+++ b/src/components/TemplateSketchPage/SketchBreadcrumb.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+
+import {
+  getEngineLabel
+} from "@/engines/engineCatalog";
+
+type Props = {
+  engineId: string;
+  name: string;
+  category?: string | null;
+  activeSlideIndex?: number;
+};
+
+/**
+ * Breadcrumb displayed above the sketch preview canvas.
+ *
+ * Renders: <engine> · <category?> · <name> ( · slide <n>?)
+ *   - engine    → /templates/<engineId>
+ *   - category  → /templates/<engineId>?category=<category>
+ *   - name      → /templates/<engineId>/<category?>/<name>
+ *
+ * The category segment is skipped when the sketch has no category.
+ */
+export default function SketchBreadcrumb( {
+  engineId,
+  name,
+  category,
+  activeSlideIndex
+}: Props ) {
+  const engineLabel = getEngineLabel( engineId );
+  const sketchHref = category
+    ? `/templates/${ engineId }/${ category }/${ name }`
+    : `/templates/${ engineId }/${ name }`;
+
+  return (
+    <p className="truncate">
+      <Link
+        href={ `/templates/${ engineId }` }
+        target="_blank"
+      >
+        {engineLabel}
+      </Link>
+
+      {category && (
+        <>
+          <span className="text-xs">{" · "}</span>
+          <Link
+            href={ `/templates/${ engineId }?category=${ encodeURIComponent( category ) }` }
+            target="_blank"
+          >
+            {category}
+          </Link>
+        </>
+      )}
+
+      <span className="text-xs">{" · "}</span>
+      <Link
+        href={ sketchHref }
+        target="_blank"
+      >
+        {name}
+      </Link>
+
+      <span>
+        {activeSlideIndex !== undefined && ` · slide ${ activeSlideIndex + 1 }`}
+      </span>
+    </p>
+  );
+}

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import type React from "react";
 import {
   useCallback, useEffect, useMemo, useRef, useState
 } from "react";
 import AnimationProgressionBar from "@/components/AnimationProgressionBar";
 import EngineSketchRenderer from "@/components/TemplateSketchPage/EngineSketchRenderer";
+import SketchBreadcrumb from "@/components/TemplateSketchPage/SketchBreadcrumb";
 import SketchPerformanceLabel from "@/components/TemplateSketchPage/SketchPerformanceLabel";
 import {
   EngineControls
@@ -33,7 +33,7 @@ const TemplateOptions = dynamic( () =>
 export default function TemplateSketchPage() {
   const [
     {
-      name, capturing, options, persistedJob, engineId, sketchLoaded, activeSlideIndex,
+      name, capturing, options, persistedJob, engineId, category, sketchLoaded, activeSlideIndex,
       engine, looping
     },
     dispatch
@@ -254,25 +254,12 @@ export default function TemplateSketchPage() {
                 } as React.CSSProperties
               }
             >
-              <p className="truncate">
-                <Link
-                  href={ `/templates/${ engineId }` }
-                  target="_blank"
-                >
-                  {engineId}
-                </Link>
-                <span className="text-xs">{" · "}</span>
-                <Link
-                  href={ `/templates/${ engineId }/${ name }` }
-                  target="_blank"
-                >
-                  {name}
-                </Link>
-
-                <span>
-                  {activeSlideIndex !== undefined && ` · slide ${ activeSlideIndex + 1 }`}
-                </span>
-              </p>
+              <SketchBreadcrumb
+                engineId={ engineId }
+                name={ name }
+                category={ category }
+                activeSlideIndex={ activeSlideIndex }
+              />
 
               <SketchPerformanceLabel
                 targetFps={ effectiveSettings.animation?.framerate ?? 60 }

--- a/src/components/TemplatesList.tsx
+++ b/src/components/TemplatesList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  ChevronDown, Grid, List, Search
+  ChevronDown, Grid, List, Search, X
 } from "lucide-react";
 import {
   useRouter, useSearchParams
@@ -96,6 +96,22 @@ export default function TemplatesList( {
     search,
     setSearch
   ] = useState<string>( searchParams.get( "keyword" ) || "" );
+  const [
+    categoryFilter,
+    setCategoryFilter
+  ] = useState<string>( searchParams.get( "category" ) || "" );
+
+  // Keep category in sync with the URL so back/forward or external links
+  // (e.g. the sketch breadcrumb opening /templates/<engine>?category=...)
+  // update the active filter without a full reload.
+  useEffect(
+    () => {
+      setCategoryFilter( searchParams.get( "category" ) || "" );
+    },
+    [
+      searchParams
+    ]
+  );
 
   // Per-category expansion state. By default every category renders as a
   // horizontal carousel (no ids open); expanding one swaps it to the full
@@ -109,9 +125,10 @@ export default function TemplatesList( {
     PERSIST_EXPANDED
   );
 
-  // While a search is active, every matching section is shown as a full grid
-  // so all results are visible regardless of the carousel/expanded state.
-  const searchActive = search.trim().length > 0;
+  // While a search or category filter is active, every matching section is
+  // shown as a full grid so all results are visible regardless of the
+  // carousel/expanded state.
+  const searchActive = search.trim().length > 0 || categoryFilter.length > 0;
 
   // Expand/collapse a category. No View Transition here: the cards stay
   // mounted across the toggle and CategorySection animates only the newly
@@ -135,18 +152,42 @@ export default function TemplatesList( {
     ]
   );
 
-  // Keep ?keyword= in sync with the search state
+  // Build a `?keyword=…&category=…` suffix from the current filter state.
+  const buildQuerySuffix = (
+    keyword: string, category: string
+  ) => {
+    const params = new URLSearchParams();
+
+    if ( category ) {
+      params.set(
+        "category",
+        category
+      );
+    }
+
+    if ( keyword ) {
+      params.set(
+        "keyword",
+        keyword
+      );
+    }
+
+    const qs = params.toString();
+
+    return qs ? `?${ qs }` : "";
+  };
+
+  // Keep ?keyword= / ?category= in sync with the filter state.
   useEffect(
     () => {
       const basePath =
         currentEngine === "all" ? "/templates" : `/templates/${ currentEngine }`;
 
-      const newUrl = search
-        ? `${ basePath }?keyword=${ encodeURIComponent( search ) }`
-        : basePath;
-
       router.replace(
-        newUrl,
+        `${ basePath }${ buildQuerySuffix(
+          search,
+          categoryFilter
+        ) }`,
         {
           scroll: false
         }
@@ -154,7 +195,8 @@ export default function TemplatesList( {
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      search
+      search,
+      categoryFilter
     ]
   );
 
@@ -164,14 +206,15 @@ export default function TemplatesList( {
 
     const basePath =
       engineId === "all" ? "/templates" : `/templates/${ engineId }`;
-    const suffix = search
-      ? `?keyword=${ encodeURIComponent( search ) }`
-      : "";
 
-    router.push( `${ basePath }${ suffix }` );
+    router.push( `${ basePath }${ buildQuerySuffix(
+      search,
+      categoryFilter
+    ) }` );
   };
 
-  // Fuzzy-filter templates per engine
+  // Filter per engine: exact category match first (when active), then
+  // fuzzy keyword over the remaining items.
   const filteredTemplates = Object.entries( templates ).reduce(
     (
       acc, [
@@ -179,8 +222,12 @@ export default function TemplatesList( {
         items
       ]
     ) => {
+      const byCategory = categoryFilter
+        ? items.filter( ( item ) => item.category === categoryFilter )
+        : items;
+
       const filtered = fuzzyFilter(
-        items,
+        byCategory,
         search,
         ( item ) => [
           item.name,
@@ -250,8 +297,23 @@ export default function TemplatesList( {
               placeholder="Search templates..."
               value={ search }
               onChange={ ( e ) => setSearch( e.target.value ) }
-              className="pl-9 pr-3 py-2 sm:pl-11 sm:pr-4 sm:py-2.5 rounded-lg sm:rounded-xl w-full bg-background border border-border hover:border-foreground/30 focus:border-foreground/50 focus:outline-none focus:ring-2 focus:ring-foreground/10 transition-all text-xs sm:text-sm placeholder:text-foreground/40"
+              className={ `pl-9 py-2 sm:pl-11 sm:py-2.5 rounded-lg sm:rounded-xl w-full bg-background border border-border hover:border-foreground/30 focus:border-foreground/50 focus:outline-none focus:ring-2 focus:ring-foreground/10 transition-all text-xs sm:text-sm placeholder:text-foreground/40 ${
+                search
+                  ? "pr-9 sm:pr-11"
+                  : "pr-3 sm:pr-4"
+              }` }
             />
+            { search && (
+              <button
+                type="button"
+                onClick={ () => setSearch( "" ) }
+                aria-label="Clear search"
+                title="Clear search"
+                className="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 grid place-items-center w-6 h-6 sm:w-7 sm:h-7 rounded-md text-foreground/50 hover:text-foreground hover:bg-hover/50 transition-colors"
+              >
+                <X className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+              </button>
+            ) }
           </div>
 
           {/* View Toggle */}
@@ -283,6 +345,28 @@ export default function TemplatesList( {
             </button>
           </div>
         </div>
+
+        {/* Active filters — currently only the category chip */}
+        { categoryFilter && (
+          <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
+            <span className="text-xs text-foreground/50 font-medium">
+              Filters:
+            </span>
+            <span className="inline-flex items-center gap-1 sm:gap-1.5 pl-2 pr-1 sm:pl-2.5 sm:pr-1.5 py-0.5 sm:py-1 rounded-md sm:rounded-lg bg-hover/60 border border-border text-xs sm:text-sm text-foreground">
+              <span className="text-foreground/60">Category:</span>
+              <span className="font-medium">{ categoryFilter }</span>
+              <button
+                type="button"
+                onClick={ () => setCategoryFilter( "" ) }
+                aria-label={ `Remove ${ categoryFilter } category filter` }
+                title="Clear category filter"
+                className="grid place-items-center w-4 h-4 sm:w-5 sm:h-5 rounded-md text-foreground/50 hover:text-foreground hover:bg-hover transition-colors"
+              >
+                <X className="w-3 h-3 sm:w-3.5 sm:h-3.5" />
+              </button>
+            </span>
+          </div>
+        ) }
 
         {/* Engine Tabs */}
         <div className="flex gap-1.5 sm:gap-2 overflow-x-auto pb-0.5 scrollbar-hide">


### PR DESCRIPTION
## Summary

- Extract the `engine · name` label above the sketch preview canvas into a dedicated `SketchBreadcrumb` component, and slot the sketch's **category** between engine and name when one is set. Each segment is a link:
  - **engine** → `/templates/<engine>`
  - **category** → `/templates/<engine>?category=<category>`
  - **name** → canonical sketch page
- Plumb `category` from the sketch route through `SketchContextProvider`/`SketchState` so the breadcrumb has it client-side.
- Add a dedicated `?category=` filter to the templates gallery (exact match on `item.category`, applied **before** the existing fuzzy `?keyword=` search) so clicking a category breadcrumb only shows that category — not every template whose name happens to fuzzy-match.
- Surface the active category filter as a removable chip ("Category: X ×") above the engine tabs; clearing it strips `?category=` from the URL.
- Add a clear button (×) to the right of the search input that empties `?keyword=`.

## Test plan

- [ ] Open a sketch with a category → breadcrumb shows `<engine> · <category> · <name>`.
- [ ] Open a sketch without a category → breadcrumb skips the category segment.
- [ ] Click the category segment → templates page opens prefiltered, chip visible, only that category's items shown.
- [ ] Type a search term while the category chip is active → filtering narrows further within the category.
- [ ] Click the × on the chip → category filter cleared, URL no longer has `?category=`.
- [ ] Click the × inside the search input → keyword cleared, URL no longer has `?keyword=`.
- [ ] Browser back/forward across category links keeps the filter in sync.
- [ ] Switching engine tabs preserves both filters in the URL.

https://claude.ai/code/session_01X88tRYbsRLfaZpCJQjoXj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01X88tRYbsRLfaZpCJQjoXj6)_