### PR TITLE
fix(interaction): per-frame guards, in-place trail pulls, chase mode

### DIFF
--- a/src/templates/p5/sketches/splines/_shared.js
+++ b/src/templates/p5/sketches/splines/_shared.js
@@ -3,6 +3,7 @@ import {
 } from "@/p5/utils/sketch.js";
 import colors from "@/p5/utils/colors.js";
 import animation from "@/p5/utils/animation.js";
+import easing from "@/p5/utils/easing.js";
 import createGlowBatchRenderer from "@/p5/utils/glowBatchGpu.js";
 
 // The glowing curve used to be stroked segment-by-segment on the CPU, once per
@@ -562,21 +563,53 @@ export function drawPointMarkers(
 }
 
 /**
+ * Per-segment half-thickness factor for the variable-thickness stroke profile.
+ * t is the segment midpoint along the curve, 0..1. Returns 1.0 for closed curves
+ * (no start/end to taper) and lerps between startFactor → 1 → endFactor with the
+ * chosen easing for open curves, so the user can independently dial the start
+ * thickness, the end thickness, and how aggressive the transition is.
+ */
+function _thicknessProfile(
+  t, startFactor, endFactor, easeFn, closed
+) {
+  if ( closed || ( startFactor === 1 && endFactor === 1 ) ) {
+    return 1;
+  }
+
+  if ( t <= 0.5 ) {
+    return startFactor + ( 1 - startFactor ) * easeFn( t * 2 );
+  }
+
+  return 1 + ( endFactor - 1 ) * easeFn( ( t - 0.5 ) * 2 );
+}
+
+/**
  * Queue one spline's dense Chaikin polyline onto the GPU stroke batch: open a new
- * stroke group, then push one segment per dense edge with its hue. The hue is the
- * only thing that varies along the curve — the per-layer thickness and opacity are
- * applied by the GPU when `drawStrokes` re-draws the geometry — so each segment is
- * emitted ONCE here instead of once per glow layer.
+ * stroke group, then push one segment per dense edge with its hue + half-thickness
+ * factor. Per-layer thickness and opacity are still applied by the GPU when
+ * `drawStrokes` re-draws the geometry — so each segment is emitted ONCE here
+ * instead of once per glow layer.
  *
  *   gradient → hue swept along the path (a free neon gradient).
  *   uniform  → a single hue for the whole stroke (still drifts with time).
+ *
+ * `hueSpread` stretches the gradient across more of the rainbow (>1 = several
+ * cycles along the curve, <1 = a calmer band), `hueOffset` shifts the starting
+ * colour, and `hueEasing` reshapes the distribution so the user can move the
+ * colour density toward either end of the spline.
  */
 function emitStroke(
   points, {
     iterations,
     closed,
     hueSpeed,
-    gradient
+    hueSpread,
+    hueOffset,
+    hueEaseFn,
+    gradient,
+    weightStart,
+    weightEnd,
+    weightEaseFn
   }
 ) {
   const dense = chaikinFlat(
@@ -592,23 +625,37 @@ function emitStroke(
   }
 
   const angle = animation.angle;
-  const uniformHue = Math.sin( angle * hueSpeed ) * TWO_PI;
+  const timeHue = angle * hueSpeed;
+  const uniformHue = timeHue + hueOffset;
+  const denom = Math.max(
+    1,
+    segments - ( closed ? 0 : 1 )
+  );
 
   batch.openStroke();
 
   for ( let i = 0; i < segments; i++ ) {
     const ai = i * 2;
     const bi = ( ( i + 1 ) % total ) * 2;
+    const t = i / denom;
     const hueIndex = gradient
-      ? Math.sin( ( i / segments ) * TWO_PI + angle * hueSpeed ) * TWO_PI
+      ? hueOffset + timeHue + hueEaseFn( t ) * TWO_PI * hueSpread
       : uniformHue;
+    const halfFactor = _thicknessProfile(
+      ( i + 0.5 ) / segments,
+      weightStart,
+      weightEnd,
+      weightEaseFn,
+      closed
+    );
 
     batch.strokeSegment(
       dense[ ai ],
       dense[ ai + 1 ],
       dense[ bi ],
       dense[ bi + 1 ],
-      hueIndex
+      hueIndex,
+      halfFactor
     );
   }
 }
@@ -716,7 +763,13 @@ export function renderSplines(
     tension: curve.tension ?? 0,
     weight: stroke.weight ?? 6,
     glow: stroke.glow ?? 3,
-    hueSpeed: stroke.hueSpeed ?? 1
+    hueSpeed: stroke.hueSpeed ?? 1,
+    hueSpread: stroke.hueSpread ?? 1,
+    hueOffset: stroke.hueOffset ?? 0,
+    hueEaseFn: easing[ stroke.hueEasing ] ?? easing.linear,
+    weightStart: stroke.weightStart ?? 1,
+    weightEnd: stroke.weightEnd ?? 1,
+    weightEaseFn: easing[ stroke.weightEasing ] ?? easing.linear
   };
 
   // Raw polygon overlay (behind the curve), straight onto the p2d canvas.
@@ -744,7 +797,13 @@ export function renderSplines(
         iterations: curveOptions.iterations,
         closed,
         hueSpeed: curveOptions.hueSpeed,
-        gradient
+        hueSpread: curveOptions.hueSpread,
+        hueOffset: curveOptions.hueOffset,
+        hueEaseFn: curveOptions.hueEaseFn,
+        gradient,
+        weightStart: curveOptions.weightStart,
+        weightEnd: curveOptions.weightEnd,
+        weightEaseFn: curveOptions.weightEaseFn
       }
     ) );
     batch.drawStrokes( {

--- a/src/templates/p5/sketches/splines/splines-v0-chaikin/options.ts
+++ b/src/templates/p5/sketches/splines/splines-v0-chaikin/options.ts
@@ -16,7 +16,20 @@ export const formValues = {
   stroke: {
     weight: 27,
     glow: 2,
+    // Variable thickness profile: 0..2 multipliers on `weight` at each end of the
+    // (open) spline with an easing for the transition. Both at 1 = uniform tube.
+    // Only applies to open curves — a closed loop has no start/end to taper.
+    weightStart: 1,
+    weightEnd: 1,
+    weightEasing: "linear",
     hueSpeed: 2,
+    // Colour spread along the curve: hueSpread scales how many rainbow cycles
+    // fit between the ends, hueOffset shifts the starting colour and hueEasing
+    // reshapes the distribution so the user can move the colour density toward
+    // either tip. Default = one cycle spread evenly across the curve.
+    hueSpread: 1,
+    hueOffset: 0,
+    hueEasing: "linear",
     gradient: true
   },
   overlay: {
@@ -166,11 +179,29 @@ export const formConfiguration: Record<string, any> = {
     component: "nested-object",
     fields: {
       weight: {
-        label: "Weight",
+        label: "Weight (middle of the curve)",
         component: "slider",
         min: 1,
         max: 40,
         step: 0.5
+      },
+      weightStart: {
+        label: "Weight × at start (open curves only)",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.05
+      },
+      weightEnd: {
+        label: "Weight × at end (open curves only)",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.05
+      },
+      weightEasing: {
+        label: "Weight taper easing",
+        component: "easing"
       },
       glow: {
         label: "Glow layers",
@@ -180,11 +211,29 @@ export const formConfiguration: Record<string, any> = {
         step: 1
       },
       hueSpeed: {
-        label: "Hue speed",
+        label: "Hue speed (over time)",
         component: "slider",
         min: 0,
         max: 5,
         step: 0.1
+      },
+      hueSpread: {
+        label: "Hue spread along path (Chaikin only)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 0.05
+      },
+      hueOffset: {
+        label: "Hue offset",
+        component: "slider",
+        min: -Math.PI,
+        max: Math.PI,
+        step: 0.01
+      },
+      hueEasing: {
+        label: "Hue spread easing",
+        component: "easing"
       },
       gradient: {
         label: "Gradient along path (Chaikin only)",

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
@@ -125,9 +125,8 @@ function collectLive( groups ) {
 }
 
 function collectTrails(
-  groups, mode, recallSpeed = 0
+  groups, mode, behaviour = "trail", pullSpeed = 0
 ) {
-  const p = getP5();
   const maxPoints = mode.maxPoints ?? 90;
   const minDistance = mode.minDistance ?? 6;
   const present = new Set();
@@ -142,19 +141,49 @@ function collectTrails(
       ? group.points[ group.points.length - 1 ]
       : centroid( group.points );
 
-    // In `recall` mode every existing trail point lerps a step toward the live
-    // anchor each frame, so the moment the entity stops feeding new points the
-    // tail visibly collapses back into the anchor — turning the trail into an
-    // elastic ribbon instead of a static drawing. When recallSpeed is 0 this is
-    // a no-op so the classic `trail` mode is unchanged.
-    if ( recallSpeed > 0 ) {
-      const entry = trails.get( group.id );
+    const entry = trails.get( group.id );
 
-      if ( entry ) {
-        entry.points = entry.points.map( ( pt ) => p.createVector(
-          pt.x + ( anchor.x - pt.x ) * recallSpeed,
-          pt.y + ( anchor.y - pt.y ) * recallSpeed
-        ) );
+    // Both `recall` and `chase` retract the existing trail toward the live
+    // anchor each frame; what differs is how the points get there.
+    //
+    //   recall → every point lerps directly at `pullSpeed` toward the anchor,
+    //            so the whole tail collapses along the straight line between
+    //            it and the anchor.
+    //   chase  → every point lerps toward its SUCCESSOR (the newer neighbour),
+    //            and the newest point lerps toward the anchor — so the chain
+    //            collapses by following the path that earlier points carved.
+    //
+    // Both branches mutate the existing vectors in place instead of replacing
+    // them with new ones, because the per-frame allocation churn ( N points ×
+    // M entities × hundreds of frames ) was triggering enough GC to slow the
+    // sketch down by itself in long recall sessions.
+    if ( entry && entry.points.length > 0 && pullSpeed > 0 ) {
+      const points = entry.points;
+      const n = points.length;
+
+      if ( behaviour === "chase" ) {
+        // Older first: each point's new target is the NEWER neighbour BEFORE
+        // we mutate it, so the chain shifts smoothly along the recorded path
+        // instead of compressing in a single frame.
+        for ( let i = 0; i < n - 1; i++ ) {
+          const target = points[ i + 1 ];
+
+          points[ i ].x += ( target.x - points[ i ].x ) * pullSpeed;
+          points[ i ].y += ( target.y - points[ i ].y ) * pullSpeed;
+        }
+
+        const head = points[ n - 1 ];
+
+        head.x += ( anchor.x - head.x ) * pullSpeed;
+        head.y += ( anchor.y - head.y ) * pullSpeed;
+      } else {
+        // recall: straight pull toward the anchor.
+        for ( let i = 0; i < n; i++ ) {
+          const pt = points[ i ];
+
+          pt.x += ( anchor.x - pt.x ) * pullSpeed;
+          pt.y += ( anchor.y - pt.y ) * pullSpeed;
+        }
       }
     }
 
@@ -221,18 +250,30 @@ sketch.draw( () => {
   const curve = o.curve ?? {};
   const stroke = o.stroke ?? {};
 
-  if ( modeType === "trail" || modeType === "recall" ) {
+  if ( modeType === "trail" || modeType === "recall" || modeType === "chase" ) {
     // Trails are time-series ribbons, so the raw-polygon / point markers overlay
     // (which annotates the source points) is intentionally suppressed. `recall`
-    // is `trail` with a non-zero pull-back factor so the tail gathers when the
-    // entity stops moving — same renderer, same overlay rules.
-    const recallSpeed = modeType === "recall" ? ( mode.recallSpeed ?? 0.08 ) : 0;
+    // and `chase` are `trail` with non-zero pull-back factors — recall pulls
+    // every point straight toward the anchor (collapses along the line),
+    // chase makes each point follow its newer neighbour (collapses along the
+    // recorded path). Same renderer, same overlay rules.
+    let behaviour = "trail";
+    let pullSpeed = 0;
+
+    if ( modeType === "recall" ) {
+      behaviour = "recall";
+      pullSpeed = mode.recallSpeed ?? 0.08;
+    } else if ( modeType === "chase" ) {
+      behaviour = "chase";
+      pullSpeed = mode.chaseSpeed ?? 0.12;
+    }
 
     renderSplines(
       collectTrails(
         groups,
         mode,
-        recallSpeed
+        behaviour,
+        pullSpeed
       ),
       {
         curve,

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
@@ -31,8 +31,8 @@ import {
 // It works with no webcam out of the box because the orbit source is enabled by
 // default; turn on Vision → Hands / Body / Face to drive it with the camera.
 
-// Per-entity trail history for "trail" mode, keyed by group id so each hand /
-// pose / source keeps its own ribbon.
+// Per-entity trail history for "trail" / "recall" modes, keyed by group id so
+// each hand / pose / source keeps its own ribbon.
 const trails = new Map();
 
 function centroid( points ) {
@@ -93,8 +93,9 @@ function collectLive( groups ) {
 }
 
 function collectTrails(
-  groups, mode
+  groups, mode, recallSpeed = 0
 ) {
+  const p = getP5();
   const maxPoints = mode.maxPoints ?? 90;
   const minDistance = mode.minDistance ?? 6;
   const present = new Set();
@@ -108,6 +109,22 @@ function collectTrails(
     const anchor = group.source === "fingers"
       ? group.points[ group.points.length - 1 ]
       : centroid( group.points );
+
+    // In `recall` mode every existing trail point lerps a step toward the live
+    // anchor each frame, so the moment the entity stops feeding new points the
+    // tail visibly collapses back into the anchor — turning the trail into an
+    // elastic ribbon instead of a static drawing. When recallSpeed is 0 this is
+    // a no-op so the classic `trail` mode is unchanged.
+    if ( recallSpeed > 0 ) {
+      const entry = trails.get( group.id );
+
+      if ( entry ) {
+        entry.points = entry.points.map( ( pt ) => p.createVector(
+          pt.x + ( anchor.x - pt.x ) * recallSpeed,
+          pt.y + ( anchor.y - pt.y ) * recallSpeed
+        ) );
+      }
+    }
 
     pushTrailPoint(
       group.id,
@@ -172,13 +189,18 @@ sketch.draw( () => {
   const curve = o.curve ?? {};
   const stroke = o.stroke ?? {};
 
-  if ( modeType === "trail" ) {
+  if ( modeType === "trail" || modeType === "recall" ) {
     // Trails are time-series ribbons, so the raw-polygon / point markers overlay
-    // (which annotates the source points) is intentionally suppressed.
+    // (which annotates the source points) is intentionally suppressed. `recall`
+    // is `trail` with a non-zero pull-back factor so the tail gathers when the
+    // entity stops moving — same renderer, same overlay rules.
+    const recallSpeed = modeType === "recall" ? ( mode.recallSpeed ?? 0.08 ) : 0;
+
     renderSplines(
       collectTrails(
         groups,
-        mode
+        mode,
+        recallSpeed
       ),
       {
         curve,

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/index.js
@@ -87,9 +87,41 @@ function pushTrailPoint(
 }
 
 // One ordered point list per live entity, so every spline in the frame can be
-// drawn in a single batched pass.
+// drawn in a single batched pass. Multi-point flat sources (orbit, perlinNoise,
+// audio, …) now arrive as one group per point — great for trail/recall mode
+// where each point gets its own ribbon, but useless on its own for a LIVE
+// spline (a single point can't form a curve). Re-aggregate same-source
+// singletons here so the source still draws as one connected polyline in live
+// mode, matching the prior look while keeping trail/recall split per-point.
 function collectLive( groups ) {
-  return groups.map( ( group ) => group.points );
+  const lists = [];
+  const singletonsBySource = new Map();
+
+  groups.forEach( ( group ) => {
+    if ( group.points.length >= 2 ) {
+      lists.push( group.points );
+
+      return;
+    }
+
+    if ( group.points.length === 1 ) {
+      const accumulator = singletonsBySource.get( group.source ) ?? [];
+
+      accumulator.push( group.points[ 0 ] );
+      singletonsBySource.set(
+        group.source,
+        accumulator
+      );
+    }
+  } );
+
+  for ( const points of singletonsBySource.values() ) {
+    if ( points.length >= 2 ) {
+      lists.push( points );
+    }
+  }
+
+  return lists;
 }
 
 function collectTrails(

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
@@ -5,10 +5,14 @@ import {
 
 export const formValues = {
   mode: {
-    type: "live" as "live" | "trail",
+    type: "live" as "live" | "trail" | "recall",
     smoothing: 0.35,
     maxPoints: 25,
-    minDistance: 6
+    minDistance: 6,
+    // How fast each trail point is pulled back toward the current anchor every
+    // frame in `recall` mode (0 = stays put like classic trail, 1 = collapses
+    // instantly). Ignored in `live` and `trail`.
+    recallSpeed: 0.08
   },
 
   // A virtual orbit source is on by default so the sketch animates immediately
@@ -51,7 +55,20 @@ export const formValues = {
   stroke: {
     weight: 19.5,
     glow: 2,
+    // Variable thickness profile: 0..2 multipliers on `weight` at each end of the
+    // open spline, with an easing for the transition. Both at 1 = uniform thickness
+    // (the classic tube). Both at 0 = both ends taper to a pointy nib.
+    weightStart: 0,
+    weightEnd: 0,
+    weightEasing: "easeOutQuad",
     hueSpeed: 1.5,
+    // Colour spread along the curve: hueSpread scales how many rainbow cycles
+    // fit between the ends (>1 = several cycles, <1 = a calmer band), hueOffset
+    // shifts the starting colour, and hueEasing reshapes the distribution so the
+    // user can move the colour density toward either tip.
+    hueSpread: 2,
+    hueOffset: 0,
+    hueEasing: "linear",
     gradient: true
   },
 
@@ -112,6 +129,10 @@ export const formConfiguration: Record<string, any> = {
           {
             label: "Trail (draw in the air)",
             value: "trail"
+          },
+          {
+            label: "Recall (trail that gathers back when still)",
+            value: "recall"
           }
         ]
       },
@@ -135,6 +156,13 @@ export const formConfiguration: Record<string, any> = {
         min: 0,
         max: 40,
         step: 1
+      },
+      recallSpeed: {
+        label: "Recall speed (recall mode)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
       }
     }
   },
@@ -189,11 +217,29 @@ export const formConfiguration: Record<string, any> = {
     component: "nested-object",
     fields: {
       weight: {
-        label: "Weight",
+        label: "Weight (middle of the curve)",
         component: "slider",
         min: 1,
         max: 40,
         step: 0.5
+      },
+      weightStart: {
+        label: "Weight × at start (Chaikin only)",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.05
+      },
+      weightEnd: {
+        label: "Weight × at end (Chaikin only)",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.05
+      },
+      weightEasing: {
+        label: "Weight taper easing",
+        component: "easing"
       },
       glow: {
         label: "Glow layers",
@@ -203,11 +249,29 @@ export const formConfiguration: Record<string, any> = {
         step: 1
       },
       hueSpeed: {
-        label: "Hue speed",
+        label: "Hue speed (over time)",
         component: "slider",
         min: 0,
         max: 5,
         step: 0.1
+      },
+      hueSpread: {
+        label: "Hue spread along path (Chaikin only)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 0.05
+      },
+      hueOffset: {
+        label: "Hue offset",
+        component: "slider",
+        min: -Math.PI,
+        max: Math.PI,
+        step: 0.01
+      },
+      hueEasing: {
+        label: "Hue spread easing",
+        component: "easing"
       },
       gradient: {
         label: "Gradient along path (Chaikin only)",

--- a/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
+++ b/src/templates/p5/sketches/splines/splines-v1-interactive/options.ts
@@ -5,14 +5,18 @@ import {
 
 export const formValues = {
   mode: {
-    type: "live" as "live" | "trail" | "recall",
+    type: "live" as "live" | "trail" | "recall" | "chase",
     smoothing: 0.35,
     maxPoints: 25,
     minDistance: 6,
     // How fast each trail point is pulled back toward the current anchor every
     // frame in `recall` mode (0 = stays put like classic trail, 1 = collapses
-    // instantly). Ignored in `live` and `trail`.
-    recallSpeed: 0.08
+    // instantly). Ignored in `live` / `trail` / `chase`.
+    recallSpeed: 0.08,
+    // Same idea for `chase` mode, but each point lerps toward its NEWER
+    // neighbour (the newest follows the live anchor) so the chain collapses
+    // ALONG the recorded path instead of jumping straight to the anchor.
+    chaseSpeed: 0.12
   },
 
   // A virtual orbit source is on by default so the sketch animates immediately
@@ -133,6 +137,10 @@ export const formConfiguration: Record<string, any> = {
           {
             label: "Recall (trail that gathers back when still)",
             value: "recall"
+          },
+          {
+            label: "Chase (trail that retracts along its own path)",
+            value: "chase"
           }
         ]
       },
@@ -159,6 +167,13 @@ export const formConfiguration: Record<string, any> = {
       },
       recallSpeed: {
         label: "Recall speed (recall mode)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      chaseSpeed: {
+        label: "Chase speed (chase mode)",
         component: "slider",
         min: 0,
         max: 1,

--- a/src/templates/p5/utils/glowBatchGpu.js
+++ b/src/templates/p5/utils/glowBatchGpu.js
@@ -30,9 +30,13 @@ import {
 //
 //   Mode B — stroke layers (one polyline drawn once, re-drawn per glow layer):
 //     batch.beginStrokes();
-//     batch.openStroke();                                  // one per spline
-//     batch.strokeSegment(ax, ay, bx, by, hueIndex);       // per dense segment
-//     batch.drawStrokes({ weight, glow });                 // hueOffset defaults 0
+//     batch.openStroke();                                              // one per spline
+//     batch.strokeSegment(ax, ay, bx, by, hueIndex, halfFactor);       // per dense segment
+//     batch.drawStrokes({ weight, glow });                             // hueOffset defaults 0
+//
+//   `halfFactor` is an optional per-segment multiplier on the per-layer half
+//   thickness (defaults to 1.0 — uniform stroke). Pass a 0..1 factor that varies
+//   along the polyline to taper the ends to a point, swell the middle, etc.
 //
 //   In Mode B the geometry is uploaded once and re-drawn `glow + 1` times with
 //   the per-layer half-thickness and opacityFactor supplied as constants, so the
@@ -48,12 +52,13 @@ import {
 // Mode A instance: vec4 segment, half-thickness, hueOffset, hueIndex, opacity.
 const FLOATS_A = 8;
 
-// Mode B segment: vec4 segment + hueIndex (half/hueOffset/opacity are constants).
-const FLOATS_B = 5;
+// Mode B segment: vec4 segment + hueIndex + halfFactor (per-segment thickness
+// multiplier; half/hueOffset/opacity remain per-layer constants).
+const FLOATS_B = 6;
 
 const BYTES_PER_FLOAT = 4;
 const STRIDE_A = FLOATS_A * BYTES_PER_FLOAT; // 32
-const STRIDE_B = FLOATS_B * BYTES_PER_FLOAT; // 20
+const STRIDE_B = FLOATS_B * BYTES_PER_FLOAT; // 24
 
 // Antialiasing half-band, in pixels, applied around every capsule edge.
 const EDGE_PAD = 1.0;
@@ -61,12 +66,13 @@ const EDGE_PAD = 1.0;
 const VERT_SRC = `
   precision highp float;
 
-  attribute vec2  aCorner;    // unit quad: x in [0,1] along the segment, y in [-1,1] across
-  attribute vec4  aSeg;       // (ax, ay, bx, by) in pixels, top-left origin
-  attribute float aHalf;      // half thickness in pixels
+  attribute vec2  aCorner;     // unit quad: x in [0,1] along the segment, y in [-1,1] across
+  attribute vec4  aSeg;        // (ax, ay, bx, by) in pixels, top-left origin
+  attribute float aHalf;       // base half thickness in pixels (per-layer constant)
+  attribute float aHalfFactor; // per-segment multiplier for variable thickness; 1.0 = uniform
   attribute float aHueOffset;
   attribute float aHueIndex;
-  attribute float aOpacity;   // opacityFactor for the rainbow palette
+  attribute float aOpacity;    // opacityFactor for the rainbow palette
 
   uniform vec2  uResolution;
   uniform float uPad;
@@ -88,16 +94,18 @@ const VERT_SRC = `
     vec2  dir  = len > 1e-4 ? axis / len : vec2(1.0, 0.0);
     vec2  nrm  = vec2(-dir.y, dir.x);
 
+    float halfWidth = aHalf * aHalfFactor;
+
     // Expand the quad past both ends and both sides by half-thickness + AA pad so
     // the round caps and antialiased rim always fall inside the rasterised area.
-    float ext   = aHalf + uPad;
+    float ext   = halfWidth + uPad;
     vec2  along = mix(a - dir * ext, b + dir * ext, aCorner.x);
     vec2  pos   = along + nrm * (aCorner.y * ext);
 
     vPos       = pos;
     vA         = a;
     vB         = b;
-    vHalf      = aHalf;
+    vHalf      = halfWidth;
     vHueOffset = aHueOffset;
     vHueIndex  = aHueIndex;
     vOpacity   = aOpacity;
@@ -375,6 +383,7 @@ export default function createGlowBatchRenderer() {
       "aCorner",
       "aSeg",
       "aHalf",
+      "aHalfFactor",
       "aHueOffset",
       "aHueIndex",
       "aOpacity"
@@ -495,6 +504,7 @@ export default function createGlowBatchRenderer() {
       "aCorner",
       "aSeg",
       "aHalf",
+      "aHalfFactor",
       "aHueOffset",
       "aHueIndex",
       "aOpacity"
@@ -641,7 +651,9 @@ export default function createGlowBatchRenderer() {
       state.instanceVBO
     );
 
-    // All eight inputs vary per instance.
+    // Per-instance attributes. aHalfFactor is a Mode B knob (variable thickness
+    // along a polyline) and stays at 1.0 here so Mode A discs/capsules use aHalf
+    // verbatim.
     const perInstance = [
       [
         "aSeg",
@@ -697,6 +709,14 @@ export default function createGlowBatchRenderer() {
         1
       );
     } );
+
+    if ( state.locs.aHalfFactor >= 0 ) {
+      gl.disableVertexAttribArray( state.locs.aHalfFactor );
+      gl.vertexAttrib1f(
+        state.locs.aHalfFactor,
+        1.0
+      );
+    }
 
     drawArraysInstanced(
       gl,
@@ -760,10 +780,14 @@ export default function createGlowBatchRenderer() {
   }
 
   /**
-   * Queue one dense segment of the current spline, hued by `hueIndex` on the GPU.
+   * Queue one dense segment of the current spline, hued by `hueIndex` on the GPU
+   * and optionally tapered: `halfFactor` is a 0..N multiplier on the per-layer
+   * half-thickness, so 1 keeps the segment at the base weight, 0 collapses it to
+   * nothing (a pointy cap), and >1 swells it past the base weight. Defaults to 1
+   * for callers that don't care about variable thickness.
    */
   function strokeSegment(
-    ax, ay, bx, by, hueIndex
+    ax, ay, bx, by, hueIndex, halfFactor = 1.0
   ) {
     if ( !state.currentGroup ) {
       openStroke();
@@ -779,6 +803,7 @@ export default function createGlowBatchRenderer() {
     out[ base + 2 ] = bx;
     out[ base + 3 ] = by;
     out[ base + 4 ] = hueIndex;
+    out[ base + 5 ] = halfFactor;
 
     state.countB++;
     state.currentGroup.count++;
@@ -834,10 +859,12 @@ export default function createGlowBatchRenderer() {
       state.instanceVBO
     );
 
-    // hueIndex varies per segment; half-thickness, opacityFactor and hueOffset are
-    // constant within a layer, so they ride on disabled attributes set per pass.
+    // hueIndex and halfFactor vary per segment; the base half-thickness,
+    // opacityFactor and hueOffset are constant within a layer, so they ride on
+    // disabled attributes set per pass.
     const aSeg = state.locs.aSeg;
     const aHueIndex = state.locs.aHueIndex;
+    const aHalfFactor = state.locs.aHalfFactor;
 
     gl.disableVertexAttribArray( state.locs.aHalf );
     gl.disableVertexAttribArray( state.locs.aOpacity );
@@ -894,6 +921,24 @@ export default function createGlowBatchRenderer() {
         aHueIndex,
         1
       );
+
+      if ( aHalfFactor >= 0 ) {
+        gl.enableVertexAttribArray( aHalfFactor );
+        gl.vertexAttribPointer(
+          aHalfFactor,
+          1,
+          gl.FLOAT,
+          false,
+          STRIDE_B,
+          byteOffset + 20
+        );
+        setDivisor(
+          gl,
+          state.ext,
+          aHalfFactor,
+          1
+        );
+      }
 
       // Widest, dimmest layer first; the bright core lands on top.
       for ( let shadow = layers; shadow >= 0; shadow-- ) {

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -132,10 +132,20 @@ const _rawMouse = {
 let _rawTouches = []; // Array of { clientX, clientY }
 
 let _noiseOffset = 0;
+// Frame guards for collectors that mutate global state. Without them, every
+// extra call inside the same frame (e.g. the debug overlay running
+// getPointersDebug for the legend AND for the crosshairs AND for the pointer
+// markers, plus the main sketch calling getPointerGroups) would advance the
+// state again — so Perlin noise visibly accelerated when the visualization was
+// enabled, and mouse smoothing converged faster too. Tracking the last frame
+// that updated each piece of state keeps the rate independent of how many
+// times the collector runs per frame.
+let _noiseFrame = -1;
 const _smoothedMouse = {
   x: 0,
   y: 0
 };
+let _smoothedMouseFrame = -1;
 const _gyro = {
   beta: 0,
   gamma: 0
@@ -415,6 +425,8 @@ async function _initAudio( opts ) {
  */
 export async function initInteraction( opts = {} ) {
   _noiseOffset = opts.perlinNoise?.seed ?? 0;
+  _noiseFrame = -1;
+  _smoothedMouseFrame = -1;
 
   // ── Gyroscope reset (lazy init triggered by _collectGyroscope) ───────────
   _disposeGyro();
@@ -885,16 +897,23 @@ function _collectMouse(
   }
 
   if ( smoothing > 0 ) {
-    _smoothedMouse.x = p.lerp(
-      _smoothedMouse.x,
-      rawX,
-      1 - smoothing
-    );
-    _smoothedMouse.y = p.lerp(
-      _smoothedMouse.y,
-      rawY,
-      1 - smoothing
-    );
+    // Step the smoothing filter at most once per frame so its convergence rate
+    // doesn't speed up when the debug overlay also reads pointers (see
+    // _smoothedMouseFrame above).
+    if ( _smoothedMouseFrame !== p.frameCount ) {
+      _smoothedMouse.x = p.lerp(
+        _smoothedMouse.x,
+        rawX,
+        1 - smoothing
+      );
+      _smoothedMouse.y = p.lerp(
+        _smoothedMouse.y,
+        rawY,
+        1 - smoothing
+      );
+      _smoothedMouseFrame = p.frameCount;
+    }
+
     out.push( p.createVector(
       _smoothedMouse.x + ox,
       _smoothedMouse.y + oy
@@ -1649,7 +1668,12 @@ function _collectPerlinNoise(
   const speed = noise.speed ?? 0.005;
   const margin = noise.margin ?? 50;
 
-  _noiseOffset += speed;
+  // Advance the noise offset at most once per frame so the scroll rate stays
+  // independent of how many times this collector runs (see _noiseFrame above).
+  if ( _noiseFrame !== p.frameCount ) {
+    _noiseOffset += speed;
+    _noiseFrame = p.frameCount;
+  }
 
   for ( let i = 0; i < count; i++ ) {
     out.push( p.createVector(

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -752,7 +752,16 @@ export function getPointerGroups( opts ) {
 
   const groups = [];
 
-  const addFlat = (
+  // Vision sources already split their points into per-entity groups (one hand,
+  // one finger, one pose, one face). The flat sources used to bundle every
+  // point they produced into a single group (one "orbit" group with N orbit
+  // points, one "perlinNoise" group with N noise points, …), so downstream
+  // sketches saw them as ONE moving polyline / ONE averaged trail no matter
+  // how many points were visible. Splitting per-point here matches the vision
+  // behaviour: 6 orbits → 6 entities → 6 trails / 6 ribbons, and the demo
+  // overlay still shows 6 markers because the underlying point count never
+  // changed. Single-point sources (mouse, gyroscope) come out unchanged.
+  const addPerPoint = (
     source, collector
   ) => {
     const points = [];
@@ -763,20 +772,24 @@ export function getPointerGroups( opts ) {
       points
     );
 
-    if ( points.length > 0 ) {
+    points.forEach( (
+      point, index
+    ) => {
       groups.push( {
         source,
-        id: source,
-        points
+        id: `${ source }-${ index }`,
+        points: [
+          point
+        ]
       } );
-    }
+    } );
   };
 
-  addFlat(
+  addPerPoint(
     "mouse",
     _collectMouse
   );
-  addFlat(
+  addPerPoint(
     "touch",
     _collectTouch
   );
@@ -803,27 +816,27 @@ export function getPointerGroups( opts ) {
     groups
   );
 
-  addFlat(
+  addPerPoint(
     "orbit",
     _collectOrbit
   );
-  addFlat(
+  addPerPoint(
     "perlinNoise",
     _collectPerlinNoise
   );
-  addFlat(
+  addPerPoint(
     "gyroscope",
     _collectGyroscope
   );
-  addFlat(
+  addPerPoint(
     "midi",
     _collectMidi
   );
-  addFlat(
+  addPerPoint(
     "audio",
     _collectAudio
   );
-  addFlat(
+  addPerPoint(
     "joypad",
     _collectJoypad
   );


### PR DESCRIPTION
fix(interaction): per-frame guards, in-place trail pulls, chase mode
Three independent fixes that all converge on smoother interactive
sketches:

* Perlin noise advanced its offset every time _collectPerlinNoise ran,
  and mouse smoothing stepped every time _collectMouse ran. The debug
  overlay calls the flat collectors 3-4 times per frame on top of the
  main sketch's call, so both effects sped up when the visualization
  was enabled and slowed back down when it was turned off. Frame
  guards (_noiseFrame, _smoothedMouseFrame) make those updates happen
  at most once per frame, independent of how many times the collector
  is invoked.

* `recall` mode rebuilt every trail entry's points array with fresh
  p5.Vector instances every frame (entry.points.map). On long
  sessions with high maxPoints + many entities (e.g. 16 audio bands ×
  300 points) the per-frame allocation churn was triggering enough GC
  to slow the sketch down by itself. The pull now mutates the
  existing vectors in place, so a recall session no longer slows
  down the longer it runs.

* New `chase` drawing mode: same idea as `recall`, but each trail
  point lerps toward its NEWER neighbour (and the newest follows the
  live anchor) so the chain collapses ALONG the path the entity drew
  instead of snapping back via the shortest line — the splines
  visibly follow their own recorded path back to the anchor.

https://claude.ai/code/session_01SQwGp5qrpwbgDtGRxJYRh4
5fe828d7