### PR TITLE
feat(studio): sketch viewport shrinks above the open mobile drawer

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileStudioDrawer.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/MobileStudioDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {
-  useEffect, useState
+  useEffect, useRef, useState
 } from "react";
 import clsx from "clsx";
 import {
@@ -25,7 +25,7 @@ import {
   useSketchSettings, SketchSettingsActions
 } from "./SketchSettings/SketchSettings";
 import {
-  OPEN_EXPORT_DRAWER_EVENT
+  OPEN_EXPORT_DRAWER_EVENT, STUDIO_DRAWER_HEIGHT_VAR
 } from "../constants/drawer-events";
 import type {
   SketchOption
@@ -93,6 +93,50 @@ export default function MobileStudioDrawer( {
     setActiveTab
   ] = useState<Tab>( sketchConfig ? "sketch" : "template" );
 
+  // Publish the drawer's rendered height so the sketch viewport can shrink
+  // to the area above it (and fit-to-viewport targets the visible half).
+  // The ResizeObserver tracks the open/close animation and any future height
+  // changes; collapsed (pill) reserves nothing.
+  const rootRef = useRef<HTMLDivElement | null>( null );
+
+  useEffect(
+    () => {
+      const setHeightVar = ( px: number ) =>
+        document.documentElement.style.setProperty(
+          STUDIO_DRAWER_HEIGHT_VAR,
+          `${ Math.round( px ) }px`
+        );
+
+      const root = rootRef.current;
+
+      if ( !expanded || !root ) {
+        setHeightVar( 0 );
+
+        return;
+      }
+
+      const observer = new ResizeObserver( () => {
+        setHeightVar( root.getBoundingClientRect().height );
+      } );
+
+      observer.observe( root );
+
+      return () => observer.disconnect();
+    },
+    [
+      expanded
+    ]
+  );
+
+  // Release the reserved space entirely when the drawer leaves the tree
+  // (e.g. rotating into the desktop layout).
+  useEffect(
+    () => () => {
+      document.documentElement.style.removeProperty( STUDIO_DRAWER_HEIGHT_VAR );
+    },
+    []
+  );
+
   // The engine controls' record shortcut opens the drawer on the Export tab.
   useEffect(
     () => {
@@ -136,6 +180,7 @@ export default function MobileStudioDrawer( {
 
   return (
     <CollapsibleItem
+      rootRef={ rootRef }
       expanded={ expanded }
       onToggle={ onToggle }
       swipeToCollapse

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/constants/drawer-events.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/constants/drawer-events.ts
@@ -4,3 +4,11 @@
  * importers don't pull the whole drawer subtree into their bundle.
  */
 export const OPEN_EXPORT_DRAWER_EVENT = "studio:open-export-drawer";
+
+/**
+ * Root-level CSS variable holding the rendered height of the open mobile
+ * drawer (0 when collapsed or on desktop). The sketch viewport subtracts it
+ * from its own height so fit-to-viewport targets the visible area above the
+ * drawer.
+ */
+export const STUDIO_DRAWER_HEIGHT_VAR = "--studio-drawer-height";

--- a/src/components/CollapsibleItem.tsx
+++ b/src/components/CollapsibleItem.tsx
@@ -11,6 +11,8 @@ type CollapsibleItemProps = {
   initialExpandedValue?: boolean;
   children: React.ReactNode;
   className?: string;
+  /** Exposes the root element, e.g. to observe the rendered panel size. */
+  rootRef?: React.Ref<HTMLDivElement>;
   headerContainerClassName?: string;
   /**
    * Applied to the inner wrapper that holds the children. Use it to restore
@@ -59,7 +61,8 @@ const CollapsibleItem = ( {
   expanded: controlledExpanded,
   onToggle,
   swipeToCollapse = false,
-  keepMounted = false
+  keepMounted = false,
+  rootRef
 }: CollapsibleItemProps ) => {
   const [
     internalExpanded,
@@ -313,6 +316,7 @@ const CollapsibleItem = ( {
 
   return (
     <div
+      ref={ rootRef }
       className={ className }
       style={ {
         ...style,

--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -176,13 +176,11 @@ export default function ScalableViewport( {
   }
 
   return (
-    <div
-      ref={ containerRef }
-      className="w-full h-full overflow-hidden touch-none relative cursor-grab active:cursor-grabbing"
-      style={ {
-        touchAction: "none"
-      } }
-    >
+    <>
+      {/* Outside the overflow-hidden container so the controls can sit in
+          the top strip the page reserves for the floating bars on mobile —
+          they position against the page wrapper, whose origin stays at the
+          top of the screen regardless of that padding. */}
       {showZoomControls && (
         <ZoomControls
           scale={ displayScale }
@@ -194,11 +192,19 @@ export default function ScalableViewport( {
       )}
 
       <div
-        ref={ contentRef }
-        className="origin-top-left absolute top-0 left-0 will-change-transform"
+        ref={ containerRef }
+        className="w-full h-full overflow-hidden touch-none relative cursor-grab active:cursor-grabbing"
+        style={ {
+          touchAction: "none"
+        } }
       >
-        {children}
+        <div
+          ref={ contentRef }
+          className="origin-top-left absolute top-0 left-0 will-change-transform"
+        >
+          {children}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/TemplateSketchPage/EngineControls.tsx
+++ b/src/components/TemplateSketchPage/EngineControls.tsx
@@ -185,7 +185,7 @@ export function EngineControls( ) {
             rel="noopener noreferrer"
             title="View source code on GitHub"
             aria-label="View source code on GitHub"
-            className="h-full px-3 hover:bg-hover transition-colors border-r border-border group inline-flex items-center justify-center"
+            className="hidden md:inline-flex h-full px-3 hover:bg-hover transition-colors border-r border-border group items-center justify-center"
           >
             <Github className="h-4 w-4 text-foreground/70 group-hover:text-foreground transition-colors" />
           </Link>
@@ -233,7 +233,7 @@ export function EngineControls( ) {
           disabled={ thumbnailSaveState === "saving" }
           onClick={ handleCaptureClick }
           onDoubleClick={ handleSaveCanvasAsThumbnail }
-          className="h-full px-3 hover:bg-hover transition-colors group inline-flex items-center justify-center"
+          className="hidden md:inline-flex h-full px-3 hover:bg-hover transition-colors group items-center justify-center"
         >
           {thumbnailSaveState === "saving" ? (
             <Loader2 className="h-4 w-4 text-yellow-400/70 animate-spin" />
@@ -260,7 +260,7 @@ export function EngineControls( ) {
           aria-label="Open recording and export options"
           onClick={ () =>
             window.dispatchEvent( new CustomEvent( OPEN_EXPORT_DRAWER_EVENT ) ) }
-          className="h-full px-3 hover:bg-hover transition-colors border-l border-border group inline-flex items-center justify-center md:hidden"
+          className="h-full px-3 hover:bg-hover transition-colors group inline-flex items-center justify-center md:hidden"
         >
           <Circle className="h-4 w-4 fill-red-500/80 text-red-500/80 transition-colors group-hover:fill-red-500 group-hover:text-red-500" />
         </button>

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -26,6 +26,9 @@ import {
 import useSketchDevWatch from "@/hooks/useSketchDevWatch";
 import usePageVisibility from "@/hooks/usePageVisibility";
 import getSketchThumbnailURL from "@/utils/getSketchThumbnailURL";
+import {
+  STUDIO_DRAWER_HEIGHT_VAR
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/constants/drawer-events";
 
 const TemplateOptions = dynamic( () =>
   import( "@/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions" ) );
@@ -252,9 +255,14 @@ export default function TemplateSketchPage() {
         </div>
       )}
 
-      {/* Sketch viewport */}
+      {/* Sketch viewport — shrinks above the open mobile drawer so
+          fit-to-viewport targets the visible area (the container resize
+          triggers ScalableViewport's own refit observer). */}
       <div
-        className="h-full w-full relative"
+        className="w-full relative"
+        style={ {
+          height: `calc(100% - var(${ STUDIO_DRAWER_HEIGHT_VAR }, 0px))`
+        } }
         hidden={ !sketchLoaded }
       >
         <ScalableViewport

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -257,9 +257,12 @@ export default function TemplateSketchPage() {
 
       {/* Sketch viewport — shrinks above the open mobile drawer so
           fit-to-viewport targets the visible area (the container resize
-          triggers ScalableViewport's own refit observer). */}
+          triggers ScalableViewport's own refit observer). On mobile we
+          also reserve the top strip occupied by the engine and zoom
+          controls so the sketch header (engine · name · perf) never
+          slides under them when the drawer compresses the viewport. */}
       <div
-        className="w-full relative"
+        className="w-full relative pt-12 md:pt-0"
         style={ {
           height: `calc(100% - var(${ STUDIO_DRAWER_HEIGHT_VAR }, 0px))`
         } }


### PR DESCRIPTION
## Summary

Follow-up to #107. On mobile, fit-to-viewport targeted the full screen, so the open studio drawer covered the bottom half of the fitted canvas — you couldn't tweak a value and watch the whole result.

The drawer now publishes its rendered height (a `ResizeObserver` on the panel root) into a root-level CSS variable (`--studio-drawer-height`), and the sketch viewport wrapper subtracts it from its own height. Shrinking the container triggers `ScalableViewport`'s existing container resize observer, so **auto-fit, the manual fit button, centering and pan bounds all target the visible area above the drawer** — a true 50/50 split where the whole canvas (title and progression bar included) stays visible while editing.

Behavior:
- the variable follows the drawer's real rendered height: the open/close animation drives it frame-by-frame, shorter content reserves less, and any future snap-point/drag-height feature is picked up for free
- collapsed pill or desktop layout → variable resets to 0, viewport reclaims the full screen
- `CollapsibleItem` gains a `rootRef` prop to expose its panel element for measurement

## Verification

Production build driven with Playwright (iPhone 14 viewport): drawer open → `--studio-drawer-height: 265px`, canvas bottom at y=504 vs drawer top at y=579 (entire canvas visible above the drawer); collapse → variable back to `0px` and the canvas refits to the full screen; reopen → split restored. `tsc` and `next build` pass (only pre-existing `traceLetters.test.ts` errors).

https://claude.ai/code/session_01RcYKbHuJN6USB9SD6RDsTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcYKbHuJN6USB9SD6RDsTp)_