### PR TITLE
Vision source selector: webcam device, video asset or image asset

### DIFF
--- a/src/app/api/progression/stream/[id]/route.ts
+++ b/src/app/api/progression/stream/[id]/route.ts
@@ -14,7 +14,7 @@ import {
  * GET /api/progression/stream/[id]
  */
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   {
     params
   }: {
@@ -36,58 +36,90 @@ export async function GET(
   }
 
   let intervalId: NodeJS.Timeout | undefined = undefined;
+  // The status query (DB) can outlast the 250ms tick, so the client may
+  // disconnect mid-poll; enqueuing/closing the controller afterwards would
+  // throw an unhandled ERR_INVALID_STATE. Guard with a closed flag, prevent
+  // overlapping polls, and make stop() idempotent.
+  let closed = false;
+  let polling = false;
+
+  const stop = () => {
+    closed = true;
+
+    if ( intervalId ) {
+      clearInterval( intervalId );
+      intervalId = undefined;
+    }
+  };
 
   const stream = new ReadableStream( {
     async start( controller ) {
       controller.enqueue( "retry: 250\n\n" );
 
-      const sendUpdate = async() => {
-        const jobCurrentStepAndPercentage =
-          await getRecordingStatusAndTotalPercentage( id );
+      req.signal.addEventListener(
+        "abort",
+        stop
+      );
 
-        if ( !jobCurrentStepAndPercentage ) {
-          if ( intervalId ) {
-            clearInterval( intervalId );
-          }
+      const finish = () => {
+        stop();
 
+        try {
           controller.close();
+        } catch {
+          // Already closed by the client — nothing to do.
+        }
+      };
+
+      const sendUpdate = async() => {
+        if ( closed || polling ) {
           return;
         }
 
-        if (
-          jobCurrentStepAndPercentage.percentage === 100 ||
-          [
-            "completed",
-            "failed",
-            "cancelled"
-          ].includes( jobCurrentStepAndPercentage.status )
-        ) {
+        polling = true;
+
+        try {
+          const jobCurrentStepAndPercentage =
+            await getRecordingStatusAndTotalPercentage( id );
+
+          if ( closed ) {
+            return;
+          }
+
+          if ( !jobCurrentStepAndPercentage ) {
+            finish();
+            return;
+          }
+
           controller.enqueue( `data: ${ JSON.stringify( jobCurrentStepAndPercentage ) }\n\n` );
 
-          if ( intervalId ) {
-            clearInterval( intervalId );
+          if (
+            jobCurrentStepAndPercentage.percentage === 100 ||
+            [
+              "completed",
+              "failed",
+              "cancelled"
+            ].includes( jobCurrentStepAndPercentage.status )
+          ) {
+            finish();
           }
-
-          controller.close();
-          return;
+        } catch {
+          // Controller closed mid-poll or the query failed — stop streaming.
+          finish();
+        } finally {
+          polling = false;
         }
-
-        controller.enqueue( `data: ${ JSON.stringify( jobCurrentStepAndPercentage ) }\n\n` );
       };
 
       intervalId = setInterval(
-        async() => {
-          await sendUpdate();
-        },
+        sendUpdate,
         250
       );
 
       await sendUpdate();
     },
     cancel() {
-      if ( intervalId ) {
-        clearInterval( intervalId );
-      }
+      stop();
     }
   } );
 

--- a/src/app/api/progression/stream/route.ts
+++ b/src/app/api/progression/stream/route.ts
@@ -32,17 +32,49 @@ export async function GET( req: NextRequest ) {
   }
 
   let intervalId: NodeJS.Timeout | undefined = undefined;
+  // A poll can take longer than the 500ms tick (the status query hits the DB),
+  // so guard against the client disconnecting mid-poll — enqueuing on the
+  // closed controller would otherwise throw an unhandled ERR_INVALID_STATE.
+  let closed = false;
+  // Don't let slow polls overlap and pile up; skip a tick while one is running.
+  let polling = false;
+
+  const stop = () => {
+    closed = true;
+
+    if ( intervalId ) {
+      clearInterval( intervalId );
+      intervalId = undefined;
+    }
+  };
 
   const stream = new ReadableStream( {
     async start( controller ) {
       controller.enqueue( "retry: 500\n\n" );
 
+      // Stop as soon as the request is aborted (tab closed, navigation…).
+      req.signal.addEventListener(
+        "abort",
+        stop
+      );
+
       intervalId = setInterval(
         async() => {
-          for ( const id of jobIds ) {
-            const update = await getRecordingStatusAndTotalPercentage( id );
+          if ( closed || polling ) {
+            return;
+          }
 
-            if ( update ) {
+          polling = true;
+
+          try {
+            for ( const id of jobIds ) {
+              const update = await getRecordingStatusAndTotalPercentage( id );
+
+              // The client may have disconnected during the await above.
+              if ( closed || !update ) {
+                continue;
+              }
+
               controller.enqueue( `data: ${ JSON.stringify( {
                 jobId: id,
                 percentage: update.percentage,
@@ -52,15 +84,19 @@ export async function GET( req: NextRequest ) {
                 currentSlideIndex: update.currentSlideIndex
               } ) }\n\n` );
             }
+          } catch {
+            // Controller closed between the guard and the enqueue, or the
+            // status query failed — stop polling either way.
+            stop();
+          } finally {
+            polling = false;
           }
         },
         500
       );
     },
     cancel() {
-      if ( intervalId ) {
-        clearInterval( intervalId );
-      }
+      stop();
     }
   } );
 

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ConditionalGroup.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ConditionalGroup.tsx
@@ -22,6 +22,12 @@ import {
 } from "./ControlChrome";
 
 function getDefaultValueForFieldConfig( config: any ): any {
+  // A field config can pin its own default (e.g. a checkbox that should
+  // start checked when its branch is selected).
+  if ( config?.default !== undefined ) {
+    return config.default;
+  }
+
   switch ( config?.component ) {
     case "text":
     case "textarea":
@@ -37,8 +43,18 @@ function getDefaultValueForFieldConfig( config: any ): any {
         255,
         255
       ];
-    case "select":
-      return config.options?.[ 0 ]?.value ?? "";
+    case "select": {
+      const value = config.options?.[ 0 ]?.value ?? "";
+
+      return config.asNumber && value !== "" ? Number( value ) : value;
+    }
+    case "webcam-device-select":
+      return "";
+    case "asset":
+    case "asset-stack":
+    case "image":
+    case "images-stack":
+      return [];
     case "nested-object": {
       const result: Record<string, any> = {};
 

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledWebcamDeviceSelect.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledWebcamDeviceSelect.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, {
+  useEffect, useState
+} from "react";
+import {
+  ChevronDown
+} from "lucide-react";
+import {
+  useController, useFormContext
+} from "react-hook-form";
+import {
+  CONTROL_BAR_CLASS,
+  CONTROL_CHEVRON_CLASS
+} from "../constants/control-bar";
+import {
+  BarLabelSegment
+} from "./ControlChrome";
+
+type Props = {
+  name: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+};
+
+type DeviceOption = {
+  deviceId: string;
+  label: string;
+};
+
+/**
+ * Select bound to a webcam deviceId ("" = browser default). Device labels are
+ * only exposed by the browser once a camera permission has been granted, so
+ * the list refreshes on `devicechange` — which also fires after the vision
+ * layer first opens the webcam — and falls back to "Camera N" labels.
+ */
+export default function ControlledWebcamDeviceSelect( {
+  name,
+  label,
+  isModified,
+  onReset
+}: Props ) {
+  const {
+    control
+  } = useFormContext();
+  const {
+    field
+  } = useController( {
+    name,
+    control
+  } );
+
+  const [
+    devices,
+    setDevices
+  ] = useState<DeviceOption[]>( [] );
+
+  useEffect(
+    () => {
+      const media = navigator.mediaDevices;
+
+      if ( !media?.enumerateDevices ) {
+        return;
+      }
+
+      let cancelled = false;
+
+      async function refresh() {
+        try {
+          const all = await media.enumerateDevices();
+
+          if ( cancelled ) {
+            return;
+          }
+
+          setDevices( all
+            .filter( ( device ) => device.kind === "videoinput" )
+            .map( (
+              device, index
+            ) => ( {
+              deviceId: device.deviceId,
+              label: device.label || `Camera ${ index + 1 }`
+            } ) ) );
+        } catch {
+          // Enumeration unavailable (permissions, insecure context…): keep
+          // whatever list we had — the "Default" option always works.
+        }
+      }
+
+      refresh();
+      media.addEventListener?.(
+        "devicechange",
+        refresh
+      );
+
+      return () => {
+        cancelled = true;
+        media.removeEventListener?.(
+          "devicechange",
+          refresh
+        );
+      };
+    },
+    []
+  );
+
+  const currentValue = typeof field.value === "string" ? field.value : "";
+  const matched = devices.find( ( device ) => device.deviceId === currentValue );
+  // A saved deviceId may belong to an unplugged camera: keep it selectable so
+  // saving the form doesn't silently drop it.
+  const displayLabel = matched?.label ??
+    ( currentValue ? `Unavailable (${ currentValue.slice(
+      0,
+      8
+    ) }…)` : "Default" );
+
+  return (
+    <div className={ CONTROL_BAR_CLASS }>
+      <BarLabelSegment
+        label={ label }
+        isModified={ isModified }
+        onReset={ onReset }
+      />
+
+      <span className="pointer-events-none flex min-w-0 flex-1 items-center justify-between gap-1 px-2.5">
+        <span className="truncate">{displayLabel}</span>
+        <ChevronDown className={ CONTROL_CHEVRON_CLASS } />
+      </span>
+
+      <select
+        id={ name }
+        aria-label={ label ?? "Camera" }
+        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+        value={ currentValue }
+        onChange={ ( e ) => field.onChange( e.target.value ) }
+        onBlur={ field.onBlur }
+      >
+        <option value="">Default</option>
+
+        {currentValue && !matched && (
+          <option value={ currentValue } hidden>
+            {displayLabel}
+          </option>
+        )}
+
+        {devices.map( ( device ) => (
+          <option key={ device.deviceId } value={ device.deviceId }>
+            {device.label}
+          </option>
+        ) )}
+      </select>
+    </div>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -18,6 +18,12 @@ import {
 interface BaseConfig {
   label?: string; // Label is often optional (e.g., inside a group)
   placeholder?: string;
+  /**
+   * Default value used when a conditional-group branch is (re)selected and
+   * builds a fresh object for its fields. Optional; each component otherwise
+   * falls back to a sensible zero value.
+   */
+  default?: unknown;
 }
 
 // Step 2: Define the config shape for each component type
@@ -98,8 +104,9 @@ export interface ConditionalGroupConfig extends BaseConfig {
   typeSelector: Omit<SelectConfig, "component">; // It's a select, but we don't need the 'component' key here
   // A map of type names to their corresponding field configurations
   configs: Record<string, Record<string, FieldConfig>>;
-  // The Zod schema is crucial for creating default objects when the type changes
-  schema: ZodDiscriminatedUnion<any, any> | ZodObject<any>;
+  // Zod schema used to create default objects when the type changes. Optional:
+  // without one, defaults are derived per-field from the branch's configs.
+  schema?: ZodDiscriminatedUnion<any, any> | ZodObject<any>;
   // When true, omit the empty "--" (None) option from the selector. Use it for
   // required discriminators that should always resolve to a concrete variant.
   hideNone?: boolean;
@@ -206,6 +213,12 @@ interface AssetStackConfig extends BaseConfig {
   jobId?: string;
 }
 
+// A select listing the machine's video input devices (webcams), bound to a
+// deviceId string. "" means the browser's default camera.
+interface WebcamDeviceSelectConfig extends BaseConfig {
+  component: "webcam-device-select";
+}
+
 // Step 3: Create the master Discriminated Union
 // This tells TypeScript: "If component is 'select', then it MUST have an 'options' property."
 export type FieldConfig =
@@ -228,7 +241,8 @@ export type FieldConfig =
   | EasingConfig
   | Vector2DConfig
   | AssetInputConfig
-  | AssetStackConfig;
+  | AssetStackConfig
+  | WebcamDeviceSelectConfig;
 
 // Define the configuration for an entire item type (e.g., 'meta' or 'text')
 // The keys of this record must match the field names in the Zod schema

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer.tsx
@@ -25,6 +25,8 @@ import ControlledVector2DInput
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledVector2DInput/ControlledVector2DInput";
 import ControlledSliderInput
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/ControlledSliderInput";
+import ControlledWebcamDeviceSelect
+  from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledWebcamDeviceSelect";
 import CollapsibleItem from "@/components/CollapsibleItem";
 import RandomizeSettingsButton from "@/components/RandomizeSettingsButton";
 import type {
@@ -415,6 +417,16 @@ export default function FieldRenderer( {
 
       case "asset":
         return <ControlledAssetInput name={ registeredName } kind={ config.kind } />;
+
+      case "webcam-device-select":
+        return (
+          <ControlledWebcamDeviceSelect
+            name={ registeredName }
+            label={ inlineLabel }
+            isModified={ isModified }
+            onReset={ handleReset }
+          />
+        );
 
       case "asset-stack":
         return <ControlledAssetStackInput name={ registeredName } kind={ config.kind } />;

--- a/src/lib/recordSketch.ts
+++ b/src/lib/recordSketch.ts
@@ -53,6 +53,97 @@ async function waitForSketchReady(
 }
 
 /**
+ * Navigate to a capture page, waiting for `networkidle` exactly as before.
+ *
+ * Diagnostic only: this is behaviour-preserving (same wait condition, same
+ * timeout, the original error is re-thrown). The single addition is that, when
+ * the navigation times out waiting for the network to settle, it logs the
+ * requests still in flight — the ones keeping the page from reaching
+ * `networkidle`. That pinpoints the culprit (a never-finishing fetch, a
+ * long-poll, a heavy asset still downloading on a slow dev server, …) so we can
+ * decide the real fix from evidence instead of guessing.
+ */
+async function gotoSketchPage(
+  page: Page,
+  url: string
+): Promise<void> {
+  // Track requests that started but haven't completed yet.
+  const inFlight = new Map<unknown, { url: string;
+    method: string;
+    startedAt: number }>();
+
+  const onRequest = ( request: { url(): string;
+    method(): string } ) => {
+    inFlight.set(
+      request,
+      {
+        url: request.url(),
+        method: request.method(),
+        startedAt: Date.now()
+      }
+    );
+  };
+  const onSettled = ( request: unknown ) => {
+    inFlight.delete( request );
+  };
+
+  page.on(
+    "request",
+    onRequest
+  );
+  page.on(
+    "requestfinished",
+    onSettled
+  );
+  page.on(
+    "requestfailed",
+    onSettled
+  );
+
+  try {
+    await page.goto(
+      url,
+      {
+        waitUntil: "networkidle"
+      }
+    );
+  } catch( error ) {
+    const isTimeout =
+      error instanceof Error &&
+      ( error.name === "TimeoutError" || /Timeout/.test( error.message ) );
+
+    if ( isTimeout ) {
+      const now = Date.now();
+      const pending = Array.from( inFlight.values() )
+        .sort( (
+          a, b
+        ) => a.startedAt - b.startedAt )
+        .map( ( request ) =>
+          `  ${ now - request.startedAt }ms  ${ request.method }  ${ request.url }` );
+
+      console.error( `[recordSketch] networkidle timeout for ${ url }\n` +
+          `${ pending.length } request(s) still in flight (kept the page from going idle):\n` +
+          ( pending.length ? pending.join( "\n" ) : "  (none — the wait timed out with no pending requests)" ) );
+    }
+
+    throw error;
+  } finally {
+    page.off(
+      "request",
+      onRequest
+    );
+    page.off(
+      "requestfinished",
+      onSettled
+    );
+    page.off(
+      "requestfailed",
+      onSettled
+    );
+  }
+}
+
+/**
  * Calculate total frames from animation options
  */
 function calculateTotalFrames( animationOptions: any ): number {
@@ -191,11 +282,9 @@ async function recordSingleSketch(
     0
   );
 
-  await page.goto(
-    `http://localhost:3000/${ template }?id=${ jobId }&capturing`,
-    {
-      waitUntil: "networkidle"
-    }
+  await gotoSketchPage(
+    page,
+    `http://localhost:3000/${ template }?id=${ jobId }&capturing`
   );
 
   await waitForSketchReady(
@@ -319,11 +408,9 @@ async function recordMultipleSlides(
     0
   );
 
-  await page.goto(
-    `http://localhost:3000/${ template }?id=${ jobId }&capturing`,
-    {
-      waitUntil: "networkidle"
-    }
+  await gotoSketchPage(
+    page,
+    `http://localhost:3000/${ template }?id=${ jobId }&capturing`
   );
 
   await waitForSketchReady(
@@ -346,11 +433,9 @@ async function recordMultipleSlides(
 
     if ( slideIndex > 0 ) {
       // Re-navigate for subsequent slides (no dedicated step)
-      await page.goto(
-        `http://localhost:3000/${ template }?id=${ jobId }&capturing`,
-        {
-          waitUntil: "networkidle"
-        }
+      await gotoSketchPage(
+        page,
+        `http://localhost:3000/${ template }?id=${ jobId }&capturing`
       );
 
       await waitForSketchReady(

--- a/src/templates/p5/utils/interaction/defaults.js
+++ b/src/templates/p5/utils/interaction/defaults.js
@@ -22,7 +22,12 @@ export const interactionFormValues = {
 
   vision: {
     enabled: false,
-    camera: {
+    // What inference runs on. mode "webcam" uses the camera (deviceId picks
+    // one of several attached cameras); mode "video" / "image" runs the same
+    // trackers on a video or image asset instead — no webcam involved.
+    source: {
+      mode: "webcam",
+      deviceId: "",
       width: 320,
       height: 240,
       flip: true,
@@ -201,55 +206,110 @@ export const interactionFormConfiguration = {
           label: "Enabled"
         },
 
-        camera: {
-          component: "nested-object",
-          label: "Camera",
-          fields: {
-            width: {
-              component: "select",
-              label: "Width",
-              asNumber: true,
-              options: [
-                {
-                  label: "320",
-                  value: "320"
-                },
-                {
-                  label: "640",
-                  value: "640"
-                },
-                {
-                  label: "1280",
-                  value: "1280"
-                }
-              ]
+        source: {
+          component: "conditional-group",
+          label: "Source",
+          conditionalOn: "mode",
+          hideNone: true,
+          typeSelector: {
+            label: "Source",
+            options: [
+              {
+                label: "Webcam",
+                value: "webcam"
+              },
+              {
+                label: "Video asset",
+                value: "video"
+              },
+              {
+                label: "Image asset",
+                value: "image"
+              }
+            ]
+          },
+          configs: {
+            webcam: {
+              deviceId: {
+                component: "webcam-device-select",
+                label: "Camera"
+              },
+              width: {
+                component: "select",
+                label: "Width",
+                asNumber: true,
+                options: [
+                  {
+                    label: "320",
+                    value: "320"
+                  },
+                  {
+                    label: "640",
+                    value: "640"
+                  },
+                  {
+                    label: "1280",
+                    value: "1280"
+                  }
+                ]
+              },
+              height: {
+                component: "select",
+                label: "Height",
+                asNumber: true,
+                options: [
+                  {
+                    label: "240",
+                    value: "240"
+                  },
+                  {
+                    label: "480",
+                    value: "480"
+                  },
+                  {
+                    label: "720",
+                    value: "720"
+                  }
+                ]
+              },
+              flip: {
+                component: "checkbox",
+                label: "Flip (mirror)",
+                default: true
+              },
+              showPreview: {
+                component: "checkbox",
+                label: "Show preview"
+              }
             },
-            height: {
-              component: "select",
-              label: "Height",
-              asNumber: true,
-              options: [
-                {
-                  label: "240",
-                  value: "240"
-                },
-                {
-                  label: "480",
-                  value: "480"
-                },
-                {
-                  label: "720",
-                  value: "720"
-                }
-              ]
+            video: {
+              videos: {
+                component: "asset-stack",
+                kind: "videos",
+                label: "Video (first one drives inference)"
+              },
+              flip: {
+                component: "checkbox",
+                label: "Flip (mirror)"
+              },
+              showPreview: {
+                component: "checkbox",
+                label: "Show preview"
+              }
             },
-            flip: {
-              component: "checkbox",
-              label: "Flip (mirror)"
-            },
-            showPreview: {
-              component: "checkbox",
-              label: "Show preview"
+            image: {
+              image: {
+                component: "image",
+                label: "Image"
+              },
+              flip: {
+                component: "checkbox",
+                label: "Flip (mirror)"
+              },
+              showPreview: {
+                component: "checkbox",
+                label: "Show preview"
+              }
             }
           }
         },

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -1091,14 +1091,48 @@ function _ensureVisionSourceMedia( opts ) {
       return null;
     }
 
-    // Playback follows the sketch progression through the asset's own params
-    // — the same time-stretch behaviour as a video drawn by the videos pool,
-    // which keeps live preview and recordings consistent.
-    source.seekToProgression( animation.progression ).catch( () => {} );
+    // Live preview: let the video play at its natural rate so
+    // requestVideoFrameCallback delivers every decoded frame to MediaPipe.
+    // Per-frame seekToProgression would constantly reset currentTime — the
+    // frame stream would never advance, only the seeked-to frame would
+    // reach inference, and the video would stutter in every preview. The
+    // playback params we can honour cheaply (speed, loop) are mirrored to
+    // the element; the full repeat/offset/loopMode time-stretch curve is
+    // reserved for the recording pipeline, which frame-steps the video
+    // deterministically.
+    const element = source.element;
+
+    if ( element ) {
+      const speed = Number( source.params?.speed ) || 1;
+      // Clamp to the range every browser supports.
+      const rate = Math.min(
+        16,
+        Math.max(
+          0.0625,
+          speed
+        )
+      );
+
+      if ( element.playbackRate !== rate ) {
+        element.playbackRate = rate;
+      }
+
+      // "clamp" stops at the end, everything else loops in live preview
+      // (ping-pong reverse playback isn't supported natively).
+      const shouldLoop = ( source.params?.loopMode ?? "loop" ) !== "clamp";
+
+      if ( element.loop !== shouldLoop ) {
+        element.loop = shouldLoop;
+      }
+
+      if ( element.paused && element.readyState >= 2 ) {
+        element.play().catch( () => {} );
+      }
+    }
 
     return {
       type: "video",
-      element: source.element,
+      element,
       // The instance id is part of the key: removing a video and re-adding
       // the same file swaps the element, so mediapipe must re-adopt it.
       key: `video:${ instances[ 0 ].id }:${ source.path }`

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -5,8 +5,7 @@ import mediapipe, {
   init as mediapipeInit,
   setEnabled as setMediapipeEnabled,
   dispose as disposeMediapipe,
-  getTaskResult,
-  isWarmedUp as isVisionWarmedUp
+  getTaskResult
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   getP5
@@ -184,15 +183,6 @@ let _audioFreqData = null;
 // an in-flight guard so we never kick off two mediapipe initializations at once.
 let _visionSignature = "";
 let _visionInitInFlight = null;
-
-// Warm-up gate state. `_lastVisionOpts` is the most recent interaction options
-// seen by _ensureVision, so the no-arg readiness helpers (consumed by the
-// clock hold and the capture hook) know which tasks to wait for. The deadline
-// is a safety valve: if a camera is denied or a model fails, warm-up never
-// completes, so the gate gives up after this long and lets the sketch run.
-let _lastVisionOpts = null;
-let _visionWarmupDeadline = 0;
-const VISION_WARMUP_TIMEOUT_MS = 8000;
 
 // Vision source media state (vision.source mode "video" / "image"): the video
 // sync pool that loads/seeks the selected video asset, and the image element
@@ -560,15 +550,6 @@ export async function initInteraction( opts = {} ) {
 
   _audioInitialized = false;
 
-  // ── Vision warm-up gate ──────────────────────────────────────────────────
-  // Publish the readiness signal so the timeline clock can freeze the animation
-  // while vision warms up (hiding the first-inference jank) and so the headless
-  // capture pipeline can await it before frame 0. Both are no-ops once warm.
-  if ( typeof window !== "undefined" ) {
-    window.__visionWarmupHold = _isVisionWarmupHolding;
-    window.isInteractionVisionReady = () => isVisionReady();
-  }
-
   // ── MediaPipe ────────────────────────────────────────────────────────────
   // Pre-warm vision when a camera tracker is already enabled at setup. The same
   // routine also runs every frame from getPointers()/getPointerGroups(), so
@@ -645,13 +626,6 @@ export function disposeInteraction() {
   _releaseVisionMedia();
   _visionSignature = "";
   _visionInitInFlight = null;
-  _lastVisionOpts = null;
-  _visionWarmupDeadline = 0;
-
-  // Stop holding the next sketch's clock on this sketch's warm-up state.
-  delete window.__visionWarmupHold;
-  delete window.isInteractionVisionReady;
-
   _groupSmoothing.clear();
   _canvasRectCache.frame = -1;
   _canvasRectCache.canvas = null;
@@ -1117,48 +1091,14 @@ function _ensureVisionSourceMedia( opts ) {
       return null;
     }
 
-    // Live preview: let the video play at its natural rate so
-    // requestVideoFrameCallback delivers every decoded frame to MediaPipe.
-    // Per-frame seekToProgression would constantly reset currentTime — the
-    // frame stream would never advance, only the seeked-to frame would
-    // reach inference, and the video would stutter in every preview. The
-    // playback params we can honour cheaply (speed, loop) are mirrored to
-    // the element; the full repeat/offset/loopMode time-stretch curve is
-    // reserved for the recording pipeline, which frame-steps the video
-    // deterministically.
-    const element = source.element;
-
-    if ( element ) {
-      const speed = Number( source.params?.speed ) || 1;
-      // Clamp to the range every browser supports.
-      const rate = Math.min(
-        16,
-        Math.max(
-          0.0625,
-          speed
-        )
-      );
-
-      if ( element.playbackRate !== rate ) {
-        element.playbackRate = rate;
-      }
-
-      // "clamp" stops at the end, everything else loops in live preview
-      // (ping-pong reverse playback isn't supported natively).
-      const shouldLoop = ( source.params?.loopMode ?? "loop" ) !== "clamp";
-
-      if ( element.loop !== shouldLoop ) {
-        element.loop = shouldLoop;
-      }
-
-      if ( element.paused && element.readyState >= 2 ) {
-        element.play().catch( () => {} );
-      }
-    }
+    // Playback follows the sketch progression through the asset's own params
+    // — the same time-stretch behaviour as a video drawn by the videos pool,
+    // which keeps live preview and recordings consistent.
+    source.seekToProgression( animation.progression ).catch( () => {} );
 
     return {
       type: "video",
-      element,
+      element: source.element,
       // The instance id is part of the key: removing a video and re-adding
       // the same file swaps the element, so mediapipe must re-adopt it.
       key: `video:${ instances[ 0 ].id }:${ source.path }`
@@ -1302,10 +1242,6 @@ function _visionSignatureFor( config ) {
 // or camera changes, and releases the webcam once every tracker is off.
 // Safe to call each frame — it no-ops while the requested configuration is live.
 function _ensureVision( opts ) {
-  // Remember the live options so the no-arg readiness helpers (clock hold,
-  // capture hook) know which tasks the warm-up gate is waiting on.
-  _lastVisionOpts = opts;
-
   // An init is already running — let it settle; we reconcile next frame.
   if ( _visionInitInFlight ) {
     return _visionInitInFlight;
@@ -1365,11 +1301,6 @@ function _ensureVision( opts ) {
 
   _visionSignature = signature;
 
-  // Arm the warm-up safety deadline from the moment a (re)init starts.
-  _visionWarmupDeadline = ( typeof performance !== "undefined"
-    ? performance.now()
-    : Date.now() ) + VISION_WARMUP_TIMEOUT_MS;
-
   _visionInitInFlight = mediapipeInit( config )
     .then( () =>
       // init() doesn't restore mediapipe.enabled after a prior deallocate, so
@@ -1384,40 +1315,6 @@ function _ensureVision( opts ) {
     } );
 
   return _visionInitInFlight;
-}
-
-/**
- * Whether the vision pipeline for the given options has warmed up enough to
- * start the visible timeline / a recording: true when vision isn't needed,
- * when every requested task has produced its first result, or when the warm-up
- * safety deadline has passed (so a denied camera never blocks forever).
- *
- * Defaults to the last options _ensureVision saw, so the clock hold and the
- * `window.isInteractionVisionReady` capture hook can call it with no args.
- */
-export function isVisionReady( opts = _lastVisionOpts ) {
-  if ( !opts || opts.enabled === false ) {
-    return true;
-  }
-
-  if ( _desiredVisionTasks( opts ).length === 0 ) {
-    return true;
-  }
-
-  if ( isVisionWarmedUp() ) {
-    return true;
-  }
-
-  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-
-  return _visionWarmupDeadline > 0 && now > _visionWarmupDeadline;
-}
-
-// Predicate published on window so the timeline clock (time.js) can freeze the
-// animation while vision warms up — without time.js importing this heavy
-// module. Returns true only while a hold is warranted.
-function _isVisionWarmupHolding() {
-  return _lastVisionOpts != null && !isVisionReady( _lastVisionOpts );
 }
 
 // Convert a MediaPipe normalized landmark (0..1) to p5 canvas space, honouring

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -1117,48 +1117,24 @@ function _ensureVisionSourceMedia( opts ) {
       return null;
     }
 
-    // Live preview: let the video play at its natural rate so
-    // requestVideoFrameCallback delivers every decoded frame to MediaPipe.
-    // Per-frame seekToProgression would constantly reset currentTime — the
-    // frame stream would never advance, only the seeked-to frame would
-    // reach inference, and the video would stutter in every preview. The
-    // playback params we can honour cheaply (speed, loop) are mirrored to
-    // the element; the full repeat/offset/loopMode time-stretch curve is
-    // reserved for the recording pipeline, which frame-steps the video
-    // deterministically.
-    const element = source.element;
-
-    if ( element ) {
-      const speed = Number( source.params?.speed ) || 1;
-      // Clamp to the range every browser supports.
-      const rate = Math.min(
-        16,
-        Math.max(
-          0.0625,
-          speed
-        )
-      );
-
-      if ( element.playbackRate !== rate ) {
-        element.playbackRate = rate;
-      }
-
-      // "clamp" stops at the end, everything else loops in live preview
-      // (ping-pong reverse playback isn't supported natively).
-      const shouldLoop = ( source.params?.loopMode ?? "loop" ) !== "clamp";
-
-      if ( element.loop !== shouldLoop ) {
-        element.loop = shouldLoop;
-      }
-
-      if ( element.paused && element.readyState >= 2 ) {
-        element.play().catch( () => {} );
-      }
-    }
+    // Drive the video off the sketch progression — exactly like a video drawn
+    // by the videos pool — so scrubbing the timeline moves the video (and the
+    // landmarks) with it, honouring the asset's repeat/speed/offset/loopMode
+    // params via seekToProgression. seekToProgression dedupes repeat calls in
+    // the same frame (the interaction layer calls this several times per
+    // frame), so this issues at most one seek per progression value.
+    //
+    // MediaPipe must NOT gate inference on requestVideoFrameCallback for this
+    // element (see adoptCaptureElement): the seek uses rVFC internally for
+    // frame-accurate stepping, and a second rVFC consumer made the frame
+    // stream erratic — only the seeked-to frame reached inference and the
+    // preview stuttered. With rVFC gating off, mediapipe samples whatever
+    // frame the seek last settled on at its inference interval.
+    source.seekToProgression( animation.progression ).catch( () => {} );
 
     return {
       type: "video",
-      element,
+      element: source.element,
       // The instance id is part of the key: removing a video and re-adding
       // the same file swaps the element, so mediapipe must re-adopt it.
       key: `video:${ instances[ 0 ].id }:${ source.path }`

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -1,5 +1,6 @@
 import * as common from "@/p5/utils/common.js";
 import animation from "@/p5/utils/animation.js";
+import options from "@/p5/utils/options.js";
 import mediapipe, {
   init as mediapipeInit,
   setEnabled as setMediapipeEnabled,
@@ -9,6 +10,15 @@ import mediapipe, {
 import {
   getP5
 } from "@/p5/utils/sketch.js";
+import {
+  createVideoSync
+} from "@/lib/assets/kinds/videos/createVideoSync";
+import {
+  defaultVideoParams
+} from "@/lib/assets/kinds/videos/types";
+import {
+  resolveAssetURL
+} from "@/lib/assets/resolveAssetURL";
 
 // ── Hand landmark indices ──────────────────────────────────────────────────
 // Fingertip indices: thumb, index, middle, ring, pinky
@@ -173,6 +183,17 @@ let _audioFreqData = null;
 // an in-flight guard so we never kick off two mediapipe initializations at once.
 let _visionSignature = "";
 let _visionInitInFlight = null;
+
+// Vision source media state (vision.source mode "video" / "image"): the video
+// sync pool that loads/seeks the selected video asset, and the image element
+// inference runs on. Owned here — mediapipe only borrows the elements.
+let _visionVideoSync = null;
+let _visionVideoKey = "";
+let _visionVideoInstances = [];
+let _visionImage = {
+  path: "",
+  element: null
+};
 
 // Vision results older than this read as "nothing detected", so a stalled
 // pipeline never leaves a frozen hand/face on screen.
@@ -478,8 +499,7 @@ export async function initInteraction( opts = {} ) {
     const _onTouch = ( e ) => {
       _rawTouches = Array.from( e.touches ).map( ( t ) => ( {
         clientX: t.clientX,
-        clientY: t.clientY,
-        identifier: t.identifier
+        clientY: t.clientY
       } ) );
     };
 
@@ -603,6 +623,7 @@ export function disposeInteraction() {
   // Vision / webcam / inference processor. Full dispose (not just the webcam)
   // so MediaPipe task memory and the worker don't leak across sketch switches.
   disposeMediapipe();
+  _releaseVisionMedia();
   _visionSignature = "";
   _visionInitInFlight = null;
   _groupSmoothing.clear();
@@ -802,15 +823,9 @@ export function getPointerGroups( opts ) {
     "mouse",
     _collectMouse
   );
-
-  // Touch is grouped per FINGER with a stable id (the browser touch identifier),
-  // not the array index — so a sketch tracking which finger drags which thing
-  // (and the per-group temporal smoothing) stays correct even when a finger in
-  // the middle of the list lifts and the remaining touches reindex.
-  _collectTouchGroups(
-    opts,
-    p,
-    groups
+  addPerPoint(
+    "touch",
+    _collectTouch
   );
 
   // Vision: one ordered group per detected entity.
@@ -964,45 +979,173 @@ function _collectTouch(
   }
 }
 
-// One ordered group per active finger, keyed by the browser touch identifier so
-// the id follows a physical finger across frames (see the getPointerGroups call
-// site). Each group holds that finger's single point.
-function _collectTouchGroups(
-  opts, p, groups
-) {
-  const touch = opts.touch;
+// ── Vision source (webcam / video asset / image asset) ────────────────────
+// vision.source selects what inference runs on: the webcam (with an optional
+// deviceId), a video asset (driven by the sketch progression through its own
+// repeat/speed/offset/loopMode params) or a still image asset. Older saved
+// options only have vision.camera — that reads as webcam mode.
 
-  if ( !touch?.enabled ) {
-    return;
+function _visionSourceMode( vision ) {
+  return vision?.source?.mode || "webcam";
+}
+
+// Mirror handling depends on the source: webcams are mirrored by default,
+// recorded videos and images are not (a right hand must stay a right hand).
+function _visionFlip( vision ) {
+  const mode = _visionSourceMode( vision );
+
+  if ( mode === "video" || mode === "image" ) {
+    return vision?.source?.flip ?? false;
   }
 
-  const maxTouches = touch.maxTouches ?? 5;
-  const count = Math.min(
-    _rawTouches.length,
-    maxTouches
-  );
+  return vision?.source?.flip ?? vision?.camera?.flip ?? true;
+}
 
-  for ( let i = 0; i < count; i++ ) {
-    const raw = _rawTouches[ i ];
-    const {
-      x, y
-    } = _clientToCanvas(
-      raw.clientX,
-      raw.clientY,
-      p
-    );
-
-    groups.push( {
-      source: "touch",
-      id: `touch-${ raw.identifier ?? i }`,
-      points: [
-        p.createVector(
-          x,
-          y
-        )
-      ]
-    } );
+// The videos field stores serialized AssetInstances but tolerates bare path
+// strings — normalize to full instances for the video sync pool.
+function _normalizeVisionVideoInstances( raw ) {
+  if ( !Array.isArray( raw ) ) {
+    return [];
   }
+
+  return raw
+    .filter( ( entry ) => entry )
+    .map( ( entry ) => ( typeof entry === "string"
+      ? {
+        id: `vision-${ entry }`,
+        path: entry,
+        params: {
+          ...defaultVideoParams
+        }
+      }
+      : {
+        id: entry.id ?? `vision-${ entry.path }`,
+        path: entry.path ?? "",
+        params: {
+          ...defaultVideoParams,
+          ...( entry.params ?? {} )
+        }
+      } ) )
+    .filter( ( instance ) => instance.path );
+}
+
+function _releaseVisionVideo() {
+  if ( _visionVideoSync ) {
+    _visionVideoSync.dispose();
+    _visionVideoSync = null;
+  }
+
+  _visionVideoKey = "";
+  _visionVideoInstances = [];
+}
+
+function _releaseVisionImage() {
+  _visionImage = {
+    path: "",
+    element: null
+  };
+}
+
+function _releaseVisionMedia() {
+  _releaseVisionVideo();
+  _releaseVisionImage();
+}
+
+// Per-frame upkeep of the vision source media. Returns the mediapipe `source`
+// config (with a stable `key` for the re-init signature), or null while there
+// is nothing to run inference on yet (e.g. video mode with no video picked).
+function _ensureVisionSourceMedia( opts ) {
+  const vision = opts.vision ?? {};
+  const src = vision.source ?? {};
+  const mode = _visionSourceMode( vision );
+
+  if ( mode === "video" ) {
+    _releaseVisionImage();
+
+    const instances = _normalizeVisionVideoInstances( src.videos );
+    const key = JSON.stringify( instances );
+
+    _visionVideoInstances = instances;
+
+    if ( !instances.length ) {
+      _releaseVisionVideo();
+
+      return null;
+    }
+
+    if ( !_visionVideoSync ) {
+      _visionVideoSync = createVideoSync( {
+        getInstances: () => _visionVideoInstances,
+        jobId: () => options.id
+      } );
+      _visionVideoKey = key;
+    } else if ( key !== _visionVideoKey ) {
+      _visionVideoSync.refresh();
+      _visionVideoKey = key;
+    }
+
+    // Inference runs on the first video of the stack.
+    const source = _visionVideoSync.sources()[ 0 ];
+
+    if ( !source ) {
+      return null;
+    }
+
+    // Playback follows the sketch progression through the asset's own params
+    // — the same time-stretch behaviour as a video drawn by the videos pool,
+    // which keeps live preview and recordings consistent.
+    source.seekToProgression( animation.progression ).catch( () => {} );
+
+    return {
+      type: "video",
+      element: source.element,
+      // The instance id is part of the key: removing a video and re-adding
+      // the same file swaps the element, so mediapipe must re-adopt it.
+      key: `video:${ instances[ 0 ].id }:${ source.path }`
+    };
+  }
+
+  if ( mode === "image" ) {
+    _releaseVisionVideo();
+
+    const raw = Array.isArray( src.image ) ? src.image[ 0 ] : src.image;
+    const path = typeof raw === "string" ? raw : raw?.path ?? "";
+
+    if ( !path ) {
+      _releaseVisionImage();
+
+      return null;
+    }
+
+    if ( _visionImage.path !== path ) {
+      const element = document.createElement( "img" );
+
+      element.crossOrigin = "anonymous";
+      element.src = resolveAssetURL(
+        path,
+        options.id
+      );
+      _visionImage = {
+        path,
+        element
+      };
+    }
+
+    return {
+      type: "image",
+      element: _visionImage.element,
+      key: `image:${ path }`
+    };
+  }
+
+  // Webcam (default), incl. legacy options without a vision.source block.
+  _releaseVisionMedia();
+
+  return {
+    type: "webcam",
+    deviceId: src.deviceId || "",
+    key: `webcam:${ src.deviceId || "" }`
+  };
 }
 
 // The MediaPipe task names wanted by the current options.
@@ -1030,13 +1173,14 @@ function _desiredVisionTasks( opts ) {
   return tasks;
 }
 
-// The full mediapipe init config for the current options: trackers, camera,
+// The full mediapipe init config for the current options: source, trackers,
 // per-task model options and scheduling knobs.
 function _visionConfigFor(
-  opts, tasks
+  opts, tasks, source
 ) {
   const vision = opts.vision ?? {};
   const cam = vision.camera ?? {};
+  const src = vision.source ?? {};
   const perf = vision.performance ?? {};
 
   return {
@@ -1044,11 +1188,12 @@ function _visionConfigFor(
     // back to main-thread inference automatically when it can't start.
     worker: perf.useWorker ?? true,
     tasks,
+    source,
     captureSize: {
-      width: cam.width ?? 320,
-      height: cam.height ?? 240
+      width: src.width ?? cam.width ?? 320,
+      height: src.height ?? cam.height ?? 240
     },
-    captureFlip: cam.flip ?? true,
+    captureFlip: _visionFlip( vision ),
     inferenceInterval: perf.inferenceInterval ?? 20,
     idleInterval: perf.idleInterval ?? 280,
     idleAfter: perf.idleAfter ?? 3000,
@@ -1081,7 +1226,9 @@ function _visionSignatureFor( config ) {
     config.tasks,
     config.captureSize,
     config.captureFlip,
-    config.taskOptions
+    config.taskOptions,
+    // Only the stable key — the source element itself can't be stringified.
+    config.source?.key ?? ""
   ] );
 }
 
@@ -1109,12 +1256,28 @@ function _ensureVision( opts ) {
       _visionSignature = "";
     }
 
+    _releaseVisionMedia();
+
+    return Promise.resolve();
+  }
+
+  // Per-frame upkeep of the source media (video seek, asset changes). Null
+  // means the selected source has nothing to infer on yet (no asset picked).
+  const source = _ensureVisionSourceMedia( opts );
+
+  if ( !source ) {
+    if ( _visionSignature !== "" ) {
+      setMediapipeEnabled( false );
+      _visionSignature = "";
+    }
+
     return Promise.resolve();
   }
 
   const config = _visionConfigFor(
     opts,
-    tasks
+    tasks,
+    source
   );
   const signature = _visionSignatureFor( config );
 
@@ -1175,7 +1338,7 @@ function _collectHands(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const lm = hands.landmarks ?? {};
   const maxHands = hands.maxHands ?? 2;
   const results = getTaskResult(
@@ -1228,7 +1391,7 @@ function _eachDetectedFinger(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const maxHands = fingers.maxHands ?? 2;
   const results = getTaskResult(
     "hands",
@@ -1314,7 +1477,7 @@ function _collectFace(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const detections = getTaskResult(
     "faces",
     VISION_RESULT_TTL_MS
@@ -1354,7 +1517,7 @@ function _collectBody(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const lm = body.landmarks ?? {};
   const maxPoses = body.maxPoses ?? 1;
   const minConf = body.confidence ?? 0.3;
@@ -1413,7 +1576,7 @@ function _collectHandGroups(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const lm = hands.landmarks ?? {};
   const maxHands = hands.maxHands ?? 2;
   const results = getTaskResult(
@@ -1477,7 +1640,7 @@ function _collectBodyGroups(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const lm = body.landmarks ?? {};
   const maxPoses = body.maxPoses ?? 1;
   const minConf = body.confidence ?? 0.3;
@@ -1542,7 +1705,7 @@ function _collectFaceGroups(
     return;
   }
 
-  const flip = vision?.camera?.flip ?? true;
+  const flip = _visionFlip( vision );
   const maxFaces = face.maxFaces ?? 1;
   const minConf = face.confidence ?? 0.5;
   const detections = getTaskResult(

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -200,6 +200,15 @@ const VISION_WARMUP_TIMEOUT_MS = 8000;
 let _visionVideoSync = null;
 let _visionVideoKey = "";
 let _visionVideoInstances = [];
+// Offscreen canvas the seeked video frame is blitted into each frame. MediaPipe
+// infers on this canvas, never the raw <video>: a video that is paused and
+// re-seeked every frame is an unreliable createImageBitmap/detectForVideo
+// source (only the seeked-to frame lands, the rest read back black/stale),
+// whereas a canvas drawn via drawImage is always a valid, stable frame — the
+// exact pattern the videos pool uses to render seeked video reliably.
+let _visionVideoCanvas = null;
+let _visionVideoCtx = null;
+let _visionVideoCanvasFrame = -1;
 let _visionImage = {
   path: "",
   element: null
@@ -1063,6 +1072,10 @@ function _releaseVisionVideo() {
 
   _visionVideoKey = "";
   _visionVideoInstances = [];
+  // The detached canvas is GC'd once dereferenced.
+  _visionVideoCanvas = null;
+  _visionVideoCtx = null;
+  _visionVideoCanvasFrame = -1;
 }
 
 function _releaseVisionImage() {
@@ -1119,22 +1132,57 @@ function _ensureVisionSourceMedia( opts ) {
 
     // Drive the video off the sketch progression — exactly like a video drawn
     // by the videos pool — so scrubbing the timeline moves the video (and the
-    // landmarks) with it, honouring the asset's repeat/speed/offset/loopMode
-    // params via seekToProgression. seekToProgression dedupes repeat calls in
-    // the same frame (the interaction layer calls this several times per
-    // frame), so this issues at most one seek per progression value.
-    //
-    // MediaPipe must NOT gate inference on requestVideoFrameCallback for this
-    // element (see adoptCaptureElement): the seek uses rVFC internally for
-    // frame-accurate stepping, and a second rVFC consumer made the frame
-    // stream erratic — only the seeked-to frame reached inference and the
-    // preview stuttered. With rVFC gating off, mediapipe samples whatever
-    // frame the seek last settled on at its inference interval.
+    // landmarks it produces) with it, honouring the asset's
+    // repeat/speed/offset/loopMode params via seekToProgression.
+    // seekToProgression dedupes repeat calls with the same target, so the
+    // several calls per frame issue at most one seek per progression value.
     source.seekToProgression( animation.progression ).catch( () => {} );
+
+    const video = source.element;
+    const vw = video?.videoWidth ?? 0;
+    const vh = video?.videoHeight ?? 0;
+
+    // Metadata not decoded yet → nothing to infer on. The warm-up gate keeps
+    // the loading mask up until the first frame is available.
+    if ( !vw || !vh ) {
+      return null;
+    }
+
+    if ( !_visionVideoCanvas ) {
+      _visionVideoCanvas = document.createElement( "canvas" );
+      _visionVideoCtx = _visionVideoCanvas.getContext( "2d" );
+    }
+
+    if ( _visionVideoCanvas.width !== vw || _visionVideoCanvas.height !== vh ) {
+      _visionVideoCanvas.width = vw;
+      _visionVideoCanvas.height = vh;
+    }
+
+    // Blit the video's current frame into the canvas once per draw frame (the
+    // interaction layer calls this several times per frame). drawImage grabs
+    // whatever the seek last settled on — forgiving where createImageBitmap on
+    // the live <video> was not.
+    const frame = getP5()?.frameCount ?? 0;
+
+    if ( frame !== _visionVideoCanvasFrame && _visionVideoCtx ) {
+      _visionVideoCanvasFrame = frame;
+
+      try {
+        _visionVideoCtx.drawImage(
+          video,
+          0,
+          0,
+          vw,
+          vh
+        );
+      } catch {
+        // Frame not decodable this tick — keep the previous canvas contents.
+      }
+    }
 
     return {
       type: "video",
-      element: source.element,
+      element: _visionVideoCanvas,
       // The instance id is part of the key: removing a video and re-adding
       // the same file swaps the element, so mediapipe must re-adopt it.
       key: `video:${ instances[ 0 ].id }:${ source.path }`
@@ -1297,8 +1345,20 @@ function _ensureVision( opts ) {
     }
 
     _releaseVisionMedia();
+    // Reset the warm-up deadline so a later re-enable arms a fresh window.
+    _visionWarmupDeadline = 0;
 
     return Promise.resolve();
+  }
+
+  // Arm the warm-up safety deadline as soon as a tracker is wanted — even
+  // before a source is ready — so the clock-hold mask can never get stuck
+  // (e.g. a video whose metadata never loads, a denied camera). Re-init below
+  // refreshes it; this only seeds it when nothing has started the window yet.
+  if ( _visionWarmupDeadline === 0 ) {
+    _visionWarmupDeadline = ( typeof performance !== "undefined"
+      ? performance.now()
+      : Date.now() ) + VISION_WARMUP_TIMEOUT_MS;
   }
 
   // Per-frame upkeep of the source media (video seek, asset changes). Null

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -569,12 +569,12 @@ export async function initInteraction( opts = {} ) {
 
   _audioInitialized = false;
 
-  // ── Vision warm-up gate ──────────────────────────────────────────────────
-  // Publish the readiness signal so the timeline clock can freeze the animation
-  // while vision warms up (hiding the first-inference jank) and so the headless
-  // capture pipeline can await it before frame 0. Both are no-ops once warm.
+  // ── Vision readiness signal ──────────────────────────────────────────────
+  // Published so the headless capture pipeline can await a warmed-up vision
+  // source before frame 0 (see prepareCapture). Live preview deliberately does
+  // NOT block on this — the sketch animates from the start; freezing it while
+  // MediaPipe warmed up read as startup stutter, so that hold was removed.
   if ( typeof window !== "undefined" ) {
-    window.__visionWarmupHold = _isVisionWarmupHolding;
     window.isInteractionVisionReady = () => isVisionReady();
   }
 
@@ -657,8 +657,6 @@ export function disposeInteraction() {
   _lastVisionOpts = null;
   _visionWarmupDeadline = 0;
 
-  // Stop holding the next sketch's clock on this sketch's warm-up state.
-  delete window.__visionWarmupHold;
   delete window.isInteractionVisionReady;
 
   _groupSmoothing.clear();
@@ -1090,10 +1088,31 @@ function _releaseVisionMedia() {
   _releaseVisionImage();
 }
 
+// Per-frame source-media result cache. _ensureVision runs ~5× per draw frame
+// (the sketch's getPointerGroups plus the debug-overlay collectors), and the
+// upkeep below allocates + JSON.stringifies the video instances and reconciles
+// the source every call. Compute it once per frame and reuse it for the rest.
+let _visionSourceFrame = -1;
+let _visionSourceCache = null;
+
 // Per-frame upkeep of the vision source media. Returns the mediapipe `source`
 // config (with a stable `key` for the re-init signature), or null while there
 // is nothing to run inference on yet (e.g. video mode with no video picked).
 function _ensureVisionSourceMedia( opts ) {
+  const frame = getP5()?.frameCount ?? -1;
+
+  // -1 means no p5 yet (pre-first-draw) — don't cache, just recompute.
+  if ( frame !== -1 && frame === _visionSourceFrame ) {
+    return _visionSourceCache;
+  }
+
+  _visionSourceFrame = frame;
+  _visionSourceCache = _computeVisionSourceMedia( opts );
+
+  return _visionSourceCache;
+}
+
+function _computeVisionSourceMedia( opts ) {
   const vision = opts.vision ?? {};
   const src = vision.source ?? {};
   const mode = _visionSourceMode( vision );
@@ -1447,13 +1466,6 @@ export function isVisionReady( opts = _lastVisionOpts ) {
   const now = typeof performance !== "undefined" ? performance.now() : Date.now();
 
   return _visionWarmupDeadline > 0 && now > _visionWarmupDeadline;
-}
-
-// Predicate published on window so the timeline clock (time.js) can freeze the
-// animation while vision warms up — without time.js importing this heavy
-// module. Returns true only while a hold is warranted.
-function _isVisionWarmupHolding() {
-  return _lastVisionOpts != null && !isVisionReady( _lastVisionOpts );
 }
 
 // Convert a MediaPipe normalized landmark (0..1) to p5 canvas space, honouring

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -5,7 +5,8 @@ import mediapipe, {
   init as mediapipeInit,
   setEnabled as setMediapipeEnabled,
   dispose as disposeMediapipe,
-  getTaskResult
+  getTaskResult,
+  isWarmedUp as isVisionWarmedUp
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   getP5
@@ -183,6 +184,15 @@ let _audioFreqData = null;
 // an in-flight guard so we never kick off two mediapipe initializations at once.
 let _visionSignature = "";
 let _visionInitInFlight = null;
+
+// Warm-up gate state. `_lastVisionOpts` is the most recent interaction options
+// seen by _ensureVision, so the no-arg readiness helpers (consumed by the
+// clock hold and the capture hook) know which tasks to wait for. The deadline
+// is a safety valve: if a camera is denied or a model fails, warm-up never
+// completes, so the gate gives up after this long and lets the sketch run.
+let _lastVisionOpts = null;
+let _visionWarmupDeadline = 0;
+const VISION_WARMUP_TIMEOUT_MS = 8000;
 
 // Vision source media state (vision.source mode "video" / "image"): the video
 // sync pool that loads/seeks the selected video asset, and the image element
@@ -550,6 +560,15 @@ export async function initInteraction( opts = {} ) {
 
   _audioInitialized = false;
 
+  // ── Vision warm-up gate ──────────────────────────────────────────────────
+  // Publish the readiness signal so the timeline clock can freeze the animation
+  // while vision warms up (hiding the first-inference jank) and so the headless
+  // capture pipeline can await it before frame 0. Both are no-ops once warm.
+  if ( typeof window !== "undefined" ) {
+    window.__visionWarmupHold = _isVisionWarmupHolding;
+    window.isInteractionVisionReady = () => isVisionReady();
+  }
+
   // ── MediaPipe ────────────────────────────────────────────────────────────
   // Pre-warm vision when a camera tracker is already enabled at setup. The same
   // routine also runs every frame from getPointers()/getPointerGroups(), so
@@ -626,6 +645,13 @@ export function disposeInteraction() {
   _releaseVisionMedia();
   _visionSignature = "";
   _visionInitInFlight = null;
+  _lastVisionOpts = null;
+  _visionWarmupDeadline = 0;
+
+  // Stop holding the next sketch's clock on this sketch's warm-up state.
+  delete window.__visionWarmupHold;
+  delete window.isInteractionVisionReady;
+
   _groupSmoothing.clear();
   _canvasRectCache.frame = -1;
   _canvasRectCache.canvas = null;
@@ -1276,6 +1302,10 @@ function _visionSignatureFor( config ) {
 // or camera changes, and releases the webcam once every tracker is off.
 // Safe to call each frame — it no-ops while the requested configuration is live.
 function _ensureVision( opts ) {
+  // Remember the live options so the no-arg readiness helpers (clock hold,
+  // capture hook) know which tasks the warm-up gate is waiting on.
+  _lastVisionOpts = opts;
+
   // An init is already running — let it settle; we reconcile next frame.
   if ( _visionInitInFlight ) {
     return _visionInitInFlight;
@@ -1335,6 +1365,11 @@ function _ensureVision( opts ) {
 
   _visionSignature = signature;
 
+  // Arm the warm-up safety deadline from the moment a (re)init starts.
+  _visionWarmupDeadline = ( typeof performance !== "undefined"
+    ? performance.now()
+    : Date.now() ) + VISION_WARMUP_TIMEOUT_MS;
+
   _visionInitInFlight = mediapipeInit( config )
     .then( () =>
       // init() doesn't restore mediapipe.enabled after a prior deallocate, so
@@ -1349,6 +1384,40 @@ function _ensureVision( opts ) {
     } );
 
   return _visionInitInFlight;
+}
+
+/**
+ * Whether the vision pipeline for the given options has warmed up enough to
+ * start the visible timeline / a recording: true when vision isn't needed,
+ * when every requested task has produced its first result, or when the warm-up
+ * safety deadline has passed (so a denied camera never blocks forever).
+ *
+ * Defaults to the last options _ensureVision saw, so the clock hold and the
+ * `window.isInteractionVisionReady` capture hook can call it with no args.
+ */
+export function isVisionReady( opts = _lastVisionOpts ) {
+  if ( !opts || opts.enabled === false ) {
+    return true;
+  }
+
+  if ( _desiredVisionTasks( opts ).length === 0 ) {
+    return true;
+  }
+
+  if ( isVisionWarmedUp() ) {
+    return true;
+  }
+
+  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+
+  return _visionWarmupDeadline > 0 && now > _visionWarmupDeadline;
+}
+
+// Predicate published on window so the timeline clock (time.js) can freeze the
+// animation while vision warms up — without time.js importing this heavy
+// module. Returns true only while a hold is warranted.
+function _isVisionWarmupHolding() {
+  return _lastVisionOpts != null && !isVisionReady( _lastVisionOpts );
 }
 
 // Convert a MediaPipe normalized landmark (0..1) to p5 canvas space, honouring

--- a/src/templates/p5/utils/interaction/overlay.js
+++ b/src/templates/p5/utils/interaction/overlay.js
@@ -222,13 +222,16 @@ export function drawInteractionPointers( opts ) {
 }
 
 /**
- * Webcam preview in the top-right corner. Gated by `vision.camera.showPreview`
- * — works exactly the same in any sketch that has the camera running.
+ * Vision-source preview in the top-right corner (webcam, or the video/image
+ * asset inference runs on). Gated by `vision.source.showPreview` — with a
+ * fallback to the legacy `vision.camera.showPreview`.
  */
 export function drawInteractionCameraPreview( opts ) {
   const vision = opts?.vision;
+  const showPreview =
+    vision?.source?.showPreview ?? vision?.camera?.showPreview;
 
-  if ( !vision?.camera?.showPreview || !mediapipe.capture?.element ) {
+  if ( !showPreview || !mediapipe.capture?.element ) {
     return;
   }
 
@@ -236,19 +239,40 @@ export function drawInteractionCameraPreview( opts ) {
   const previewW = p.width / 5;
   const previewH = p.height / 5;
 
-  p.push();
-  p.tint(
-    255,
-    160
-  );
-  p.image(
-    mediapipe.capture.element,
-    p.width - previewW - 8,
-    8,
-    previewW,
-    previewH
-  );
-  p.pop();
+  if ( mediapipe.capture.owned ) {
+    p.push();
+    p.tint(
+      255,
+      160
+    );
+    p.image(
+      mediapipe.capture.element,
+      p.width - previewW - 8,
+      8,
+      previewW,
+      previewH
+    );
+    p.pop();
+  } else {
+    // Adopted video/image source: capture holds a bare { elt } wrapper, not
+    // a p5.MediaElement, so p.image() can't draw it — blit the raw element
+    // instead (2D renderer only; WEBGL has no drawImage on its context).
+    const elt = mediapipe.capture.element.elt;
+
+    if ( elt && typeof p.drawingContext?.drawImage === "function" ) {
+      try {
+        p.drawingContext.drawImage(
+          elt,
+          p.width - previewW - 8,
+          8,
+          previewW,
+          previewH
+        );
+      } catch {
+        // Frame not decodable yet — skip this frame's preview.
+      }
+    }
+  }
 
   p.push();
   p.noFill();

--- a/src/templates/p5/utils/interaction/overlay.js
+++ b/src/templates/p5/utils/interaction/overlay.js
@@ -16,8 +16,7 @@ import {
 } from "@/p5/utils/sketch.js";
 import {
   getPointersDebug,
-  getPointerGroups,
-  isVisionReady
+  getPointerGroups
 } from "./index.js";
 
 // Per-source colour palette (RGB). Shared so the legend dot, the crosshair,
@@ -423,13 +422,6 @@ export function drawInteractionOverlay( opts ) {
     return;
   }
 
-  // While the vision pipeline warms up, the timeline is frozen at frame 0 (see
-  // time.js): cover the held first frame with a loading mask and skip the debug
-  // overlays, which would only show empty data. Lifts itself once warm.
-  if ( drawInteractionWarmupOverlay( opts ) ) {
-    return;
-  }
-
   const viz = opts.visualization ?? {};
 
   // The camera preview lives under `vision.camera`, so it stays available even
@@ -445,82 +437,4 @@ export function drawInteractionOverlay( opts ) {
   drawInteractionFingerChains( opts );
   drawInteractionPointers( opts );
   drawInteractionLegend( opts );
-}
-
-/**
- * Loading mask shown while the vision pipeline warms up (model load, first
- * shader-compiling inference, first camera/video frame). The timeline is held
- * at frame 0 during this window (time.js), so this covers the static first
- * frame with a dimmed veil + a "preparing vision" label and three pulsing
- * dots. Returns true while it is masking, so the caller skips the rest of the
- * overlay. No-op (returns false) when vision isn't used or is already warm.
- *
- * 2D-canvas sketches only (like the rest of this overlay): positions use
- * top-left canvas coordinates.
- */
-export function drawInteractionWarmupOverlay( opts ) {
-  const vision = opts?.vision;
-
-  if ( !vision || vision.enabled === false ) {
-    return false;
-  }
-
-  if ( isVisionReady( opts ) ) {
-    return false;
-  }
-
-  const p = getP5();
-
-  p.push();
-
-  // Dimmed veil over the held frame.
-  p.noStroke();
-  p.fill(
-    0,
-    150
-  );
-  p.rect(
-    0,
-    0,
-    p.width,
-    p.height
-  );
-
-  const cx = p.width / 2;
-  const cy = p.height / 2;
-
-  p.textAlign(
-    p.CENTER,
-    p.CENTER
-  );
-  p.textSize( 14 );
-  p.fill(
-    255,
-    230
-  );
-  p.text(
-    "Preparing vision…",
-    cx,
-    cy - 14
-  );
-
-  // Three dots pulsing in sequence as a lightweight activity indicator.
-  const frame = p.frameCount ?? 0;
-  const active = Math.floor( frame / 12 ) % 3;
-
-  for ( let i = 0; i < 3; i++ ) {
-    p.fill(
-      255,
-      i === active ? 230 : 90
-    );
-    p.circle(
-      cx + ( i - 1 ) * 16,
-      cy + 12,
-      6
-    );
-  }
-
-  p.pop();
-
-  return true;
 }

--- a/src/templates/p5/utils/interaction/overlay.js
+++ b/src/templates/p5/utils/interaction/overlay.js
@@ -16,7 +16,8 @@ import {
 } from "@/p5/utils/sketch.js";
 import {
   getPointersDebug,
-  getPointerGroups
+  getPointerGroups,
+  isVisionReady
 } from "./index.js";
 
 // Per-source colour palette (RGB). Shared so the legend dot, the crosshair,
@@ -422,6 +423,13 @@ export function drawInteractionOverlay( opts ) {
     return;
   }
 
+  // While the vision pipeline warms up, the timeline is frozen at frame 0 (see
+  // time.js): cover the held first frame with a loading mask and skip the debug
+  // overlays, which would only show empty data. Lifts itself once warm.
+  if ( drawInteractionWarmupOverlay( opts ) ) {
+    return;
+  }
+
   const viz = opts.visualization ?? {};
 
   // The camera preview lives under `vision.camera`, so it stays available even
@@ -437,4 +445,82 @@ export function drawInteractionOverlay( opts ) {
   drawInteractionFingerChains( opts );
   drawInteractionPointers( opts );
   drawInteractionLegend( opts );
+}
+
+/**
+ * Loading mask shown while the vision pipeline warms up (model load, first
+ * shader-compiling inference, first camera/video frame). The timeline is held
+ * at frame 0 during this window (time.js), so this covers the static first
+ * frame with a dimmed veil + a "preparing vision" label and three pulsing
+ * dots. Returns true while it is masking, so the caller skips the rest of the
+ * overlay. No-op (returns false) when vision isn't used or is already warm.
+ *
+ * 2D-canvas sketches only (like the rest of this overlay): positions use
+ * top-left canvas coordinates.
+ */
+export function drawInteractionWarmupOverlay( opts ) {
+  const vision = opts?.vision;
+
+  if ( !vision || vision.enabled === false ) {
+    return false;
+  }
+
+  if ( isVisionReady( opts ) ) {
+    return false;
+  }
+
+  const p = getP5();
+
+  p.push();
+
+  // Dimmed veil over the held frame.
+  p.noStroke();
+  p.fill(
+    0,
+    150
+  );
+  p.rect(
+    0,
+    0,
+    p.width,
+    p.height
+  );
+
+  const cx = p.width / 2;
+  const cy = p.height / 2;
+
+  p.textAlign(
+    p.CENTER,
+    p.CENTER
+  );
+  p.textSize( 14 );
+  p.fill(
+    255,
+    230
+  );
+  p.text(
+    "Preparing vision…",
+    cx,
+    cy - 14
+  );
+
+  // Three dots pulsing in sequence as a lightweight activity indicator.
+  const frame = p.frameCount ?? 0;
+  const active = Math.floor( frame / 12 ) % 3;
+
+  for ( let i = 0; i < 3; i++ ) {
+    p.fill(
+      255,
+      i === active ? 230 : 90
+    );
+    p.circle(
+      cx + ( i - 1 ) * 16,
+      cy + 12,
+      6
+    );
+  }
+
+  p.pop();
+
+  return true;
 }

--- a/src/templates/p5/utils/loadProfiler.js
+++ b/src/templates/p5/utils/loadProfiler.js
@@ -140,32 +140,9 @@ function frameAnalysis() {
   const median = sorted.length ? sorted[ Math.floor( sorted.length / 2 ) ] : 0;
   const slow = frames.filter( ( f ) => f.index > 0 && f.gap > SLOW_FRAME_MS );
 
-  // When did it settle? First frame after which 10 consecutive frames are all
-  // under the slow threshold.
-  let settledIndex = -1;
-
-  for ( let i = 1; i < frames.length; i++ ) {
-    let ok = true;
-
-    for ( let j = i; j < Math.min(
-      i + 10,
-      frames.length
-    ); j++ ) {
-      if ( frames[ j ].gap > SLOW_FRAME_MS ) {
-        ok = false;
-        break;
-      }
-    }
-
-    if ( ok ) {
-      settledIndex = i;
-      break;
-    }
-  }
-
-  const settledAtMs = settledIndex >= 0
-    ? round( settledIndexTimeMs( settledIndex ) )
-    : -1;
+  // When did the jank stop? The last frame whose gap exceeded the threshold.
+  const lastSlow = slow.length ? slow[ slow.length - 1 ] : null;
+  const lastSlowAt = lastSlow ? round( frameTimeMs( lastSlow.index ) ) : 0;
 
   // Top 6 worst frames, each with work-vs-gap so main-thread jank (work≈gap)
   // is distinguishable from GPU/contention jank (work≪gap).
@@ -186,12 +163,14 @@ function frameAnalysis() {
     summary:
       `${ frames.length } frames in first ${ FRAME_WINDOW_MS / 1000 }s, ` +
       `median gap ${ median }ms, ${ slow.length } slow (>${ SLOW_FRAME_MS }ms), ` +
-      `settled at frame ${ settledIndex } (${ settledAtMs }ms after first draw)`,
+      ( lastSlow
+        ? `last jank at frame ${ lastSlow.index } (~${ lastSlowAt }ms after first draw)`
+        : "no jank after the first frame" ),
     worst
   };
 }
 
-function settledIndexTimeMs( index ) {
+function frameTimeMs( index ) {
   // Approx time-after-first-draw by summing gaps up to `index`.
   let total = 0;
 
@@ -211,16 +190,22 @@ function logProfile() {
   const setup = profile.setupEndAt && profile.setupBeginAt
     ? round( profile.setupEndAt - profile.setupBeginAt )
     : -1;
-  const setupToDraw = profile.firstDrawAt && profile.setupEndAt
-    ? round( profile.firstDrawAt - profile.setupEndAt )
+  const startToDraw = profile.firstDrawAt
+    ? round( profile.firstDrawAt - profile.startedAt )
     : -1;
+  // p5 starts the draw loop without awaiting the async setup(), so the first
+  // animated frame usually lands before setup (incl. the vision load) finishes
+  // — i.e. the sketch animates *concurrently* with MediaPipe loading.
+  const overlap = profile.setupEndAt && profile.firstDrawAt &&
+    profile.setupEndAt > profile.firstDrawAt;
 
   const analysis = frameAnalysis();
 
   console.info( `[load profile] ${ profile.name }\n` +
       `  page:   ${ pageMilestones() || "n/a" }\n` +
       `  engine: p5 load + canvas ${ p5Load }ms, setup (incl. vision) ${ setup }ms, ` +
-      `setup → first draw ${ setupToDraw }ms\n` +
+      `first draw ${ startToDraw }ms after engine start` +
+      ( overlap ? " (draw loop runs during async setup)" : "" ) + "\n" +
       `  frames: ${ analysis.summary }\n` +
       ( analysis.worst ? `  worst:  ${ analysis.worst }\n` : "" ) +
       "  (see [vision warmup] for the MediaPipe worker+model+shader breakdown)" );

--- a/src/templates/p5/utils/loadProfiler.js
+++ b/src/templates/p5/utils/loadProfiler.js
@@ -1,0 +1,236 @@
+// One-shot load profiler. Captures how long a sketch takes to become smooth —
+// the page paint milestones, the engine phases (p5 load → setup → first draw),
+// and the per-frame jank over the first couple of seconds — then logs a single
+// breakdown so "what's taking the time on load" is measured, not guessed.
+//
+// Purely diagnostic: it only reads timestamps and never touches rendering. The
+// phase marks are also emitted via performance.mark(), so they line up in the
+// Chrome DevTools Performance panel's "Timings" track when recording a reload.
+//
+// Pairs with the "[vision warmup]" log (mediapipe.js), which breaks down the
+// MediaPipe worker + model load and the first shader-compiling inference.
+
+const FRAME_WINDOW_MS = 2500; // how long after the first draw to sample frames
+const SLOW_FRAME_MS = 20; // a frame gap above this counts as jank (≈ <50fps)
+
+const profile = {
+  name: "",
+  startedAt: 0,
+  setupBeginAt: 0,
+  setupEndAt: 0,
+  firstDrawAt: 0,
+  lastFrameAt: 0,
+  frames: [], // { index, gap, work }
+  logged: false
+};
+
+function nowMs() {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function mark( name ) {
+  if ( typeof performance !== "undefined" && typeof performance.mark === "function" ) {
+    try {
+      performance.mark( name );
+    } catch {
+      // marks are best-effort
+    }
+  }
+}
+
+export function markSketchStart( name ) {
+  profile.name = name ?? "";
+  profile.startedAt = nowMs();
+  profile.setupBeginAt = 0;
+  profile.setupEndAt = 0;
+  profile.firstDrawAt = 0;
+  profile.lastFrameAt = 0;
+  profile.frames = [];
+  profile.logged = false;
+  mark( "sketch:start" );
+}
+
+export function markSetupBegin() {
+  profile.setupBeginAt = nowMs();
+  mark( "sketch:setup-begin" );
+}
+
+export function markSetupEnd() {
+  profile.setupEndAt = nowMs();
+  mark( "sketch:setup-end" );
+}
+
+// Called once per drawn frame with the main-thread work time spent inside the
+// draw handler. Records the frame gap (real frame time, incl. GPU/idle) and the
+// work time for the first window, then logs the summary once the window closes.
+export function recordFrame( workMs ) {
+  const at = nowMs();
+
+  if ( !profile.firstDrawAt ) {
+    profile.firstDrawAt = at;
+    mark( "sketch:first-draw" );
+  }
+
+  const gap = profile.lastFrameAt ? at - profile.lastFrameAt : 0;
+
+  profile.lastFrameAt = at;
+
+  if ( at - profile.firstDrawAt <= FRAME_WINDOW_MS ) {
+    profile.frames.push( {
+      index: profile.frames.length,
+      gap: Math.round( gap ),
+      work: Math.round( workMs )
+    } );
+  } else if ( !profile.logged ) {
+    logProfile();
+  }
+}
+
+function round( value ) {
+  return Number.isFinite( value ) ? Math.round( value ) : -1;
+}
+
+// Page-level paint + navigation milestones, relative to navigationStart.
+function pageMilestones() {
+  if ( typeof performance === "undefined" || !performance.getEntriesByType ) {
+    return "";
+  }
+
+  const nav = performance.getEntriesByType( "navigation" )[ 0 ];
+  const paints = performance.getEntriesByType( "paint" );
+  const fp = paints.find( ( p ) => p.name === "first-paint" );
+  const fcp = paints.find( ( p ) => p.name === "first-contentful-paint" );
+
+  const parts = [];
+
+  if ( nav ) {
+    parts.push( `TTFB ${ round( nav.responseStart ) }ms` );
+    parts.push( `DOMContentLoaded ${ round( nav.domContentLoadedEventEnd ) }ms` );
+    parts.push( `load ${ round( nav.loadEventEnd ) }ms` );
+  }
+
+  if ( fp ) {
+    parts.push( `first-paint ${ round( fp.startTime ) }ms` );
+  }
+
+  if ( fcp ) {
+    parts.push( `first-contentful-paint ${ round( fcp.startTime ) }ms` );
+  }
+
+  return parts.join( ", " );
+}
+
+function frameAnalysis() {
+  const frames = profile.frames;
+
+  if ( frames.length === 0 ) {
+    return {
+      summary: "no frames sampled",
+      worst: ""
+    };
+  }
+
+  // Skip the first frame's gap (it's the setup→first-draw boundary, not a gap).
+  const gaps = frames.slice( 1 ).map( ( f ) => f.gap );
+  const sorted = [
+    ...gaps
+  ].sort( (
+    a, b
+  ) => a - b );
+  const median = sorted.length ? sorted[ Math.floor( sorted.length / 2 ) ] : 0;
+  const slow = frames.filter( ( f ) => f.index > 0 && f.gap > SLOW_FRAME_MS );
+
+  // When did it settle? First frame after which 10 consecutive frames are all
+  // under the slow threshold.
+  let settledIndex = -1;
+
+  for ( let i = 1; i < frames.length; i++ ) {
+    let ok = true;
+
+    for ( let j = i; j < Math.min(
+      i + 10,
+      frames.length
+    ); j++ ) {
+      if ( frames[ j ].gap > SLOW_FRAME_MS ) {
+        ok = false;
+        break;
+      }
+    }
+
+    if ( ok ) {
+      settledIndex = i;
+      break;
+    }
+  }
+
+  const settledAtMs = settledIndex >= 0
+    ? round( settledIndexTimeMs( settledIndex ) )
+    : -1;
+
+  // Top 6 worst frames, each with work-vs-gap so main-thread jank (work≈gap)
+  // is distinguishable from GPU/contention jank (work≪gap).
+  const worst = [
+    ...slow
+  ]
+    .sort( (
+      a, b
+    ) => b.gap - a.gap )
+    .slice(
+      0,
+      6
+    )
+    .map( ( f ) => `f${ f.index } gap=${ f.gap }ms work=${ f.work }ms` )
+    .join( ", " );
+
+  return {
+    summary:
+      `${ frames.length } frames in first ${ FRAME_WINDOW_MS / 1000 }s, ` +
+      `median gap ${ median }ms, ${ slow.length } slow (>${ SLOW_FRAME_MS }ms), ` +
+      `settled at frame ${ settledIndex } (${ settledAtMs }ms after first draw)`,
+    worst
+  };
+}
+
+function settledIndexTimeMs( index ) {
+  // Approx time-after-first-draw by summing gaps up to `index`.
+  let total = 0;
+
+  for ( let i = 1; i <= index && i < profile.frames.length; i++ ) {
+    total += profile.frames[ i ].gap;
+  }
+
+  return total;
+}
+
+function logProfile() {
+  profile.logged = true;
+
+  const p5Load = profile.setupBeginAt
+    ? round( profile.setupBeginAt - profile.startedAt )
+    : -1;
+  const setup = profile.setupEndAt && profile.setupBeginAt
+    ? round( profile.setupEndAt - profile.setupBeginAt )
+    : -1;
+  const setupToDraw = profile.firstDrawAt && profile.setupEndAt
+    ? round( profile.firstDrawAt - profile.setupEndAt )
+    : -1;
+
+  const analysis = frameAnalysis();
+
+  console.info( `[load profile] ${ profile.name }\n` +
+      `  page:   ${ pageMilestones() || "n/a" }\n` +
+      `  engine: p5 load + canvas ${ p5Load }ms, setup (incl. vision) ${ setup }ms, ` +
+      `setup → first draw ${ setupToDraw }ms\n` +
+      `  frames: ${ analysis.summary }\n` +
+      ( analysis.worst ? `  worst:  ${ analysis.worst }\n` : "" ) +
+      "  (see [vision warmup] for the MediaPipe worker+model+shader breakdown)" );
+}
+
+const loadProfiler = {
+  markSketchStart,
+  markSetupBegin,
+  markSetupEnd,
+  recordFrame
+};
+
+export default loadProfiler;

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -199,12 +199,13 @@ function setupWorker() {
   return new Promise( (
     resolve, reject
   ) => {
-    const worker = new Worker(
-      "/assets/scripts/vision-worker.js",
-      {
-        type: "module"
-      }
-    );
+    // A CLASSIC worker, deliberately NOT { type: "module" }. The worker script
+    // and vision-manager use only dynamic import(), which works in classic
+    // workers — while MediaPipe's WASM glue calls importScripts(), which exists
+    // ONLY in classic workers. As a module worker the init always threw
+    // ("Module scripts don't support importScripts()") and silently fell back
+    // to MAIN-THREAD inference, stalling the render loop on every frame.
+    const worker = new Worker( "/assets/scripts/vision-worker.js" );
 
     mediapipe.processor.instance = worker;
 

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -68,6 +68,12 @@ const mediapipe = {
   enabled: true, // Dynamic enable/disable flag
   videoReady: false,
 
+  // True while prewarm() is running its synthetic warm-up inference. Real
+  // frames are held back during this window so the slow first (shader-
+  // compiling) inference always lands on the throwaway frame, not the sketch's
+  // first real one.
+  warming: false,
+
   // True once no task has produced a detection for idleAfterMilliseconds.
   // Sketches can read this to dim/skip work while nobody is interacting.
   idle: false,
@@ -142,6 +148,7 @@ export async function init( config = {} ) {
   mediapipe.tasks = {};
   mediapipe.mode = "VIDEO";
   mediapipe.enabled = true;
+  mediapipe.warming = false;
   mediapipe.idle = false;
   mediapipe.previousFrameSentTime = 0;
   mediapipe.scheduler.lastDetectionTime = performance.now();
@@ -180,6 +187,12 @@ export async function init( config = {} ) {
   } else {
     await setupMainThread();
   }
+
+  // Pre-warm the task graph on a synthetic frame so the first, shader-compiling
+  // inference happens here — during setup, before the sketch animates — instead
+  // of stalling the render loop on its first real frame (the visible init
+  // stutter). Bounded + best-effort: never blocks init for long, never throws.
+  await prewarm();
 }
 
 function setupWorker() {
@@ -281,6 +294,19 @@ function handleResult( {
 
   entry.result = result;
   entry.updatedAt = performance.now();
+
+  if ( mediapipe.warming ) {
+    // Synthetic prewarm frame: it compiled the task's GPU shaders, but it's a
+    // throwaway image — it must NOT satisfy `firstResultAt` (the source-ready
+    // latch the recording waits on, which has to mean "the real source
+    // produced a frame"). Record graph warmth separately so prewarm() knows
+    // when to stop, then bail before the real-result bookkeeping.
+    if ( entry.prewarmedAt === undefined ) {
+      entry.prewarmedAt = entry.updatedAt;
+    }
+
+    return;
+  }
 
   // One-way warm-up latch: the first result a task ever emits means its model
   // is loaded, its GPU shaders are compiled and the source delivered a frame.
@@ -386,6 +412,131 @@ function maybeLogWarmup() {
       `warm-up ${ round( w.worstFrameGapMs ) }ms (smooth 60fps ≈ 16.7ms); ` +
       `worker=${ mediapipe.config.useWorker }, source=${ mediapipe.config.source?.type }, ` +
       `dropped ${ mediapipe.stats.droppedFrames }, watchdog ${ mediapipe.stats.watchdogRecoveries }` );
+}
+
+function _delay( milliseconds ) {
+  return new Promise( ( resolve ) => setTimeout(
+    resolve,
+    milliseconds
+  ) );
+}
+
+// Every configured task has run its first (shader-compiling) inference on the
+// synthetic prewarm frame.
+function _allPrewarmed() {
+  const tasks = mediapipe.config.tasks ?? [];
+
+  return tasks.length > 0 &&
+    tasks.every( ( lib ) => mediapipe.tasks[ lib ]?.prewarmedAt !== undefined );
+}
+
+// Sends one synthetic frame straight to the processor (bypassing the
+// scheduler/draw loop), reusing the normal FRAME path so it compiles the same
+// shaders a real frame would. Best-effort: swallows transfer errors.
+async function _sendWarmupFrame( source ) {
+  if ( mediapipe.processor.busy ) {
+    return;
+  }
+
+  const now = performance.now();
+
+  mediapipe.processor.busy = true;
+  mediapipe.processor.busySince = now;
+
+  if ( mediapipe.config.useWorker ) {
+    try {
+      const bitmap = await createImageBitmap( source );
+
+      mediapipe.processor.instance.postMessage(
+        {
+          type: "FRAME",
+          bitmap,
+          timestamp: now
+        },
+        [
+          bitmap
+        ]
+      );
+    } catch( error ) {
+      mediapipe.stats.lastError = error?.message ?? String( error );
+      mediapipe.processor.busy = false;
+    }
+  } else {
+    try {
+      mediapipe.processor.instance.detect(
+        source,
+        now
+      );
+    } catch( error ) {
+      mediapipe.stats.lastError = error?.message ?? String( error );
+    } finally {
+      markFrameDone();
+    }
+  }
+}
+
+/**
+ * Pre-compiles the task graph on a throwaway neutral frame so the first
+ * shader-compiling inference happens here (during init, before the sketch's
+ * real animation) rather than stalling the render loop on the first real
+ * frame. Bounded by `timeoutMs` and never throws — a broken processor just
+ * falls through and the sketch runs as before.
+ *
+ * The synthetic results are flagged (mediapipe.warming) so they don't satisfy
+ * the real source-ready latch the recording pipeline waits on.
+ */
+export async function prewarm( timeoutMs = 4000 ) {
+  const tasks = mediapipe.config.tasks ?? [];
+
+  if (
+    !mediapipe.processor.ready ||
+    tasks.length === 0 ||
+    typeof document === "undefined"
+  ) {
+    return;
+  }
+
+  const size = mediapipe.config.captureSize ?? {
+    width: 256,
+    height: 256
+  };
+  const canvas = document.createElement( "canvas" );
+
+  canvas.width = size.width || 256;
+  canvas.height = size.height || 256;
+
+  const context = canvas.getContext( "2d" );
+
+  if ( context ) {
+    // A flat mid-grey is enough to build + compile the graph; we don't need a
+    // real detection, only the shaders.
+    context.fillStyle = "#808080";
+    context.fillRect(
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    );
+  }
+
+  mediapipe.warming = true;
+
+  const startedAt = performance.now();
+
+  try {
+    while (
+      !_allPrewarmed() &&
+      performance.now() - startedAt < timeoutMs
+    ) {
+      await _sendWarmupFrame( canvas );
+      // Let the worker round-trip (or the next main-thread slot) before the
+      // next probe; detectForVideo also needs strictly increasing timestamps.
+      await _delay( 40 );
+    }
+  } finally {
+    mediapipe.warming = false;
+    mediapipe.processor.busy = false;
+  }
 }
 
 /**
@@ -755,7 +906,7 @@ events.register(
 );
 
 function sendImageIfDue() {
-  if ( !mediapipe.enabled || !mediapipe.processor.ready ) {
+  if ( !mediapipe.enabled || !mediapipe.processor.ready || mediapipe.warming ) {
     return;
   }
 
@@ -796,7 +947,7 @@ function sendImageIfDue() {
 }
 
 function sendFrameIfDue() {
-  if ( !mediapipe.enabled || !mediapipe.processor.ready ) {
+  if ( !mediapipe.enabled || !mediapipe.processor.ready || mediapipe.warming ) {
     return;
   }
 

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -98,6 +98,20 @@ const mediapipe = {
     droppedFrames: 0, // frames due but skipped because inference was busy
     watchdogRecoveries: 0,
     lastError: null
+  },
+
+  // One-shot diagnostic for the startup jank: times the warm-up phase (worker
+  // + model load, first shader-compiling inference) and the worst main-thread
+  // frame gap seen while it ran, then logs a single breakdown so the cause of
+  // the init stutter is measured, not guessed. Reset on every init().
+  warmup: {
+    initStartedAt: 0,
+    readyAt: 0,
+    firstFrameSentAt: 0,
+    firstResultAt: 0,
+    lastPostDrawAt: 0,
+    worstFrameGapMs: 0,
+    logged: false
   }
 };
 
@@ -131,6 +145,15 @@ export async function init( config = {} ) {
   mediapipe.idle = false;
   mediapipe.previousFrameSentTime = 0;
   mediapipe.scheduler.lastDetectionTime = performance.now();
+  mediapipe.warmup = {
+    initStartedAt: performance.now(),
+    readyAt: 0,
+    firstFrameSentAt: 0,
+    firstResultAt: 0,
+    lastPostDrawAt: 0,
+    worstFrameGapMs: 0,
+    logged: false
+  };
   resetStats();
 
   // Only initialize camera if enableCapture is true (default: true for backward compatibility)
@@ -194,6 +217,7 @@ function setupWorker() {
 
       if ( type === "READY" ) {
         mediapipe.processor.ready = true;
+        mediapipe.warmup.readyAt = performance.now();
         clearTimeout( initTimeout );
         resolve();
       } else if ( type === "INIT_ERROR" ) {
@@ -230,6 +254,7 @@ async function setupMainThread() {
     mediapipeLibraryPath: "/assets/libraries/mediapipe"
   } );
   mediapipe.processor.ready = true;
+  mediapipe.warmup.readyAt = performance.now();
 }
 
 function resultHasDetections( result ) {
@@ -262,6 +287,12 @@ function handleResult( {
   // Never cleared (unlike `result`), so isWarmedUp() reflects "has run once".
   if ( entry.firstResultAt === undefined ) {
     entry.firstResultAt = entry.updatedAt;
+
+    if ( !mediapipe.warmup.firstResultAt ) {
+      mediapipe.warmup.firstResultAt = entry.updatedAt;
+    }
+
+    maybeLogWarmup();
   }
 
   if ( resultHasDetections( result ) ) {
@@ -326,6 +357,37 @@ export function isWarmedUp() {
   return tasks.every( ( lib ) => mediapipe.tasks[ lib ]?.firstResultAt !== undefined );
 }
 
+// Logs a one-shot breakdown of the warm-up phase the first time every task is
+// warm, so the cause of the init stutter is measured: how long the worker +
+// model took to load, how long the first (shader-compiling) inference ran, and
+// the worst gap between consecutive frames the main thread saw while it all
+// happened (a large gap = the render loop was starved → the visible stutter).
+function maybeLogWarmup() {
+  const w = mediapipe.warmup;
+
+  if ( w.logged || !isWarmedUp() ) {
+    return;
+  }
+
+  w.logged = true;
+
+  const round = ( value ) => Math.round( value );
+  const completedAt = performance.now();
+  const total = w.initStartedAt ? round( completedAt - w.initStartedAt ) : -1;
+  const modelLoad =
+    w.readyAt && w.initStartedAt ? round( w.readyAt - w.initStartedAt ) : -1;
+  const firstInference =
+    w.firstResultAt && w.firstFrameSentAt
+      ? round( w.firstResultAt - w.firstFrameSentAt )
+      : -1;
+
+  console.info( `[vision warmup] total ${ total }ms — worker+model load ${ modelLoad }ms, ` +
+      `first inference ${ firstInference }ms; worst main-thread frame gap during ` +
+      `warm-up ${ round( w.worstFrameGapMs ) }ms (smooth 60fps ≈ 16.7ms); ` +
+      `worker=${ mediapipe.config.useWorker }, source=${ mediapipe.config.source?.type }, ` +
+      `dropped ${ mediapipe.stats.droppedFrames }, watchdog ${ mediapipe.stats.watchdogRecoveries }` );
+}
+
 /**
  * Returns the latest result for a task, or null when there is none or it is
  * older than maxAgeMilliseconds — so a stalled pipeline reads as "nothing
@@ -368,6 +430,10 @@ export async function predictImage( imageSource ) {
 
   mediapipe.processor.busy = true;
   mediapipe.processor.busySince = performance.now();
+
+  if ( !mediapipe.warmup.firstFrameSentAt ) {
+    mediapipe.warmup.firstFrameSentAt = mediapipe.processor.busySince;
+  }
 
   // 2. Send Data
   if ( mediapipe.config.useWorker ) {
@@ -658,6 +724,21 @@ function armFrameCallback( videoEl ) {
 events.register(
   "post-draw",
   () => {
+    // Diagnostic: record the worst gap between consecutive frames while the
+    // warm-up is still running — a big gap means the render loop was starved
+    // (the visible init stutter). Stops once the breakdown has been logged.
+    const w = mediapipe.warmup;
+
+    if ( !w.logged ) {
+      const tick = performance.now();
+
+      if ( w.lastPostDrawAt && tick - w.lastPostDrawAt > w.worstFrameGapMs ) {
+        w.worstFrameGapMs = tick - w.lastPostDrawAt;
+      }
+
+      w.lastPostDrawAt = tick;
+    }
+
     // Image sources have no frame stream: re-detect at a slow fixed pace so
     // results stay fresher than the interaction layer's staleness TTL.
     if ( mediapipe.config.source?.type === "image" ) {
@@ -791,6 +872,10 @@ function sendFrameIfDue() {
   mediapipe.processor.busySince = now;
   mediapipe.previousFrameSentTime = now;
   scheduler.freshFrame = false;
+
+  if ( !mediapipe.warmup.firstFrameSentAt ) {
+    mediapipe.warmup.firstFrameSentAt = now;
+  }
 
   if ( mediapipe.config.useWorker ) {
     createImageBitmap( videoEl )

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -585,7 +585,14 @@ function adoptCaptureElement(
       );
     }
 
-    armFrameCallback( element );
+    // Don't gate inference on requestVideoFrameCallback: this adopted video is
+    // driven by the owner seeking it to the sketch progression, and that seek
+    // uses rVFC internally for frame-accurate stepping. A second rVFC consumer
+    // here made the frame stream erratic (only seeked-to frames reached
+    // inference, the preview stuttered). Instead sample whatever frame the seek
+    // settled on at the inference interval, like the image path.
+    mediapipe.scheduler.usingFrameCallback = false;
+    mediapipe.scheduler.freshFrame = true;
   } else {
     // Images have no frame stream: the post-draw loop re-detects them at the
     // idle interval instead (see sendImageIfDue).

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -556,10 +556,12 @@ function adoptCaptureElement(
       width:
         element.videoWidth ||
         element.naturalWidth ||
+        element.width ||
         mediapipe.config.captureSize.width,
       height:
         element.videoHeight ||
         element.naturalHeight ||
+        element.height ||
         mediapipe.config.captureSize.height
     };
   };
@@ -567,7 +569,15 @@ function adoptCaptureElement(
   applySize();
 
   if ( type === "video" ) {
-    if ( element.readyState >= 2 ) {
+    // The "video" source is adopted as an offscreen <canvas> the owner blits
+    // the seeked video frame into (see the interaction layer): a canvas is a
+    // stable, always-valid inference source, unlike a paused+re-seeked <video>
+    // read directly. A bare <video> is still tolerated as a fallback.
+    const isCanvas = typeof element.getContext === "function";
+
+    if ( isCanvas || element.readyState >= 2 ) {
+      // The owner only hands over the canvas once it has drawn into it, so it
+      // is drawable immediately.
       mediapipe.videoReady = true;
     } else {
       element.addEventListener(
@@ -585,12 +595,10 @@ function adoptCaptureElement(
       );
     }
 
-    // Don't gate inference on requestVideoFrameCallback: this adopted video is
-    // driven by the owner seeking it to the sketch progression, and that seek
-    // uses rVFC internally for frame-accurate stepping. A second rVFC consumer
-    // here made the frame stream erratic (only seeked-to frames reached
-    // inference, the preview stuttered). Instead sample whatever frame the seek
-    // settled on at the inference interval, like the image path.
+    // Don't gate inference on requestVideoFrameCallback: a canvas has none, and
+    // even a raw video here is driven by the owner seeking it, whose seek uses
+    // rVFC internally — a second consumer made the frame stream erratic. Sample
+    // the current frame at the inference interval instead, like the image path.
     mediapipe.scheduler.usingFrameCallback = false;
     mediapipe.scheduler.freshFrame = true;
   } else {

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -27,7 +27,15 @@ const mediapipe = {
       width: 320,
       height: 240
     },
-    captureFlip: true
+    captureFlip: true,
+
+    // Where frames come from:
+    //   { type: "webcam", deviceId? }          → p5 createCapture (owned)
+    //   { type: "video" | "image", element }   → adopted external element
+    //     (a video/image asset; its owner keeps loading/seeking/disposing it)
+    source: {
+      type: "webcam"
+    }
   },
 
   // Latest result per task: mediapipe.tasks[ lib ] = { result, updatedAt }.
@@ -35,6 +43,9 @@ const mediapipe = {
 
   capture: {
     element: null,
+    // False when the element is adopted from outside (video/image source):
+    // teardown must not stop tracks or remove an element it doesn't own.
+    owned: true,
     size: {
       width: 320,
       height: 240
@@ -103,6 +114,9 @@ export async function init( config = {} ) {
     height: 240
   };
   mediapipe.config.captureFlip = config.captureFlip ?? true;
+  mediapipe.config.source = config.source ?? {
+    type: "webcam"
+  };
 
   mediapipe.inferenceIntervalMilliseconds =
     config.inferenceInterval ?? mediapipe.inferenceIntervalMilliseconds;
@@ -123,7 +137,7 @@ export async function init( config = {} ) {
   const enableCapture = config.enableCapture ?? true;
 
   if ( enableCapture ) {
-    createVideoCaptureElements();
+    setupCaptureSource();
   }
 
   if ( mediapipe.config.useWorker ) {
@@ -421,14 +435,58 @@ export function interact(
   }
 }
 
+// Creates or adopts the element frames are read from, according to
+// config.source. Webcam sources own a fresh p5 capture; video/image sources
+// borrow an element whose lifecycle (loading, seeking, disposal) belongs to
+// the caller — typically a video/image asset from the sketch options.
+function setupCaptureSource() {
+  const source = mediapipe.config.source ?? {
+    type: "webcam"
+  };
+
+  if (
+    ( source.type === "video" || source.type === "image" ) &&
+    source.element
+  ) {
+    adoptCaptureElement(
+      source.element,
+      source.type
+    );
+  } else {
+    createVideoCaptureElements();
+  }
+}
+
 function createVideoCaptureElements() {
   const p = getP5();
   const size = mediapipe.config.captureSize;
   const flip = mediapipe.config.captureFlip;
+  const deviceId = mediapipe.config.source?.deviceId;
 
   mediapipe.videoReady = false;
+  mediapipe.capture.owned = true;
+
+  // A specific camera was requested → pass full getUserMedia constraints
+  // (p5 accepts a constraints object in place of the VIDEO constant).
+  const constraints = deviceId
+    ? {
+      audio: false,
+      video: {
+        deviceId: {
+          exact: deviceId
+        },
+        width: {
+          ideal: size.width
+        },
+        height: {
+          ideal: size.height
+        }
+      }
+    }
+    : p.VIDEO;
+
   mediapipe.capture.element = p.createCapture(
-    p.VIDEO,
+    constraints,
     {
       flipped: flip
     }
@@ -453,6 +511,78 @@ function createVideoCaptureElements() {
   );
 
   armFrameCallback( mediapipe.capture.element.elt );
+}
+
+// Borrows an external <video> or <img> as the inference source. Only a thin
+// wrapper is stored ({ elt }) so every consumer that reads capture.element.elt
+// keeps working; capture.owned = false tells teardown to leave it alone.
+function adoptCaptureElement(
+  element, type
+) {
+  mediapipe.videoReady = false;
+  mediapipe.capture.owned = false;
+  mediapipe.capture.element = {
+    elt: element
+  };
+
+  const applySize = () => {
+    mediapipe.capture.size = {
+      width:
+        element.videoWidth ||
+        element.naturalWidth ||
+        mediapipe.config.captureSize.width,
+      height:
+        element.videoHeight ||
+        element.naturalHeight ||
+        mediapipe.config.captureSize.height
+    };
+  };
+
+  applySize();
+
+  if ( type === "video" ) {
+    if ( element.readyState >= 2 ) {
+      mediapipe.videoReady = true;
+    } else {
+      element.addEventListener(
+        "loadeddata",
+        () => {
+          // Bail if the source changed while the video was still loading.
+          if ( mediapipe.capture.element?.elt === element ) {
+            mediapipe.videoReady = true;
+            applySize();
+          }
+        },
+        {
+          once: true
+        }
+      );
+    }
+
+    armFrameCallback( element );
+  } else {
+    // Images have no frame stream: the post-draw loop re-detects them at the
+    // idle interval instead (see sendImageIfDue).
+    if ( element.complete && element.naturalWidth > 0 ) {
+      mediapipe.videoReady = true;
+    } else {
+      element.addEventListener(
+        "load",
+        () => {
+          if ( mediapipe.capture.element?.elt === element ) {
+            mediapipe.videoReady = true;
+            applySize();
+          }
+        },
+        {
+          once: true
+        }
+      );
+    }
+
+    mediapipe.scheduler.usingFrameCallback = false;
+    mediapipe.scheduler.freshFrame = true;
+  }
 }
 
 // With requestVideoFrameCallback support we know exactly when the camera
@@ -487,12 +617,61 @@ function armFrameCallback( videoEl ) {
 events.register(
   "post-draw",
   () => {
-  // Only run automatic video loop if we are in VIDEO mode
+    // Image sources have no frame stream: re-detect at a slow fixed pace so
+    // results stay fresher than the interaction layer's staleness TTL.
+    if ( mediapipe.config.source?.type === "image" ) {
+      sendImageIfDue();
+
+      return;
+    }
+
+    // Only run automatic video loop if we are in VIDEO mode
     if ( mediapipe.mode === "VIDEO" ) {
       sendFrameIfDue();
     }
   }
 );
+
+function sendImageIfDue() {
+  if ( !mediapipe.enabled || !mediapipe.processor.ready ) {
+    return;
+  }
+
+  const element = mediapipe.capture.element?.elt;
+
+  if ( !element || !element.complete || !element.naturalWidth ) {
+    return;
+  }
+
+  const now = performance.now();
+
+  // A static image never changes, so the active-rate interval is pointless:
+  // always pace at the (slower) idle interval.
+  const interval = Math.max(
+    mediapipe.inferenceIntervalMilliseconds,
+    mediapipe.scheduler.idleIntervalMilliseconds
+  );
+
+  if ( now - mediapipe.previousFrameSentTime < interval ) {
+    return;
+  }
+
+  if ( mediapipe.processor.busy ) {
+    // Same watchdog as the video loop: never stay stuck on a lost frame.
+    if (
+      now - mediapipe.processor.busySince >
+      mediapipe.scheduler.busyTimeoutMilliseconds
+    ) {
+      mediapipe.processor.busy = false;
+      mediapipe.stats.watchdogRecoveries++;
+    } else {
+      return;
+    }
+  }
+
+  mediapipe.previousFrameSentTime = now;
+  predictImage( element );
+}
 
 function sendFrameIfDue() {
   if ( !mediapipe.enabled || !mediapipe.processor.ready ) {
@@ -608,9 +787,9 @@ function sendFrameIfDue() {
 export function enable() {
   mediapipe.enabled = true;
 
-  // If capture element doesn't exist, create it
+  // If capture element doesn't exist, create (or re-adopt) it
   if ( !mediapipe.capture.element ) {
-    createVideoCaptureElements();
+    setupCaptureSource();
   }
 }
 
@@ -631,21 +810,25 @@ export function disable() {
 export function deallocateWebcam() {
   disable();
 
-  // Stop and remove webcam stream
-  if ( mediapipe.capture.element?.elt?.srcObject ) {
-    const stream = mediapipe.capture.element.elt.srcObject;
-    const tracks = stream.getTracks();
+  // Adopted elements (video/image assets) belong to their loader: just drop
+  // the reference. Only an owned webcam capture gets stopped and removed.
+  if ( mediapipe.capture.owned ) {
+    // Stop and remove webcam stream
+    if ( mediapipe.capture.element?.elt?.srcObject ) {
+      const stream = mediapipe.capture.element.elt.srcObject;
+      const tracks = stream.getTracks();
 
-    tracks.forEach( ( track ) => track.stop() );
-    mediapipe.capture.element.elt.srcObject = null;
+      tracks.forEach( ( track ) => track.stop() );
+      mediapipe.capture.element.elt.srcObject = null;
+    }
+
+    // Remove the video element
+    if ( mediapipe.capture.element ) {
+      mediapipe.capture.element.remove();
+    }
   }
 
-  // Remove the video element
-  if ( mediapipe.capture.element ) {
-    mediapipe.capture.element.remove();
-    mediapipe.capture.element = null;
-  }
-
+  mediapipe.capture.element = null;
   mediapipe.videoReady = false;
 }
 

--- a/src/templates/p5/utils/mediapipe/mediapipe.js
+++ b/src/templates/p5/utils/mediapipe/mediapipe.js
@@ -257,6 +257,13 @@ function handleResult( {
   entry.result = result;
   entry.updatedAt = performance.now();
 
+  // One-way warm-up latch: the first result a task ever emits means its model
+  // is loaded, its GPU shaders are compiled and the source delivered a frame.
+  // Never cleared (unlike `result`), so isWarmedUp() reflects "has run once".
+  if ( entry.firstResultAt === undefined ) {
+    entry.firstResultAt = entry.updatedAt;
+  }
+
   if ( resultHasDetections( result ) ) {
     mediapipe.scheduler.lastDetectionTime = entry.updatedAt;
     mediapipe.idle = false;
@@ -298,6 +305,25 @@ function resetStats() {
   mediapipe.stats.droppedFrames = 0;
   mediapipe.stats.watchdogRecoveries = 0;
   mediapipe.stats.lastError = null;
+}
+
+/**
+ * True once the pipeline has fully warmed up: the processor is ready, the
+ * source has delivered a frame (`videoReady`) and every configured task has
+ * produced at least one result — i.e. each model's first, shader-compiling
+ * inference has completed. This is the signal a warm-up gate waits on before
+ * starting the timeline or a recording, so the visible animation never plays
+ * through the first-inference jank. With no tasks configured it reads as
+ * warm (nothing to wait for).
+ */
+export function isWarmedUp() {
+  if ( !mediapipe.processor.ready || !mediapipe.videoReady ) {
+    return false;
+  }
+
+  const tasks = mediapipe.config.tasks ?? [];
+
+  return tasks.every( ( lib ) => mediapipe.tasks[ lib ]?.firstResultAt !== undefined );
 }
 
 /**

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -11,6 +11,7 @@ import {
 import {
   pauseLoop, resumeLoop
 } from "./loopControl.js";
+import loadProfiler from "./loadProfiler.js";
 import {
   coerceFramerate
 } from "./framerate.js";
@@ -118,6 +119,8 @@ const sketch = {
   // ---- start (called by P5Engine.ts after sketch module import) -------
 
   start: async( container ) => {
+    loadProfiler.markSketchStart( sketch.name );
+
     const p5 = await loadP5Class();
 
     setContainer( container );
@@ -172,6 +175,8 @@ const sketch = {
         };
 
         p.setup = async() => {
+          loadProfiler.markSetupBegin();
+
           // -- pre-setup ------------------------------------------------
           sketch.favoriteColors.purple = p.color(
             128,
@@ -276,9 +281,13 @@ const sketch = {
 
           // -- post-setup -----------------------------------------------
           events.handle( "post-setup" );
+
+          loadProfiler.markSetupEnd();
         };
 
         p.draw = async() => {
+          const drawStartedAt = performance.now();
+
           events.handle( "pre-draw" );
 
           // Call the user's draw function with the same args as before
@@ -290,6 +299,10 @@ const sketch = {
           );
 
           events.handle( "post-draw" );
+
+          // Diagnostic: per-frame main-thread work + frame gap over the first
+          // couple of seconds, logged once (see loadProfiler).
+          loadProfiler.recordFrame( performance.now() - drawStartedAt );
         };
 
         // Keyboard

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -412,12 +412,9 @@ const sketch = {
     // Reset animation time so the next sketch starts at t=0
     time.reset();
 
-    // Drop the interaction warm-up gate hooks so a sketch interrupted mid
-    // warm-up can't freeze the next sketch's clock. Interaction sketches
-    // re-publish them from initInteraction(); non-interaction sketches leave
-    // them cleared so time.js never holds.
+    // Drop the interaction vision-readiness hook between sketches; interaction
+    // sketches re-publish it from initInteraction().
     if ( typeof window !== "undefined" ) {
-      delete window.__visionWarmupHold;
       delete window.isInteractionVisionReady;
     }
   },

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -411,6 +411,15 @@ const sketch = {
 
     // Reset animation time so the next sketch starts at t=0
     time.reset();
+
+    // Drop the interaction warm-up gate hooks so a sketch interrupted mid
+    // warm-up can't freeze the next sketch's clock. Interaction sketches
+    // re-publish them from initInteraction(); non-interaction sketches leave
+    // them cleared so time.js never holds.
+    if ( typeof window !== "undefined" ) {
+      delete window.__visionWarmupHold;
+      delete window.isInteractionVisionReady;
+    }
   },
 
   // ---- engine methods (backward compat for time.js, debug.js, etc.) ---

--- a/src/templates/p5/utils/time.js
+++ b/src/templates/p5/utils/time.js
@@ -35,6 +35,25 @@ const time = {
     // Normal operation: use p5.js millis()
     const now = sketch?.engine?.getElapsedTime();
 
+    // Freeze the timeline while the interaction layer warms up its vision
+    // pipeline (set via window.__visionWarmupHold), so the visible animation
+    // doesn't play through the first-inference / shader-compile jank. Keep
+    // lastUpdate current so the resumed delta doesn't jump by the held span.
+    // No-op when nothing registered the hold or vision is already warm. Never
+    // applies during recording (handled above) — capture awaits readiness
+    // separately before stepping frame 0.
+    if (
+      typeof window !== "undefined" &&
+      typeof window.__visionWarmupHold === "function" &&
+      window.__visionWarmupHold()
+    ) {
+      if ( typeof now === "number" ) {
+        time.lastUpdate = now;
+      }
+
+      return;
+    }
+
     if ( typeof now === "number" ) {
       const delta = now - time.lastUpdate;
 

--- a/src/templates/p5/utils/time.js
+++ b/src/templates/p5/utils/time.js
@@ -35,25 +35,6 @@ const time = {
     // Normal operation: use p5.js millis()
     const now = sketch?.engine?.getElapsedTime();
 
-    // Freeze the timeline while the interaction layer warms up its vision
-    // pipeline (set via window.__visionWarmupHold), so the visible animation
-    // doesn't play through the first-inference / shader-compile jank. Keep
-    // lastUpdate current so the resumed delta doesn't jump by the held span.
-    // No-op when nothing registered the hold or vision is already warm. Never
-    // applies during recording (handled above) — capture awaits readiness
-    // separately before stepping frame 0.
-    if (
-      typeof window !== "undefined" &&
-      typeof window.__visionWarmupHold === "function" &&
-      window.__visionWarmupHold()
-    ) {
-      if ( typeof now === "number" ) {
-        time.lastUpdate = now;
-      }
-
-      return;
-    }
-
     if ( typeof now === "number" ) {
       const delta = now - time.lastUpdate;
 

--- a/src/types/recording.types.ts
+++ b/src/types/recording.types.ts
@@ -143,12 +143,10 @@ declare global {
     enableRecordingMode?: () => void;
     disableRecordingMode?: () => void;
 
-    // Interaction vision warm-up gate (set by the interaction layer). Returns
-    // true once the vision source has loaded and produced a first result, or
-    // when no vision is needed. Awaited before capture so a recording never
-    // starts mid warm-up. __visionWarmupHold is its inverse, read by the
-    // timeline clock to freeze live preview during warm-up.
+    // Interaction vision readiness (set by the interaction layer). Returns true
+    // once the vision source has loaded and produced a first result, or when no
+    // vision is needed. Awaited before capture so a recording never starts mid
+    // warm-up.
     isInteractionVisionReady?: () => boolean;
-    __visionWarmupHold?: () => boolean;
   }
 }

--- a/src/types/recording.types.ts
+++ b/src/types/recording.types.ts
@@ -142,5 +142,13 @@ declare global {
     // Server-side / deterministic recording controls (time utility)
     enableRecordingMode?: () => void;
     disableRecordingMode?: () => void;
+
+    // Interaction vision warm-up gate (set by the interaction layer). Returns
+    // true once the vision source has loaded and produced a first result, or
+    // when no vision is needed. Awaited before capture so a recording never
+    // starts mid warm-up. __visionWarmupHold is its inverse, read by the
+    // timeline clock to freeze live preview during warm-up.
+    isInteractionVisionReady?: () => boolean;
+    __visionWarmupHold?: () => boolean;
   }
 }

--- a/src/utils/captureSurface.ts
+++ b/src/utils/captureSurface.ts
@@ -49,6 +49,28 @@ export async function detectCaptureSurface( page: Page ): Promise<CaptureSurface
 
 /** Put the active engine into deterministic, frame-stepped capture mode. */
 export async function prepareCapture( page: Page ): Promise<void> {
+  // Let the interaction layer's vision pipeline warm up before we freeze the
+  // timeline: load the video/image source, compile the first inference, emit a
+  // first result. Otherwise the recording frame-steps from frame 0 while the
+  // source is still loading and captures the "preparing vision" pre-roll for
+  // the whole clip. The gate resolves true when ready, when no vision is
+  // needed, or after its own safety deadline; the catch keeps a stuck gate
+  // from failing the whole job (it just proceeds, as before).
+  await page
+    .waitForFunction(
+      () => {
+        const ready = window.isInteractionVisionReady;
+
+        return typeof ready !== "function" || ready() === true;
+      },
+      undefined,
+      {
+        timeout: 20000,
+        polling: 100
+      }
+    )
+    .catch( () => {} );
+
   await page.evaluate( () => {
     // Sound-producing sketches register an audio bridge; switch it to
     // capture mode so triggers are logged against the deterministic


### PR DESCRIPTION
# Vision source selector

MediaPipe inference no longer assumes the webcam. A new **`vision.source` conditional group** in the shared interaction options (`interaction/defaults.js`) selects what frames inference runs on, with mode-specific fields per branch:

| Mode | Fields | Behaviour |
|---|---|---|
| **Webcam** (default) | camera picker (deviceId), width, height, flip, preview | Same capture as before, plus a device selector to switch between attached cameras (MacBook, external display, iPhone Continuity Camera…) |
| **Video asset** | video stack (first one drives inference), flip, preview | The hand/face/body trackers run on a video asset. Playback follows the sketch progression through the asset's own `repeat` / `speed` / `offset` / `loopMode` params — same time-stretch behaviour as videos drawn by the videos pool, so live preview and future recordings stay consistent |
| **Image asset** | image, flip, preview | One-shot detection on a still image, re-run at the idle interval so results stay fresher than the interaction staleness TTL |

## How it works

- **`mediapipe.js`** gains a `config.source` and can now *adopt* an external `<video>`/`<img>` element instead of creating a capture. A `capture.owned` flag guards teardown so borrowed elements (owned by the asset loader) are never stopped or removed. `createCapture` forwards `deviceId` getUserMedia constraints when a camera is picked.
- **`interaction/index.js`** resolves the source each frame: video mode reuses `createVideoSync`/`loadVideoAsset` (loading, param updates, disposal) and seeks the video to `animation.progression`; the re-init signature now includes a stable source key so switching mode/device/asset re-initializes cleanly.
- **Mirroring is source-aware**: webcams stay flipped (mirrored) by default, video/image assets default to unflipped — so a right hand filmed with Ray-Ban Meta glasses stays a right hand in the landmarks.
- **New `webcam-device-select` form component**: lists `videoinput` devices, refreshes on `devicechange` (labels appear once camera permission is granted), keeps unplugged saved devices selectable.
- **Backward compatible**: legacy saved options with only `vision.camera` read as webcam mode; the debug overlay preview works for adopted sources too.

## Out of scope (next iteration)
Deterministic server-side recording: per-frame awaited inference during Playwright capture + JSON export of landmarks per frame.

## Testing
- `npm test`: 950/950 pass
- `npx tsc --noEmit`: no new errors (pre-existing failures in `traceLetters.test.ts`, `NotificationService.ts`, prisma generated client untouched)
- `eslint` clean on all touched files

https://claude.ai/code/session_01VNXkPiNJL3GyMpfQsY4JwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNXkPiNJL3GyMpfQsY4JwZ)_