### PR TITLE
fix(framerate): robust runtime framerate changes and truthful FPS counter

### DIFF
--- a/src/engines/__tests__/frameRateMeter.test.ts
+++ b/src/engines/__tests__/frameRateMeter.test.ts
@@ -1,0 +1,199 @@
+import {
+  FrameRateMeter
+} from "@/engines/frameRateMeter";
+
+/**
+ * Feed the meter rAF-style ticks (every ~16.7ms) while the frame counter
+ * advances at `fps`, starting from `startTime`/`startFrame`. Returns the
+ * last reading.
+ */
+function run(
+  meter: FrameRateMeter,
+  {
+    fps,
+    durationMs,
+    startTime = 0,
+    startFrame = 0,
+    tickMs = 16.7
+  }: {
+    fps: number;
+    durationMs: number;
+    startTime?: number;
+    startFrame?: number;
+    tickMs?: number;
+  }
+) {
+  let reading = 0;
+  let time = startTime;
+
+  while ( time <= startTime + durationMs ) {
+    const frameCount = startFrame + Math.floor( ( time - startTime ) * fps / 1000 );
+
+    reading = meter.sample(
+      time,
+      frameCount
+    );
+    time += tickMs;
+  }
+
+  return {
+    reading,
+    endTime: time,
+    endFrame: startFrame + Math.floor( durationMs * fps / 1000 )
+  };
+}
+
+describe(
+  "FrameRateMeter",
+  () => {
+    test(
+      "measures a steady rate",
+      () => {
+        const meter = new FrameRateMeter();
+        const {
+          reading
+        } = run(
+          meter,
+          {
+            fps: 60,
+            durationMs: 2000
+          }
+        );
+
+        expect( Math.round( reading ) ).toBe( 60 );
+      }
+    );
+
+    test(
+      "measures a low rate sampled at display frequency (no aliasing)",
+      () => {
+        const meter = new FrameRateMeter();
+        const {
+          reading
+        } = run(
+          meter,
+          {
+            fps: 5,
+            durationMs: 3000
+          }
+        );
+
+        // The synthetic feed floor-quantises frame counts, so allow ±1.
+        expect( Math.abs( reading - 5 ) ).toBeLessThan( 1 );
+      }
+    );
+
+    test(
+      "converges within one window after a framerate change",
+      () => {
+        const meter = new FrameRateMeter( 1000 );
+        const phase1 = run(
+          meter,
+          {
+            fps: 60,
+            durationMs: 2000
+          }
+        );
+
+        const {
+          reading
+        } = run(
+          meter,
+          {
+            fps: 24,
+            durationMs: 1100,
+            startTime: phase1.endTime,
+            startFrame: phase1.endFrame
+          }
+        );
+
+        expect( Math.round( reading ) ).toBe( 24 );
+      }
+    );
+
+    test(
+      "a rewound frame counter (seek/stop) restarts the window",
+      () => {
+        const meter = new FrameRateMeter();
+
+        run(
+          meter,
+          {
+            fps: 60,
+            durationMs: 1000
+          }
+        );
+
+        // Seek back to frame 0: the next reading must not mix pre-seek
+        // samples into the window.
+        const first = meter.sample(
+          2000,
+          0
+        );
+
+        expect( first ).toBe( 0 );
+
+        const {
+          reading
+        } = run(
+          meter,
+          {
+            fps: 30,
+            durationMs: 1100,
+            startTime: 2016,
+            startFrame: 1
+          }
+        );
+
+        // The synthetic feed floor-quantises frame counts, so allow ±1.
+        expect( Math.abs( reading - 30 ) ).toBeLessThan( 1 );
+      }
+    );
+
+    test(
+      "a frozen counter (paused loop) reads 0 once the window fills",
+      () => {
+        const meter = new FrameRateMeter( 1000 );
+        const phase1 = run(
+          meter,
+          {
+            fps: 60,
+            durationMs: 1500
+          }
+        );
+
+        const {
+          reading
+        } = run(
+          meter,
+          {
+            fps: 0,
+            durationMs: 1500,
+            startTime: phase1.endTime,
+            startFrame: phase1.endFrame
+          }
+        );
+
+        expect( reading ).toBe( 0 );
+      }
+    );
+
+    test(
+      "reset clears the window",
+      () => {
+        const meter = new FrameRateMeter();
+
+        run(
+          meter,
+          {
+            fps: 60,
+            durationMs: 1000
+          }
+        );
+        meter.reset();
+
+        expect( meter.fps ).toBe( 0 );
+      }
+    );
+  }
+);

