### PR TITLE
fix(sw): cache WebP template thumbnails in service worker

### DIFF
--- a/docs/THUMBNAIL_CACHING.md
+++ b/docs/THUMBNAIL_CACHING.md
@@ -9,9 +9,11 @@ The PWA service worker now caches thumbnail images to improve loading performanc
 The service worker caches the following thumbnail images:
 
 1. **Template Thumbnails**
-   - Path: `/assets/images/templates/**/*.{jpeg,jpg}`
+   - Path: `/assets/images/templates/**/*.{webp,jpeg,jpg}`
    - Used in: Templates page (`/templates`)
-   - Example: `/assets/images/templates/p5/sketch-name/thumbnail.jpeg`
+   - Example: `/assets/images/templates/p5/sketch-name/thumbnail.webp`
+   - Thumbnails are generated as WebP (quality 80) by sharp; `.jpeg`/`.jpg`
+     remain matched for backwards compatibility with legacy stills.
 
 2. **Recording Thumbnails**
    - API: `/api/recordings/[id]/thumbnail`
@@ -71,6 +73,6 @@ To clear cache:
 
 ## Service Worker Version
 
-Current version: `0.2.0-thumbnail-cache`
+Current version: `0.3.0-thumbnail-cache-webp`
 
 When updating the service worker, increment the version to trigger cache cleanup.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service worker for PWA installation, push notifications, and thumbnail caching
 // Caches thumbnail images for better performance on slow NAS storage
 
-const SW_VERSION = "0.2.0-thumbnail-cache";
+const SW_VERSION = "0.3.0-thumbnail-cache-webp";
 const THUMBNAIL_CACHE = "thumbnail-cache-v1";
 
 // Push notification handler
@@ -109,10 +109,16 @@ function isThumbnailImage( url ) {
   const urlObj = new URL( url );
   const pathname = urlObj.pathname;
 
-  // Template thumbnails: assets/images/templates/**/*.{jpeg,jpg}
+  // Template thumbnails: assets/images/templates/**/*.{webp,jpeg,jpg}
+  // Thumbnails are now generated as WebP (see src/lib/createSketchThumbnails.ts);
+  // .jpeg/.jpg are kept for backwards compatibility with any legacy stills.
   if (
     pathname.startsWith( "/assets/images/templates/" ) &&
-    ( pathname.endsWith( ".jpeg" ) || pathname.endsWith( ".jpg" ) )
+    (
+      pathname.endsWith( ".webp" ) ||
+      pathname.endsWith( ".jpeg" ) ||
+      pathname.endsWith( ".jpg" )
+    )
   ) {
     return true;
   }


### PR DESCRIPTION
## Problem

`isThumbnailImage()` in `public/sw.js` only matched template still images with `.jpeg`/`.jpg` extensions. Generated thumbnails are now **WebP** (`.webp`, quality 80, produced by sharp in `src/lib/createSketchThumbnails.ts` and served from `/assets/images/templates/{engine}/{name}/thumbnail.webp` via `getSketchThumbnailURL`). As a result, the service worker's stale-while-revalidate thumbnail cache never matched template stills, so they were never cached.

## Fix

- **`public/sw.js`**: `isThumbnailImage()` now matches `.webp` (in addition to legacy `.jpeg`/`.jpg`) under `/assets/images/templates/`.
- Bumped `SW_VERSION` `0.2.0-thumbnail-cache` → `0.3.0-thumbnail-cache-webp` so clients re-install the updated worker.
- Updated `docs/THUMBNAIL_CACHING.md` to reflect the WebP extension and version.

## Verification against how thumbnails are actually served

| Source | How it's matched | WebP-affected? |
| --- | --- | --- |
| Template stills (`getSketchThumbnailURL`, `seo.ts`) → `/assets/images/templates/**/thumbnail.webp` | **extension check** — was the bug, now matches `.webp` | ✅ fixed |
| `/api/recordings/[id]/thumbnail` route | path regex `^/api/recordings/[^/]+/thumbnail$` — extension-independent | ✅ already correct |
| S3 recording/slide thumbnails (`recordSketch.ts`) → keys like `{jobId}/thumbnail-{jobId}.webp` | `pathname.includes("thumbnail")` substring — extension-independent | ✅ already correct |

`.webm` preview videos in the same template directory are unaffected (`.webp` ≠ `.webm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaqMcYDCTQ8KEcpPo6ruXB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaqMcYDCTQ8KEcpPo6ruXB)_