### PR TITLE
perf(template-options): code-split MobileStudioDrawer, CaptureActions & progression bar off initial compile

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -1,3 +1,4 @@
+import dynamic from "next/dynamic";
 import type React from "react";
 import {
   useEffect, useRef, useState
@@ -14,12 +15,11 @@ import type {
   SketchOption, SlideOption
 } from "@/types/sketch.types";
 import useSketch from "../SketchProvider/hooks/useSketch";
-import CaptureActions, {
-  type CaptureActionsRef
+import type {
+  CaptureActionsRef
 } from "./components/CaptureActions";
 import useBrowserRecordingSupported from "./components/CaptureActions/hooks/useBrowserRecordingSupported";
 import OptionsPanel from "./components/OptionsPanel";
-import MobileStudioDrawer from "./components/MobileStudioDrawer";
 import RecordingLockBanner from "./components/RecordingLockBanner";
 import SketchSettings from "./components/SketchSettings/SketchSettings";
 import TemplateAssetsProvider from "./components/TemplateAssetsProvider/TemplateAssetsProvider";
@@ -42,6 +42,21 @@ import {
 import {
   subscribeSketchOptions
 } from "@/lib/syncSketchOptions";
+
+// CaptureActions drags the whole recording subtree into the sketch page's
+// initial compile: useBrowserRecorder -> @/engines/recording -> createRecorder
+// pulls in the mediabunny + gif.js encoders, plus the action buttons and
+// VideoPreviewModal. It only renders behind `recordingSupported &&`, so load it
+// as a separate chunk. next/dynamic does not forward refs, so the imperative
+// handle (auto-save / clone-as-draft) is wired through a `forwardedRef` prop.
+const CaptureActions = dynamic( () => import( "./components/CaptureActions" ) );
+
+// MobileStudioDrawer is a full mobile-only duplicate of the panel/settings/
+// capture UI (its own CaptureActions, GenericObjectForm, asset providers). It
+// renders only on the mobile media-query branch, so desktop should never
+// compile it — and the desktop panels are never compiled for mobile. Code-split
+// it so each layout's initial compile only covers what it actually shows.
+const MobileStudioDrawer = dynamic( () => import( "./components/MobileStudioDrawer" ) );
 
 type TemplateOptionsProps = {
   name: string;
@@ -450,7 +465,7 @@ export default function TemplateOptions( {
 
               {recordingSupported && (
                 <CaptureActions
-                  ref={ captureActionsRef }
+                  forwardedRef={ captureActionsRef }
                   activeSlideIndex={ activeSlideIndex }
                   { ...captureProps }
                 />

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/CaptureActions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/CaptureActions.tsx
@@ -55,6 +55,10 @@ type CaptureActionsProps = {
   lifecycle: RecordingLifecycle;
   recordingProgress: RecordingProgressionStream | null;
   subscribeToRecordingStatus: ( jobId: JobId ) => void;
+  // next/dynamic does not forward refs, so when CaptureActions is loaded as a
+  // lazy chunk the parent passes its imperative-handle ref through this prop
+  // instead of `ref`. The native `ref` still works for static call sites.
+  forwardedRef?: React.Ref<CaptureActionsRef>;
 };
 
 const CaptureActions = forwardRef<CaptureActionsRef, CaptureActionsProps>( (
@@ -68,7 +72,8 @@ const CaptureActions = forwardRef<CaptureActionsRef, CaptureActionsProps>( (
     thumbnails,
     lifecycle,
     recordingProgress,
-    subscribeToRecordingStatus
+    subscribeToRecordingStatus,
+    forwardedRef
   },
   ref
 ) => {
@@ -433,9 +438,11 @@ const CaptureActions = forwardRef<CaptureActionsRef, CaptureActionsProps>( (
     }
   };
 
-  // Expose imperative actions to parent via ref
+  // Expose imperative actions to parent via ref. Prefer the prop-forwarded ref
+  // (used when CaptureActions is mounted through next/dynamic, which drops the
+  // native `ref`); fall back to the native ref for static call sites.
   useImperativeHandle(
-    ref,
+    forwardedRef ?? ref,
     () => ( {
       saveAsDraft: async() => {
         await handleSubmit(

--- a/src/components/TemplateSketchPage/TemplateSketchPage.tsx
+++ b/src/components/TemplateSketchPage/TemplateSketchPage.tsx
@@ -5,7 +5,6 @@ import type React from "react";
 import {
   useCallback, useEffect, useMemo, useRef, useState
 } from "react";
-import AnimationProgressionBar from "@/components/AnimationProgressionBar";
 import EngineSketchRenderer from "@/components/TemplateSketchPage/EngineSketchRenderer";
 import SketchBreadcrumb from "@/components/TemplateSketchPage/SketchBreadcrumb";
 import SketchPerformanceLabel from "@/components/TemplateSketchPage/SketchPerformanceLabel";
@@ -32,6 +31,13 @@ import {
 
 const TemplateOptions = dynamic( () =>
   import( "@/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions" ) );
+
+// AnimationProgressionBar is a self-contained scrubber subtree (RAF polling,
+// pointer/scrub handlers, animationBridge/syncSketchOptions wiring) that only
+// renders once `sketchLoaded && !capturing`. Load it as a separate chunk so it
+// stays out of the sketch page's initial compile.
+const AnimationProgressionBar = dynamic( () =>
+  import( "@/components/AnimationProgressionBar" ) );
 
 export default function TemplateSketchPage() {
   const [


### PR DESCRIPTION
## Why

The sketch studio page (`/templates/[engine]/[...sketch]`) is slow to load/compile again. This is the same class of problem fixed in b9bb0e9 (`code-split FieldRenderer`) and in `OptionsPanel` (`ContentItems`/`SlideCarousel`/`SlideEditor`): heavy subtrees that are **statically imported** into the page's initial dev-server compile even though they only render **behind a gate**.

An audit of the static-import graph reachable from the sketch page surfaced three more such subtrees. This PR defers them with `next/dynamic`, following the established pattern.

## What changed

**`TemplateOptions.tsx`**
- **`MobileStudioDrawer` → `next/dynamic`.** It's a full mobile-only duplicate of the panel/settings/capture UI, but `TemplateOptions` statically imported *both* sides of the `isDesktop ? … : …` branch — so the entire mobile tree compiled on desktop and the desktop panels compiled for mobile. Now each layout's initial compile only covers what it actually shows.
- **`CaptureActions` → `next/dynamic`.** It only renders behind `recordingSupported &&`, but its static chain (`useBrowserRecorder` → `@/engines/recording` → `createRecorder`) dragged the **`mediabunny` + `gif.js` encoders**, the action buttons, and `VideoPreviewModal` into the always-compiled path. `next/dynamic` doesn't forward refs, so the load-bearing imperative handle (auto-save / clone-as-draft) is rewired through a new `forwardedRef` prop — see below.

**`CaptureActions.tsx`**
- Accepts an optional `forwardedRef?: React.Ref<CaptureActionsRef>` prop and uses `useImperativeHandle(forwardedRef ?? ref, …)`. Backward-compatible: the native `ref` still works for the static call site inside `MobileStudioDrawer`.

**`TemplateSketchPage.tsx`**
- **`AnimationProgressionBar` → `next/dynamic`.** A self-contained ~660-line scrubber subtree (RAF polling, pointer/scrub handlers) that only renders once `sketchLoaded && !capturing`.

## Flash-safety

Every converted component sits behind an existing render gate, and the static chrome around each gate stays static. Because the parent `TemplateOptions` boundary is *already* lazy, these splits add no new user-facing loading flash — they only narrow each initial chunk. The `forwardedRef` change is null-safe at every consumer (`useFormState` guards `captureActionsRef.current`; the banner clone CTA guards on it too), so a ref that populates a tick later just skips an early auto-save rather than crashing.

## Verification

- `npx tsc --noEmit` — **clean** on all changed files (remaining errors in the tree are pre-existing / the missing generated Prisma client, unrelated to this change).
- `npx eslint` — **clean** on all changed files.
- A full `npm run build` / bundle-analysis (to confirm `mediabunny`/`gif.js` land only in lazy chunks) could **not** be run in this environment: Prisma's engine-binary download is blocked by the network policy, and the build imports the generated Prisma client. Worth confirming locally that `mediabunny`/`gif.js` no longer appear in the route's first-load chunk, and that desktop auto-save + the banner "clone as draft" CTA still work (proves the `forwardedRef` imperative handle resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqtWKKN2oVUKFvmDoygGnF)_