--- a/src/engines/frameRateMeter.ts
+++ b/src/engines/frameRateMeter.ts
@@ -1,0 +1,74 @@
+/**
+ * Sliding-window frame-rate meter.
+ *
+ * Derives the real draw rate from a monotonically increasing frame counter
+ * (p5's `frameCount`) instead of sampling an engine-reported instantaneous
+ * fps: counter deltas only count frames that actually rendered, so the
+ * reading is immune to rAF sampling aliasing and converges within one
+ * window after a framerate change.
+ */
+
+type FrameSample = {
+  time: number;
+  frameCount: number;
+};
+
+const DEFAULT_WINDOW_MS = 1000;
+
+export class FrameRateMeter {
+  private samples: FrameSample[] = [];
+
+  constructor( private readonly windowMs: number = DEFAULT_WINDOW_MS ) {}
+
+  /**
+   * Record the frame counter at `time` (ms) and return the rate over the
+   * current window.
+   */
+  sample(
+    time: number,
+    frameCount: number
+  ): number {
+    const last = this.samples[ this.samples.length - 1 ];
+
+    // A backwards counter or clock means the engine was rewound (seek,
+    // stop, restart) — the old window no longer measures continuous
+    // playback.
+    if ( last && ( frameCount < last.frameCount || time < last.time ) ) {
+      this.samples.length = 0;
+    }
+
+    this.samples.push( {
+      time,
+      frameCount
+    } );
+
+    while (
+      this.samples.length > 1 &&
+      time - this.samples[ 0 ].time > this.windowMs
+    ) {
+      this.samples.shift();
+    }
+
+    return this.fps;
+  }
+
+  get fps(): number {
+    if ( this.samples.length < 2 ) {
+      return 0;
+    }
+
+    const first = this.samples[ 0 ];
+    const last = this.samples[ this.samples.length - 1 ];
+    const elapsed = last.time - first.time;
+
+    if ( elapsed <= 0 ) {
+      return 0;
+    }
+
+    return ( ( last.frameCount - first.frameCount ) * 1000 ) / elapsed;
+  }
+
+  reset(): void {
+    this.samples.length = 0;
+  }
+}

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -33,6 +33,9 @@ import {
 import {
   pauseLoop, resumeLoop
 } from "@/p5/utils/loopControl.js";
+import {
+  FrameRateMeter
+} from "@/engines/frameRateMeter";
 
 type P5SketchRuntime = {
   start: ( container: HTMLElement ) => Promise<any>;
@@ -65,11 +68,15 @@ export class P5Engine implements SketchEngine {
   private sketchRuntime: P5SketchRuntime | null = null;
   private listeners = new Map<string, Set<( payload: any ) => void>>();
   private perfLoopId: number | null = null;
+  // Measures the real draw rate from p5's frameCount: counter deltas over a
+  // sliding window converge within ~1s of a framerate change, where sampling
+  // p5's instantaneous frameRate() (display-rate aliased, then smoothed)
+  // lagged the true rate by several seconds.
+  private perfMeter = new FrameRateMeter();
   private perfSample = {
     paused: false,
-    smoothedFps: 0,
-    lastEmitTime: 0,
-    rawSamples: [] as number[]
+    fps: 0,
+    lastEmitTime: 0
   };
 
   get isReady(): boolean {
@@ -170,17 +177,11 @@ export class P5Engine implements SketchEngine {
       return;
     }
 
-    const p = this.sketchRuntime?.getP5();
-
+    this.perfMeter.reset();
     this.perfSample = {
       paused: false,
-      smoothedFps: 0,
-      lastEmitTime: performance.now(),
-      rawSamples: typeof p?.frameRate === "function"
-        ? [
-          p.frameRate()
-        ].filter( ( value ) => Number.isFinite( value ) && value > 0 )
-        : []
+      fps: 0,
+      lastEmitTime: performance.now()
     };
 
     // Wait for the first draw cycle to complete before marking as ready.
@@ -268,6 +269,9 @@ export class P5Engine implements SketchEngine {
     }
 
     resumeLoop( this.sketchRuntime?.getP5() );
+    // Restart the measurement window: frameCount stood still while paused
+    // and averaging across the gap would report a stale, too-low rate.
+    this.perfMeter.reset();
     this.perfSample.paused = false;
     this.emitPerformanceSample();
   }
@@ -288,8 +292,8 @@ export class P5Engine implements SketchEngine {
       p.frameCount = 0;
     }
 
-    this.perfSample.rawSamples = [];
-    this.perfSample.smoothedFps = 0;
+    this.perfMeter.reset();
+    this.perfSample.fps = 0;
     this.emitPerformanceSample();
   }
 
@@ -460,27 +464,17 @@ export class P5Engine implements SketchEngine {
       const p = this.sketchRuntime?.getP5();
 
       if ( p && this._isReady ) {
-        const rawFps = typeof p.frameRate === "function"
-          ? p.frameRate()
+        const frameCount = typeof p.frameCount === "number"
+          ? p.frameCount
           : 0;
 
-        if ( Number.isFinite( rawFps ) && rawFps > 0 ) {
-          this.perfSample.rawSamples.push( rawFps );
-
-          if ( this.perfSample.rawSamples.length > 20 ) {
-            this.perfSample.rawSamples.shift();
-          }
-        }
+        const fps = this.perfMeter.sample(
+          now,
+          frameCount
+        );
 
         if ( now - this.perfSample.lastEmitTime >= 500 ) {
-          const robustFps = this.getMedian( this.perfSample.rawSamples );
-
-          if ( robustFps > 0 ) {
-            this.perfSample.smoothedFps = this.perfSample.smoothedFps > 0
-              ? this.perfSample.smoothedFps * 0.8 + robustFps * 0.2
-              : robustFps;
-          }
-
+          this.perfSample.fps = fps;
           this.perfSample.lastEmitTime = now;
           this.emitPerformanceSample();
         }
@@ -503,8 +497,8 @@ export class P5Engine implements SketchEngine {
 
   private emitPerformanceSample(): void {
     const payload: EnginePerformanceSample = {
-      fps: Number.isFinite( this.perfSample.smoothedFps )
-        ? this.perfSample.smoothedFps
+      fps: Number.isFinite( this.perfSample.fps )
+        ? this.perfSample.fps
         : 0,
       paused: this.perfSample.paused,
       timestamp: performance.now()
@@ -514,29 +508,5 @@ export class P5Engine implements SketchEngine {
       "performance",
       payload
     );
-  }
-
-  private getMedian( values: number[] ): number {
-    if ( values.length === 0 ) {
-      return 0;
-    }
-
-    const sorted = [
-      ...values
-    ].sort( this.compareNumbersAscending );
-    const middle = Math.floor( sorted.length / 2 );
-
-    if ( sorted.length % 2 === 0 ) {
-      return ( sorted[ middle - 1 ] + sorted[ middle ] ) / 2;
-    }
-
-    return sorted[ middle ];
-  }
-
-  private compareNumbersAscending(
-    a: number,
-    b: number
-  ): number {
-    return a - b;
   }
 }

--- a/src/lib/__tests__/effectiveSlideSettings.test.ts
+++ b/src/lib/__tests__/effectiveSlideSettings.test.ts
@@ -1,0 +1,172 @@
+import {
+  getEffectiveSlideSettings,
+  mergeSlideOverride
+} from "@/lib/effectiveSlideSettings";
+
+describe(
+  "mergeSlideOverride",
+  () => {
+    test(
+      "returns the global value when there is no override",
+      () => {
+        const globalValue = {
+          framerate: 60,
+          duration: 12
+        };
+
+        expect( mergeSlideOverride(
+          globalValue,
+          undefined
+        ) ).toBe( globalValue );
+        expect( mergeSlideOverride(
+          globalValue,
+          null
+        ) ).toBe( globalValue );
+      }
+    );
+
+    test(
+      "fills the missing keys of a partial override from the global value",
+      () => {
+        expect( mergeSlideOverride(
+          {
+            framerate: 60,
+            duration: 12
+          },
+          {
+            framerate: 24
+          }
+        ) ).toEqual( {
+          framerate: 24,
+          duration: 12
+        } );
+      }
+    );
+
+    test(
+      "returns the override when there is no global value",
+      () => {
+        expect( mergeSlideOverride(
+          undefined,
+          {
+            framerate: 24
+          }
+        ) ).toEqual( {
+          framerate: 24
+        } );
+      }
+    );
+  }
+);
+
+describe(
+  "getEffectiveSlideSettings",
+  () => {
+    const options = {
+      size: {
+        width: 1920,
+        height: 1080
+      },
+      animation: {
+        framerate: 60,
+        duration: 12
+      },
+      slides: [
+        {
+          name: "full override",
+          size: {
+            width: 1080,
+            height: 1350
+          },
+          animation: {
+            framerate: 24,
+            duration: 4
+          }
+        },
+        {
+          name: "partial animation override",
+          animation: {
+            framerate: 30
+          }
+        },
+        {
+          name: "no overrides"
+        }
+      ]
+    };
+
+    test(
+      "global settings without a slide index",
+      () => {
+        expect( getEffectiveSlideSettings( options ) ).toEqual( {
+          size: {
+            width: 1920,
+            height: 1080
+          },
+          animation: {
+            framerate: 60,
+            duration: 12
+          }
+        } );
+      }
+    );
+
+    test(
+      "full per-slide override wins",
+      () => {
+        expect( getEffectiveSlideSettings(
+          options,
+          0
+        ).animation ).toEqual( {
+          framerate: 24,
+          duration: 4
+        } );
+      }
+    );
+
+    test(
+      "partial per-slide override keeps the global duration",
+      () => {
+        expect( getEffectiveSlideSettings(
+          options,
+          1
+        ).animation ).toEqual( {
+          framerate: 30,
+          duration: 12
+        } );
+      }
+    );
+
+    test(
+      "slide without overrides falls back to globals",
+      () => {
+        expect( getEffectiveSlideSettings(
+          options,
+          2
+        ) ).toEqual( {
+          size: {
+            width: 1920,
+            height: 1080
+          },
+          animation: {
+            framerate: 60,
+            duration: 12
+          }
+        } );
+      }
+    );
+
+    test(
+      "out-of-range slide index falls back to globals",
+      () => {
+        expect( getEffectiveSlideSettings(
+          options,
+          99
+        ).animation ).toEqual( {
+          framerate: 60,
+          duration: 12
+        } );
+      }
+    );
+  }
+);

--- a/src/lib/effectiveSlideSettings.ts
+++ b/src/lib/effectiveSlideSettings.ts
@@ -26,6 +26,27 @@ const DEFAULTS: EffectiveSlideSettings = {
 };
 
 /**
+ * Merge a per-slide override over the global value.
+ *
+ * Overrides can be partial — a slide form may have set only the framerate —
+ * so a plain `override ?? global` would drop the global duration entirely.
+ * Merging keeps every unset key on the global value.
+ */
+export function mergeSlideOverride<T extends object>(
+  globalValue: T | undefined,
+  override: Partial<T> | null | undefined
+): T | undefined {
+  if ( !override ) {
+    return globalValue;
+  }
+
+  return {
+    ...( globalValue ?? {} ),
+    ...override
+  } as T;
+}
+
+/**
  * Return the effective size + animation for `slideIndex`.
  *
  * - `slideIndex === undefined` → global settings.
@@ -56,7 +77,13 @@ export function getEffectiveSlideSettings(
   }
 
   return {
-    size: slide.size ?? globalSize,
-    animation: slide.animation ?? globalAnimation
+    size: mergeSlideOverride(
+      globalSize,
+      slide.size
+    ) as Size,
+    animation: mergeSlideOverride(
+      globalAnimation,
+      slide.animation
+    ) as Animation
   };
 }

--- a/src/templates/p5/utils/__tests__/framerateChange.test.ts
+++ b/src/templates/p5/utils/__tests__/framerateChange.test.ts
@@ -1,0 +1,345 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for runtime framerate changes.
+ *
+ * The pipeline under test: option-store update (or slide switch) →
+ * options.js / slides.applyEffectiveSettings → "engine-framerate-change"
+ * → sketch.js handler → p.frameRate().
+ *
+ * Bugs these tests guard against:
+ *
+ * 1. p5's `frameRate()` silently ignores non-number arguments. A framerate
+ *    arriving as a numeric string (imported options.json, persisted job)
+ *    passed the slides path's bare `> 0` check and was then dropped by p5
+ *    with no error — the loop kept running at the old rate. Every call
+ *    site now coerces through `coerceFramerate()`.
+ *
+ * 2. options.js gated the event behind `typeof framerate === "number"`,
+ *    so the same string framerate never even fired the event — while the
+ *    comparison baseline still advanced, permanently swallowing the change.
+ *
+ * 3. A per-slide animation override can be partial ({ framerate } only);
+ *    resolving it with `??` instead of a merge dropped the global duration.
+ */
+
+// Module scope (not script scope): the sibling test files declare the same
+// require'd names at top level.
+export {};
+
+if ( typeof globalThis.structuredClone !== "function" ) {
+  globalThis.structuredClone = ( value: unknown ) =>
+    JSON.parse( JSON.stringify( value ) );
+}
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const events = require( "@/p5/utils/events.js" ).default;
+const sketch = require( "@/p5/utils/sketch.js" ).default;
+const {
+  setContainer, setP5
+} = require( "@/p5/utils/sketch.js" );
+const slides = require( "@/p5/utils/slides/index.js" ).default;
+const {
+  registerEvents: registerOptionsEvents
+} = require( "@/p5/utils/options.js" );
+const {
+  setSketchOptions, getSketchOptions
+} = require( "@/p5/shared/syncSketchOptions.js" );
+const {
+  coerceFramerate
+} = require( "@/p5/utils/framerate.js" );
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function resetStore( opts: Record<string, unknown> ) {
+  const store = getSketchOptions();
+
+  for ( const key of Object.keys( store ) ) {
+    delete store[ key ];
+  }
+  Object.assign(
+    store,
+    JSON.parse( JSON.stringify( opts ) )
+  );
+}
+
+function freshOptions( overrides: Record<string, unknown> = {} ) {
+  return {
+    size: {
+      width: 1080,
+      height: 1350
+    },
+    animation: {
+      framerate: 60,
+      duration: 12
+    },
+    slides: [],
+    ...overrides
+  };
+}
+
+// Minimal p5 stand-in mirroring p5 1.11's frameRate() argument handling:
+// non-number arguments are silently ignored (the getter path).
+function makeFakeP5() {
+  const p: any = {
+    _targetFrameRate: 60,
+    frameRate( fps?: unknown ) {
+      if ( typeof fps !== "number" || ( fps as number ) < 0 ) {
+        return p._targetFrameRate;
+      }
+      p._targetFrameRate = fps;
+
+      return p;
+    }
+  };
+
+  return p;
+}
+
+describe(
+  "coerceFramerate",
+  () => {
+    test(
+      "accepts numbers and numeric strings",
+      () => {
+        expect( coerceFramerate( 24 ) ).toBe( 24 );
+        expect( coerceFramerate( "24" ) ).toBe( 24 );
+        expect( coerceFramerate( 0.5 ) ).toBe( 0.5 );
+      }
+    );
+
+    test(
+      "rejects unusable values",
+      () => {
+        expect( coerceFramerate( undefined ) ).toBeNull();
+        expect( coerceFramerate( null ) ).toBeNull();
+        expect( coerceFramerate( "" ) ).toBeNull();
+        expect( coerceFramerate( "abc" ) ).toBeNull();
+        expect( coerceFramerate( 0 ) ).toBeNull();
+        expect( coerceFramerate( -30 ) ).toBeNull();
+        expect( coerceFramerate( Infinity ) ).toBeNull();
+        expect( coerceFramerate( NaN ) ).toBeNull();
+      }
+    );
+  }
+);
+
+describe(
+  "runtime framerate changes",
+  () => {
+    let p: any;
+
+    beforeEach( () => {
+      events.registeredEvents = {};
+      slides.index = 0;
+      sketch.sketchOptions = {
+        size: {
+          width: 1080,
+          height: 1350
+        },
+        animation: {
+          framerate: 60,
+          duration: 12
+        }
+      };
+
+      document.body.innerHTML = "";
+      setContainer( null );
+
+      p = makeFakeP5();
+      setP5( p );
+
+      // Register engine handlers the way sketch.start() does.
+      Object.entries( sketch.eventHandlers ).forEach( ( [
+        name,
+        handler
+      ] ) => {
+        events.register(
+          name,
+          handler as ( ...args: unknown[] ) => unknown
+        );
+      } );
+    } );
+
+    afterEach( () => {
+      setP5( null );
+    } );
+
+    test(
+      "editing the active slide's framerate in the store reaches p.frameRate",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        registerOptionsEvents();
+        events.handle( "pre-setup" );
+        slides.setSlide( 0 );
+
+        const next = JSON.parse( JSON.stringify( getSketchOptions() ) );
+
+        next.slides[ 0 ].animation.framerate = 24;
+        setSketchOptions(
+          next,
+          "react"
+        );
+
+        expect( p._targetFrameRate ).toBe( 24 );
+      }
+    );
+
+    test(
+      "a string framerate from the store still applies (options path)",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        registerOptionsEvents();
+        events.handle( "pre-setup" );
+        slides.setSlide( 0 );
+
+        const next = JSON.parse( JSON.stringify( getSketchOptions() ) );
+
+        next.slides[ 0 ].animation.framerate = "24";
+        setSketchOptions(
+          next,
+          "react"
+        );
+
+        expect( p._targetFrameRate ).toBe( 24 );
+      }
+    );
+
+    test(
+      "a string framerate still applies on slide switch (slides path)",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: "30",
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( p._targetFrameRate ).toBe( 30 );
+      }
+    );
+
+    test(
+      "switching slides applies each slide's framerate",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 60,
+                duration: 12
+              }
+            },
+            {
+              name: "Slide 2",
+              animation: {
+                framerate: 24,
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 1 );
+        expect( p._targetFrameRate ).toBe( 24 );
+
+        slides.setSlide( 0 );
+        expect( p._targetFrameRate ).toBe( 60 );
+      }
+    );
+
+    test(
+      "an invalid framerate is ignored and keeps the current rate",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: "abc",
+                duration: 12
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( p._targetFrameRate ).toBe( 60 );
+      }
+    );
+
+    test(
+      "a partial slide override ({ framerate } only) keeps the global duration",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                framerate: 24
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( p._targetFrameRate ).toBe( 24 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 12 );
+        expect( sketch.sketchOptions.animation.framerate ).toBe( 24 );
+      }
+    );
+
+    test(
+      "a partial slide override ({ duration } only) keeps the global framerate",
+      () => {
+        resetStore( freshOptions( {
+          slides: [
+            {
+              name: "Slide 1",
+              animation: {
+                duration: 4
+              }
+            }
+          ]
+        } ) );
+
+        slides.setSlide( 0 );
+
+        expect( p._targetFrameRate ).toBe( 60 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+        expect( sketch.sketchOptions.animation.framerate ).toBe( 60 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/framerate.js
+++ b/src/templates/p5/utils/framerate.js
@@ -1,0 +1,19 @@
+/**
+ * Normalise a framerate coming from the option store or an engine event.
+ *
+ * Options travel through JSON imports, persisted jobs and form inputs, so a
+ * framerate can arrive as a numeric string. p5's `frameRate()` silently
+ * ignores anything that isn't a number — the loop keeps running at the old
+ * rate with no error — so every call site funnels through this guard.
+ *
+ * @returns {number|null} a finite framerate > 0, or null when unusable.
+ */
+export function coerceFramerate( value ) {
+  const fps = Number( value );
+
+  if ( !Number.isFinite( fps ) || fps <= 0 ) {
+    return null;
+  }
+
+  return fps;
+}

--- a/src/templates/p5/utils/options.js
+++ b/src/templates/p5/utils/options.js
@@ -18,6 +18,14 @@ import {
   resolveAssetURL
 } from "../shared/utils.js";
 
+import {
+  coerceFramerate
+} from "./framerate.js";
+
+import {
+  mergeSlideOverride
+} from "@/lib/effectiveSlideSettings";
+
 /* ------------------------------------------------------------------ */
 /*  Debounced, de-duplicated asset refresher                          */
 /* ------------------------------------------------------------------ */
@@ -274,8 +282,14 @@ function getEffective( opts ) {
   const slide = current?.slide ?? null;
 
   return {
-    size: slide?.size ?? opts?.size,
-    animation: slide?.animation ?? opts?.animation
+    size: mergeSlideOverride(
+      opts?.size,
+      slide?.size
+    ),
+    animation: mergeSlideOverride(
+      opts?.animation,
+      slide?.animation
+    )
   };
 }
 
@@ -337,15 +351,13 @@ function handleOptionsChange(
     effectiveAnimation,
     previousOptions.effectiveAnimation
   ) ) {
-    const framerate = effectiveAnimation?.framerate;
-    const previousFramerate = previousOptions.effectiveAnimation?.framerate;
+    // Coerce both sides: a framerate may arrive as a numeric string
+    // (imported options, persisted job) and must still apply — p5 would
+    // silently ignore it otherwise.
+    const framerate = coerceFramerate( effectiveAnimation?.framerate );
+    const previousFramerate = coerceFramerate( previousOptions.effectiveAnimation?.framerate );
 
-    if (
-      framerate &&
-      typeof framerate === "number" &&
-      framerate > 0 &&
-      framerate !== previousFramerate
-    ) {
+    if ( framerate !== null && framerate !== previousFramerate ) {
       events.handle(
         "engine-framerate-change",
         framerate

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -11,6 +11,9 @@ import {
 import {
   pauseLoop, resumeLoop
 } from "./loopControl.js";
+import {
+  coerceFramerate
+} from "./framerate.js";
 
 let _p5 = null;
 let _container = null;
@@ -196,7 +199,7 @@ const sketch = {
             p.setCamera( sketch.camera );
           }
 
-          p.frameRate( sketchOptions?.animation?.framerate );
+          p.frameRate( coerceFramerate( sketchOptions?.animation?.framerate ) ?? 60 );
           p.smooth();
 
           // Canvas-level event handlers
@@ -248,6 +251,17 @@ const sketch = {
           );
 
           events.handle( "pre-setup" );
+
+          // pre-setup ran initializeOptionsSubscription, which resolved the
+          // *effective* animation (per-slide override, persisted job) into
+          // sketch.sketchOptions — the frameRate call above only saw the
+          // module snapshot. Re-apply so the loop boots on the effective
+          // rate instead of waiting for the next framerate-change event.
+          const effectiveFramerate = coerceFramerate( sketch.sketchOptions?.animation?.framerate );
+
+          if ( effectiveFramerate !== null ) {
+            p.frameRate( effectiveFramerate );
+          }
 
           // -- setup (user function) ------------------------------------
           p.noStroke();
@@ -573,7 +587,11 @@ const sketch = {
     "engine-smooth-pixel-change": ( checked ) =>
       checked ? getP5()?.smooth() : getP5()?.noSmooth(),
     "engine-framerate-change": ( value ) => {
-      getP5()?.frameRate( value );
+      const framerate = coerceFramerate( value );
+
+      if ( framerate !== null ) {
+        getP5()?.frameRate( framerate );
+      }
     }
   }
 };

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -10,6 +10,14 @@ import {
   _layouts
 } from "./layouts";
 
+import {
+  coerceFramerate
+} from "../framerate.js";
+
+import {
+  mergeSlideOverride
+} from "@/lib/effectiveSlideSettings";
+
 // Safe modulo that wraps negatives too
 const wrap = (
   i, n
@@ -58,8 +66,12 @@ const slides = {
           slides.setSlide( 0 );
         }
 
-        if ( canvas.dataset.slide !== slides.index ) {
-          canvas.dataset.slide = slides.index;
+        // dataset values are strings — compare like-for-like or the guard
+        // never matches and the attribute is rewritten every frame.
+        const datasetIndex = String( slides.index );
+
+        if ( canvas.dataset.slide !== datasetIndex ) {
+          canvas.dataset.slide = datasetIndex;
         }
       }
     );
@@ -123,8 +135,14 @@ const slides = {
    */
   applyEffectiveSettings() {
     const slide = this.current;
-    const effectiveSize = slide?.size ?? options?.size;
-    const effectiveAnimation = slide?.animation ?? options?.animation;
+    const effectiveSize = mergeSlideOverride(
+      options?.size,
+      slide?.size
+    );
+    const effectiveAnimation = mergeSlideOverride(
+      options?.animation,
+      slide?.animation
+    );
 
     if ( effectiveSize?.width && effectiveSize?.height ) {
       events.handle(
@@ -134,10 +152,14 @@ const slides = {
       );
     }
 
-    if ( effectiveAnimation?.framerate && effectiveAnimation.framerate > 0 ) {
+    // Coerced: a string framerate would pass a bare `> 0` check and then be
+    // silently ignored by p5's frameRate(), leaving the loop on the old rate.
+    const framerate = coerceFramerate( effectiveAnimation?.framerate );
+
+    if ( framerate !== null ) {
       events.handle(
         "engine-framerate-change",
-        effectiveAnimation.framerate
+        framerate
       );
     }
 

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -574,7 +574,7 @@ export const SketchSizeSchema = z.object( {
 } );
 
 export const SketchAnimationSchema = z.object( {
-  framerate: z.number().int()
+  framerate: z.coerce.number().int()
     .min( 1 )
     .max( 240 )
     .default( 60 ),


### PR DESCRIPTION
## Problem

Changing the framerate on the sketch page — especially through a slide's settings — could silently have no effect, and the FPS counter lagged reality enough to make even successful changes look broken.

## Root causes & fixes

1. **p5 silently drops non-number framerates.** `p5.frameRate()` returns without applying anything when the argument isn't a `number`. The slides path (`applyEffectiveSettings`) forwarded the raw store value behind a bare `> 0` check, so a framerate arriving as a numeric string (imported `options.json`, persisted job) passed the guard and was then ignored by p5 — no error, loop stays on the old rate. `options.js` had the inverse flaw: its `typeof === "number"` gate never fired the event for the same string, while still advancing its comparison baseline, permanently swallowing the change. Every call site now goes through a shared `coerceFramerate()` (`src/templates/p5/utils/framerate.js`).

2. **Boot applied a stale framerate.** In `p.setup`, `p.frameRate()` ran *before* the `pre-setup` event resolved the effective per-slide / persisted-job animation into `sketch.sketchOptions`. The effective rate is now re-applied right after `pre-setup`, so every boot starts on the correct rate instead of waiting for the next slide switch, and a change that arrived while p5 was rebooting is no longer lost.

3. **Partial per-slide overrides dropped global values.** Effective settings were resolved with `slide.animation ?? global` — a slide whose override only contains `framerate` lost the global `duration` (falling back to the hard-coded 12). A shared `mergeSlideOverride()` now fills missing keys from the globals, used consistently in `effectiveSlideSettings.ts`, `options.js` and `slides/index.js`.

4. **The FPS counter was structurally unreliable.** `P5Engine` sampled p5's *instantaneous* `frameRate()` on every rAF tick (display-rate aliased), took a median over a tiny window, then EMA-smoothed 0.8/0.2 every 500 ms — after a 60→24 change the label took 5+ seconds to converge, which read as "the framerate change did nothing". It now measures **real draws** via `frameCount` deltas over a sliding 1 s window (`FrameRateMeter`), converging within a second, and resets the window on seek/stop/resume so it never averages across a pause or rewind.

5. **Schema hardening.** `animation.framerate` is now `z.coerce.number()` (matching `duration`), so a string framerate in imported options no longer fails `OptionsSchema` — which, via `initOptions`'s `.catch()`, used to reset the *entire* options object to defaults.

Also fixed in passing: the `canvas.dataset.slide` guard compared a string to a number and rewrote the attribute every frame.

## Notes

- One p5 limitation remains (not addressed here): p5 quantises draws to rAF ticks with a 5 ms epsilon, so e.g. a 24 fps target on a 60 Hz display actually draws at ~20 fps. The counter now reports that truth instead of a smoothed fiction.
- The GSAP runtime's live playback still reads the *global* framerate only (its recording path is already slide-aware); GSAP templates don't currently drive slides at runtime, so this was left out of scope.

## Tests

- `framerateChange.test.ts`: full pipeline regression (store edit → event → `p.frameRate`), string coercion on both paths, invalid values ignored, slide switching, partial overrides keeping global duration/framerate.
- `frameRateMeter.test.ts`: steady rate, low-rate aliasing, 1-window convergence after a change, rewind reset, frozen-counter (pause) decay.
- `effectiveSlideSettings.test.ts`: override merge semantics.
- Full suite: 973 passed. Lint clean (one pre-existing warning). `tsc --noEmit` clean except pre-existing `traceLetters.test.ts` errors.

https://claude.ai/code/session_017rKBdFxrQy35VH21kWty2C