### PR TITLE
Fix async-loop recording desync (mp4/webm/gif)

### DIFF
--- a/src/engines/gsap/GsapEngine.ts
+++ b/src/engines/gsap/GsapEngine.ts
@@ -116,7 +116,7 @@ export class GsapEngine implements SketchEngine {
     registerServerCaptureController( {
       captureKind: "dom",
       surfaceSelector: "[data-capture-surface]",
-      prepare: () => this.runtime?.enterRecordingMode(),
+      prepare: () => this.beginDeterministicCapture(),
       renderFrame: ( index: number ) => this.runtime?.seekFrame( index )
     } );
 
@@ -201,6 +201,17 @@ export class GsapEngine implements SketchEngine {
 
   async resetToStart(): Promise<void> {
     await this.runtime?.resetToStart();
+  }
+
+  beginDeterministicCapture(): void {
+    // The GSAP timeline is already scrubbed off a frame clock, so the only
+    // thing recording mode changes here is that progression stops wrapping
+    // (clamped to [0, 1]) for the duration of the capture.
+    this.runtime?.enterRecordingMode();
+  }
+
+  endDeterministicCapture(): void {
+    this.runtime?.exitRecordingMode();
   }
 
   getRecordingCapabilities(

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -209,13 +209,14 @@ export class P5Engine implements SketchEngine {
     registerServerCaptureController( {
       captureKind: "canvas",
       surfaceSelector: "canvas.p5Canvas",
-      prepare: () => {
-        window.enableRecordingMode?.();
-        pauseLoop( this.sketchRuntime?.getP5() );
-      },
-      renderFrame: () => {
-        // enableRecordingMode makes incrementElapsedTime advance frame-based
-        // time on each pre-draw, so a bare redraw steps exactly one frame.
+      prepare: () => this.beginDeterministicCapture(),
+      renderFrame: ( index ) => {
+        // Pin the deterministic clock to this frame, then step exactly one
+        // redraw. enableRecordingMode makes incrementElapsedTime derive time
+        // from the pinned index, so each redraw advances by exactly one frame
+        // — and an out-of-order or repeated request still renders the right
+        // frame rather than drifting.
+        window.setRecordingFrame?.( index );
         this.sketchRuntime?.getP5()?.redraw();
       }
     } );
@@ -304,6 +305,11 @@ export class P5Engine implements SketchEngine {
       p.frameCount = frame;
     }
 
+    // Pin the deterministic recording clock to this frame so the upcoming
+    // redraw renders at t = frame / frameRate. No-op during normal playback —
+    // the sketch only consults the pinned index while in recording mode.
+    window.setRecordingFrame?.( frame );
+
     this.sketchRuntime?.getP5()?.redraw();
   }
 
@@ -352,6 +358,20 @@ export class P5Engine implements SketchEngine {
     bridge?.setProgression( 0 );
 
     await this.seekAndDraw( 0 );
+  }
+
+  beginDeterministicCapture(): void {
+    // Stop the live draw loop and switch the time utility to frame-based time.
+    // From here `incrementElapsedTime` derives `elapsed` from the pinned
+    // recording frame index (see `window.setRecordingFrame`, set inside
+    // `seek()`) instead of p5 `millis()`, so every captured frame lands at
+    // exactly t = frame / frameRate — identical to the server pipeline.
+    pauseLoop( this.sketchRuntime?.getP5() );
+    window.enableRecordingMode?.();
+  }
+
+  endDeterministicCapture(): void {
+    window.disableRecordingMode?.();
   }
 
   getRecordingCapabilities(

--- a/src/engines/recording/__tests__/AsyncLoopRecorder.test.ts
+++ b/src/engines/recording/__tests__/AsyncLoopRecorder.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for the async-loop (deterministic) browser recorder.
+ *
+ * The bug these guard against: browser async-loop capture used to step the
+ * frame *index* through the encoder while letting the sketch clock free-run on
+ * wall-clock time, so the captured animation finished before (fast machines) or
+ * after (slow machines) the loop. The recorder must now switch the host into
+ * deterministic, frame-stepped time for the *entire* capture — entered before
+ * the first draw and left only on teardown.
+ */
+
+import {
+  AsyncLoopRecorder
+} from "../strategies/AsyncLoopRecorder";
+import type {
+  CaptureSource,
+  FrameEncoder,
+  FrameEncoderFactory,
+  RecorderHost
+} from "../types";
+
+function makeSource(): CaptureSource {
+  return {
+    width: 100,
+    height: 100,
+    getStreamCanvas: () => null,
+    readFrame: async() => ( {} as unknown as CanvasImageSource ),
+    beginRealtime: () => undefined,
+    endRealtime: () => undefined
+  };
+}
+
+function makeHost(
+  totalFrames: number,
+  frameRate: number,
+  calls: string[]
+): RecorderHost {
+  const source = makeSource();
+
+  return {
+    getCaptureSource: () => source,
+    getCanvas: () => null,
+    seekAndDraw: async( frame: number ) => {
+      calls.push( `seek:${ frame }` );
+    },
+    resetToStart: async() => {
+      calls.push( "reset" );
+    },
+    pause: () => calls.push( "pause" ),
+    resume: () => calls.push( "resume" ),
+    beginDeterministicCapture: () => calls.push( "begin" ),
+    endDeterministicCapture: () => calls.push( "end" ),
+    totalFrames,
+    frameRate
+  };
+}
+
+function makeEncoderFactory(
+  addFrameCounter: { count: number },
+  receivedParams: { value: Parameters<FrameEncoderFactory>[ 0 ] | null }
+): FrameEncoderFactory {
+  return ( params ) => {
+    receivedParams.value = params;
+
+    const encoder: FrameEncoder = {
+      format: "webm",
+      mimeType: "video/webm",
+      fileExtension: "webm",
+      hasAudioTrack: false,
+      addFrame: async() => {
+        addFrameCounter.count += 1;
+      },
+      finalize: async() => ( {} as unknown as Blob ),
+      dispose: () => undefined
+    };
+
+    return encoder;
+  };
+}
+
+describe(
+  "AsyncLoopRecorder deterministic capture",
+  () => {
+    test(
+      "enters deterministic mode before any draw and captures every frame",
+      async() => {
+        const totalFrames = 4;
+        const calls: string[] = [];
+        const host = makeHost(
+          totalFrames,
+          30,
+          calls
+        );
+        const addFrameCounter = {
+          count: 0
+        };
+        const receivedParams = {
+          value: null as Parameters<FrameEncoderFactory>[ 0 ] | null
+        };
+        const recorder = new AsyncLoopRecorder(
+          host,
+          "webm",
+          makeEncoderFactory(
+            addFrameCounter,
+            receivedParams
+          )
+        );
+
+        await recorder.start();
+        await recorder.stop();
+
+        // Encoder is built with the host's resolved cadence + frame count.
+        expect( receivedParams.value?.totalFrames ).toBe( totalFrames );
+        expect( receivedParams.value?.frameRate ).toBe( 30 );
+
+        // Every frame index was stepped + encoded.
+        expect( addFrameCounter.count ).toBe( totalFrames );
+        const seeks = calls.filter( ( c ) => c.startsWith( "seek:" ) );
+
+        expect( seeks ).toEqual( [
+          "seek:0",
+          "seek:1",
+          "seek:2",
+          "seek:3"
+        ] );
+
+        // Deterministic mode is entered exactly once, before reset + all seeks.
+        expect( calls.filter( ( c ) => c === "begin" ) ).toHaveLength( 1 );
+        expect( calls.filter( ( c ) => c === "end" ) ).toHaveLength( 1 );
+
+        const beginIdx = calls.indexOf( "begin" );
+        const resetIdx = calls.indexOf( "reset" );
+        const firstSeekIdx = calls.indexOf( "seek:0" );
+
+        expect( beginIdx ).toBeGreaterThanOrEqual( 0 );
+        expect( beginIdx ).toBeLessThan( resetIdx );
+        expect( resetIdx ).toBeLessThan( firstSeekIdx );
+
+        // Teardown leaves deterministic mode before resuming the live loop.
+        const endIdx = calls.indexOf( "end" );
+        const resumeIdx = calls.indexOf( "resume" );
+
+        expect( endIdx ).toBeGreaterThan( firstSeekIdx );
+        expect( endIdx ).toBeLessThan( resumeIdx );
+      }
+    );
+
+    test(
+      "leaves deterministic mode + resumes the host when setup fails",
+      async() => {
+        const calls: string[] = [];
+        const host = makeHost(
+          4,
+          30,
+          calls
+        );
+
+        // Force a setup failure after deterministic mode is entered.
+        host.resetToStart = async() => {
+          calls.push( "reset" );
+          throw new Error( "boom" );
+        };
+
+        const addFrameCounter = {
+          count: 0
+        };
+        const receivedParams = {
+          value: null as Parameters<FrameEncoderFactory>[ 0 ] | null
+        };
+        const recorder = new AsyncLoopRecorder(
+          host,
+          "webm",
+          makeEncoderFactory(
+            addFrameCounter,
+            receivedParams
+          )
+        );
+
+        await expect( recorder.start() ).rejects.toThrow( "boom" );
+
+        // The host must not be left paused or stuck in recording mode.
+        expect( calls ).toContain( "begin" );
+        expect( calls ).toContain( "end" );
+        expect( calls ).toContain( "resume" );
+        expect( calls.indexOf( "end" ) ).toBeLessThan( calls.indexOf( "resume" ) );
+      }
+    );
+  }
+);

--- a/src/engines/recording/createEngineHost.ts
+++ b/src/engines/recording/createEngineHost.ts
@@ -37,6 +37,8 @@ export function createEngineHost(
     resetToStart: () => engine.resetToStart(),
     pause: () => engine.pause(),
     resume: () => engine.play(),
+    beginDeterministicCapture: () => engine.beginDeterministicCapture(),
+    endDeterministicCapture: () => engine.endDeterministicCapture(),
     totalFrames,
     frameRate
   };

--- a/src/engines/recording/strategies/AsyncLoopRecorder.ts
+++ b/src/engines/recording/strategies/AsyncLoopRecorder.ts
@@ -34,6 +34,7 @@ export class AsyncLoopRecorder extends BaseRecorder {
   private cancelled = false;
   private runPromise: Promise<RecorderResult> | null = null;
   private hostPaused = false;
+  private deterministicActive = false;
   private audioCaptureActive = false;
 
   constructor(
@@ -57,12 +58,19 @@ export class AsyncLoopRecorder extends BaseRecorder {
       throw new Error( "AsyncLoopRecorder: host.totalFrames must be a positive number." );
     }
 
+    // Put the host into deterministic, frame-stepped time BEFORE anything
+    // draws, so `resetToStart()` and every `seekAndDraw(i)` render at exactly
+    // t = i / frameRate instead of advancing on wall-clock. This is the fix
+    // for the loop-desync: without it the captured animation progresses at
+    // whatever rate the machine happens to draw frames, so the recording ends
+    // before (fast) or after (slow) the loop completes.
+    this.host.pause();
+    this.hostPaused = true;
+    this.enterDeterministic();
+
     // Reset progression FIRST so the surface reflects frame 0 before we
     // snapshot dimensions into the encoder. Otherwise a reset-triggered
     // resize would invalidate the encoder's codec string mid-recording.
-    this.host.pause();
-    this.hostPaused = true;
-
     try {
       await this.host.resetToStart();
 
@@ -81,7 +89,8 @@ export class AsyncLoopRecorder extends BaseRecorder {
         totalFrames
       } );
     } catch( error ) {
-      // Setup failure must not leave the host stuck in paused state.
+      // Setup failure must not leave the host stuck in paused/recording state.
+      this.exitDeterministic();
       this.resumeHost();
       this.encoder?.dispose();
       this.encoder = null;
@@ -238,6 +247,7 @@ export class AsyncLoopRecorder extends BaseRecorder {
       this._isRecording = false;
       this.encoder?.dispose();
       this.encoder = null;
+      this.exitDeterministic();
       this.resumeHost();
     }
   }
@@ -268,6 +278,32 @@ export class AsyncLoopRecorder extends BaseRecorder {
     } catch {
       // Resuming should never throw, but if it does we don't want to
       // mask the original error from `run`.
+    }
+  }
+
+  private enterDeterministic(): void {
+    if ( this.deterministicActive ) {
+      return;
+    }
+    this.deterministicActive = true;
+    try {
+      this.host.beginDeterministicCapture();
+    } catch {
+      // Entering deterministic mode must never abort the recording — fall
+      // back to the host's default timing rather than throwing here.
+    }
+  }
+
+  private exitDeterministic(): void {
+    if ( !this.deterministicActive ) {
+      return;
+    }
+    this.deterministicActive = false;
+    try {
+      this.host.endDeterministicCapture();
+    } catch {
+      // Teardown must never throw — leaving the host in recording mode is
+      // recoverable on the next play()/record, an exception here is not.
     }
   }
 }

--- a/src/engines/recording/types.ts
+++ b/src/engines/recording/types.ts
@@ -134,6 +134,16 @@ export interface RecorderHost {
   /** Stop the host's own draw loop during async-loop capture. */
   pause(): void;
   resume(): void;
+  /**
+   * Enter deterministic, frame-stepped capture mode: the sketch clock is
+   * driven by the frame index passed to `seekAndDraw` (t = frame / frameRate)
+   * instead of wall-clock, so async-loop capture stays in lock-step with the
+   * encoder's frame timestamps no matter how fast/slow frames render. Called
+   * once before `resetToStart()` and paired with `endDeterministicCapture()`.
+   */
+  beginDeterministicCapture(): void;
+  /** Leave deterministic capture mode, restoring normal wall-clock time. */
+  endDeterministicCapture(): void;
   /** Resolved frame count for the active sketch. */
   readonly totalFrames: number;
   /** Resolved frames-per-second for the active sketch. */

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -135,6 +135,19 @@ export interface SketchEngine {
   resetToStart(): Promise<void>;
 
   /**
+   * Enter deterministic, frame-stepped capture mode for client-side
+   * async-loop recording: subsequent `seekAndDraw(frame)` calls render the
+   * sketch at t = frame / frameRate instead of advancing on wall-clock. This
+   * is what keeps the captured clip in sync with the loop (and with the
+   * server-side pipeline). Paired with `endDeterministicCapture()` in the
+   * recorder's teardown.
+   */
+  beginDeterministicCapture(): void;
+
+  /** Leave deterministic capture mode and restore wall-clock timing. */
+  endDeterministicCapture(): void;
+
+  /**
    * Declare what client-side recording modes/formats this engine
    * supports for the given sketch options. Consumed by the browser
    * recorder UI to pick a sensible default mode and gate formats.

--- a/src/templates/gsap/utils/runtime.tsx
+++ b/src/templates/gsap/utils/runtime.tsx
@@ -511,6 +511,16 @@ class GsapRuntime {
     this.scrub();
   }
 
+  /**
+   * Leave deterministic capture mode so the progression bar wraps again. The
+   * recorder calls this on teardown; without it a sketch that was paused
+   * before recording (so teardown calls `pause()`, not `play()`) would stay
+   * stuck in clamped-progression mode.
+   */
+  exitRecordingMode(): void {
+    this.recording = false;
+  }
+
   private startRaf(): void {
     if ( this.rafId !== null ) {
       return;

--- a/src/templates/metadata.json
+++ b/src/templates/metadata.json
@@ -2772,6 +2772,18 @@
     "ctime": "2026-06-14T03:35:33.673Z"
   },
   {
+    "name": "hand-tracking-v5-catch",
+    "engine": "p5",
+    "category": "hand-capture",
+    "hasSketchForm": true,
+    "hasThumbnail": true,
+    "hasPreview": false,
+    "hiddenFromHome": false,
+    "hiddenFromTemplates": false,
+    "mtime": "2026-06-14T18:05:38.135Z",
+    "ctime": "2026-06-14T18:05:16.283Z"
+  },
+  {
     "name": "splines-v2-draggable",
     "engine": "p5",
     "category": "splines",
@@ -2806,18 +2818,6 @@
     "hiddenFromTemplates": false,
     "mtime": "2026-06-14T21:08:17.827Z",
     "ctime": "2026-06-14T17:31:05.902Z"
-  },
-  {
-    "name": "hand-tracking-v5-catch",
-    "engine": "p5",
-    "category": "hand-capture",
-    "hasSketchForm": true,
-    "hasThumbnail": true,
-    "hasPreview": false,
-    "hiddenFromHome": false,
-    "hiddenFromTemplates": false,
-    "mtime": "2026-06-14T18:05:38.135Z",
-    "ctime": "2026-06-14T18:05:16.283Z"
   },
   {
     "name": "hand-tracking-v6-slice",

--- a/src/templates/p5/utils/__tests__/recordingClock.test.ts
+++ b/src/templates/p5/utils/__tests__/recordingClock.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for the deterministic recording clock.
+ *
+ * Browser async-loop capture used to let the sketch clock advance on
+ * wall-clock `millis()` deltas while the encoder stepped the frame index, so
+ * the captured animation drifted out of sync with the loop (finishing early on
+ * fast machines, late on slow ones). In recording mode `time.elapsed` must be a
+ * pure function of the pinned frame index: t = frame / framerate.
+ */
+
+export {};
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const time = require( "@/p5/utils/time.js" ).default;
+const sketch = require( "@/p5/utils/sketch.js" ).default;
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const FRAMERATE = 30;
+const DURATION = 4;
+
+describe(
+  "deterministic recording clock",
+  () => {
+    beforeEach( () => {
+      sketch.sketchOptions = {
+        size: {
+          width: 1080,
+          height: 1350
+        },
+        animation: {
+          framerate: FRAMERATE,
+          duration: DURATION
+        }
+      };
+      window.disableRecordingMode!();
+      time.reset();
+    } );
+
+    test(
+      "pinned frame index drives elapsed time at frame / framerate",
+      () => {
+        window.enableRecordingMode!();
+
+        const totalFrames = FRAMERATE * DURATION;
+
+        for ( let frame = 0; frame < totalFrames; frame++ ) {
+          window.setRecordingFrame!( frame );
+          // Stands in for the pre-draw step the p5 loop runs each redraw.
+          time.incrementElapsedTime();
+          expect( time.seconds() ).toBeCloseTo(
+            frame / FRAMERATE,
+            6
+          );
+        }
+      }
+    );
+
+    test(
+      "re-pinning the same frame is idempotent — no wall-clock drift",
+      () => {
+        window.enableRecordingMode!();
+
+        window.setRecordingFrame!( 10 );
+        time.incrementElapsedTime();
+        const first = time.seconds();
+
+        // Drawing the same frame again must not advance the clock.
+        window.setRecordingFrame!( 10 );
+        time.incrementElapsedTime();
+
+        expect( time.seconds() ).toBeCloseTo(
+          first,
+          6
+        );
+        expect( time.seconds() ).toBeCloseTo(
+          10 / FRAMERATE,
+          6
+        );
+      }
+    );
+
+    test(
+      "the last captured frame lands just under a full loop",
+      () => {
+        window.enableRecordingMode!();
+
+        const totalFrames = FRAMERATE * DURATION;
+        const lastFrame = totalFrames - 1;
+
+        window.setRecordingFrame!( lastFrame );
+        time.incrementElapsedTime();
+
+        const progression = window.getAnimationProgression!();
+
+        // The wrap frame (progression === 1) is the same as frame 0, so the
+        // last captured frame sits one step below it — a clean, seamless loop.
+        expect( progression ).toBeCloseTo(
+          lastFrame / totalFrames,
+          6
+        );
+        expect( progression ).toBeLessThan( 1 );
+      }
+    );
+
+    test(
+      "outside recording mode the pinned frame index is ignored",
+      () => {
+        // No recording mode + no p5 engine clock → elapsed stays put, proving
+        // the pin only takes effect during deterministic capture.
+        window.setRecordingFrame!( 100 );
+        time.incrementElapsedTime();
+
+        expect( time.seconds() ).toBe( 0 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/time.js
+++ b/src/templates/p5/utils/time.js
@@ -54,6 +54,22 @@ window.disableRecordingMode = function() {
   time.isRecording = false;
 };
 
+// Pin the deterministic recording clock to an explicit frame index. The client
+// async-loop recorder and the server capture controller both call this before
+// each redraw, so `incrementElapsedTime` derives `elapsed` from this frame
+// (frame * millisecondsPerFrame) instead of letting it free-run on the
+// auto-incrementing counter. Without an explicit pin the index only
+// auto-advances, which silently drifts whenever a frame is drawn more than once
+// (reset-to-start, a stray resize/redraw, a re-entered capture) — leaving the
+// captured animation out of sync with the encoder's frame timestamps.
+window.setRecordingFrame = function( frameIndex ) {
+  const index = Math.floor( Number( frameIndex ) );
+
+  time.recordingFrameIndex = Number.isFinite( index ) && index >= 0
+    ? index
+    : 0;
+};
+
 // Expose global functions for animation progression control
 window.setAnimationProgression = function( progression ) {
   // Clamp progression to valid range [0, 1]

--- a/src/types/recording.types.ts
+++ b/src/types/recording.types.ts
@@ -142,6 +142,12 @@ declare global {
     // Server-side / deterministic recording controls (time utility)
     enableRecordingMode?: () => void;
     disableRecordingMode?: () => void;
+    // Pin the deterministic recording clock to an explicit frame index so the
+    // next redraw renders at exactly frame / framerate seconds. Set before
+    // every captured frame by both the client async-loop recorder and the
+    // server capture controller, keeping the sketch clock in lock-step with
+    // the encoder's frame timestamps regardless of wall-clock render speed.
+    setRecordingFrame?: ( frame: number ) => void;
 
     // Interaction vision readiness (set by the interaction layer). Returns true
     // once the vision source has loaded and produced a first result, or when no


### PR DESCRIPTION
## Problem

When recording in **async-loop** mode (mp4/webm/gif) from the browser, the clip was out of sync with the loop:

- the recording finished **before** the animation reached the end of the loop, and the `.mp4` downloaded mid-loop;
- behaviour depended on the machine/sketch, so it looked like a fresh regression every time the recorder was touched.

## Root cause

Async-loop capture steps the **frame index** through the encoder — for `i = 0 … totalFrames-1` it calls `host.seekAndDraw(i)` and the encoder stamps each frame at `t = i / frameRate`. So the **output file is always exactly `duration` seconds** with the right frame count. That correct length masked the real bug.

The p5 sketch's animation clock (`time.elapsed`, read by every sketch via `time.seconds()`) was **not** driven by the frame index during browser capture. It advanced on wall-clock `p5.millis()` deltas, because the client path never enabled the deterministic *recording mode* that the **server** pipeline uses (`prepareCapture → enableRecordingMode`).

So captured frame `i` showed the animation at *whatever wall-clock time had elapsed*, not at `i / frameRate`. The result depended entirely on render speed:

- 60 fps on a 60 Hz display ≈ one rAF (~16.6 ms)/frame ≈ coincidentally right;
- **30 fps**: still ~16.6 ms wall/step but each clip frame needs 33 ms → the animation only reaches ~50% when the recorder hits `totalFrames` → **recording finishes before the loop**;
- heavy sketch / encoder backpressure: each step > frame duration → animation overshoots and repeats.

That accidental coupling between rAF cadence and target framerate is why it "kept breaking again and again".

## Fix

Make client async-loop capture deterministic — drive the sketch clock from the explicit frame index, identical to the proven server pipeline.

- **`time.js`**: add `window.setRecordingFrame(i)` to pin the recording clock to an explicit frame index (`frame * msPerFrame`), robust against the reset-to-start double-draw and any stray redraw (no more counter drift).
- **`P5Engine`**: pin the frame inside `seek()`; add `begin/endDeterministicCapture()` (enable/disable recording mode); route the server capture controller through the same entrypoint and honour its explicit frame index.
- **`GsapEngine` / runtime**: add `begin/endDeterministicCapture` (+ `exitRecordingMode`). GSAP already scrubs a paused timeline off a frame clock, so this only restores its progression-wrap state on teardown (fixes a sketch left paused-before-record staying clamped).
- **`SketchEngine` + `RecorderHost`**: add `beginDeterministicCapture` / `endDeterministicCapture`; wire through `createEngineHost`.
- **`AsyncLoopRecorder`**: enter deterministic mode **before** `resetToStart` and leave it on **every** teardown path (success, setup failure, cancel).

Realtime (MediaRecorder) capture is intentionally untouched — it should stay wall-clock.

## Tests

- `recordingClock.test.ts` — `time.js` deterministic clock: `elapsed == frame / framerate`, idempotent re-pin (no wall-clock drift), last frame lands just under a full loop, and the pin is ignored outside recording mode.
- `AsyncLoopRecorder.test.ts` — deterministic mode is entered before any draw and left on teardown (incl. the setup-failure path), and every frame is stepped + encoded.

Full suite: **1013 tests green**, lint clean, no new `tsc` errors.

https://claude.ai/code/session_01K2ozxBAeGpKJe7L2zVqkn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2ozxBAeGpKJe7L2zVqkn1)_