### PR TITLE
Interactivité (souris, caméra, audio, orbite, gyro…) sur Metaballs & Voronoi

### DIFF
--- a/src/templates/p5/sketches/metaballs/__tests__/metaballs.test.ts
+++ b/src/templates/p5/sketches/metaballs/__tests__/metaballs.test.ts
@@ -29,7 +29,9 @@ import {
   buildFieldGrid,
   marchingSquaresContour,
   palette,
-  fieldToUnit
+  fieldToUnit,
+  pointersToBalls,
+  combineBalls
 } from "@/p5/sketches/metaballs/_metaballs.js";
 
 type Ball = { x: number;
@@ -195,6 +197,95 @@ describe(
         );
 
         expect( segments ).toBe( 1 );
+      }
+    );
+  }
+);
+
+describe(
+  "interaction → balls",
+  () => {
+    it(
+      "pointersToBalls maps each pointer to a ball with the given radius",
+      () => {
+        const balls = pointersToBalls(
+          [
+            {
+              x: 10,
+              y: 20
+            },
+            {
+              x: 30,
+              y: 40
+            }
+          ],
+          50
+        );
+
+        expect( balls ).toEqual( [
+          {
+            x: 10,
+            y: 20,
+            r: 50
+          },
+          {
+            x: 30,
+            y: 40,
+            r: 50
+          }
+        ] );
+      }
+    );
+
+    it(
+      "combineBalls honours add / replace / off",
+      () => {
+        const proc = [
+          {
+            x: 0,
+            y: 0,
+            r: 5
+          }
+        ];
+        const pointers = [
+          {
+            x: 1,
+            y: 1
+          }
+        ];
+
+        expect( combineBalls(
+          proc,
+          pointers,
+          9,
+          "add"
+        ) ).toHaveLength( 2 );
+        expect( combineBalls(
+          proc,
+          pointers,
+          9,
+          "replace"
+        ) ).toEqual( [
+          {
+            x: 1,
+            y: 1,
+            r: 9
+          }
+        ] );
+
+        // "off" and "add with no pointers" both return the procedural set as-is.
+        expect( combineBalls(
+          proc,
+          pointers,
+          9,
+          "off"
+        ) ).toBe( proc );
+        expect( combineBalls(
+          proc,
+          [],
+          9,
+          "add"
+        ) ).toBe( proc );
       }
     );
   }

--- a/src/templates/p5/sketches/metaballs/_metaballs.js
+++ b/src/templates/p5/sketches/metaballs/_metaballs.js
@@ -160,6 +160,54 @@ export function animateBalls(
   }
 }
 
