### PR TITLE
feat(video-mosaic): raise displacement cap 1 → 10 for an exaggerated effect

### DIFF
--- a/src/templates/p5/sketches/video/video-mosaic/index.js
+++ b/src/templates/p5/sketches/video/video-mosaic/index.js
@@ -129,7 +129,7 @@ sketch.draw( () => {
   const displacement = clamp(
     cfg.displacement ?? 0.4,
     0,
-    1
+    10
   );
   const colorShift = clamp(
     cfg.colorShift ?? 0.4,

--- a/src/templates/p5/sketches/video/video-mosaic/options.ts
+++ b/src/templates/p5/sketches/video/video-mosaic/options.ts
@@ -58,7 +58,7 @@ export const formConfiguration: Record<string, any> = {
     component: "slider",
     label: "Displacement",
     min: 0,
-    max: 1,
+    max: 10,
     step: 0.01
   },
 


### PR DESCRIPTION
## What

Raise the **Displacement** ceiling in `video-mosaic` from `1` to `10` so the effect can be pushed into exaggerated, glitchy territory — especially satisfying when the value is driven by an audio source (the mosaic cells jump hard on claps).

- `options.ts`: Displacement slider `max: 1 → 10` (min/step/default unchanged).
- `index.js`: in-sketch `clamp(..., 0, 1) → clamp(..., 0, 10)` — without this the slider would still be capped at 1.

**Default stays at `1`**, so the out-of-the-box look is unchanged; the extra range is opt-in.

## Side effects (checked)

None harmful. Per-cell displacement is `(noise - 0.5) · 2 · displacement · cellSize`, but the resulting sample coordinates are already clamped to the work buffer (`sampleX/sampleY` → `[0, bw-cellBW]` / `[0, bh-cellBH]`). So higher values don't read out of bounds — cells just sample crops from across the whole frame and saturate toward the edges, which is exactly the exaggerated "everything jumps" look. No crash, no perf change.

## Validation
- `npx eslint` on both files → **0 errors**.
- `npx jest sketches.test.ts` → **847/847 pass**.
- `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPXnXAN5DipSME9gjieb1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPXnXAN5DipSME9gjieb1g)_