### PR TITLE
fix(recording): restore play/pause state after browser recording + fix(p5): apply per-slide duration

### DIFF
--- a/src/components/AnimationProgressionBar.tsx
+++ b/src/components/AnimationProgressionBar.tsx
@@ -73,10 +73,17 @@ export default function AnimationProgressionBar( {
     {
       activeSlideIndex,
       engine,
-      looping
+      looping,
+      browserRecording
     },
     dispatch
   ] = useSketch();
+
+  // A browser-side recording owns the engine clock; let the user scrub
+  // mid-recording and the captured frames jump backwards (async-loop) or
+  // the live stream pauses (realtime). Lock interactions while a capture
+  // is in flight.
+  const interactionsLocked = disabled || browserRecording;
   const activeSlideIndexRef = useRef( activeSlideIndex );
 
   activeSlideIndexRef.current = activeSlideIndex;
@@ -301,7 +308,7 @@ export default function AnimationProgressionBar( {
 
   const handleClick = useCallback(
     ( event: React.MouseEvent ) => {
-      if ( disabled || isDraggingRef.current ) {
+      if ( interactionsLocked || isDraggingRef.current ) {
         return;
       }
 
@@ -311,7 +318,7 @@ export default function AnimationProgressionBar( {
       setAnimationProgression( calculateProgressionFromEvent( event ) );
     },
     [
-      disabled,
+      interactionsLocked,
       calculateProgressionFromEvent,
       setAnimationProgression
     ]
@@ -319,7 +326,7 @@ export default function AnimationProgressionBar( {
 
   const handlePointerDown = useCallback(
     ( event: React.PointerEvent ) => {
-      if ( disabled ) {
+      if ( interactionsLocked ) {
         return;
       }
 
@@ -340,7 +347,7 @@ export default function AnimationProgressionBar( {
       event.currentTarget.setPointerCapture( event.pointerId );
     },
     [
-      disabled,
+      interactionsLocked,
       calculateProgressionFromEvent,
       pauseLoopForScrubbing,
       setAnimationProgression,
@@ -409,7 +416,7 @@ export default function AnimationProgressionBar( {
 
   const handleMouseMove = useCallback(
     ( event: React.MouseEvent ) => {
-      if ( disabled || isDraggingRef.current ) {
+      if ( interactionsLocked || isDraggingRef.current ) {
         return;
       }
 
@@ -418,7 +425,7 @@ export default function AnimationProgressionBar( {
       setHoverPosition( calculateProgressionFromEvent( event ) );
     },
     [
-      disabled,
+      interactionsLocked,
       calculateProgressionFromEvent
     ]
   );
@@ -432,7 +439,7 @@ export default function AnimationProgressionBar( {
 
   const handleKeyDown = useCallback(
     ( event: React.KeyboardEvent ) => {
-      if ( disabled ) {
+      if ( interactionsLocked ) {
         return;
       }
 
@@ -462,7 +469,7 @@ export default function AnimationProgressionBar( {
       setAnimationProgression( next );
     },
     [
-      disabled,
+      interactionsLocked,
       progression,
       setAnimationProgression
     ]

--- a/src/components/ClientProcessingSketch/components/SketchProvider/SketchContextProvider.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchProvider/SketchContextProvider.tsx
@@ -53,6 +53,11 @@ function sketchReducer(
         ...state,
         capturing: action.payload
       };
+    case "SET_BROWSER_RECORDING":
+      return {
+        ...state,
+        browserRecording: action.payload
+      };
     default:
       return state;
   }
@@ -66,7 +71,8 @@ export default function SketchContextProvider( {
     ...props,
     sketchLoaded: false,
     engine: null,
-    looping: true
+    looping: true,
+    browserRecording: false
   };
 
   const [

--- a/src/components/ClientProcessingSketch/components/SketchProvider/types/SketchContextType.ts
+++ b/src/components/ClientProcessingSketch/components/SketchProvider/types/SketchContextType.ts
@@ -25,6 +25,12 @@ export type SketchState = {
   engine: SketchEngine | null;
   /** Whether the engine draw-loop is currently running. */
   looping: boolean;
+  /**
+   * True while a browser-side (frontend) recording is in progress. Used to
+   * lock playback controls (Play/Pause, progression scrub) so the user
+   * can't corrupt the in-flight capture or desync engine vs. looping state.
+   */
+  browserRecording: boolean;
 };
 
 export type SketchAction =
@@ -50,6 +56,10 @@ export type SketchAction =
   }
   | {
     type: "SET_CAPTURING";
+    payload: boolean
+  }
+  | {
+    type: "SET_BROWSER_RECORDING";
     payload: boolean
   };
 

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
@@ -18,6 +18,7 @@ import type {
 import type {
   SketchOption
 } from "@/types/sketch.types";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
 
 export type UseBrowserRecorderArgs = {
   engine: SketchEngine | null;
@@ -94,13 +95,63 @@ export function useBrowserRecorder( {
 
   sketchNameRef.current = sketchName;
 
+  // The recorder strategies unconditionally call `host.pause()` then
+  // `host.resume()` around the capture, which leaves the engine playing
+  // regardless of the playback state the user had set before. Snapshot
+  // `looping` at start and restore both the engine + React state on end
+  // so the Play/Pause button matches reality after every recording.
+  const [
+    {
+      looping
+    },
+    dispatch
+  ] = useSketch();
+  const loopingRef = useRef( looping );
+
+  loopingRef.current = looping;
+  const loopingAtStartRef = useRef<boolean>( true );
+  const engineAtStartRef = useRef<SketchEngine | null>( null );
+
   const cleanup = useCallback(
     () => {
       recorderRef.current = null;
       setIsRecording( false );
       setProgress( null );
+
+      // Restore engine playback to what it was before recording started.
+      // The strategies always leave the engine resumed in teardown, so a
+      // user who was paused would otherwise come back to a playing engine
+      // with a stale paused button.
+      const startEngine = engineAtStartRef.current;
+      const wasLooping = loopingAtStartRef.current;
+
+      if ( startEngine ) {
+        try {
+          if ( wasLooping ) {
+            startEngine.play();
+          } else {
+            startEngine.pause();
+          }
+        } catch {
+          // Restoring playback must never throw — recorder lifecycle
+          // events are still in flight when this runs.
+        }
+      }
+
+      engineAtStartRef.current = null;
+
+      dispatch( {
+        type: "SET_LOOPING",
+        payload: wasLooping
+      } );
+      dispatch( {
+        type: "SET_BROWSER_RECORDING",
+        payload: false
+      } );
     },
-    []
+    [
+      dispatch
+    ]
   );
 
   const start = useCallback(
@@ -183,7 +234,17 @@ export function useBrowserRecorder( {
       );
 
       recorderRef.current = recorder;
+      // Snapshot the engine + intended playback state before the recorder
+      // takes over. The strategies always end with `host.resume()`, so
+      // without this snapshot a sketch that was paused before recording
+      // would come back playing with a stale Pause icon.
+      engineAtStartRef.current = engine;
+      loopingAtStartRef.current = loopingRef.current;
       setIsRecording( true );
+      dispatch( {
+        type: "SET_BROWSER_RECORDING",
+        payload: true
+      } );
 
       try {
         await recorder.start();
@@ -200,7 +261,8 @@ export function useBrowserRecorder( {
       engine,
       options,
       activeSlideIndex,
-      cleanup
+      cleanup,
+      dispatch
     ]
   );
 

--- a/src/components/TemplateSketchPage/EngineControls.tsx
+++ b/src/components/TemplateSketchPage/EngineControls.tsx
@@ -24,7 +24,7 @@ type ThumbnailSaveState = "idle" | "saving" | "done" | "error";
 export function EngineControls( ) {
   const [
     {
-      engineId, name, engine, looping
+      engineId, name, engine, looping, browserRecording
     },
     dispatch
   ] = useSketch();
@@ -200,9 +200,16 @@ export function EngineControls( ) {
               payload: !looping
             } );
           } }
-          title={ looping ? "Pause animation" : "Play animation" }
+          disabled={ browserRecording }
+          title={
+            browserRecording
+              ? "Locked while recording"
+              : looping
+                ? "Pause animation"
+                : "Play animation"
+          }
           aria-label={ looping ? "Pause animation" : "Play animation" }
-          className="h-full px-3 hover:bg-hover transition-colors border-r border-border group inline-flex items-center justify-center"
+          className="h-full px-3 hover:bg-hover transition-colors border-r border-border group inline-flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
         >
           {looping ? (
             <Pause className="h-4 w-4 text-foreground/70 group-hover:text-foreground transition-colors" />

--- a/src/templates/p5/utils/__tests__/effectiveSlideDuration.test.ts
+++ b/src/templates/p5/utils/__tests__/effectiveSlideDuration.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for per-slide duration propagation.
+ *
+ * The engine clock (animation.progression, the animation bridge,
+ * window.get/setAnimationProgression) reads its duration from
+ * `sketch.sketchOptions.animation` — a snapshot, not the live option
+ * store. The bugs these tests guard against:
+ *
+ * 1. `slides.applyEffectiveSettings()` (slide switch) used to forward
+ *    size/framerate to the engine but never wrote the effective animation
+ *    into `sketch.sketchOptions` — AND it advanced the comparison baseline
+ *    via `syncEffectivePrevious`, so the subsequent `handleOptionsChange`
+ *    couldn't apply the duration either. Per-slide durations never reached
+ *    the running sketch.
+ *
+ * 2. The post-draw bookkeeping nulls `slides.index` while the option store
+ *    has no slides. Adding the first slide races that store update (React
+ *    calls `setSlide(0)` before the watch→dispatch round-trip lands), so
+ *    the index stayed null forever. Rendering coerces null→0, but the
+ *    effective-settings resolution treated null as "no slide" and silently
+ *    masked every per-slide override.
+ */
+
+// jest-environment-jsdom doesn't expose Node's structuredClone; the
+// option-sync layer relies on it being a browser global.
+if ( typeof globalThis.structuredClone !== "function" ) {
+  globalThis.structuredClone = ( value: unknown ) =>
+    JSON.parse( JSON.stringify( value ) );
+}
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const events = require( "@/p5/utils/events.js" ).default;
+const sketch = require( "@/p5/utils/sketch.js" ).default;
+const {
+  setContainer
+} = require( "@/p5/utils/sketch.js" );
+const slides = require( "@/p5/utils/slides/index.js" ).default;
+const {
+  registerEvents: registerOptionsEvents
+} = require( "@/p5/utils/options.js" );
+const {
+  setSketchOptions, getSketchOptions
+} = require( "@/p5/shared/syncSketchOptions.js" );
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function resetStore( opts: Record<string, unknown> ) {
+  const store = getSketchOptions();
+
+  for ( const key of Object.keys( store ) ) {
+    delete store[ key ];
+  }
+  Object.assign(
+    store,
+    JSON.parse( JSON.stringify( opts ) )
+  );
+}
+
+function freshOptions( overrides: Record<string, unknown> = {} ) {
+  return {
+    size: {
+      width: 1080,
+      height: 1350
+    },
+    animation: {
+      framerate: 60,
+      duration: 12
+    },
+    slides: [],
+    ...overrides
+  };
+}
+
+describe(
+  "per-slide effective duration",
+  () => {
+    beforeEach( () => {
+      // Reset module-level state shared across tests.
+      events.registeredEvents = {};
+      slides.index = 0;
+      sketch.sketchOptions = {
+        size: {
+          width: 1080,
+          height: 1350
+        },
+        animation: {
+          framerate: 60,
+          duration: 12
+        }
+      };
+
+      document.body.innerHTML = "";
+      setContainer( null );
+    } );
+
+    test(
+      "applyEffectiveSettings pushes the slide's duration into sketch.sketchOptions",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 4
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+        expect( sketch.sketchOptions.animation.framerate ).toBe( 60 );
+      }
+    );
+
+    test(
+      "switching between slides with different durations updates the engine clock each time",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 4
+              }
+            },
+            {
+              name: "Slide 2",
+              animation: {
+                framerate: 60,
+                duration: 8
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+
+        slides.setSlide( 1 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 8 );
+
+        slides.setSlide( 0 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+      }
+    );
+
+    test(
+      "slide without animation override falls back to the global animation",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1"
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( sketch.sketchOptions.animation.duration ).toBe( 12 );
+      }
+    );
+
+    test(
+      "option-store changes to the slide duration apply even when slides.index is null",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        // Activate the options subscription the way sketch.start() does.
+        registerOptionsEvents();
+        events.handle( "pre-setup" );
+
+        // Simulate the add-first-slide race aftermath: the index was nulled
+        // by a post-draw that ran before the store update landed.
+        slides.index = null;
+
+        // User edits the slide duration in the form → store update.
+        const next = JSON.parse( JSON.stringify( getSketchOptions() ) );
+
+        next.slides[ 0 ].animation.duration = 3;
+        setSketchOptions(
+          next,
+          "react"
+        );
+
+        expect( sketch.sketchOptions.animation.duration ).toBe( 3 );
+      }
+    );
+
+    test(
+      "post-draw recovers a nulled slides.index once slides exist in the store",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 5
+              }
+            }
+          ]
+        } ) );
+
+        // post-draw needs a canvas to do its bookkeeping.
+        const container = document.createElement( "div" );
+        const canvas = document.createElement( "canvas" );
+
+        canvas.className = "p5Canvas";
+        container.appendChild( canvas );
+        document.body.appendChild( container );
+        setContainer( container );
+
+        slides.registerEvents();
+        slides.index = null;
+
+        events.handle( "post-draw" );
+
+        expect( slides.index ).toBe( 0 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 5 );
+      }
+    );
+
+    test(
+      "post-draw still nulls the index when the store has no slides",
+      () => {
+        resetStore( freshOptions() );
+
+        const container = document.createElement( "div" );
+        const canvas = document.createElement( "canvas" );
+
+        canvas.className = "p5Canvas";
+        container.appendChild( canvas );
+        document.body.appendChild( container );
+        setContainer( container );
+
+        slides.registerEvents();
+        slides.index = 0;
+
+        events.handle( "post-draw" );
+
+        expect( slides.index ).toBeNull();
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/options.js
+++ b/src/templates/p5/utils/options.js
@@ -261,12 +261,17 @@ function isEqual(
 /**
  * Resolve the effective size/animation for the current slide.
  * Per-slide overrides win; otherwise global values are used.
+ *
+ * Uses the resolved `slide` object (not the raw index): rendering coerces
+ * a null/out-of-range index to slide 0, so the effective settings must
+ * follow the slide that is actually drawn — otherwise a transiently null
+ * index would silently mask every per-slide override.
  */
 function getEffective( opts ) {
-  const slideIndex = typeof window !== "undefined" && window.getCurrentSlide
-    ? window.getCurrentSlide()?.index
-    : undefined;
-  const slide = slideIndex != null ? opts?.slides?.[ slideIndex ] : null;
+  const current = typeof window !== "undefined" && window.getCurrentSlide
+    ? window.getCurrentSlide()
+    : null;
+  const slide = current?.slide ?? null;
 
   return {
     size: slide?.size ?? opts?.size,
@@ -323,31 +328,43 @@ function handleOptionsChange(
     }
   }
 
-  // Check for effective animation/framerate changes (slide override or global)
+  // Check for effective animation changes (slide override or global).
+  // Duration and framerate are decoupled: the engine clock must pick up a
+  // duration change even when the framerate is untouched (or missing from
+  // a partial per-slide override), so the sketchOptions update is never
+  // gated behind framerate validity.
   if ( effectiveAnimation && !isEqual(
     effectiveAnimation,
     previousOptions.effectiveAnimation
   ) ) {
     const framerate = effectiveAnimation?.framerate;
+    const previousFramerate = previousOptions.effectiveAnimation?.framerate;
 
-    if ( framerate && typeof framerate === "number" && framerate > 0 ) {
+    if (
+      framerate &&
+      typeof framerate === "number" &&
+      framerate > 0 &&
+      framerate !== previousFramerate
+    ) {
       events.handle(
         "engine-framerate-change",
         framerate
       );
+    }
 
-      // Update sketch options reference
-      if ( sketch.sketchOptions ) {
-        sketch.sketchOptions.animation = {
-          ...effectiveAnimation
-        };
-      }
-
-      previousOptions.effectiveAnimation = {
+    // Update sketch options reference — merge so a partial override
+    // (e.g. duration-only) doesn't drop the other animation keys.
+    if ( sketch.sketchOptions ) {
+      sketch.sketchOptions.animation = {
+        ...sketch.sketchOptions.animation,
         ...effectiveAnimation
       };
-      hasChanges = true;
     }
+
+    previousOptions.effectiveAnimation = {
+      ...effectiveAnimation
+    };
+    hasChanges = true;
   }
 
   // Also track raw globals for reference
@@ -385,6 +402,22 @@ function initializeOptionsSubscription() {
   // Get initial options and store them
   const initialOptions = getSketchOptions();
 
+  // Baseline on the *effective* values (per-slide overrides included) so
+  // a deck loaded with a slide whose animation differs from the globals
+  // starts from the right comparison point — and the engine clock starts
+  // on the slide's duration, not the global one.
+  const {
+    size: initialEffectiveSize,
+    animation: initialEffectiveAnimation
+  } = getEffective( initialOptions );
+
+  if ( initialEffectiveAnimation && sketch.sketchOptions ) {
+    sketch.sketchOptions.animation = {
+      ...sketch.sketchOptions.animation,
+      ...initialEffectiveAnimation
+    };
+  }
+
   previousOptions = {
     size: initialOptions?.size ? {
       ...initialOptions.size
@@ -392,11 +425,11 @@ function initializeOptionsSubscription() {
     animation: initialOptions?.animation ? {
       ...initialOptions.animation
     } : null,
-    effectiveSize: initialOptions?.size ? {
-      ...initialOptions.size
+    effectiveSize: initialEffectiveSize ? {
+      ...initialEffectiveSize
     } : null,
-    effectiveAnimation: initialOptions?.animation ? {
-      ...initialOptions.animation
+    effectiveAnimation: initialEffectiveAnimation ? {
+      ...initialEffectiveAnimation
     } : null,
     assets: initialOptions?.assets,
     slides: initialOptions?.slides

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -2,7 +2,7 @@ import options, {
   syncEffectivePrevious
 } from "../options.js";
 import events from "../events.js";
-import {
+import sketch, {
   getContainer, getP5
 } from "../sketch.js";
 
@@ -48,6 +48,14 @@ const slides = {
 
         if ( !slides.hasSlides ) {
           slides.index = null;
+        } else if ( slides.index == null ) {
+          // Recover from the add-first-slide race: React calls setSlide(0)
+          // before the new slide reaches the option store, so the very next
+          // post-draw (store still slide-less) nulled the index. Rendering
+          // coerces null→0 so it looks fine, but the effective-settings
+          // resolution (per-slide animation/size overrides) stays stuck on
+          // the globals until the index is restored.
+          slides.setSlide( 0 );
         }
 
         if ( canvas.dataset.slide !== slides.index ) {
@@ -131,6 +139,19 @@ const slides = {
         "engine-framerate-change",
         effectiveAnimation.framerate
       );
+    }
+
+    // The engine clock (animation.progression, the animation bridge,
+    // window.get/setAnimationProgression) reads duration from
+    // sketch.sketchOptions.animation — not from the option store. Without
+    // this write a per-slide duration override would never reach the
+    // running sketch: syncEffectivePrevious below updates the comparison
+    // baseline, so the next handleOptionsChange wouldn't apply it either.
+    if ( effectiveAnimation && sketch.sketchOptions ) {
+      sketch.sketchOptions.animation = {
+        ...sketch.sketchOptions.animation,
+        ...effectiveAnimation
+      };
     }
 
     // Keep previousOptions in options.js in sync so the next


### PR DESCRIPTION
## Summary

Two fixes, discovered in sequence while verifying the recording flow.

### 1. Browser recording desyncs the Play/Pause state

The frontend recorder strategies (`RealtimeRecorder`, `AsyncLoopRecorder`) unconditionally call `host.pause()` then `host.resume()` around a capture. That left the engine playing after recording even when the user had paused the sketch beforehand — and the React `looping` flag never moved, so the Play/Pause icon stayed stale. Toggling Play/Pause or scrubbing the progression bar during a capture made the desync worse and could corrupt the in-flight recording.

- `useBrowserRecorder` now snapshots the engine + intended `looping` value when a browser recording starts and restores both the engine playback and React state on every termination path (stop / cancel / error / synchronous start failure).
- Added a `browserRecording` flag to the sketch context (`SET_BROWSER_RECORDING` action), dispatched by `useBrowserRecorder`.
- `EngineControls` Play/Pause button is disabled while a frontend recording is in flight, with a "Locked while recording" tooltip.
- `AnimationProgressionBar` interactions (click, drag, hover, keyboard) are locked while a frontend recording is in flight.

### 2. Per-slide duration never reaches the running sketch

The engine clock (`animation.progression`, the animation bridge, `window.get/setAnimationProgression`) reads its duration from `sketch.sketchOptions.animation` — a snapshot, not the live option store. Two paths failed to keep that snapshot in sync, so editing a slide's duration in the options panel never changed the sketch speed:

- **`slides.applyEffectiveSettings()` (slide switch)** forwarded size/framerate to the engine but never wrote the effective animation into `sketch.sketchOptions` — and it advanced the comparison baseline via `syncEffectivePrevious`, preventing the next `handleOptionsChange` from applying the duration either. It now merges the effective animation into the snapshot.
- **`slides.index` stayed stuck at `null`**: adding the first slide races the form→store round-trip (React calls `setSlide(0)` before the watch→dispatch update lands), so the next post-draw nulled the index and nothing restored it. Rendering coerces `null→0` so the canvas looked right, but `getEffective()` treated `null` as "no slide" and silently masked every per-slide override forever. post-draw now recovers the index through `setSlide(0)` when slides exist, and `getEffective()` resolves overrides from the coerced current slide instead of the raw index.
- `handleOptionsChange`: the animation snapshot update is no longer gated behind framerate validity (duration-only / partial overrides apply; `engine-framerate-change` only fires when the framerate actually changed), and `initializeOptionsSubscription` baselines on the effective per-slide values so a deck loaded with slide overrides starts on the right duration.

Verified end-to-end with Playwright against the dev server on `photo-switch`:
- global duration change without slides: 12s → 3s ✓
- slide-duration edit after adding a slide: 12s → 3s ✓ (broken before the fix)
- per-slide durations (4s / 8s) follow slide switches both ways ✓

Covered by `effectiveSlideDuration.test.ts` — 4 of its 6 tests fail on the previous code.

## Test plan

- [ ] Pause the sketch, run an async-loop and a realtime browser recording — playback state and Play/Pause icon must be restored after each.
- [ ] During a browser recording, Play/Pause and the progression bar must be locked.
- [ ] On a slide-based template, change the active slide's Animation → Duration and confirm the sketch speed follows immediately.
- [ ] Switch between slides with different durations and confirm the loop length follows the active slide.
- [ ] `npm test` — 946 tests pass.

https://claude.ai/code/session_01Unm5WitUbJ3BV2mCfgbzsQ