+/**
+ * Turn live interaction pointers (from `getPointers`) into metaballs. Each
+ * pointer becomes a ball at its position with a uniform radius, so a mouse,
+ * fingertip, audio band, orbit source, … all push the field around.
+ */
+export function pointersToBalls(
+  pointers, radius
+) {
+  const balls = [];
+
+  for ( let i = 0; i < pointers.length; i++ ) {
+    const pt = pointers[ i ];
+
+    balls.push( {
+      x: pt.x,
+      y: pt.y,
+      r: radius
+    } );
+  }
+
+  return balls;
+}
+
+/**
+ * Combine the procedural balls with interaction pointers according to the mix
+ * mode: "add" appends pointer balls, "replace" uses only pointer balls, "off"
+ * (or no pointers) keeps the procedural set untouched.
+ */
+export function combineBalls(
+  procedural, pointers, radius, mode
+) {
+  if ( mode === "replace" ) {
+    return pointersToBalls(
+      pointers,
+      radius
+    );
+  }
+
+  if ( mode === "off" || !pointers || pointers.length === 0 ) {
+    return procedural;
+  }
+
+  return procedural.concat( pointersToBalls(
+    pointers,
+    radius
+  ) );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Scalar field                                                      */
 /* ------------------------------------------------------------------ */

--- a/src/templates/p5/sketches/metaballs/_options.ts
+++ b/src/templates/p5/sketches/metaballs/_options.ts
@@ -1,6 +1,67 @@
 // Shared form fragments for the "metaballs" category so every variant exposes
 // the same ball-simulation, grid and palette controls without duplication.
 
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+export {
+  interactionFormConfiguration
+};
+
+// Interaction defaults tuned for these sketches: every source starts OFF (so the
+// procedural look is preserved until the user opts in) and the debug overlay is
+// muted. Flip on Mouse / Vision / Audio / Orbit / Gyroscope to push the field.
+export const interactionDefaults = {
+  ...interactionFormValues,
+  orbit: {
+    ...interactionFormValues.orbit,
+    enabled: false
+  },
+  visualization: {
+    ...interactionFormValues.visualization,
+    enabled: false
+  }
+};
+
+export const interactionMixValues = {
+  mode: "add",
+  pointerRadius: 130
+};
+
+export const interactionMixConfig = {
+  label: "Interaction → metaballs",
+  component: "nested-object",
+  fields: {
+    mode: {
+      label: "Mix mode",
+      component: "select",
+      options: [
+        {
+          label: "Add (pointers become extra balls)",
+          value: "add"
+        },
+        {
+          label: "Replace (only pointer balls)",
+          value: "replace"
+        },
+        {
+          label: "Off (ignore pointers)",
+          value: "off"
+        }
+      ]
+    },
+    pointerRadius: {
+      label: "Pointer ball radius",
+      component: "slider",
+      min: 10,
+      max: 400,
+      step: 5
+    }
+  }
+};
+
 export const PALETTE_OPTIONS = [
   {
     label: "Rainbow",

--- a/src/templates/p5/sketches/metaballs/metaballs-v1-field/index.js
+++ b/src/templates/p5/sketches/metaballs/metaballs-v1-field/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createBalls,
   animateBalls,
+  combineBalls,
   sampleField,
   palette,
   fieldToUnit
@@ -75,7 +83,9 @@ function ensureBuffer( cols ) {
   }
 }
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -106,6 +116,24 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const balls = combineBalls(
+    state.balls,
+    pointers,
+    mix.pointerRadius ?? 130,
+    mixMode
+  );
+
+  if ( balls.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const render = o.render ?? {};
   const threshold = o.grid?.threshold ?? 1;
   const gamma = render.gamma ?? 1;
@@ -130,7 +158,7 @@ sketch.draw( () => {
 
     for ( let x = 0; x < bufW; x++ ) {
       const value = sampleField(
-        state.balls,
+        balls,
         x * scaleX,
         wy
       );
@@ -176,7 +204,7 @@ sketch.draw( () => {
     );
     p.strokeWeight( 1.5 );
 
-    for ( const ball of state.balls ) {
+    for ( const ball of balls ) {
       p.circle(
         ball.x,
         ball.y,
@@ -189,5 +217,6 @@ sketch.draw( () => {
     }
   }
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/metaballs/metaballs-v1-field/options.ts
+++ b/src/templates/p5/sketches/metaballs/metaballs-v1-field/options.ts
@@ -5,7 +5,11 @@ import {
   ballsValues,
   ballsConfig,
   gridValues,
-  gridConfig
+  gridConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -21,6 +25,8 @@ export const formValues = {
     outsideDim: 0.6,
     showBalls: false
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     0,
     0,
@@ -85,6 +91,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/metaballs/metaballs-v2-marching-squares/index.js
+++ b/src/templates/p5/sketches/metaballs/metaballs-v2-marching-squares/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createBalls,
   animateBalls,
+  combineBalls,
   buildFieldGrid,
   marchingSquaresContour,
   palette
@@ -52,7 +60,9 @@ function ensureBalls( o ) {
   }
 }
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -83,6 +93,24 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const balls = combineBalls(
+    state.balls,
+    pointers,
+    mix.pointerRadius ?? 130,
+    mixMode
+  );
+
+  if ( balls.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const gridOpts = o.grid ?? {};
   const cellSize = Math.max(
     4,
@@ -103,7 +131,7 @@ sketch.draw( () => {
   const cellH = p.height / rows;
 
   state.field = buildFieldGrid(
-    state.balls,
+    balls,
     cols,
     rows,
     cellW,
@@ -196,7 +224,7 @@ sketch.draw( () => {
     );
     p.strokeWeight( 1 );
 
-    for ( const ball of state.balls ) {
+    for ( const ball of balls ) {
       p.circle(
         ball.x,
         ball.y,
@@ -262,5 +290,6 @@ sketch.draw( () => {
     }
   );
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/metaballs/metaballs-v2-marching-squares/options.ts
+++ b/src/templates/p5/sketches/metaballs/metaballs-v2-marching-squares/options.ts
@@ -5,7 +5,11 @@ import {
   ballsValues,
   ballsConfig,
   gridValues,
-  gridConfig
+  gridConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -28,6 +32,8 @@ export const formValues = {
     showSamples: false,
     showBalls: false
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     8,
     8,
@@ -94,6 +100,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/metaballs/metaballs-v3-blobs/index.js
+++ b/src/templates/p5/sketches/metaballs/metaballs-v3-blobs/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createBalls,
   animateBalls,
+  combineBalls,
   buildFieldGrid,
   marchingSquaresFill,
   marchingSquaresContour,
@@ -52,7 +60,9 @@ function ensureBalls( o ) {
   }
 }
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -83,6 +93,24 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const balls = combineBalls(
+    state.balls,
+    pointers,
+    mix.pointerRadius ?? 130,
+    mixMode
+  );
+
+  if ( balls.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const gridOpts = o.grid ?? {};
   const cellSize = Math.max(
     4,
@@ -103,7 +131,7 @@ sketch.draw( () => {
   const cellH = p.height / rows;
 
   state.field = buildFieldGrid(
-    state.balls,
+    balls,
     cols,
     rows,
     cellW,
@@ -251,5 +279,6 @@ sketch.draw( () => {
     }
   }
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/metaballs/metaballs-v3-blobs/options.ts
+++ b/src/templates/p5/sketches/metaballs/metaballs-v3-blobs/options.ts
@@ -5,7 +5,11 @@ import {
   ballsValues,
   ballsConfig,
   gridValues,
-  gridConfig
+  gridConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -38,6 +42,8 @@ export const formValues = {
       255
     ]
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     6,
     4,
@@ -103,6 +109,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/metaballs/metaballs-v4-contours/index.js
+++ b/src/templates/p5/sketches/metaballs/metaballs-v4-contours/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createBalls,
   animateBalls,
+  combineBalls,
   buildFieldGrid,
   marchingSquaresContour,
   marchingSquaresFill,
@@ -54,7 +62,9 @@ function ensureBalls( o ) {
   }
 }
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -85,6 +95,24 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const balls = combineBalls(
+    state.balls,
+    pointers,
+    mix.pointerRadius ?? 130,
+    mixMode
+  );
+
+  if ( balls.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const gridOpts = o.grid ?? {};
   const cellSize = Math.max(
     4,
@@ -104,7 +132,7 @@ sketch.draw( () => {
   const cellH = p.height / rows;
 
   state.field = buildFieldGrid(
-    state.balls,
+    balls,
     cols,
     rows,
     cellW,
@@ -237,5 +265,6 @@ sketch.draw( () => {
     }
   }
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/metaballs/metaballs-v4-contours/options.ts
+++ b/src/templates/p5/sketches/metaballs/metaballs-v4-contours/options.ts
@@ -5,7 +5,11 @@ import {
   ballsValues,
   ballsConfig,
   gridValues,
-  gridConfig
+  gridConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -24,6 +28,8 @@ export const formValues = {
     lines: true,
     lineWeight: 1.5
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     4,
     6,
@@ -100,6 +106,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/voronoi/__tests__/voronoi.test.ts
+++ b/src/templates/p5/sketches/voronoi/__tests__/voronoi.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the voronoi maths shared module.
+ *
+ * Covers the nearest-site query, the swappable distance metrics, and the
+ * interaction → sites helpers. getP5 is mocked because the pure maths under test
+ * never touch p5 (only the drift motion mode does).
+ */
+jest.mock(
+  "@/p5/utils/sketch.js",
+  () => ( {
+    getP5: () => ( {
+      noise: () => 0.5
+    } )
+  } ),
+  {
+    virtual: true
+  }
+);
+
+import {
+  METRICS,
+  nearestTwo,
+  pointersToSites,
+  combineSites
+} from "@/p5/sketches/voronoi/_voronoi.js";
+
+describe(
+  "distance metrics",
+  () => {
+    it(
+      "euclidean returns the squared distance",
+      () => {
+        expect( METRICS.euclidean(
+          3,
+          4
+        ) ).toBe( 25 );
+      }
+    );
+
+    it(
+      "manhattan and chebyshev use the expected norms",
+      () => {
+        expect( METRICS.manhattan(
+          3,
+          -4
+        ) ).toBe( 7 );
+        expect( METRICS.chebyshev(
+          3,
+          -4
+        ) ).toBe( 4 );
+      }
+    );
+  }
+);
+
+describe(
+  "nearestTwo",
+  () => {
+    it(
+      "finds the nearest and second-nearest sites",
+      () => {
+        const sites = [
+          {
+            x: 0,
+            y: 0
+          },
+          {
+            x: 100,
+            y: 0
+          },
+          {
+            x: 10,
+            y: 0
+          }
+        ];
+        const result = {
+          i1: -1,
+          d1: 0,
+          i2: -1,
+          d2: 0
+        };
+
+        nearestTwo(
+          sites,
+          2,
+          0,
+          METRICS.euclidean,
+          3,
+          result
+        );
+
+        // Closest is site 0 (d=4), second is site 2 (d=64).
+        expect( result.i1 ).toBe( 0 );
+        expect( result.i2 ).toBe( 2 );
+        expect( result.d1 ).toBeLessThan( result.d2 );
+      }
+    );
+  }
+);
+
+describe(
+  "interaction → sites",
+  () => {
+    it(
+      "pointersToSites positions sites and assigns distinct hues",
+      () => {
+        const sites = pointersToSites(
+          [
+            {
+              x: 5,
+              y: 6
+            },
+            {
+              x: 7,
+              y: 8
+            }
+          ],
+          0
+        );
+
+        expect( sites[ 0 ].x ).toBe( 5 );
+        expect( sites[ 0 ].y ).toBe( 6 );
+
+        for ( const site of sites ) {
+          expect( site.colorT ).toBeGreaterThanOrEqual( 0 );
+          expect( site.colorT ).toBeLessThan( 1 );
+        }
+
+        expect( sites[ 0 ].colorT ).not.toBe( sites[ 1 ].colorT );
+      }
+    );
+
+    it(
+      "combineSites honours add / replace / off",
+      () => {
+        const proc = [
+          {
+            x: 0,
+            y: 0,
+            colorT: 0.5
+          }
+        ];
+        const pointers = [
+          {
+            x: 1,
+            y: 1
+          }
+        ];
+
+        expect( combineSites(
+          proc,
+          pointers,
+          "add"
+        ) ).toHaveLength( 2 );
+        expect( combineSites(
+          proc,
+          pointers,
+          "replace"
+        ) ).toHaveLength( 1 );
+        expect( combineSites(
+          proc,
+          pointers,
+          "off"
+        ) ).toBe( proc );
+        expect( combineSites(
+          proc,
+          [],
+          "add"
+        ) ).toBe( proc );
+      }
+    );
+  }
+);

--- a/src/templates/p5/sketches/voronoi/_options.ts
+++ b/src/templates/p5/sketches/voronoi/_options.ts
@@ -1,5 +1,58 @@
 // Shared form fragments for the "voronoi" category.
 
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+export {
+  interactionFormConfiguration
+};
+
+// Interaction defaults: every source starts OFF and the debug overlay is muted,
+// so the procedural diagram is unchanged until the user enables a source. Then
+// each pointer (Mouse / Vision / Audio / Orbit / Gyroscope) becomes a live site.
+export const interactionDefaults = {
+  ...interactionFormValues,
+  orbit: {
+    ...interactionFormValues.orbit,
+    enabled: false
+  },
+  visualization: {
+    ...interactionFormValues.visualization,
+    enabled: false
+  }
+};
+
+export const interactionMixValues = {
+  mode: "add"
+};
+
+export const interactionMixConfig = {
+  label: "Interaction → sites",
+  component: "nested-object",
+  fields: {
+    mode: {
+      label: "Mix mode",
+      component: "select",
+      options: [
+        {
+          label: "Add (pointers become extra sites)",
+          value: "add"
+        },
+        {
+          label: "Replace (only pointer sites)",
+          value: "replace"
+        },
+        {
+          label: "Off (ignore pointers)",
+          value: "off"
+        }
+      ]
+    }
+  }
+};
+
 export const PALETTE_OPTIONS = [
   {
     label: "Rainbow",

--- a/src/templates/p5/sketches/voronoi/_voronoi.js
+++ b/src/templates/p5/sketches/voronoi/_voronoi.js
@@ -214,6 +214,55 @@ export function animateSites(
   }
 }
 
+/**
+ * Turn live interaction pointers (from `getPointers`) into Voronoi sites. Each
+ * pointer becomes a site at its position; `startIndex` offsets the colour hash
+ * so injected sites keep distinct, stable hues next to the procedural ones.
+ */
+export function pointersToSites(
+  pointers, startIndex = 0
+) {
+  const sites = [];
+
+  for ( let i = 0; i < pointers.length; i++ ) {
+    const pt = pointers[ i ];
+
+    sites.push( {
+      x: pt.x,
+      y: pt.y,
+      // Golden-ratio hash → well-spread, deterministic hues per pointer.
+      colorT: ( ( startIndex + i ) * 0.6180339887 ) % 1
+    } );
+  }
+
+  return sites;
+}
+
+/**
+ * Combine procedural sites with interaction pointers per mix mode: "add" appends
+ * pointer sites, "replace" uses only pointer sites, "off" (or no pointers) keeps
+ * the procedural set.
+ */
+export function combineSites(
+  procedural, pointers, mode
+) {
+  if ( mode === "replace" ) {
+    return pointersToSites(
+      pointers,
+      0
+    );
+  }
+
+  if ( mode === "off" || !pointers || pointers.length === 0 ) {
+    return procedural;
+  }
+
+  return procedural.concat( pointersToSites(
+    pointers,
+    procedural.length
+  ) );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Nearest-site query                                                */
 /* ------------------------------------------------------------------ */

--- a/src/templates/p5/sketches/voronoi/voronoi-v1-cells/index.js
+++ b/src/templates/p5/sketches/voronoi/voronoi-v1-cells/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createSites,
   animateSites,
+  combineSites,
   nearestTwo,
   palette,
   METRICS
@@ -83,7 +91,9 @@ const result = {
   d2: 0
 };
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -113,6 +123,23 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const sites = combineSites(
+    state.sites,
+    pointers,
+    mixMode
+  );
+
+  if ( sites.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const quality = o.quality ?? {};
   const metricFn = METRICS[ quality.metric ?? "euclidean" ] ?? METRICS.euclidean;
   const pexp = quality.minkowskiP ?? 3;
@@ -131,7 +158,7 @@ sketch.draw( () => {
   ];
 
   // Per-site flat colours (cheap: one per site, recomputed each frame).
-  const siteColors = state.sites.map( ( site ) =>
+  const siteColors = sites.map( ( site ) =>
     palette(
       paletteName,
       ( site.colorT + hueShift ) % 1
@@ -158,7 +185,7 @@ sketch.draw( () => {
 
     for ( let x = 0; x < bufW; x++ ) {
       nearestTwo(
-        state.sites,
+        sites,
         x * scaleX,
         wy,
         metricFn,
@@ -228,7 +255,7 @@ sketch.draw( () => {
       230
     );
 
-    for ( const site of state.sites ) {
+    for ( const site of sites ) {
       p.circle(
         site.x,
         site.y,
@@ -237,5 +264,6 @@ sketch.draw( () => {
     }
   }
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/voronoi/voronoi-v1-cells/options.ts
+++ b/src/templates/p5/sketches/voronoi/voronoi-v1-cells/options.ts
@@ -5,7 +5,11 @@ import {
   sitesValues,
   sitesConfig,
   metricValues,
-  metricConfig
+  metricConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -23,6 +27,8 @@ export const formValues = {
     ],
     showSites: false
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     0,
     0,
@@ -78,6 +84,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/voronoi/voronoi-v2-worley/index.js
+++ b/src/templates/p5/sketches/voronoi/voronoi-v2-worley/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createSites,
   animateSites,
+  combineSites,
   nearestTwo,
   palette,
   METRICS
@@ -83,7 +91,9 @@ const result = {
   d2: 0
 };
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -113,6 +123,23 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const sites = combineSites(
+    state.sites,
+    pointers,
+    mixMode
+  );
+
+  if ( sites.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const quality = o.quality ?? {};
   const metric = quality.metric ?? "euclidean";
   const metricFn = METRICS[ metric ] ?? METRICS.euclidean;
@@ -130,7 +157,7 @@ sketch.draw( () => {
   const scale = render.scale ?? 1;
 
   // Normalise distances so a typical cell radius maps to ≈1.
-  const norm = ( Math.sqrt( state.sites.length ) / Math.min(
+  const norm = ( Math.sqrt( sites.length ) / Math.min(
     p.width,
     p.height
   ) ) * 2 * scale;
@@ -166,7 +193,7 @@ sketch.draw( () => {
 
     for ( let x = 0; x < bufW; x++ ) {
       nearestTwo(
-        state.sites,
+        sites,
         x * scaleX,
         wy,
         metricFn,
@@ -243,5 +270,6 @@ sketch.draw( () => {
   );
   p.pop();
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/voronoi/voronoi-v2-worley/options.ts
+++ b/src/templates/p5/sketches/voronoi/voronoi-v2-worley/options.ts
@@ -5,7 +5,11 @@ import {
   sitesValues,
   sitesConfig,
   metricValues,
-  metricConfig
+  metricConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 const MODE_OPTIONS = [
@@ -42,6 +46,8 @@ export const formValues = {
     scale: 1,
     hueSpeed: 0
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     0,
     0,
@@ -102,6 +108,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/sketches/voronoi/voronoi-v3-mosaic/index.js
+++ b/src/templates/p5/sketches/voronoi/voronoi-v3-mosaic/index.js
@@ -5,8 +5,16 @@ import sketch, {
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
+import {
   createSites,
   animateSites,
+  combineSites,
   nearestTwo,
   palette,
   METRICS
@@ -82,7 +90,9 @@ const result = {
   d2: 0
 };
 
-sketch.setup( () => {} );
+sketch.setup( async() => {
+  await initInteraction( options.sketch?.interaction ?? {} );
+} );
 
 sketch.draw( () => {
   const p = getP5();
@@ -112,6 +122,23 @@ sketch.draw( () => {
     }
   );
 
+  const interaction = o.interaction ?? {};
+  const mix = o.interactionMix ?? {};
+  const mixMode = mix.mode ?? "add";
+  const pointers = mixMode === "off" ? [] : getPointers( interaction );
+  const sites = combineSites(
+    state.sites,
+    pointers,
+    mixMode
+  );
+
+  if ( sites.length === 0 ) {
+    drawInteractionOverlay( interaction );
+    renderTitle();
+
+    return;
+  }
+
   const quality = o.quality ?? {};
   const metric = quality.metric ?? "euclidean";
   const metricFn = METRICS[ metric ] ?? METRICS.euclidean;
@@ -133,7 +160,7 @@ sketch.draw( () => {
     8
   ];
 
-  const siteColors = state.sites.map( ( site ) =>
+  const siteColors = sites.map( ( site ) =>
     palette(
       paletteName,
       ( site.colorT + hueShift ) % 1
@@ -161,7 +188,7 @@ sketch.draw( () => {
 
     for ( let x = 0; x < bufW; x++ ) {
       nearestTwo(
-        state.sites,
+        sites,
         x * scaleX,
         wy,
         metricFn,
@@ -253,8 +280,8 @@ sketch.draw( () => {
     p.blendMode( p.ADD );
     p.noStroke();
 
-    for ( let si = 0; si < state.sites.length; si++ ) {
-      const site = state.sites[ si ];
+    for ( let si = 0; si < sites.length; si++ ) {
+      const site = sites[ si ];
       const rgb = siteColors[ si ] ?? [
         255,
         255,
@@ -282,5 +309,6 @@ sketch.draw( () => {
     p.pop();
   }
 
+  drawInteractionOverlay( interaction );
   renderTitle();
 } );

--- a/src/templates/p5/sketches/voronoi/voronoi-v3-mosaic/options.ts
+++ b/src/templates/p5/sketches/voronoi/voronoi-v3-mosaic/options.ts
@@ -5,7 +5,11 @@ import {
   sitesValues,
   sitesConfig,
   metricValues,
-  metricConfig
+  metricConfig,
+  interactionDefaults,
+  interactionMixValues,
+  interactionMixConfig,
+  interactionFormConfiguration
 } from "../_options";
 
 export const formValues = {
@@ -23,6 +27,8 @@ export const formValues = {
     ],
     siteGlow: 0
   },
+  interactionMix: interactionMixValues,
+  interaction: interactionDefaults,
   backgroundColor: [
     8,
     8,
@@ -81,6 +87,8 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interactionMix: interactionMixConfig,
+  interaction: interactionFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"


### PR DESCRIPTION
## Résumé

Ajoute **l'interactivité** à **toutes** les variantes Metaballs (×4) et Voronoï (×3), en branchant la couche d'interaction réutilisable du projet — la même qu'utilisent `splines-v1-interactive` et le sketch `kinetic/interaction-test`.

Chaque **pointeur** renvoyé par `getPointers()` devient une **métaballe vivante** (à rayon paramétrable) ou un **site Voronoï**. Toutes les sources communes sont donc disponibles : souris, tactile, **caméra/vision** (mains, doigts, visage, corps via MediaPipe), **audio/micro**, **orbite**, Perlin, **gyroscope**, MIDI, manette.

## Contrôle « mix »
Un nouveau bloc **Interaction → metaballs / sites** par sketch choisit comment les pointeurs se combinent au set procédural :
| Mode | Effet |
|---|---|
| **add** (défaut) | les pointeurs deviennent des balles/sites supplémentaires |
| **replace** | uniquement les balles/sites pilotés par les pointeurs |
| **off** | ignore les pointeurs |

Pour les metaballs, un slider **rayon du pointeur** contrôle la taille des balles injectées.

## Non destructif par défaut
- Toutes les sources d'interaction démarrent **désactivées** et l'overlay de debug est **muet** → le rendu procédural (et les boucles d'export propres) est **inchangé** tant que l'utilisateur n'active rien. Aucun prompt caméra/micro au chargement.
- `initInteraction()` tourne dans `setup`, `drawInteractionOverlay()` en dernier → l'overlay partagé (croix, marqueurs de pointeurs, légende, aperçu caméra) est dispo dès qu'on active la *Visualization*.

## Détails techniques
- Helpers purs `pointersToBalls` / `combineBalls` et `pointersToSites` / `combineSites` dans les modules de catégorie — **sans** importer la couche interaction, pour que les tests unitaires restent légers.
- Garde « zéro pointeur » : en mode *replace* sans entrée, on rend juste le fond + l'overlay.
- Nouveaux tests unitaires pour les helpers d'interaction (mix add/replace/off, mapping pointeur→balle/site).
- ✅ `npm run lint`, `tsc --noEmit` et `jest` (1009 tests) passent.

## Comment jouer
Ouvre n'importe quel sketch Metaballs/Voronoï → section **Interaction** → active **Mouse** (bouge la souris), **Orbit** (count > 0, pointeurs virtuels bouclés), **Vision → Enabled + Hands/Fingers** (caméra), ou **Audio** (micro). Les balles/sites suivent en direct.

> Basé sur la PR #158 (déjà mergée) ; ce diff ne contient que l'ajout de l'interactivité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZyRXL65iUdwGR33C8miaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZyRXL65iUdwGR33C8miaE)_