### PR TITLE
Lock viewport during browser recording; modernize lock banner + toasts

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/RecordingLockBanner.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/RecordingLockBanner.tsx
@@ -29,7 +29,7 @@ export default function RecordingLockBanner( {
   const subtitle = "Edits to this sketch won't be saved.";
 
   return (
-    <div className="flex flex-col gap-2 px-2 py-2 border border-amber-500/40 bg-amber-500/10 rounded-2xl shadow-lg">
+    <div className="flex flex-col gap-2 px-2 py-2 border border-amber-500/40 bg-amber-500/10 backdrop-blur-xl rounded-2xl shadow-lg">
       <div className="flex items-start gap-2">
         <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500" />
         <div className="flex flex-col min-w-0">

--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -25,6 +25,7 @@ export default function ScalableViewport( {
   isReady = true,
   disable = false,
   disableTouchGestures = false,
+  lockInteractions = false,
   onInteractionStart,
   onInteractionEnd
 }: {
@@ -36,6 +37,10 @@ export default function ScalableViewport( {
   // Ignore touchscreen pan/pinch so fingers reach the content instead of
   // moving the viewport (mouse drag, wheel and zoom controls still work).
   disableTouchGestures?: boolean;
+  // Freeze all pan/zoom (gestures + zoom controls) while keeping the
+  // current transform on screen — used during a browser recording so the
+  // viewport can't disturb the in-flight capture.
+  lockInteractions?: boolean;
   isReady?: boolean;
   onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
@@ -71,6 +76,7 @@ export default function ScalableViewport( {
     setTransform,
     cancelAnimation,
     disableTouchGestures,
+    lockInteractions,
     onInteractionStart,
     onInteractionEnd
   } );
@@ -188,12 +194,13 @@ export default function ScalableViewport( {
           onMinus={ zoomOut }
           onFit={ () => fitToViewport( true ) }
           onReset={ () => resetToActualPixels( true ) }
+          disabled={ lockInteractions }
         />
       )}
 
       <div
         ref={ containerRef }
-        className="w-full h-full overflow-hidden touch-none relative cursor-grab active:cursor-grabbing"
+        className={ `w-full h-full overflow-hidden touch-none relative ${ lockInteractions ? "cursor-default" : "cursor-grab active:cursor-grabbing" }` }
         style={ {
           touchAction: "none"
         } }

--- a/src/components/ScalableViewport/components/ZoomControls.tsx
+++ b/src/components/ScalableViewport/components/ZoomControls.tsx
@@ -12,22 +12,30 @@ const ZoomControls = ( {
   onPlus,
   onMinus,
   onFit,
-  onReset
+  onReset,
+  disabled = false
 }: {
   scale: number;
   onPlus: () => void;
   onMinus: () => void;
   onReset: () => void;
   onFit: () => void;
+  // Recording owns the engine clock — surface the controls as inert so a
+  // stray zoom can't disturb an in-flight capture.
+  disabled?: boolean;
 } ) => {
   return (
     <div
       className="absolute top-2 right-2 md:top-4 md:right-4 z-50"
       data-no-drag="true"
     >
-      <div className="flex items-center h-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md overflow-hidden divide-x divide-border">
+      <div
+        className={ `flex items-center h-9 bg-background/90 backdrop-blur-xl border border-border rounded-xl shadow-md overflow-hidden divide-x divide-border transition-opacity ${ disabled ? "opacity-40 pointer-events-none" : "" }` }
+        aria-hidden={ disabled }
+      >
         <button
           onClick={ onMinus }
+          disabled={ disabled }
           className={ buttonClassName }
           title="Zoom out"
           aria-label="Zoom out"
@@ -37,6 +45,7 @@ const ZoomControls = ( {
 
         <button
           onClick={ onReset }
+          disabled={ disabled }
           className={ `${ buttonClassName } min-w-[3.5rem]` }
           title="Zoom to 100% (actual size)"
           aria-label="Zoom to 100% (actual size)"
@@ -48,6 +57,7 @@ const ZoomControls = ( {
 
         <button
           onClick={ onPlus }
+          disabled={ disabled }
           className={ buttonClassName }
           title="Zoom in"
           aria-label="Zoom in"
@@ -57,6 +67,7 @@ const ZoomControls = ( {
 
         <button
           onClick={ onFit }
+          disabled={ disabled }
           className={ buttonClassName }
           title="Fit to viewport"
           aria-label="Fit to viewport"

--- a/src/components/ScalableViewport/hooks/useViewportGestures.ts
+++ b/src/components/ScalableViewport/hooks/useViewportGestures.ts
@@ -20,6 +20,10 @@ interface UseViewportGesturesProps {
   ) => void;
   cancelAnimation: () => void;
   disableTouchGestures?: boolean;
+  // Freeze every pan/pinch/wheel gesture (used while a browser recording
+  // owns the engine clock — panning would otherwise pause the engine and
+  // desync the capture).
+  lockInteractions?: boolean;
   onInteractionStart?: ( mode: "panning" | "zooming" ) => void;
   onInteractionEnd?: () => void;
 }
@@ -45,6 +49,7 @@ export function useViewportGestures( {
   setTransform,
   cancelAnimation,
   disableTouchGestures = false,
+  lockInteractions = false,
   onInteractionStart,
   onInteractionEnd
 }: UseViewportGesturesProps ) {
@@ -228,6 +233,9 @@ export function useViewportGestures( {
     },
     {
       target: containerRef,
+      // Disabling at the shared-config level tears down every gesture
+      // recogniser, so no drag/pinch/wheel can fire while locked.
+      enabled: !lockInteractions,
       drag: {
         from: () => [
           transform.current.x,

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -37,7 +37,7 @@ export default function TemplateSketchPage() {
   const [
     {
       name, capturing, options, persistedJob, engineId, category, sketchLoaded, activeSlideIndex,
-      engine, looping
+      engine, looping, browserRecording
     },
     dispatch
   ] = useSketch();
@@ -274,6 +274,7 @@ export default function TemplateSketchPage() {
           resolutionKey={ `${ effectiveSettings.size.width }x${ effectiveSettings.size.height }` }
           isReady={ sketchLoaded }
           disableTouchGestures={ disableTouchGestures }
+          lockInteractions={ browserRecording }
           onInteractionStart={ handleInteractionStart }
           onInteractionEnd={ handleInteractionEnd }
         >

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -23,11 +23,34 @@ const iconMap = {
   warning: AlertTriangle
 };
 
-const iconColorMap = {
-  success: "text-green-600",
-  error: "text-red-600",
-  info: "text-blue-600",
-  warning: "text-orange-600"
+// Each toast type carries the same modern, frosted-glass treatment as the
+// recording-lock banner — a faint accent tint behind the glass, an accent
+// border and a matching icon. Full class literals so Tailwind keeps them.
+const accentMap: Record<ToastType, {
+  icon: string;
+  border: string;
+  tint: string;
+}> = {
+  success: {
+    icon: "text-green-500",
+    border: "border-green-500/40",
+    tint: "bg-green-500/10"
+  },
+  error: {
+    icon: "text-red-500",
+    border: "border-red-500/40",
+    tint: "bg-red-500/10"
+  },
+  info: {
+    icon: "text-blue-500",
+    border: "border-blue-500/40",
+    tint: "bg-blue-500/10"
+  },
+  warning: {
+    icon: "text-amber-500",
+    border: "border-amber-500/40",
+    tint: "bg-amber-500/10"
+  }
 };
 
 export default function Toast( {
@@ -66,6 +89,7 @@ export default function Toast( {
   );
 
   const Icon = iconMap[ type ];
+  const accent = accentMap[ type ];
 
   return (
     <div
@@ -73,29 +97,38 @@ export default function Toast( {
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }` }
     >
-      <div className="bg-background border border-border rounded-xl sm:rounded-2xl shadow-xl px-3 py-2.5 sm:px-6 sm:py-4 flex items-center gap-2 sm:gap-4">
-        <Icon
-          className={ `w-4 h-4 sm:w-5 sm:h-5 flex-shrink-0 ${ iconColorMap[ type ] }` }
+      <div
+        className={ `relative overflow-hidden glass border ${ accent.border } rounded-2xl shadow-lg` }
+      >
+        {/* Faint accent wash layered over the frosted glass. */}
+        <div
+          className={ `absolute inset-0 ${ accent.tint } pointer-events-none` }
+          aria-hidden="true"
         />
-        <span className="text-sm sm:text-base font-medium text-foreground">
-          {message}
-        </span>
 
-        <div className="w-px h-5 sm:h-6 bg-border ml-2" />
+        <div className="relative flex items-center gap-2 sm:gap-3 px-3 py-2.5 sm:px-5 sm:py-3.5">
+          <Icon
+            className={ `w-4 h-4 sm:w-5 sm:h-5 flex-shrink-0 ${ accent.icon }` }
+          />
+          <span className="text-sm sm:text-base font-medium text-foreground">
+            {message}
+          </span>
 
-        <button
-          onClick={ () => {
-            setIsVisible( false );
-            setTimeout(
-              onClose,
-              300
-            );
-          } }
-          className="p-1.5 sm:p-2 rounded-lg hover:bg-hover transition-colors"
-          title="Dismiss"
-        >
-          <X className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
-        </button>
+          <button
+            onClick={ () => {
+              setIsVisible( false );
+              setTimeout(
+                onClose,
+                300
+              );
+            } }
+            className="ml-1 sm:ml-2 p-1.5 rounded-lg text-foreground/60 hover:text-foreground hover:bg-hover transition-colors"
+            title="Dismiss"
+            aria-label="Dismiss"
+          >
+            <X className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Improves and fixes the design of template options and capture actions.

## Tasks

- [x] **Prevent seeking, zooming and panning when a recording is in progress** — so the viewport can't disturb an async-loop or realtime browser capture.
- [x] **Modernize the import success message** like the readonly/recording-in-progress message.
- [x] **Give the readonly/recording-in-progress message a blurry glass background.**

## What changed

### 1. Lock pan/zoom during a browser recording
Seeking was already locked via the `browserRecording` flag in `AnimationProgressionBar`, but pan/zoom were not — and a viewport gesture pauses the engine (`handleInteractionStart`), which would desync an in-flight capture.

- `browserRecording` now flows from the sketch context into `ScalableViewport` as a new `lockInteractions` prop.
- `useViewportGestures` disables every drag/pinch/wheel recogniser at the `use-gesture` config level (`enabled: !lockInteractions`), so no gesture fires (and the engine is never paused) while recording.
- `ZoomControls` gains a `disabled` state (dimmed + `pointer-events-none` + disabled buttons) so the zoom buttons can't change the transform either.
- The container drops its grab cursor while locked.

This completes the trio (seek + zoom + pan) for both async-loop and realtime modes.

### 2. Blurry glass recording-lock banner
`RecordingLockBanner` gains `backdrop-blur-xl` for a frosted-glass background, keeping its amber warning identity.

### 3. Modernized toast (import success/error message)
The shared `Toast` (used by the options import success/error message) now shares the banner's design language: frosted `glass` background, a per-type accent border + faint tint, and a matching accent icon. This is the component that renders "Options imported successfully", so the import message is modernized consistently — and other toasts benefit too.

## Verification
- `tsc --noEmit`: no new type errors in touched files (only pre-existing failures in an unrelated `traceLetters.test.ts`).
- `eslint` clean on all changed files (also enforced by the pre-commit hook).
- `ScalableViewport` Jest suite passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2cKc4yPfKvD5b6ChdX2jr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2cKc4yPfKvD5b6ChdX2jr)_