### PR TITLE
feat(p5): shared oscillator progression option

### DIFF
--- a/src/templates/p5/sketches/photo/photo-unzoom-bounce/index.js
+++ b/src/templates/p5/sketches/photo/photo-unzoom-bounce/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 
 import mappers from "@/p5/utils/mappers.js";
 import animation from "@/p5/utils/animation.js";
+import oscillator from "@/p5/utils/oscillator/oscillator.js";
 import imageUtils from "@/p5/utils/imageUtils.js";
 import {
   getP5
@@ -48,16 +49,9 @@ sketch.draw( ( _time ) => {
     img, filename
   } = images[ imageIndex ];
 
-  const imageStepAnimationProgression = options.sketch.animationProgression;
-  const imageStepAnimationProgressionComponent =
-    animation?.[ imageStepAnimationProgression ];
-  const isImageStepAnimationProgressionComponentFunction =
-    typeof imageStepAnimationProgressionComponent === "function";
-
-  const imageStepIndexMapValue =
-    isImageStepAnimationProgressionComponentFunction
-      ? imageStepAnimationProgressionComponent( images.length )
-      : imageStepAnimationProgressionComponent;
+  // Shared oscillation: waveform + cycles (1-9) + phase offset + amplitude,
+  // driven off the global loop progression. Returns 0..1.
+  const imageStepIndexMapValue = oscillator.value( options.sketch.oscillation );
   const imageStepMin = options.sketch.zoom ? 1 : 0;
   const imageStepMax = options.sketch.zoom ? 0 : 1;
   const imageStepIndex = p.map(

--- a/src/templates/p5/sketches/photo/photo-unzoom-bounce/options.ts
+++ b/src/templates/p5/sketches/photo/photo-unzoom-bounce/options.ts
@@ -1,4 +1,6 @@
 import getTestImagePaths from "@/utils/getTestImagePaths";
+import oscillationDefaultValues from "@/p5/utils/oscillator/oscillatorDefaultValues";
+import oscillationFormConfiguration from "@/p5/utils/oscillator/oscillatorFormConfiguration";
 
 export const formValues = {
   images: await getTestImagePaths(),
@@ -8,7 +10,11 @@ export const formValues = {
   scaleStart: 0,
   scaleEnd: 0.3,
   scaleEasingFunctionName: "easeInQuint",
-  animationProgression: "linearProgression",
+  oscillation: {
+    ...oscillationDefaultValues,
+    // A "bounce" reads best as a linear ping-pong.
+    waveform: "triangle"
+  },
   backgroundColor: [
     255,
     255,
@@ -54,20 +60,7 @@ export const formConfiguration: Record<string, any> = {
     component: "easing",
     label: "Scale easing"
   },
-  animationProgression: {
-    component: "select",
-    label: "Animation progression",
-    options: [
-      {
-        label: "Triangle progression",
-        value: "triangleProgression"
-      },
-      {
-        label: "Linear progression",
-        value: "linearProgression"
-      }
-    ]
-  },
+  oscillation: oscillationFormConfiguration,
   backgroundColor: {
     component: "color",
     label: "Background color"

--- a/src/templates/p5/utils/__tests__/oscillationWaveforms.test.ts
+++ b/src/templates/p5/utils/__tests__/oscillationWaveforms.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Guards the shared oscillation waveforms used by the "oscillation" form
+ * option. The runtime helper (oscillator.js) only wires these pure functions
+ * to animation.progression, so covering the math here covers the behaviour
+ * every sketch relies on: phases wrap, shapes stay in range, and the four
+ * named waveforms keep their defining anchor points.
+ */
+
+import {
+  WAVEFORM_NAMES,
+  oscillationPhase,
+  evaluateOscillation
+} from "../oscillator/waveforms.js";
+
+describe(
+  "oscillation waveforms",
+  () => {
+    it(
+      "exposes exactly the four documented waveforms",
+      () => {
+        expect( [
+          ...WAVEFORM_NAMES
+        ].sort() ).toEqual( [
+          "sine",
+          "square",
+          "triangle",
+          "wave"
+        ] );
+      }
+    );
+
+    it(
+      "wraps the phase into [0, 1) for cycles and offset",
+      () => {
+        // 3 cycles over a full loop returns to 0 at the loop end.
+        expect( oscillationPhase(
+          1,
+          {
+            cycles: 3
+          }
+        ) ).toBeCloseTo( 0 );
+
+        // Offset shifts the phase and wraps past 1.
+        expect( oscillationPhase(
+          0.5,
+          {
+            cycles: 1,
+            offset: 0.75
+          }
+        ) ).toBeCloseTo( 0.25 );
+      }
+    );
+
+    it(
+      "keeps the phase wrapped when progression runs past 1 (recording)",
+      () => {
+        expect( oscillationPhase(
+          2.25,
+          {
+            cycles: 1
+          }
+        ) ).toBeCloseTo( 0.25 );
+      }
+    );
+
+    it(
+      "anchors each waveform at its defining points",
+      () => {
+        // wave: linear ramp.
+        expect( evaluateOscillation(
+          0,
+          {
+            waveform: "wave"
+          }
+        ) ).toBeCloseTo( 0 );
+        expect( evaluateOscillation(
+          0.5,
+          {
+            waveform: "wave"
+          }
+        ) ).toBeCloseTo( 0.5 );
+
+        // sine + triangle: start at 0, peak at the half-cycle.
+        for ( const waveform of [
+          "sine",
+          "triangle"
+        ] ) {
+          expect( evaluateOscillation(
+            0,
+            {
+              waveform
+            }
+          ) ).toBeCloseTo( 0 );
+          expect( evaluateOscillation(
+            0.5,
+            {
+              waveform
+            }
+          ) ).toBeCloseTo( 1 );
+        }
+
+        // square: on for the first half, off for the second.
+        expect( evaluateOscillation(
+          0.25,
+          {
+            waveform: "square"
+          }
+        ) ).toBe( 1 );
+        expect( evaluateOscillation(
+          0.75,
+          {
+            waveform: "square"
+          }
+        ) ).toBe( 0 );
+      }
+    );
+
+    it(
+      "stays within [0, 1] and centers on 0.5 as amplitude scales",
+      () => {
+        // amplitude 0 collapses every shape to the midpoint.
+        expect( evaluateOscillation(
+          0.5,
+          {
+            waveform: "triangle",
+            amplitude: 0
+          }
+        ) ).toBeCloseTo( 0.5 );
+
+        // amplitude > 1 punches past the natural swing but stays clamped.
+        for ( let i = 0; i <= 10; i++ ) {
+          const value = evaluateOscillation(
+            i / 10,
+            {
+              waveform: "sine",
+              amplitude: 2
+            }
+          );
+
+          expect( value ).toBeGreaterThanOrEqual( 0 );
+          expect( value ).toBeLessThanOrEqual( 1 );
+        }
+      }
+    );
+
+    it(
+      "falls back to sine for an unknown waveform name",
+      () => {
+        expect( evaluateOscillation(
+          0.5,
+          {
+            waveform: "not-a-waveform"
+          }
+        ) ).toBeCloseTo( evaluateOscillation(
+          0.5,
+          {
+            waveform: "sine"
+          }
+        ) );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/oscillator/oscillator.js
+++ b/src/templates/p5/utils/oscillator/oscillator.js
@@ -1,0 +1,59 @@
+import animation from "../animation.js";
+import {
+  WAVEFORMS,
+  WAVEFORM_NAMES,
+  oscillationPhase,
+  evaluateOscillation
+} from "./waveforms.js";
+
+/**
+ * Runtime helper for the shared "oscillation" option.
+ *
+ * Reads the global loop progression (animation.progression, 0→1 across the
+ * loop) by default, so a sketch only needs:
+ *
+ *   import oscillator from "@/p5/utils/oscillator/oscillator.js";
+ *   const t = oscillator.value( options.sketch.oscillation ); // 0..1
+ *
+ * Pass an explicit `progression` to drive several oscillators off one clock,
+ * or to reuse the math outside the draw loop.
+ */
+const oscillator = {
+  waveforms: WAVEFORMS,
+  names: WAVEFORM_NAMES,
+
+  // Unipolar 0..1 — the everyday driver for scale / alpha / index / position.
+  value(
+    config = {}, progression = animation.progression
+  ) {
+    return evaluateOscillation(
+      progression,
+      config
+    );
+  },
+
+  // Bipolar -1..1 — centered on 0, for symmetric offsets (translate, rotate).
+  signed(
+    config = {}, progression = animation.progression
+  ) {
+    return evaluateOscillation(
+      progression,
+      config
+    ) * 2 - 1;
+  },
+
+  // Raw wrapped phase 0..1 (before the waveform) — for custom shaping.
+  phase(
+    config = {}, progression = animation.progression
+  ) {
+    return oscillationPhase(
+      progression,
+      config
+    );
+  }
+};
+
+export default oscillator;
+export {
+  WAVEFORMS, WAVEFORM_NAMES, oscillationPhase, evaluateOscillation
+};

--- a/src/templates/p5/utils/oscillator/oscillatorDefaultValues.js
+++ b/src/templates/p5/utils/oscillator/oscillatorDefaultValues.js
@@ -1,0 +1,15 @@
+/**
+ * Default values for the shared "oscillation" option.
+ *
+ * Pair with oscillatorFormConfiguration.js in a sketch's options.ts, then read
+ * it at runtime with oscillator.value() / signed() / phase().
+ */
+
+const oscillationValues = {
+  waveform: "sine",
+  cycles: 1,
+  offset: 0,
+  amplitude: 1
+};
+
+export default oscillationValues;

--- a/src/templates/p5/utils/oscillator/oscillatorFormConfiguration.js
+++ b/src/templates/p5/utils/oscillator/oscillatorFormConfiguration.js
@@ -1,0 +1,58 @@
+import {
+  WAVEFORM_NAMES
+} from "./waveforms.js";
+
+/**
+ * Standard "oscillation" configuration for form options — drop into any
+ * sketch's formConfiguration next to its `oscillationDefaultValues`:
+ *
+ *   import oscillationDefaultValues
+ *     from "@/p5/utils/oscillator/oscillatorDefaultValues";
+ *   import oscillationFormConfiguration
+ *     from "@/p5/utils/oscillator/oscillatorFormConfiguration";
+ */
+
+const waveformLabels = {
+  wave: "Wave (ramp)",
+  sine: "Sine (smooth)",
+  triangle: "Triangle (ping-pong)",
+  square: "Square (toggle)"
+};
+
+const oscillationFormConfiguration = {
+  label: "Oscillation",
+  component: "nested-object",
+  fields: {
+    waveform: {
+      label: "Waveform",
+      component: "select",
+      options: WAVEFORM_NAMES.map( ( name ) => ( {
+        value: name,
+        label: waveformLabels[ name ] ?? name
+      } ) )
+    },
+    cycles: {
+      label: "Cycles",
+      component: "slider",
+      min: 1,
+      max: 9,
+      step: 1
+    },
+    offset: {
+      label: "Phase offset",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.01
+    },
+    amplitude: {
+      label: "Amplitude",
+      component: "slider",
+      min: 0,
+      max: 2,
+      step: 0.05
+    }
+  }
+};
+
+export default oscillationFormConfiguration;

--- a/src/templates/p5/utils/oscillator/waveforms.js
+++ b/src/templates/p5/utils/oscillator/waveforms.js
@@ -1,0 +1,90 @@
+/**
+ * Shared animation-progression waveforms.
+ *
+ * Each waveform maps a normalized phase `p` in [0, 1) to a unipolar value in
+ * [0, 1]. They are the reusable building block behind the "oscillation" form
+ * option (see oscillatorFormConfiguration.js) so every sketch drives motion
+ * from the same vocabulary: pick a shape, pick how many cycles per loop.
+ *
+ *   wave     ╱╱╱  sawtooth ramp  — travels 0→1, then snaps back
+ *   sine     ◡◠   smooth breathing — eased in and out, rests at the ends
+ *   triangle ◣◢   linear ping-pong — sharp peak, constant speed
+ *   square   ▟▙   instant toggle  — on for `duty`, then off
+ *
+ * Pure module: no p5 / animation imports, so the math is unit-testable on its
+ * own and safe to pull into the server-rendered form config.
+ */
+
+const TAU = Math.PI * 2;
+
+export const WAVEFORMS = {
+  wave: ( p ) => p,
+  sine: ( p ) => 0.5 - 0.5 * Math.cos( TAU * p ),
+  triangle: ( p ) => ( p < 0.5 ? p * 2 : 2 - p * 2 ),
+  square: (
+    p, duty = 0.5
+  ) => ( p < duty ? 1 : 0 )
+};
+
+export const WAVEFORM_NAMES = Object.keys( WAVEFORMS );
+
+/**
+ * Positive modulo into [0, 1) — keeps the phase wrapped even while recording,
+ * when the raw progression runs past 1 instead of looping back to 0.
+ */
+function wrap01( value ) {
+  return ( ( value % 1 ) + 1 ) % 1;
+}
+
+/**
+ * Resolve the wrapped phase for a linear progression:
+ *   phase = wrap( progression * cycles + offset )
+ */
+export function oscillationPhase(
+  progression, {
+    cycles = 1, offset = 0
+  } = {}
+) {
+  return wrap01( progression * cycles + offset );
+}
+
+/**
+ * Evaluate an oscillation config against a linear progression (0→1).
+ *
+ * Returns a unipolar value in [0, 1]. `amplitude` scales the swing around the
+ * 0.5 midpoint (1 = natural, < 1 shallower, > 1 punchier and clamped), so the
+ * rest point stays centered no matter the depth.
+ */
+export function evaluateOscillation(
+  progression, config = {}
+) {
+  const {
+    waveform = "sine",
+    cycles = 1,
+    offset = 0,
+    amplitude = 1,
+    duty = 0.5
+  } = config;
+
+  const shape = WAVEFORMS[ waveform ] ?? WAVEFORMS.sine;
+  const phase = oscillationPhase(
+    progression,
+    {
+      cycles,
+      offset
+    }
+  );
+  const raw = shape(
+    phase,
+    duty
+  );
+  const scaled = 0.5 + ( raw - 0.5 ) * amplitude;
+
+  return Math.min(
+    1,
+    Math.max(
+      0,
+      scaled
+    )
+  );
+}


### PR DESCRIPTION
## What

Adds a **reusable animation-progression / oscillation option** so photo (and any) sketches drive their motion from one common vocabulary, importable into `options.ts` exactly like `title` or `easing`.

Today a few sketches roll their own progression controls (e.g. `photo-unzoom-bounce` had a bespoke `animationProgression` select with just *triangle* / *linear*). This makes the concept shared, uniform and creative.

## The option

One nested object with four knobs:

| field | control | meaning |
|---|---|---|
| `waveform` | select | `wave` (sawtooth ramp), `sine` (smooth), `triangle` (ping-pong), `square` (toggle) |
| `cycles` | slider **1–9** | full cycles per loop |
| `offset` | slider 0–1 | phase offset (stagger / sync) |
| `amplitude` | slider 0–2 | swing depth around the 0.5 midpoint |

## How to use it (mirrors the `title` util layout)

```ts
// options.ts
import oscillationDefaultValues      from "@/p5/utils/oscillator/oscillatorDefaultValues";
import oscillationFormConfiguration  from "@/p5/utils/oscillator/oscillatorFormConfiguration";

export const formValues        = { oscillation: oscillationDefaultValues };
export const formConfiguration = { oscillation: oscillationFormConfiguration };
```

```js
// index.js (sketch runtime)
import oscillator from "@/p5/utils/oscillator/oscillator.js";

oscillator.value(  options.sketch.oscillation );  // 0..1  (scale / alpha / index)
oscillator.signed( options.sketch.oscillation );  // -1..1 (translate / rotate)
oscillator.phase(  options.sketch.oscillation );  // raw 0..1 phase
```

By default it reads the global `animation.progression`, so it stays in sync with playback **and** server-side recording (phase wraps with a positive modulo).

## Files

- `utils/oscillator/waveforms.js` — pure, p5-free waveform math (the engine)
- `utils/oscillator/oscillator.js` — runtime helper (`value` / `signed` / `phase`)
- `utils/oscillator/oscillatorDefaultValues.js` + `oscillatorFormConfiguration.js` — drop-in form pieces
- `utils/__tests__/oscillationWaveforms.test.ts` — unit tests for the math
- **Worked example:** migrated `photo/photo-unzoom-bounce` from its custom `animationProgression` select to the shared `oscillation` option (defaults to `triangle` so the "bounce" still reads right)

## Validation

- `jest` — full suite **1140 passed** (incl. 6 new waveform tests)
- `eslint` — clean on all touched files
- `tsc --noEmit` — no errors in the touched files

## Next steps (after you validate the design)

Roll the same `oscillation` option into the other photo sketches that currently hand-roll progression/cycle controls, deleting their one-off selects in favor of the shared one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ScJTu2RA5HFKkui48kUmUS)_