### PR TITLE
Add source pickers for joypad, audio input and MIDI

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledAudioInputDeviceSelect.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledAudioInputDeviceSelect.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, {
+  useEffect, useState
+} from "react";
+import ControlledDeviceSelect, {
+  type DeviceOption
+} from "./ControlledDeviceSelect";
+
+type Props = {
+  name: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+};
+
+/**
+ * Select bound to an audio-input deviceId ("" = browser default microphone).
+ * Like the camera picker, device labels are only exposed once a microphone
+ * permission has been granted, so the list refreshes on `devicechange` — which
+ * also fires after the interaction layer first opens the mic — and falls back
+ * to "Microphone N" labels.
+ */
+export default function ControlledAudioInputDeviceSelect( props: Props ) {
+  const [
+    devices,
+    setDevices
+  ] = useState<DeviceOption[]>( [] );
+
+  useEffect(
+    () => {
+      const media = navigator.mediaDevices;
+
+      if ( !media?.enumerateDevices ) {
+        return;
+      }
+
+      let cancelled = false;
+
+      async function refresh() {
+        try {
+          const all = await media.enumerateDevices();
+
+          if ( cancelled ) {
+            return;
+          }
+
+          setDevices( all
+            .filter( ( device ) => device.kind === "audioinput" )
+            .map( (
+              device, index
+            ) => ( {
+              value: device.deviceId,
+              label: device.label || `Microphone ${ index + 1 }`
+            } ) ) );
+        } catch {
+          // Enumeration unavailable (permissions, insecure context…): keep
+          // whatever list we had — the "Default" option always works.
+        }
+      }
+
+      refresh();
+      media.addEventListener?.(
+        "devicechange",
+        refresh
+      );
+
+      return () => {
+        cancelled = true;
+        media.removeEventListener?.(
+          "devicechange",
+          refresh
+        );
+      };
+    },
+    []
+  );
+
+  return (
+    <ControlledDeviceSelect
+      { ...props }
+      devices={ devices }
+      defaultLabel="Default"
+      ariaLabel="Microphone"
+    />
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledDeviceSelect.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledDeviceSelect.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import React from "react";
+import {
+  ChevronDown
+} from "lucide-react";
+import {
+  useController, useFormContext
+} from "react-hook-form";
+import {
+  CONTROL_BAR_CLASS,
+  CONTROL_CHEVRON_CLASS
+} from "../constants/control-bar";
+import {
+  BarLabelSegment
+} from "./ControlChrome";
+
+export type DeviceOption = {
+  value: string;
+  label: string;
+};
+
+type Props = {
+  name: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+  /** Devices to list. The empty value ("") is always offered first. */
+  devices: DeviceOption[];
+  /** Label for the empty value ("") — e.g. "Default", "All inputs", "Any". */
+  defaultLabel: string;
+  /** Fallback aria-label when no `label` is provided. */
+  ariaLabel: string;
+  /**
+   * How to render a saved value that is not in the current device list (an
+   * unplugged device). Defaults to a truncated id, matching the camera picker.
+   */
+  formatUnavailable?: ( value: string ) => string;
+};
+
+/**
+ * Presentational select bound to a device id string, sharing the slider-bar
+ * chrome (label segment + value + chevron, native <select> overlaid invisibly).
+ * The enumeration of devices lives in the per-kind wrappers (audio input, MIDI
+ * input, gamepad); this component only renders the list and binds the value.
+ *
+ * A saved id that is no longer present stays selectable so saving the form
+ * never silently drops a device the user picked while it was plugged in.
+ */
+export default function ControlledDeviceSelect( {
+  name,
+  label,
+  isModified,
+  onReset,
+  devices,
+  defaultLabel,
+  ariaLabel,
+  formatUnavailable
+}: Props ) {
+  const {
+    control
+  } = useFormContext();
+  const {
+    field
+  } = useController( {
+    name,
+    control
+  } );
+
+  const currentValue = typeof field.value === "string" ? field.value : "";
+  const matched = devices.find( ( device ) => device.value === currentValue );
+  const displayLabel = matched?.label ??
+    ( currentValue
+      ? formatUnavailable?.( currentValue ) ?? `Unavailable (${ currentValue.slice(
+        0,
+        8
+      ) }…)`
+      : defaultLabel );
+
+  return (
+    <div className={ CONTROL_BAR_CLASS }>
+      <BarLabelSegment
+        label={ label }
+        isModified={ isModified }
+        onReset={ onReset }
+      />
+
+      <span className="pointer-events-none flex min-w-0 flex-1 items-center justify-between gap-1 px-2.5">
+        <span className="truncate">{displayLabel}</span>
+        <ChevronDown className={ CONTROL_CHEVRON_CLASS } />
+      </span>
+
+      <select
+        id={ name }
+        aria-label={ label ?? ariaLabel }
+        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+        value={ currentValue }
+        onChange={ ( e ) => field.onChange( e.target.value ) }
+        onBlur={ field.onBlur }
+      >
+        <option value="">{defaultLabel}</option>
+
+        {currentValue && !matched && (
+          <option value={ currentValue } hidden>
+            {displayLabel}
+          </option>
+        )}
+
+        {devices.map( ( device ) => (
+          <option key={ device.value } value={ device.value }>
+            {device.label}
+          </option>
+        ) )}
+      </select>
+    </div>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledJoypadDeviceSelect.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledJoypadDeviceSelect.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, {
+  useEffect, useState
+} from "react";
+import ControlledDeviceSelect, {
+  type DeviceOption
+} from "./ControlledDeviceSelect";
+
+type Props = {
+  name: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+};
+
+/**
+ * Select bound to a gamepad id ("" = any connected gamepad). Browsers expose a
+ * gamepad's id (a vendor/product string) only after it is connected and, on
+ * some platforms, after its first input — so the list is rebuilt on the
+ * `gamepadconnected` / `gamepaddisconnected` window events. Identical
+ * controllers share an id; the list de-duplicates by id so the dropdown stays
+ * clean, and the interaction layer matches every gamepad with that id.
+ */
+export default function ControlledJoypadDeviceSelect( props: Props ) {
+  const [
+    devices,
+    setDevices
+  ] = useState<DeviceOption[]>( [] );
+
+  useEffect(
+    () => {
+      if (
+        typeof navigator === "undefined" ||
+        typeof navigator.getGamepads !== "function"
+      ) {
+        return;
+      }
+
+      let cancelled = false;
+
+      const refresh = () => {
+        if ( cancelled ) {
+          return;
+        }
+
+        const seen = new Set<string>();
+        const list: DeviceOption[] = [];
+
+        for ( const gamepad of navigator.getGamepads() ) {
+          if ( !gamepad || !gamepad.id || seen.has( gamepad.id ) ) {
+            continue;
+          }
+
+          seen.add( gamepad.id );
+          list.push( {
+            value: gamepad.id,
+            label: gamepad.id
+          } );
+        }
+
+        setDevices( list );
+      };
+
+      refresh();
+      window.addEventListener(
+        "gamepadconnected",
+        refresh
+      );
+      window.addEventListener(
+        "gamepaddisconnected",
+        refresh
+      );
+
+      return () => {
+        cancelled = true;
+        window.removeEventListener(
+          "gamepadconnected",
+          refresh
+        );
+        window.removeEventListener(
+          "gamepaddisconnected",
+          refresh
+        );
+      };
+    },
+    []
+  );
+
+  return (
+    <ControlledDeviceSelect
+      { ...props }
+      devices={ devices }
+      defaultLabel="Any"
+      ariaLabel="Gamepad"
+      formatUnavailable={ ( value ) => value }
+    />
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledMidiInputDeviceSelect.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledMidiInputDeviceSelect.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, {
+  useEffect, useState
+} from "react";
+import ControlledDeviceSelect, {
+  type DeviceOption
+} from "./ControlledDeviceSelect";
+
+type Props = {
+  name: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+};
+
+/**
+ * Select bound to a Web MIDI input id ("" = listen to every input). The input
+ * list comes from `requestMIDIAccess()` (no sysex, so browsers that support it
+ * grant it without a prompt) and refreshes on `statechange` as devices are
+ * plugged/unplugged. Falls back to just the "All inputs" option when Web MIDI
+ * is unsupported or access is denied.
+ */
+export default function ControlledMidiInputDeviceSelect( props: Props ) {
+  const [
+    devices,
+    setDevices
+  ] = useState<DeviceOption[]>( [] );
+
+  useEffect(
+    () => {
+      if (
+        typeof navigator === "undefined" ||
+        typeof navigator.requestMIDIAccess !== "function"
+      ) {
+        return;
+      }
+
+      let cancelled = false;
+      let access: MIDIAccess | null = null;
+
+      const refresh = () => {
+        if ( !access || cancelled ) {
+          return;
+        }
+
+        const inputs: DeviceOption[] = [];
+
+        access.inputs.forEach( ( input ) => {
+          inputs.push( {
+            value: input.id,
+            label: input.name || `MIDI input ${ inputs.length + 1 }`
+          } );
+        } );
+        setDevices( inputs );
+      };
+
+      navigator.requestMIDIAccess()
+        .then( ( midiAccess ) => {
+          if ( cancelled ) {
+            return;
+          }
+
+          access = midiAccess;
+          access.onstatechange = refresh;
+          refresh();
+        } )
+        .catch( () => {
+          // MIDI permission denied / unavailable — keep only "All inputs".
+        } );
+
+      return () => {
+        cancelled = true;
+
+        if ( access ) {
+          access.onstatechange = null;
+        }
+      };
+    },
+    []
+  );
+
+  return (
+    <ControlledDeviceSelect
+      { ...props }
+      devices={ devices }
+      defaultLabel="All inputs"
+      ariaLabel="MIDI input"
+      formatUnavailable={ () => "Unavailable input" }
+    />
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -219,6 +219,24 @@ interface WebcamDeviceSelectConfig extends BaseConfig {
   component: "webcam-device-select";
 }
 
+// A select listing the machine's audio input devices (microphones), bound to a
+// deviceId string. "" means the browser's default microphone.
+interface AudioInputDeviceSelectConfig extends BaseConfig {
+  component: "audio-input-device-select";
+}
+
+// A select listing the Web MIDI input devices, bound to an input id string.
+// "" means every input is listened to.
+interface MidiInputDeviceSelectConfig extends BaseConfig {
+  component: "midi-input-device-select";
+}
+
+// A select listing the connected gamepads, bound to a gamepad id string.
+// "" means any connected gamepad.
+interface JoypadDeviceSelectConfig extends BaseConfig {
+  component: "joypad-device-select";
+}
+
 // Step 3: Create the master Discriminated Union
 // This tells TypeScript: "If component is 'select', then it MUST have an 'options' property."
 export type FieldConfig =
@@ -242,7 +260,10 @@ export type FieldConfig =
   | Vector2DConfig
   | AssetInputConfig
   | AssetStackConfig
-  | WebcamDeviceSelectConfig;
+  | WebcamDeviceSelectConfig
+  | AudioInputDeviceSelectConfig
+  | MidiInputDeviceSelectConfig
+  | JoypadDeviceSelectConfig;
 
 // Define the configuration for an entire item type (e.g., 'meta' or 'text')
 // The keys of this record must match the field names in the Zod schema

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer.tsx
@@ -27,6 +27,12 @@ import ControlledSliderInput
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/ControlledSliderInput";
 import ControlledWebcamDeviceSelect
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledWebcamDeviceSelect";
+import ControlledAudioInputDeviceSelect
+  from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledAudioInputDeviceSelect";
+import ControlledMidiInputDeviceSelect
+  from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledMidiInputDeviceSelect";
+import ControlledJoypadDeviceSelect
+  from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledJoypadDeviceSelect";
 import CollapsibleItem from "@/components/CollapsibleItem";
 import RandomizeSettingsButton from "@/components/RandomizeSettingsButton";
 import type {
@@ -421,6 +427,36 @@ export default function FieldRenderer( {
       case "webcam-device-select":
         return (
           <ControlledWebcamDeviceSelect
+            name={ registeredName }
+            label={ inlineLabel }
+            isModified={ isModified }
+            onReset={ handleReset }
+          />
+        );
+
+      case "audio-input-device-select":
+        return (
+          <ControlledAudioInputDeviceSelect
+            name={ registeredName }
+            label={ inlineLabel }
+            isModified={ isModified }
+            onReset={ handleReset }
+          />
+        );
+
+      case "midi-input-device-select":
+        return (
+          <ControlledMidiInputDeviceSelect
+            name={ registeredName }
+            label={ inlineLabel }
+            isModified={ isModified }
+            onReset={ handleReset }
+          />
+        );
+
+      case "joypad-device-select":
+        return (
+          <ControlledJoypadDeviceSelect
             name={ registeredName }
             label={ inlineLabel }
             isModified={ isModified }

--- a/src/templates/p5/utils/interaction/defaults.js
+++ b/src/templates/p5/utils/interaction/defaults.js
@@ -109,11 +109,16 @@ export const interactionFormValues = {
 
   midi: {
     enabled: false,
+    // "" listens to every MIDI input; a specific input id restricts it to one.
+    deviceId: "",
     maxNotes: 10
   },
 
   audio: {
     enabled: false,
+    // "" uses the browser's default microphone; a deviceId picks one of
+    // several attached audio inputs.
+    deviceId: "",
     count: 1,
     smoothing: 0.8,
     fftSize: 1024,
@@ -122,6 +127,8 @@ export const interactionFormValues = {
 
   joypad: {
     enabled: false,
+    // "" reads any connected gamepad; a specific gamepad id restricts it.
+    deviceId: "",
     count: 1,
     deadzone: 0.1
   },
@@ -656,6 +663,10 @@ export const interactionFormConfiguration = {
           component: "checkbox",
           label: "Enabled"
         },
+        deviceId: {
+          component: "midi-input-device-select",
+          label: "Input device"
+        },
         maxNotes: {
           component: "slider",
           label: "Max simultaneous notes",
@@ -673,6 +684,10 @@ export const interactionFormConfiguration = {
         enabled: {
           component: "checkbox",
           label: "Enabled"
+        },
+        deviceId: {
+          component: "audio-input-device-select",
+          label: "Input device"
         },
         count: {
           component: "slider",
@@ -724,6 +739,10 @@ export const interactionFormConfiguration = {
         enabled: {
           component: "checkbox",
           label: "Enabled"
+        },
+        deviceId: {
+          component: "joypad-device-select",
+          label: "Device"
         },
         count: {
           component: "slider",

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -173,12 +173,18 @@ let _touchListeners = null;
 let _midiInitialized = false;
 let _midiAccess = null;
 const _midiNotes = new Map(); // noteNumber → velocity
+// The input id the layer currently listens to ("" = every input). Tracked so a
+// runtime change of the picker re-wires the message handlers without a reload.
+let _midiDeviceId = "";
 
 // Audio state
 let _audioInitialized = false;
 let _audioContext = null;
 let _audioAnalyser = null;
 let _audioFreqData = null;
+// The microphone deviceId the live AudioContext was opened with ("" = default).
+// Tracked so changing the picker reopens the mic on the newly selected device.
+let _audioDeviceId = "";
 
 // Vision lazy-init state: the task/camera signature currently initialized, plus
 // an in-flight guard so we never kick off two mediapipe initializations at once.
@@ -380,8 +386,11 @@ function _wireMidiInputs() {
     return;
   }
 
+  // With no device picked ("") listen to every input; otherwise only the
+  // selected one fires, so the other controllers are ignored.
   _midiAccess.inputs.forEach( ( input ) => {
-    input.onmidimessage = _onMidiMessage;
+    input.onmidimessage =
+      !_midiDeviceId || input.id === _midiDeviceId ? _onMidiMessage : null;
   } );
 }
 
@@ -404,12 +413,15 @@ function _onMidiMessage( msg ) {
   }
 }
 
-async function _initMidi() {
+async function _initMidi( opts ) {
   if ( _midiInitialized ) {
     return;
   }
 
   _midiInitialized = true;
+  // Seed the selected input before the first wire so it is honoured from the
+  // start (the picker may already point at a specific device).
+  _midiDeviceId = opts?.midi?.deviceId || "";
 
   if ( typeof navigator === "undefined" || typeof navigator.requestMIDIAccess !== "function" ) {
     return;
@@ -427,17 +439,50 @@ async function _initMidi() {
 // ── Audio helpers ──────────────────────────────────────────────────────────
 
 async function _initAudio( opts ) {
-  if ( _audioInitialized ) {
+  const deviceId = opts.audio?.deviceId || "";
+
+  // Already streaming from the requested microphone → nothing to do.
+  if ( _audioInitialized && _audioDeviceId === deviceId ) {
     return;
   }
 
+  // Reopening on a different device: drop the previous context first so we
+  // don't leak it (changing the picker at runtime swaps the input).
+  if ( _audioContext ) {
+    _audioContext.close().catch( () => {} );
+    _audioContext = null;
+    _audioAnalyser = null;
+    _audioFreqData = null;
+  }
+
+  // Claim the device synchronously (before awaiting) so the per-frame collector
+  // doesn't kick off a second init while getUserMedia is still resolving.
   _audioInitialized = true;
+  _audioDeviceId = deviceId;
 
   try {
     const stream = await navigator.mediaDevices.getUserMedia( {
-      audio: true,
+      // A specific microphone was requested → constrain to it (mirrors the
+      // webcam picker); "" lets the browser pick its default input.
+      audio: deviceId
+        ? {
+          deviceId: {
+            exact: deviceId
+          }
+        }
+        : true,
       video: false
     } );
+
+    // A newer init, or a dispose, superseded this one while getUserMedia was
+    // resolving (dispose clears _audioInitialized; a re-init changes the device)
+    // — abandon this stream so it doesn't leak or clobber the live one.
+    if ( !_audioInitialized || _audioDeviceId !== deviceId ) {
+      stream.getTracks().forEach( ( track ) => track.stop() );
+
+      return;
+    }
+
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
 
     _audioContext = new AudioCtx();
@@ -557,6 +602,7 @@ export async function initInteraction( opts = {} ) {
 
   _midiAccess = null;
   _midiInitialized = false;
+  _midiDeviceId = "";
   _midiNotes.clear();
 
   // ── Audio reset (lazy init triggered by _collectAudio) ───────────────────
@@ -568,6 +614,7 @@ export async function initInteraction( opts = {} ) {
   }
 
   _audioInitialized = false;
+  _audioDeviceId = "";
 
   // ── Vision readiness signal ──────────────────────────────────────────────
   // Published so the headless capture pipeline can await a warmed-up vision
@@ -636,6 +683,7 @@ export function disposeInteraction() {
   }
 
   _midiInitialized = false;
+  _midiDeviceId = "";
   _midiNotes.clear();
 
   // Audio
@@ -647,6 +695,7 @@ export function disposeInteraction() {
   }
 
   _audioInitialized = false;
+  _audioDeviceId = "";
 
   // Vision / webcam / inference processor. Full dispose (not just the webcam)
   // so MediaPipe task memory and the worker don't leak across sketch switches.
@@ -2118,9 +2167,19 @@ function _collectMidi(
 
   // Trigger lazy MIDI access request on first call
   if ( !_midiInitialized ) {
-    _initMidi();
+    _initMidi( opts );
 
     return;
+  }
+
+  // Re-wire when the picker changes input at runtime, dropping notes still held
+  // on the previously-selected device so they don't linger.
+  const desiredDevice = midi.deviceId || "";
+
+  if ( _midiDeviceId !== desiredDevice ) {
+    _midiDeviceId = desiredDevice;
+    _midiNotes.clear();
+    _wireMidiInputs();
   }
 
   const maxNotes = midi.maxNotes ?? 10;
@@ -2164,8 +2223,9 @@ function _collectAudio(
     return;
   }
 
-  // Trigger lazy mic request on first call
-  if ( !_audioInitialized ) {
+  // Trigger lazy mic request on first call, and reopen the stream if the picker
+  // switched to a different input device since the context was created.
+  if ( !_audioInitialized || _audioDeviceId !== ( audio.deviceId || "" ) ) {
     _initAudio( opts );
 
     return;
@@ -2236,12 +2296,19 @@ function _collectJoypad(
   const gamepads = navigator.getGamepads();
   const maxCount = joypad.count ?? 1;
   const deadzone = joypad.deadzone ?? 0.1;
+  // "" reads any connected pad; a specific id restricts to matching pads
+  // (identical controllers share an id, so several may still match).
+  const deviceId = joypad.deviceId || "";
   let added = 0;
 
   for ( let i = 0; i < gamepads.length && added < maxCount; i++ ) {
     const gp = gamepads[ i ];
 
     if ( !gp || !gp.connected ) {
+      continue;
+    }
+
+    if ( deviceId && gp.id !== deviceId ) {
       continue;
     }
 


### PR DESCRIPTION
## What & why

The interaction layer could already pick a **vision** source (webcam device, video or image asset — #124), but the other input sources always used the default: the **first** connected gamepad, the **default** microphone and **every** MIDI input. This adds a per-source device picker for **joypad**, **audio in** and **MIDI**, mirroring the webcam picker.

## UI

- **`ControlledDeviceSelect`** — new shared presentational control: the slider-bar chrome + an overlaid native `<select>`, with handling for a saved id that is no longer present (kept selectable so saving never silently drops it).
- Three thin enumeration wrappers built on it:
  - **`ControlledAudioInputDeviceSelect`** — `audioinput` devices via `enumerateDevices()`, refreshed on `devicechange` (labels appear once mic permission is granted; falls back to `Microphone N`). Empty = **Default**.
  - **`ControlledMidiInputDeviceSelect`** — inputs from `requestMIDIAccess()` (no sysex → no prompt in supporting browsers), refreshed on `statechange`. Empty = **All inputs**.
  - **`ControlledJoypadDeviceSelect`** — connected gamepads via `getGamepads()`, refreshed on `gamepadconnected`/`gamepaddisconnected`, de-duplicated by id. Empty = **Any**.
- Registered the three new component kinds in `FieldRenderer` and the `FieldConfig` union, and exposed a `deviceId` field on the `midi` / `audio` / `joypad` blocks in the interaction defaults.

## Runtime (`interaction/index.js`)

- **Audio** — `getUserMedia` now constrains to the selected microphone (`{ deviceId: { exact } }`, like the webcam path) and the stream is **reopened live** when the picker changes, with a post-`await` staleness guard so an init superseded by another switch or by dispose can't leak its tracks or clobber the live context.
- **MIDI** — only the selected input's messages are wired (or all inputs when none is picked), re-wired live on change with held notes dropped.
- **Joypad** — the collector skips gamepads whose `id` doesn't match the picked device (identical controllers share an id, so several may still match — capped by `count`).

The empty value preserves each source's previous default behaviour, so existing saved options are unaffected.

## Testing

- `npx tsc --noEmit` — no new errors (the only 6 are pre-existing in `traceLetters.test.ts`).
- `npm test` — 1001 passed.
- `eslint` clean on all touched files.
- `next build` (pre-push hook) compiled and type-checked successfully.

https://claude.ai/code/session_01Q4fWQw1DCrKQvadg8HEpJT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4fWQw1DCrKQvadg8HEpJT)_