### PR TITLE
fix(animation): make template duration robust across p5/gsap and front/back recording

### DIFF
--- a/src/components/AnimationProgressionBar.tsx
+++ b/src/components/AnimationProgressionBar.tsx
@@ -14,6 +14,9 @@ import useSketch from "@/components/ClientProcessingSketch/components/SketchProv
 import {
   getEffectiveSlideSettings
 } from "@/lib/effectiveSlideSettings";
+import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
 import usePageVisibility from "@/hooks/usePageVisibility";
 
 interface AnimationProgressionBarProps {
@@ -49,12 +52,13 @@ function getAnimationConfigFromSketchOptions(
     sketchOptions,
     activeSlideIndex
   );
-  const duration = animation?.duration ?? 10;
-  const framerate = animation?.framerate ?? 60;
-  const totalFrames = Math.max(
-    1,
-    Math.floor( duration * framerate )
-  );
+  // Resolve through the shared helper so the frame readout matches the engine
+  // and the recorder exactly (same default, same Math.round) — the bar used to
+  // default to 10 and Math.floor, so its frame count disagreed with the clip.
+  const {
+    duration, framerate
+  } = resolveAnimation( animation );
+  const totalFrames = totalFramesFor( animation );
 
   return {
     duration,

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
@@ -131,7 +131,10 @@ const rootFormConfig: Record<string, FieldConfig> = {
         label: "Duration (s)",
         component: "slider",
         step: 1,
-        min: 0,
+        // Floor at 1 to match SketchAnimationSchema (`duration.min(1)`): a 0 here
+        // is schema-invalid and used to slip through `watch()` un-clamped and
+        // trip the `duration || default` fallbacks downstream.
+        min: 1,
         max: 60
       },
       framerate: {

--- a/src/engines/gsap/GsapEngine.ts
+++ b/src/engines/gsap/GsapEngine.ts
@@ -16,6 +16,9 @@ import {
   getEffectiveSlideSettings
 } from "@/lib/effectiveSlideSettings";
 import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
+import {
   resolveSketchPath
 } from "@/engines/metadata";
 import {
@@ -46,6 +49,9 @@ export class GsapEngine implements SketchEngine {
   private container: HTMLElement | null = null;
   private runtime: GsapRuntime | null = null;
   private listeners = new Map<string, Set<( payload: any ) => void>>();
+  // Saved `window.setSlide` so switching back to a p5 sketch restores its
+  // binding (p5 registers the global once at module load and never re-sets it).
+  private previousSetSlide: ( ( index: number ) => void ) | undefined;
 
   private perfLoopId: number | null = null;
   private perfSample = {
@@ -120,6 +126,15 @@ export class GsapEngine implements SketchEngine {
       renderFrame: ( index: number ) => this.runtime?.seekFrame( index )
     } );
 
+    // Expose the slide switch the shared UI + headless recorder call. p5 sets
+    // this from its `slides` module; the GSAP runtime is the equivalent here.
+    // Without it, multi-slide GSAP recordings hung on `[data-slide="N"]` and
+    // played only a fraction of each slide's animation.
+    if ( typeof window !== "undefined" ) {
+      this.previousSetSlide = window.setSlide;
+      window.setSlide = ( index: number ) => this.runtime?.setSlide( index );
+    }
+
     this.emit(
       "ready",
       undefined as any
@@ -129,6 +144,12 @@ export class GsapEngine implements SketchEngine {
   destroy(): void {
     this.stopPerformanceLoop();
     unregisterServerCaptureController();
+
+    if ( typeof window !== "undefined" &&
+      window.setSlide !== this.previousSetSlide ) {
+      window.setSlide = this.previousSetSlide as ( index: number ) => void;
+    }
+    this.previousSetSlide = undefined;
 
     this.runtime?.reset();
     this.runtime = null;
@@ -241,10 +262,8 @@ export class GsapEngine implements SketchEngine {
       options,
       slideIndex
     );
-    const framerate = animation?.framerate ?? 60;
-    const duration = animation?.duration ?? 12;
 
-    return Math.round( duration * framerate );
+    return totalFramesFor( animation );
   }
 
   getFrameRate(
@@ -258,7 +277,7 @@ export class GsapEngine implements SketchEngine {
       slideIndex
     );
 
-    return animation?.framerate ?? 60;
+    return resolveAnimation( animation ).framerate;
   }
 
   getCanvas(): HTMLCanvasElement | null {

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -22,6 +22,9 @@ import {
   getEffectiveSlideSettings
 } from "@/lib/effectiveSlideSettings";
 import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
+import {
   resolveSketchPath
 } from "@/engines/metadata";
 import {
@@ -399,10 +402,8 @@ export class P5Engine implements SketchEngine {
       options,
       slideIndex
     );
-    const framerate = animation?.framerate ?? 60;
-    const duration = animation?.duration ?? 12;
 
-    return Math.round( duration * framerate );
+    return totalFramesFor( animation );
   }
 
   getFrameRate(
@@ -416,7 +417,7 @@ export class P5Engine implements SketchEngine {
       slideIndex
     );
 
-    return animation?.framerate ?? 60;
+    return resolveAnimation( animation ).framerate;
   }
 
   getCanvas(): HTMLCanvasElement | null {

--- a/src/lib/__tests__/animationConfig.test.ts
+++ b/src/lib/__tests__/animationConfig.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Keystone regression test for duration/framerate resolution.
+ *
+ * The "setting duration doesn't work" bug was a divergence of DEFAULTS: the
+ * server encode loop used `duration || 5`, the in-page p5 clock used `|| 10`,
+ * the engines used `?? 12`, and the progression bar used `?? 10` + Math.floor.
+ * They only agreed for a present, positive number; for a missing/zero duration
+ * the recorded frame count and the clock's loop length disagreed, so the clip
+ * was the wrong length and cut off partway.
+ *
+ * This locks every path to ONE resolver + ONE default, and — crucially —
+ * asserts the recording-length invariant that the bug violated:
+ *
+ *     totalFramesFor(a) / resolveAnimation(a).framerate === resolveAnimation(a).duration
+ *
+ * i.e. the encoded video length (seconds) always equals the clock's loop length
+ * for the SAME animation, for every input shape.
+ */
+
+import {
+  DURATION_DEFAULT,
+  FRAMERATE_DEFAULT,
+  resolveAnimation,
+  totalFramesFor
+} from "@/lib/animationConfig";
+import {
+  getEffectiveSlideSettings
+} from "@/lib/effectiveSlideSettings";
+
+describe(
+  "resolveAnimation",
+  () => {
+    test(
+      "present positive numbers pass through unchanged",
+      () => {
+        expect( resolveAnimation( {
+          duration: 4,
+          framerate: 30
+        } ) ).toEqual( {
+          duration: 4,
+          framerate: 30
+        } );
+      }
+    );
+
+    test(
+      "missing block → shared defaults",
+      () => {
+        expect( resolveAnimation( undefined ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+        expect( resolveAnimation( {} ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+      }
+    );
+
+    test(
+      "partial block keeps the present value, defaults the absent one",
+      () => {
+        expect( resolveAnimation( {
+          framerate: 30
+        } ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: 30
+        } );
+      }
+    );
+
+    test(
+      "falsy 0 clamps to the default (NOT silently a different default)",
+      () => {
+        expect( resolveAnimation( {
+          duration: 0,
+          framerate: 0
+        } ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+      }
+    );
+
+    test(
+      "numeric strings are coerced (z.coerce + watch() can leak strings)",
+      () => {
+        expect( resolveAnimation( {
+          duration: "4",
+          framerate: "30"
+        } ) ).toEqual( {
+          duration: 4,
+          framerate: 30
+        } );
+      }
+    );
+
+    test(
+      "NaN / negative / non-numeric → default",
+      () => {
+        expect( resolveAnimation( {
+          duration: NaN,
+          framerate: -5
+        } ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+        expect( resolveAnimation( {
+          duration: "abc"
+        } ).duration ).toBe( DURATION_DEFAULT );
+      }
+    );
+  }
+);
+
+describe(
+  "totalFramesFor",
+  () => {
+    test(
+      "round(duration * framerate), floored at 1",
+      () => {
+        expect( totalFramesFor( {
+          duration: 4,
+          framerate: 30
+        } ) ).toBe( 120 );
+        expect( totalFramesFor( {} ) ).toBe( DURATION_DEFAULT * FRAMERATE_DEFAULT ); // 720
+      }
+    );
+
+    test(
+      "a missing/zero duration uses the shared default, never 5 (the old server fallback)",
+      () => {
+        // Old server bug: round(5 * 30) = 150. Now: round(12 * 30) = 360.
+        expect( totalFramesFor( {
+          duration: 0,
+          framerate: 30
+        } ) ).toBe( DURATION_DEFAULT * 30 );
+        expect( totalFramesFor( {
+          duration: 0,
+          framerate: 30
+        } ) ).not.toBe( 150 );
+      }
+    );
+
+    test(
+      "never zero frames for a degenerate config",
+      () => {
+        expect( totalFramesFor( {
+          duration: 0,
+          framerate: 0
+        } ) ).toBeGreaterThanOrEqual( 1 );
+      }
+    );
+  }
+);
+
+describe(
+  "recording-length invariant (front == back == clock)",
+  () => {
+    // Every shape an animation can arrive in across the form, a persisted job,
+    // an imported options.json, or a slider dragged to its edge.
+    const INPUTS: Array<Record<string, unknown> | undefined> = [
+      undefined,
+      {},
+      {
+        framerate: 30
+      },
+      {
+        duration: 0
+      },
+      {
+        duration: 0,
+        framerate: 30
+      },
+      {
+        duration: "0"
+      },
+      {
+        duration: "4",
+        framerate: "30"
+      },
+      {
+        duration: 4,
+        framerate: 30
+      },
+      {
+        duration: 12,
+        framerate: 60
+      }
+    ];
+
+    test.each( INPUTS )(
+      "video seconds == clock loop length for %p",
+      ( animation ) => {
+        const {
+          duration, framerate
+        } = resolveAnimation( animation );
+        const totalFrames = totalFramesFor( animation );
+
+        // The encoded clip length in seconds is totalFrames / framerate; it must
+        // equal the duration the clock loops over (to within one frame of
+        // rounding). This is exactly the equality the ||5-vs-||10 split broke.
+        const videoSeconds = totalFrames / framerate;
+
+        expect( Math.abs( videoSeconds - duration ) ).toBeLessThanOrEqual( 1 / framerate );
+      }
+    );
+  }
+);
+
+describe(
+  "engine ↔ effective-settings composition (what both engines now compute)",
+  () => {
+    // P5Engine/GsapEngine can't be imported under jest (they pull the generated
+    // sketch registry, which is modulePathIgnore'd), but both now compute
+    // exactly `totalFramesFor(getEffectiveSlideSettings(opts, idx).animation)`.
+    // Assert that composition is slide-aware and default-consistent.
+    test(
+      "global duration with no slide override",
+      () => {
+        const opts = {
+          animation: {
+            duration: 4,
+            framerate: 30
+          },
+          slides: []
+        };
+
+        expect( totalFramesFor( getEffectiveSlideSettings(
+          opts,
+          undefined
+        ).animation ) ).toBe( 120 );
+      }
+    );
+
+    test(
+      "per-slide duration override wins; partial override keeps global framerate",
+      () => {
+        const opts = {
+          animation: {
+            duration: 12,
+            framerate: 30
+          },
+          slides: [
+            {
+              animation: {
+                duration: 4
+              }
+            }
+          ]
+        };
+
+        // slide 0 → duration 4 (override) × framerate 30 (inherited) = 120.
+        expect( totalFramesFor( getEffectiveSlideSettings(
+          opts,
+          0
+        ).animation ) ).toBe( 120 );
+      }
+    );
+
+    test(
+      "a slide whose override zeroes duration still resolves to the shared default",
+      () => {
+        const opts = {
+          animation: {
+            duration: 12,
+            framerate: 30
+          },
+          slides: [
+            {
+              animation: {
+                duration: 0
+              }
+            }
+          ]
+        };
+
+        expect( totalFramesFor( getEffectiveSlideSettings(
+          opts,
+          0
+        ).animation ) ).toBe( DURATION_DEFAULT * 30 );
+      }
+    );
+  }
+);

--- a/src/lib/animationConfig.ts
+++ b/src/lib/animationConfig.ts
@@ -1,0 +1,99 @@
+/**
+ * Single source of truth for animation duration / framerate resolution.
+ *
+ * Before this module, the same two numbers were defaulted in at least four
+ * different places with three different fallbacks:
+ *
+ *   - the server encode loop          → `duration || 5`   (recordSketch.ts)
+ *   - the in-page p5 recording clock   → `duration || 10`  (time.js / sketch.js)
+ *   - the engines / effective settings → `duration ?? 12`
+ *   - the progression bar              → `duration ?? 10`  (Math.floor)
+ *
+ * They only agreed when `duration` was a present, positive number. The instant
+ * it was absent or `0` (the duration slider used to allow `0`), the server
+ * encoded `round(5 * fps)` frames while the clock looped over a 10- or
+ * 12-second window — so the recording was a fixed wrong length whose animation
+ * was cut off partway and never closed the loop. Changing the slider appeared
+ * to "do nothing" because the value the server read was never the slider's.
+ *
+ * Every consumer that needs a frame count or a clock denominator must now go
+ * through `resolveAnimation` / `totalFramesFor`, so the encoded frame count and
+ * the sketch clock can never derive duration from different defaults. The
+ * `> 0` guards (not `||`) also mean a falsy-but-explicit `0` clamps to the
+ * shared default instead of silently substituting a *different* default for a
+ * value the user typed.
+ *
+ * Kept dependency-free and isomorphic so both the browser sketch runtimes
+ * (p5 `time.js`/`sketch.js`, the GSAP runtime) and the Node recording pipeline
+ * import the exact same logic.
+ */
+
+/** The canonical default loop length, in seconds. Matches `SketchAnimationSchema`. */
+export const DURATION_DEFAULT = 12;
+
+/** The canonical default framerate, in fps. Matches `SketchAnimationSchema`. */
+export const FRAMERATE_DEFAULT = 60;
+
+export type ResolvedAnimation = {
+  duration: number;
+  framerate: number;
+};
+
+type AnimationLike =
+  | {
+    duration?: unknown;
+    framerate?: unknown;
+  }
+  | null
+  | undefined;
+
+/** Coerce a value to a positive finite number, or fall back to `fallback`. */
+function positiveOr(
+  value: unknown,
+  fallback: number
+): number {
+  const numeric = typeof value === "number" ? value : Number( value );
+
+  return Number.isFinite( numeric ) && numeric > 0 ? numeric : fallback;
+}
+
+/**
+ * Resolve an `{ duration, framerate }` block to safe, positive numbers.
+ *
+ * Accepts partial / missing / string / zero / NaN inputs (imported options,
+ * a persisted job, a slider dragged to its edge) and always returns usable
+ * values. A present, positive number is returned as-is (coerced from string);
+ * anything else becomes the shared default.
+ */
+export function resolveAnimation( animation?: AnimationLike ): ResolvedAnimation {
+  return {
+    duration: positiveOr(
+      animation?.duration,
+      DURATION_DEFAULT
+    ),
+    framerate: positiveOr(
+      animation?.framerate,
+      FRAMERATE_DEFAULT
+    )
+  };
+}
+
+/**
+ * The number of frames in exactly one loop of the given animation.
+ *
+ * This is THE definition of a recording's length: every encoder loop (browser
+ * and server) and the clock's progression denominator are derived from it, so
+ * they cannot disagree. Always `>= 1` so a degenerate config never produces a
+ * zero-frame (empty) recording.
+ */
+export function totalFramesFor( animation?: AnimationLike ): number {
+  const {
+    duration,
+    framerate
+  } = resolveAnimation( animation );
+
+  return Math.max(
+    1,
+    Math.round( duration * framerate )
+  );
+}

--- a/src/lib/effectiveSlideSettings.ts
+++ b/src/lib/effectiveSlideSettings.ts
@@ -4,6 +4,10 @@
  * is used as the fallback.
  */
 
+import {
+  DURATION_DEFAULT, FRAMERATE_DEFAULT
+} from "@/lib/animationConfig";
+
 type Size = { width: number;
   height: number };
 type Animation = { framerate: number;
@@ -20,8 +24,8 @@ const DEFAULTS: EffectiveSlideSettings = {
     height: 1350
   },
   animation: {
-    framerate: 60,
-    duration: 12
+    framerate: FRAMERATE_DEFAULT,
+    duration: DURATION_DEFAULT
   }
 };
 

--- a/src/lib/recordSketch.ts
+++ b/src/lib/recordSketch.ts
@@ -33,6 +33,12 @@ import {
   RECORDING_STEPS,
   UPLOAD_STEPS
 } from "@/lib/progression/stepConfig";
+import {
+  getEffectiveSlideSettings
+} from "@/lib/effectiveSlideSettings";
+import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
 
 /**
  * Wait for the sketch canvas to be ready.
@@ -144,13 +150,16 @@ async function gotoSketchPage(
 }
 
 /**
- * Calculate total frames from animation options
+ * Calculate total frames from animation options.
+ *
+ * Delegates to the shared `totalFramesFor` so the server encode loop counts
+ * the exact same number of frames the engines + in-page clock derive from the
+ * same animation — no more `duration || 5` here vs `duration || 10` in the
+ * sketch clock, which used to make a missing/zero duration record a wrong
+ * length, cut-off clip.
  */
 function calculateTotalFrames( animationOptions: any ): number {
-  const framerate = animationOptions?.framerate || 60;
-  const duration = animationOptions?.duration || 5;
-
-  return Math.round( duration * framerate );
+  return totalFramesFor( animationOptions );
 }
 
 /**
@@ -300,7 +309,7 @@ async function recordSingleSketch(
 
   // ─── Capture frames and encode video ──────────────────────────────────────
   const totalFrames = calculateTotalFrames( options.animation );
-  const framerate = options.animation?.framerate || 60;
+  const framerate = resolveAnimation( options.animation ).framerate;
   const outputVideoPath = path.join(
     temporaryDirectoryPath,
     `${ path.basename( template ) }-${ jobId }.mp4`
@@ -459,15 +468,16 @@ async function recordMultipleSlides(
     );
 
     // ─── Capture frames and encode video ────────────────────────────────────
-    const slideOptions = slides[ slideIndex ];
-    const slideAnimation = slideOptions?.animation || options.animation;
+    // Resolve the slide's *effective* animation (per-slide override merged
+    // over the global) the same way the engines do, so a partial override
+    // (e.g. framerate-only) keeps the global duration instead of dropping it —
+    // and the frame count matches what the in-page clock loops over.
+    const slideAnimation = getEffectiveSlideSettings(
+      options,
+      slideIndex
+    ).animation;
     const totalFrames = calculateTotalFrames( slideAnimation );
-    const framerate = slideAnimation?.framerate || 60;
-
-    console.log( {
-      totalFrames,
-      framerate
-    } );
+    const framerate = resolveAnimation( slideAnimation ).framerate;
 
     const slideVideoPath = path.join(
       temporaryDirectoryPath,

--- a/src/templates/gsap/utils/__tests__/runtimeClock.test.tsx
+++ b/src/templates/gsap/utils/__tests__/runtimeClock.test.tsx
@@ -158,6 +158,38 @@ describe(
         expect( runtime.totalFrames ).toBe( 360 );
       }
     );
+
+    test(
+      "REGRESSION: an explicit 0 duration reaches the timeline builder as the resolved default, not 0",
+      async() => {
+        // An un-validated persisted/imported job can carry duration: 0. The
+        // builders read `opts.animation.duration ?? 12` and `0 ?? 12 === 0`,
+        // so without resolving in effectiveOptions the builder would make a
+        // zero-length timeline while the clock/recorder span 12s (frozen clip).
+        builtDurations.length = 0;
+
+        await mount( {
+          size: {
+            width: 1080,
+            height: 1350
+          },
+          animation: {
+            duration: 0,
+            framerate: 30
+          },
+          slides: []
+        } );
+
+        // The clock + recorder resolve 0 → 12.
+        expect( runtime.duration ).toBe( 12 );
+        expect( runtime.totalFrames ).toBe( 360 );
+
+        // The builder must have seen the SAME resolved 12, never the raw 0.
+        expect( builtDurations.length ).toBeGreaterThan( 0 );
+        expect( builtDurations ).not.toContain( 0 );
+        expect( builtDurations[ builtDurations.length - 1 ] ).toBe( 12 );
+      }
+    );
   }
 );
 

--- a/src/templates/gsap/utils/__tests__/runtimeClock.test.tsx
+++ b/src/templates/gsap/utils/__tests__/runtimeClock.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment jsdom
+ *
+ * First clock/duration tests for the GSAP runtime (it previously had none — and
+ * that gap is exactly where the critical "duration does nothing for GSAP" bug
+ * lived).
+ *
+ * Guards:
+ *  1. Single template: totalFrames + the progression clock follow the global
+ *     animation duration, and frame f maps to progression f / totalFrames.
+ *  2. Slide-aware (the bug): per-slide duration overrides reach the runtime
+ *     clock (not just the recorder's frame count). Before the fix the runtime
+ *     read only the GLOBAL duration, so a slide's clip played a fraction of the
+ *     animation; and the runtime never exposed `setSlide`/`data-slide`, so the
+ *     headless multi-slide recorder hung on `[data-slide="N"]`.
+ */
+
+import React from "react";
+import {
+  setSketchOptions, getSketchOptions
+} from "@/lib/syncSketchOptions";
+import runtime, {
+  useTimeline
+} from "@/gsap/utils/runtime";
+
+// jsdom doesn't implement rAF; the runtime awaits it during start()/scrub.
+beforeAll( () => {
+  globalThis.requestAnimationFrame = ( ( cb: FrameRequestCallback ) =>
+    setTimeout(
+      () => cb( Date.now() ),
+      0
+    ) as unknown as number );
+  globalThis.cancelAnimationFrame = ( ( id: number ) =>
+    clearTimeout( id as unknown as ReturnType<typeof setTimeout> ) );
+} );
+
+const flush = () =>
+  new Promise<void>( ( resolve ) =>
+    requestAnimationFrame( () => requestAnimationFrame( () => resolve() ) ) );
+
+function resetStore( opts: Record<string, unknown> ) {
+  const store = getSketchOptions();
+
+  for ( const key of Object.keys( store ) ) {
+    delete store[ key ];
+  }
+  Object.assign(
+    store,
+    JSON.parse( JSON.stringify( opts ) )
+  );
+}
+
+// Records the `duration` each timeline build saw, so we can prove the timeline
+// is rebuilt against the slide-effective duration on a slide switch.
+const builtDurations: number[] = [];
+
+function Template( {
+  options
+}: {
+  options: Record<string, any>;
+} ) {
+  useTimeline(
+    ( {
+      tl, options: opts
+    } ) => {
+      builtDurations.push( opts?.animation?.duration );
+      // A loop-length tween so the timeline actually spans the duration.
+      tl.to(
+        {},
+        {
+          duration: opts?.animation?.duration ?? 1
+        },
+        0
+      );
+    },
+    []
+  );
+
+  return <div className="tmpl" data-headline={ options?.sketch?.headline ?? "" } />;
+}
+
+async function mount( opts: Record<string, unknown> ) {
+  resetStore( opts );
+
+  const container = document.createElement( "div" );
+
+  document.body.appendChild( container );
+
+  // Avoid the SVG→Image rasterise path (jsdom can't decode it); the clock
+  // logic under test doesn't need a real raster.
+  ( runtime as any ).rasterize = async() => runtime.getMirrorCanvas();
+
+  await runtime.start(
+    container,
+    Template
+  );
+  // Freeze the auto-started playback loop so progression is deterministic.
+  runtime.enterRecordingMode();
+  await flush();
+
+  return container;
+}
+
+afterEach( () => {
+  runtime.reset();
+  document.body.innerHTML = "";
+  builtDurations.length = 0;
+} );
+
+describe(
+  "GSAP runtime — single template duration",
+  () => {
+    test(
+      "totalFrames follows the global duration and frame f → f/totalFrames",
+      async() => {
+        await mount( {
+          size: {
+            width: 1080,
+            height: 1350
+          },
+          animation: {
+            duration: 4,
+            framerate: 30
+          },
+          slides: []
+        } );
+
+        expect( runtime.duration ).toBe( 4 );
+        expect( runtime.framerate ).toBe( 30 );
+        expect( runtime.totalFrames ).toBe( 120 );
+
+        const last = runtime.totalFrames - 1;
+
+        runtime.seekFrame( last );
+        expect( runtime.getProgression() ).toBeCloseTo(
+          last / runtime.totalFrames,
+          5
+        );
+        expect( runtime.getProgression() ).toBeLessThan( 1 );
+      }
+    );
+
+    test(
+      "a missing duration resolves to the shared default, not a runtime-local one",
+      async() => {
+        await mount( {
+          size: {
+            width: 1080,
+            height: 1350
+          },
+          animation: {
+            framerate: 30
+          },
+          slides: []
+        } );
+
+        // 12 (shared default) × 30 = 360 — the same default the encoder uses.
+        expect( runtime.totalFrames ).toBe( 360 );
+      }
+    );
+  }
+);
+
+describe(
+  "GSAP runtime — slide-aware duration (the critical bug)",
+  () => {
+    const OPTS = {
+      size: {
+        width: 1080,
+        height: 1350
+      },
+      animation: {
+        duration: 12,
+        framerate: 30
+      },
+      slides: [
+        {
+          animation: {
+            duration: 4
+          }
+        },
+        {
+          animation: {
+            duration: 8
+          }
+        }
+      ]
+    };
+
+    test(
+      "setSlide switches the clock duration AND the recorded frame count to the slide's value",
+      async() => {
+        await mount( OPTS );
+
+        // No active slide yet → global duration.
+        expect( runtime.duration ).toBe( 12 );
+        expect( runtime.totalFrames ).toBe( 360 );
+
+        runtime.setSlide( 0 );
+        await flush();
+
+        // Slide 0 overrides duration to 4 (framerate inherited = 30).
+        expect( runtime.duration ).toBe( 4 );
+        expect( runtime.totalFrames ).toBe( 120 );
+
+        const last0 = runtime.totalFrames - 1;
+
+        runtime.seekFrame( last0 );
+        expect( runtime.getProgression() ).toBeCloseTo(
+          last0 / runtime.totalFrames,
+          5
+        );
+
+        runtime.setSlide( 1 );
+        await flush();
+
+        // Slide 1 overrides duration to 8.
+        expect( runtime.duration ).toBe( 8 );
+        expect( runtime.totalFrames ).toBe( 240 );
+      }
+    );
+
+    test(
+      "setSlide updates the stage data-slide attribute (unblocks the headless waitForSelector)",
+      async() => {
+        const container = await mount( OPTS );
+
+        const stage = () =>
+          container.querySelector( "[data-capture-surface=\"gsap\"]" );
+
+        expect( stage()?.getAttribute( "data-slide" ) ).toBe( "0" );
+
+        runtime.setSlide( 1 );
+        await flush();
+        expect( stage()?.getAttribute( "data-slide" ) ).toBe( "1" );
+
+        runtime.setSlide( 0 );
+        await flush();
+        expect( stage()?.getAttribute( "data-slide" ) ).toBe( "0" );
+      }
+    );
+
+    test(
+      "the timeline is rebuilt against the slide's effective duration",
+      async() => {
+        await mount( OPTS );
+
+        builtDurations.length = 0;
+
+        runtime.setSlide( 1 );
+        await flush();
+
+        // The most recent build saw the slide-1 duration (8), not the global 12.
+        expect( builtDurations[ builtDurations.length - 1 ] ).toBe( 8 );
+      }
+    );
+  }
+);

--- a/src/templates/gsap/utils/runtime.tsx
+++ b/src/templates/gsap/utils/runtime.tsx
@@ -34,6 +34,12 @@ import {
   getSketchOptions, setSketchOptions, subscribeSketchOptions
 } from "@/lib/syncSketchOptions";
 import {
+  getEffectiveSlideSettings
+} from "@/lib/effectiveSlideSettings";
+import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
+import {
   toCssColor
 } from "./dom";
 
@@ -64,10 +70,6 @@ const DEFAULT_SIZE = {
   width: 1080,
   height: 1350
 };
-const DEFAULT_ANIMATION = {
-  framerate: 60,
-  duration: 12
-};
 
 /* ------------------------------------------------------------------ */
 /*  React context (connects templates' `useTimeline` to the runtime)   */
@@ -95,6 +97,14 @@ class GsapRuntime {
   private options: Record<string, any> = {};
   private optionsVersion = 0;
   private unsubscribeOptions: ( () => void ) | null = null;
+
+  /**
+   * Active slide index, or `undefined` for a single (slide-less) template.
+   * Per-slide `size`/`animation` overrides are resolved against this so the
+   * timeline span, the recorded frame count and the progression clock all
+   * follow the slide actually on screen — mirrors the p5 `slides` module.
+   */
+  private activeSlideIndex: number | undefined = undefined;
 
   /** Wall-clock progression of the timeline, in seconds. */
   private elapsed = 0;
@@ -124,23 +134,59 @@ class GsapRuntime {
 
   /* ---- derived settings ---------------------------------------- */
 
+  /**
+   * Size + animation for the active slide (per-slide override merged over the
+   * global), resolved the same way the engine's `getTotalFrames` does so the
+   * recorder and the runtime can never disagree.
+   */
+  private get effectiveSettings() {
+    return getEffectiveSlideSettings(
+      this.options,
+      this.activeSlideIndex
+    );
+  }
+
+  /**
+   * Options handed to the template: the live store plus the slide-effective
+   * `size`/`animation`/`sketch`, so `opts.animation.duration` inside a
+   * timeline builder is the active slide's duration, not the global one.
+   */
+  private get effectiveOptions(): Record<string, any> {
+    const {
+      size, animation
+    } = this.effectiveSettings;
+    const slide = this.activeSlideIndex !== undefined
+      ? this.options?.slides?.[ this.activeSlideIndex ]
+      : undefined;
+    const sketch = slide?.sketch
+      ? {
+        ...( this.options.sketch ?? {} ),
+        ...slide.sketch
+      }
+      : this.options.sketch;
+
+    return {
+      ...this.options,
+      size,
+      animation,
+      sketch
+    };
+  }
+
   get size() {
-    return this.options.size ?? DEFAULT_SIZE;
+    return this.effectiveSettings.size ?? DEFAULT_SIZE;
   }
 
   get framerate(): number {
-    return this.options.animation?.framerate ?? DEFAULT_ANIMATION.framerate;
+    return resolveAnimation( this.effectiveSettings.animation ).framerate;
   }
 
   get duration(): number {
-    return this.options.animation?.duration ?? DEFAULT_ANIMATION.duration;
+    return resolveAnimation( this.effectiveSettings.animation ).duration;
   }
 
   get totalFrames(): number {
-    return Math.max(
-      1,
-      Math.round( this.duration * this.framerate )
-    );
+    return totalFramesFor( this.effectiveSettings.animation );
   }
 
   /* ---- lifecycle ------------------------------------------------- */
@@ -266,16 +312,18 @@ class GsapRuntime {
   private renderTree( component: React.ComponentType<{ options: Record<string, any> }> ): void {
     this.currentComponent = component;
 
+    const options = this.effectiveOptions;
+
     const value: RuntimeContextValue = {
       version: this.optionsVersion,
-      options: this.options
+      options
     };
 
     this.root?.render( <RuntimeContext.Provider value={ value }>
       { React.createElement(
         component,
         {
-          options: this.options
+          options
         }
       ) }
     </RuntimeContext.Provider> );
@@ -356,6 +404,53 @@ class GsapRuntime {
     this.recording = false;
     this.optionsVersion = 0;
     this.currentComponent = null;
+    this.activeSlideIndex = undefined;
+  }
+
+  /* ---- slides ---------------------------------------------------- */
+
+  /**
+   * Switch to a slide (per-slide `size`/`animation`/`sketch` overrides).
+   *
+   * The p5 engine exposes this via `window.setSlide`; the GSAP engine wires
+   * the same global to here so the shared studio UI (slide carousel) and the
+   * server multi-slide recorder drive both engines identically. Crucially:
+   *   • the stage's `data-slide` attribute is updated synchronously, which is
+   *     what the headless recorder waits on (`[data-slide="N"]`) — without it
+   *     the server hung forever for slide indices > 0;
+   *   • the timeline is rebuilt against the slide's effective duration, so the
+   *     clip plays the whole slide animation instead of a fraction of it.
+   */
+  setSlide( index: number ): void {
+    const next =
+      typeof index === "number" && Number.isFinite( index ) && index >= 0
+        ? Math.floor( index )
+        : 0;
+
+    this.activeSlideIndex = next;
+
+    if ( this.stage ) {
+      this.stage.setAttribute(
+        "data-slide",
+        String( next )
+      );
+      this.applyStageSize( this.stage );
+    }
+
+    if ( this.mirror ) {
+      this.mirror.width = this.size.width;
+      this.mirror.height = this.size.height;
+    }
+
+    // Re-render with the slide's effective options + bump the version so the
+    // template's `useTimeline` rebuilds the timeline at the new duration.
+    this.optionsVersion += 1;
+
+    if ( this.currentComponent ) {
+      this.renderTree( this.currentComponent );
+    }
+
+    this.scrub();
   }
 
   /* ---- timeline -------------------------------------------------- */
@@ -377,7 +472,7 @@ class GsapRuntime {
 
     const stage = this.stage;
     const builder = this.builder;
-    const options = this.options;
+    const options = this.effectiveOptions;
 
     this.ctx = gsap.context(
       () => {

--- a/src/templates/gsap/utils/runtime.tsx
+++ b/src/templates/gsap/utils/runtime.tsx
@@ -168,7 +168,13 @@ class GsapRuntime {
     return {
       ...this.options,
       size,
-      animation,
+      // Resolve before the template's timeline builder sees it: builders read
+      // `opts.animation.duration ?? 12`, and `0 ?? 12 === 0` — so an explicit
+      // 0/NaN duration from an un-validated persisted/imported job would build
+      // a zero-length timeline while the clock + recorder span the resolved
+      // default. Resolving here keeps the builder, the clock and the encoder
+      // on the exact same positive duration.
+      animation: resolveAnimation( animation ),
       sketch
     };
   }

--- a/src/templates/p5/utils/__tests__/durationRecording.test.ts
+++ b/src/templates/p5/utils/__tests__/durationRecording.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for "setting the template duration has no effect" on the p5
+ * recording path (front browser capture + back headless capture share this
+ * clock).
+ *
+ * What these guard:
+ *  1. A runtime duration change reaches BOTH the frame count the recorder steps
+ *     through (getEffectiveSlideSettings → totalFramesFor) AND the in-page
+ *     clock (sketch.sketchOptions → time.getAnimationProgression), and the two
+ *     agree across the whole loop (frame f → progression f/totalFrames).
+ *  2. A falsy/zero duration no longer makes the encode loop and the clock pick
+ *     DIFFERENT defaults (the old `||5` vs `||10` split): both resolve to the
+ *     one shared default, so the last captured frame still lands just under a
+ *     full loop.
+ */
+
+export {};
+
+if ( typeof globalThis.structuredClone !== "function" ) {
+  globalThis.structuredClone = ( value: unknown ) =>
+    JSON.parse( JSON.stringify( value ) );
+}
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const events = require( "@/p5/utils/events.js" ).default;
+const sketch = require( "@/p5/utils/sketch.js" ).default;
+const time = require( "@/p5/utils/time.js" ).default;
+const slides = require( "@/p5/utils/slides/index.js" ).default;
+const {
+  registerEvents: registerOptionsEvents
+} = require( "@/p5/utils/options.js" );
+const {
+  setSketchOptions, getSketchOptions
+} = require( "@/p5/shared/syncSketchOptions.js" );
+const {
+  getEffectiveSlideSettings
+} = require( "@/lib/effectiveSlideSettings" );
+const {
+  totalFramesFor, DURATION_DEFAULT
+} = require( "@/lib/animationConfig" );
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function resetStore( opts: Record<string, unknown> ) {
+  const store = getSketchOptions();
+
+  for ( const key of Object.keys( store ) ) {
+    delete store[ key ];
+  }
+  Object.assign(
+    store,
+    JSON.parse( JSON.stringify( opts ) )
+  );
+}
+
+function bootWith( animation: Record<string, unknown> ) {
+  events.registeredEvents = {};
+  slides.index = 0;
+  window.disableRecordingMode!();
+  time.reset();
+  sketch.sketchOptions = {
+    size: {
+      width: 1080,
+      height: 1350
+    },
+    animation: {
+      framerate: 60,
+      duration: 12
+    }
+  };
+  resetStore( {
+    size: {
+      width: 1080,
+      height: 1350
+    },
+    animation: {
+      framerate: 60,
+      duration: 12
+    },
+    slides: []
+  } );
+  registerOptionsEvents();
+  events.handle( "pre-setup" );
+
+  const next = JSON.parse( JSON.stringify( getSketchOptions() ) );
+
+  next.animation = animation;
+  setSketchOptions(
+    next,
+    "react"
+  );
+}
+
+describe(
+  "p5 recording: duration change reaches both the frame count and the clock",
+  () => {
+    test(
+      "duration 12→4 @30fps: every frame maps to f / totalFrames",
+      () => {
+        bootWith( {
+          duration: 4,
+          framerate: 30
+        } );
+
+        // (a) The frame count the recorder steps through.
+        const totalFrames = totalFramesFor( getEffectiveSlideSettings(
+          getSketchOptions(),
+          undefined
+        ).animation );
+
+        expect( totalFrames ).toBe( 120 );
+
+        // (b) The clock reads the changed duration/framerate.
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+        expect( sketch.sketchOptions.animation.framerate ).toBe( 30 );
+
+        // Deterministic capture: step the pinned frame index and confirm the
+        // clock's progression matches f / totalFrames for the whole loop.
+        window.enableRecordingMode!();
+
+        for ( let frame = 0; frame < totalFrames; frame++ ) {
+          window.setRecordingFrame!( frame );
+          time.incrementElapsedTime();
+          expect( window.getAnimationProgression!() ).toBeCloseTo(
+            frame / totalFrames,
+            6
+          );
+        }
+      }
+    );
+
+    test(
+      "duration-only change 12→4 (framerate untouched at 60) → 240 frames, last frame < 1 loop",
+      () => {
+        bootWith( {
+          duration: 4,
+          framerate: 60
+        } );
+
+        const totalFrames = totalFramesFor( getEffectiveSlideSettings(
+          getSketchOptions(),
+          undefined
+        ).animation );
+
+        expect( totalFrames ).toBe( 240 );
+        expect( sketch.sketchOptions.animation.duration ).toBe( 4 );
+
+        window.enableRecordingMode!();
+        const lastFrame = totalFrames - 1;
+
+        window.setRecordingFrame!( lastFrame );
+        time.incrementElapsedTime();
+
+        const progression = window.getAnimationProgression!();
+
+        expect( progression ).toBeCloseTo(
+          lastFrame / totalFrames,
+          6
+        );
+        expect( progression ).toBeLessThan( 1 );
+        expect( progression ).toBeGreaterThan( 0.99 );
+      }
+    );
+
+    test(
+      "REGRESSION: a falsy (0) duration no longer splits the encode default from the clock default",
+      () => {
+        // Old bug: recordSketch used `duration || 5` (→150 frames) while the
+        // clock used `duration || 10` (→loop of 10s), so the last captured
+        // frame landed at ~0.497 of the loop. Both now use the shared default.
+        bootWith( {
+          duration: 0,
+          framerate: 30
+        } );
+
+        const totalFrames = totalFramesFor( getEffectiveSlideSettings(
+          getSketchOptions(),
+          undefined
+        ).animation );
+
+        // Encode loop count uses the shared default, not the old 5.
+        expect( totalFrames ).toBe( DURATION_DEFAULT * 30 );
+        expect( totalFrames ).not.toBe( 150 );
+
+        window.enableRecordingMode!();
+        const lastFrame = totalFrames - 1;
+
+        window.setRecordingFrame!( lastFrame );
+        time.incrementElapsedTime();
+
+        const progression = window.getAnimationProgression!();
+
+        // The clock denominator equals the same default → clean loop seam.
+        expect( progression ).toBeCloseTo(
+          lastFrame / totalFrames,
+          6
+        );
+        expect( progression ).toBeLessThan( 1 );
+        expect( progression ).toBeGreaterThan( 0.99 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/animation.js
+++ b/src/templates/p5/utils/animation.js
@@ -4,6 +4,9 @@ import time from "./time.js";
 import {
   getP5
 } from "./sketch.js";
+import {
+  resolveAnimation, totalFramesFor
+} from "@/lib/animationConfig";
 
 const animation = {
   animate: (
@@ -28,14 +31,13 @@ const animation = {
   },
 
   get maximumFramesCount() {
-    return (
-      sketch.sketchOptions?.animation?.duration *
-      sketch.sketchOptions?.animation?.framerate
-    );
+    return totalFramesFor( sketch.sketchOptions?.animation );
   },
 
   get progression() {
-    const duration = sketch.sketchOptions?.animation?.duration || 10;
+    const {
+      duration
+    } = resolveAnimation( sketch.sketchOptions?.animation );
     const seconds = time.seconds();
 
     // During recording, don't wrap and don't cap - progression should match frame count

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -15,6 +15,9 @@ import loadProfiler from "./loadProfiler.js";
 import {
   coerceFramerate
 } from "./framerate.js";
+import {
+  resolveAnimation
+} from "@/lib/animationConfig";
 
 let _p5 = null;
 let _container = null;
@@ -482,7 +485,9 @@ const sketch = {
           return;
         }
 
-        const duration = sketch.sketchOptions?.animation?.duration || 10;
+        const {
+          duration
+        } = resolveAnimation( sketch.sketchOptions?.animation );
         const seconds = time.seconds();
         const progression = time.isRecording
           ? Math.min(
@@ -497,7 +502,9 @@ const sketch = {
 
     registerAnimationBridge( {
       getProgression: () => {
-        const duration = sketch.sketchOptions?.animation?.duration || 10;
+        const {
+          duration
+        } = resolveAnimation( sketch.sketchOptions?.animation );
         const seconds = time.seconds();
 
         return time.isRecording
@@ -516,7 +523,9 @@ const sketch = {
             value
           )
         );
-        const duration = sketch.sketchOptions?.animation?.duration || 10;
+        const {
+          duration
+        } = resolveAnimation( sketch.sketchOptions?.animation );
 
         time.elapsed = clamped * duration * 1000;
 

--- a/src/templates/p5/utils/time.js
+++ b/src/templates/p5/utils/time.js
@@ -1,4 +1,7 @@
 import sketch from "./sketch.js";
+import {
+  resolveAnimation
+} from "@/lib/animationConfig";
 
 const time = {
   elapsed: 0,
@@ -24,7 +27,9 @@ const time = {
   incrementElapsedTime() {
     // During server-side recording, use frame-based time
     if ( time.isRecording ) {
-      const framerate = sketch?.sketchOptions?.animation?.framerate || 60;
+      const {
+        framerate
+      } = resolveAnimation( sketch?.sketchOptions?.animation );
       const millisecondsPerFrame = 1000 / framerate;
 
       time.elapsed = time.recordingFrameIndex * millisecondsPerFrame;
@@ -81,8 +86,11 @@ window.setAnimationProgression = function( progression ) {
     )
   );
 
-  // Get animation duration, default to 10 seconds if undefined
-  const duration = sketch?.sketchOptions?.animation?.duration || 10;
+  // Resolve the loop length through the shared resolver so a missing/zero
+  // duration uses the same default everywhere (encode loop + clock).
+  const {
+    duration
+  } = resolveAnimation( sketch?.sketchOptions?.animation );
 
   // Convert progression (0-1) to elapsed time in milliseconds
   time.elapsed = clampedProgression * duration * 1000;
@@ -109,8 +117,11 @@ window.setAnimationProgression = function( progression ) {
 let lastDispatchedProgression = -1;
 
 window.getAnimationProgression = function() {
-  // Get animation duration, default to 10 seconds if undefined
-  const duration = sketch?.sketchOptions?.animation?.duration || 10;
+  // Resolve the loop length through the shared resolver (same default as the
+  // encode loop) so progression and the recorded frame count never disagree.
+  const {
+    duration
+  } = resolveAnimation( sketch?.sketchOptions?.animation );
   const seconds = time.seconds();
 
   // During recording, don't wrap and don't cap - progression should match frame count

--- a/src/types/__tests__/durationBoundary.test.ts
+++ b/src/types/__tests__/durationBoundary.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Input-boundary regression tests for the duration setting.
+ *
+ * Two defects lived here:
+ *  1. The duration slider allowed `min: 0`, but the schema is `.min(1)`; a 0
+ *     slipped through `watch()` un-validated and tripped the downstream
+ *     `duration || default` fallbacks.
+ *  2. `initOptions` wraps the WHOLE schema in `.catch`, so a single invalid
+ *     value (e.g. duration 0) reverted the entire `animation` sub-object to
+ *     defaults — silently snapping framerate back too. Leaf-level `.catch`
+ *     now heals each field independently.
+ */
+
+import {
+  SketchAnimationSchema, OptionsSchema
+} from "@/types/sketch.types";
+import {
+  DURATION_DEFAULT, FRAMERATE_DEFAULT
+} from "@/lib/animationConfig";
+import initOptions from "@/utils/initOptions";
+import rootFormConfig from "@/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config";
+
+describe(
+  "duration slider ↔ schema invariant",
+  () => {
+    test(
+      "the slider's minimum is not below the schema's minimum (1)",
+      () => {
+        // `animation` is a nested-object field; reach its `duration` sub-field.
+        const animation = rootFormConfig.animation as {
+          fields?: Record<string, { component?: string;
+            min?: number }>;
+        };
+        const durationField = animation.fields?.duration;
+
+        expect( durationField?.component ).toBe( "slider" );
+        // Schema floor is 1; the slider must not let the user pick below it.
+        expect( durationField?.min ).toBeGreaterThanOrEqual( 1 );
+      }
+    );
+  }
+);
+
+describe(
+  "SketchAnimationSchema self-heals per field",
+  () => {
+    test(
+      "a 0 duration heals to the default WITHOUT dropping a valid framerate",
+      () => {
+        const parsed = SketchAnimationSchema.parse( {
+          duration: 0,
+          framerate: 30
+        } );
+
+        expect( parsed.duration ).toBe( DURATION_DEFAULT );
+        expect( parsed.framerate ).toBe( 30 ); // sibling preserved, not reset to 60
+      }
+    );
+
+    test(
+      "numeric strings are coerced",
+      () => {
+        expect( SketchAnimationSchema.parse( {
+          duration: "4",
+          framerate: "30"
+        } ) ).toEqual( {
+          duration: 4,
+          framerate: 30
+        } );
+      }
+    );
+
+    test(
+      "out-of-range values heal to the default",
+      () => {
+        expect( SketchAnimationSchema.parse( {
+          duration: 9999,
+          framerate: 9999
+        } ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+      }
+    );
+
+    test(
+      "a partial block keeps the present value and defaults the absent one",
+      () => {
+        expect( SketchAnimationSchema.parse( {
+          framerate: 30
+        } ) ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: 30
+        } );
+      }
+    );
+  }
+);
+
+describe(
+  "initOptions does not nuke siblings on one bad field",
+  () => {
+    test(
+      "an invalid duration heals but framerate survives",
+      () => {
+        const result = initOptions( {
+          animation: {
+            duration: 0,
+            framerate: 30
+          }
+        } );
+
+        expect( result.animation.framerate ).toBe( 30 );
+        expect( result.animation.duration ).toBe( DURATION_DEFAULT );
+      }
+    );
+
+    test(
+      "a valid duration round-trips untouched",
+      () => {
+        const result = initOptions( {
+          animation: {
+            duration: 4,
+            framerate: 30
+          }
+        } );
+
+        expect( result.animation.duration ).toBe( 4 );
+        expect( result.animation.framerate ).toBe( 30 );
+      }
+    );
+
+    test(
+      "OptionsSchema top-level default matches the shared constants",
+      () => {
+        const defaults = OptionsSchema.parse( {} );
+
+        expect( defaults.animation ).toEqual( {
+          duration: DURATION_DEFAULT,
+          framerate: FRAMERATE_DEFAULT
+        } );
+      }
+    );
+  }
+);

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -2,6 +2,9 @@
 import {
   z
 } from "zod";
+import {
+  DURATION_DEFAULT, FRAMERATE_DEFAULT
+} from "@/lib/animationConfig";
 
 const RGB = z.tuple( [
   z.number(),
@@ -790,14 +793,20 @@ export const SketchSizeSchema = z.object( {
     .default( 1350 )
 } );
 
+// `.catch` on each leaf so one invalid value (e.g. a 0 duration) heals to the
+// shared default WITHOUT taking its sibling — or the whole options object via
+// the top-level catch in initOptions — down with it. `framerate` and
+// `duration` are independent, so a bad duration must not also reset framerate.
 export const SketchAnimationSchema = z.object( {
   framerate: z.coerce.number().int()
     .min( 1 )
     .max( 240 )
-    .default( 60 ),
+    .default( FRAMERATE_DEFAULT )
+    .catch( FRAMERATE_DEFAULT ),
   duration: z.coerce.number().min( 1 )
     .max( 60 )
-    .default( 12 )
+    .default( DURATION_DEFAULT )
+    .catch( DURATION_DEFAULT )
 } );
 
 /* ---------------- slide schema (with name) ---------------------- */
@@ -822,8 +831,8 @@ export const OptionsSchema = z.object( {
     height: 1350
   } ),
   animation: SketchAnimationSchema.default( {
-    framerate: 60,
-    duration: 12
+    framerate: FRAMERATE_DEFAULT,
+    duration: DURATION_DEFAULT
   } ),
   content: z.array( ContentItemSchema ).default( [] ),
   assets: Assets,


### PR DESCRIPTION
## Problem

Setting the animation **duration** appeared to "do nothing" — reproducibly, for **both p5 and gsap**, in **both** browser (front) and headless (back) recording.

The root cause wasn't a single bug. The same value was defaulted in four places with three different fallbacks:

| Path | Fallback |
|------|----------|
| server encode loop (`recordSketch`) | `duration \|\| 5` |
| in-page p5 clock (`time.js`/`sketch.js`/`animation.js`) | `duration \|\| 10` |
| engines / effective settings | `duration ?? 12` |
| progression bar | `duration ?? 10` + `Math.floor` |

They only agreed for a present, positive number. The instant duration was absent or `0` (the slider allowed `0`; the schema is `.min(1)`), the recorder encoded `round(5 × fps)` frames while the clock looped over a 10/12s window — a fixed wrong-length clip whose animation was cut off partway and never closed the loop. Changing the slider did nothing because the value the recorder read was never the slider's.

**GSAP had a second, critical break:** the runtime clock read only the *global* duration and never registered `window.setSlide`, so multi-slide GSAP recordings hung server-side on `[data-slide="N"]` and played only a fraction of each slide's animation.

## Fix — one resolver, one default, used everywhere

- **New `src/lib/animationConfig.ts`** — `resolveAnimation` / `totalFramesFor` (`DURATION_DEFAULT=12`, `FRAMERATE_DEFAULT=60`, `> 0` guards so a falsy `0` clamps to the shared default instead of silently substituting a *different* one).
- **Routed every consumer through it**: `effectiveSlideSettings`, `P5Engine`, `GsapEngine`, `recordSketch` (single + multi-slide, now via `getEffectiveSlideSettings`), p5 `time.js`/`sketch.js`/`animation.js`, the GSAP runtime, and `AnimationProgressionBar`. The encoded frame count and the clock's loop length can no longer disagree.
- **GSAP runtime is now slide-aware**: `effectiveOptions` merges per-slide `size`/`animation`/`sketch`; `setSlide()` updates `data-slide` synchronously (unblocks the headless `waitForSelector`) and rebuilds the timeline at the slide's duration; `GsapEngine` registers/restores `window.setSlide` so it composes with the p5 binding when switching engines.
- **Schema self-heals per leaf** (`.catch`) so a bad `duration` no longer drags `framerate` (or the whole options object) back to defaults; **duration slider `min` 0 → 1** to match `.min(1)`.

## Tests (the "do unit tests this time" ask) — front, back, p5, gsap, boundary

- `src/lib/__tests__/animationConfig.test.ts` — resolver matrix + the cross-path invariant the bug violated: *video seconds == clock loop length* for every input shape.
- `src/templates/p5/utils/__tests__/durationRecording.test.ts` — a duration change reaches **both** the frame count and the clock; falsy-duration loop seam.
- `src/templates/gsap/utils/__tests__/runtimeClock.test.tsx` — **first GSAP clock tests**: per-slide duration reaches the clock, `setSlide` updates `data-slide`, timeline rebuilds at the slide's duration.
- `src/types/__tests__/durationBoundary.test.ts` — slider/schema invariant, leaf `.catch` preserves siblings.

**Status:** 1133 tests pass (1096 existing + 37 new); lint clean; typecheck clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPmQSpaXMaWCiqGRob25FQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPmQSpaXMaWCiqGRob25FQ)_