### PR TITLE
fix: center the live previews toggle knob in the on state

### DIFF
--- a/src/components/AnimationsToggle.tsx
+++ b/src/components/AnimationsToggle.tsx
@@ -37,7 +37,7 @@ export default function AnimationsToggle( {
       >
         <span
           className={ `inline-block h-4 w-4 sm:h-5 sm:w-5 transform rounded-full bg-background shadow-sm transition-transform duration-200 ${
-            enabled ? "translate-x-4 sm:translate-x-5" : "translate-x-0.5"
+            enabled ? "translate-x-[18px] sm:translate-x-[22px]" : "translate-x-0.5"
           }` }
         />
       </button>


### PR DESCRIPTION
## Summary

The Live previews toggle on the templates page rendered correctly in the off state, but when toggled on, the white knob was misplaced: a noticeable gap appeared between the knob and the right edge of the track.

## Cause

In `src/components/AnimationsToggle.tsx`, the off state translates the knob 2px from the left edge (`translate-x-0.5`), but the on state translated by exactly the knob width (`translate-x-4` / `sm:translate-x-5`). That left an asymmetric gap on the right because the track is `knob_width + 2 * gap` wide, not `2 * knob_width`.

## Fix

Translate by `container_width − knob_width − 2px` so the right-side gap mirrors the left:
- small: `translate-x-[18px]` (was `translate-x-4` = 16px)
- sm: `translate-x-[22px]` (was `translate-x-5` = 20px)

## Test plan

- [ ] Open the templates page, toggle Live previews on — knob sits flush near the right edge with a small symmetric gap
- [ ] Toggle off — unchanged (still correct)
- [ ] Verify at both small and `sm:` breakpoints

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiDUz6uKVtZ6VjEtHNKgt3)_