### PR TITLE
Add interactive balls (fingers/mouse/touch/gyro) to ping-pong sketch

### DIFF
--- a/src/templates/p5/sketches/audio/ping-pong/index.js
+++ b/src/templates/p5/sketches/audio/ping-pong/index.js
@@ -18,22 +18,31 @@ import {
  * function of time, so the same beat plays in preview, realtime recording
  * and (later) deterministic offline audio rendering.
  *
- * On top of that deterministic beat sits an optional interactive layer: each
- * live pointer from the shared interaction module — fingers (camera), mouse,
- * touch and gyroscope tilt — becomes a circular bumper. The ball keeps its
- * time-based path, but the frame it enters a bumper it plays a bip (pitch
- * mapped to height) and emits a flash, so you can "play" the ball by hand.
- * Every interaction source defaults OFF, so until one is enabled the sketch
- * renders exactly as before.
+ * Interactive layer: each live pointer from the shared interaction module —
+ * fingers (camera), mouse, touch and gyroscope tilt — drives an extra ball
+ * that simply tracks the pointer. The canvas boundary is the only thing that
+ * makes a sound: whenever any ball (auto or interactive) reaches a wall it
+ * plays a bip (pitch mapped to where it hit) and emits a flash. Optionally,
+ * ball-to-ball contact can play a bip too (see the "Balls" options).
+ *
+ * The "Balls" mode select decides which balls exist — only the automatic ball
+ * (default), the automatic ball plus interactive ones, or interactive only.
+ * In "auto" mode the pointers are ignored, so the sketch renders exactly as
+ * before until the user opts in.
  */
 
 const state = {
   bouncesX: null,
   bouncesY: null,
-  flashes: [], // { x, y, at } — wall-hit + bumper ripples, `at` in sketch seconds
-  // Per-pointer "ball was inside this bumper last frame", indexed to match the
-  // getPointers() order, so a bumper bips once on entry instead of every frame.
-  bumperInside: []
+  flashes: [], // { x, y, at } — wall-hit + collision ripples, `at` in sketch seconds
+  // Per-pointer "was the interactive ball touching a wall last frame", indexed
+  // to match getPointers() order, so a wall bips once on contact (edge trigger)
+  // rather than every frame the pointer is held against the edge.
+  // Each entry: { x: bool (left/right walls), y: bool (top/bottom walls) }.
+  interactiveWalls: [],
+  // Keys of the ball pairs currently overlapping, so a ball-to-ball collision
+  // bips once on contact instead of every frame the balls stay overlapped.
+  collidingPairs: new Set()
 };
 
 /**
@@ -84,7 +93,8 @@ sketch.setup( async() => {
   state.bouncesX = null;
   state.bouncesY = null;
   state.flashes = [];
-  state.bumperInside = [];
+  state.interactiveWalls = [];
+  state.collidingPairs = new Set();
 
   await initInteraction( options.sketch?.interaction ?? {} );
 } );
@@ -95,11 +105,23 @@ sketch.draw( ( time ) => {
   const ballOptions = o.ball ?? {};
   const flashOptions = o.flash ?? {};
   const audioOptions = o.audio ?? {};
+  const modeOptions = o.mode ?? {};
+  const interaction = o.interaction ?? {};
+
+  const composition = modeOptions.composition ?? "auto";
+  const showAuto = composition !== "interactive";
+  const showInteractive = composition !== "auto";
+  const ballCollisions = modeOptions.ballCollisions === true;
 
   const radius = ballOptions.radius ?? 40;
   const rangeX = p.width - radius * 2;
   const rangeY = p.height - radius * 2;
 
+  // The balls drawn this frame. Each carries a stable `key` so ball-to-ball
+  // collisions can be edge-triggered: "auto" plus one "p<index>" per pointer.
+  const balls = [];
+
+  // ── Automatic ball (deterministic, time-based) ───────────────────────────
   const xState = pingPong(
     ( ballOptions.speedX ?? 420 ) * time,
     rangeX
@@ -109,83 +131,167 @@ sketch.draw( ( time ) => {
     rangeY
   );
 
-  const x = radius + xState.pos;
-  const y = radius + yState.pos;
+  const autoX = radius + xState.pos;
+  const autoY = radius + yState.pos;
 
-  // A bounce happened when the traversal count increased since last frame.
-  // Counts also *drop* when the preview loop wraps back to t=0 — resync
-  // silently in that case instead of firing a phantom bip.
-  if ( state.bouncesX !== null && xState.bounces > state.bouncesX ) {
-    triggerBounce(
-      audioOptions,
-      yState.pos / rangeY
-    );
-    state.flashes.push( {
-      x,
-      y,
-      at: time
+  if ( showAuto ) {
+    balls.push( {
+      key: "auto",
+      x: autoX,
+      y: autoY,
+      r: radius
     } );
-  }
 
-  if ( state.bouncesY !== null && yState.bounces > state.bouncesY ) {
-    triggerBounce(
-      audioOptions,
-      xState.pos / rangeX
-    );
-    state.flashes.push( {
-      x,
-      y,
-      at: time
-    } );
-  }
-
-  state.bouncesX = xState.bounces;
-  state.bouncesY = yState.bounces;
-
-  // ── Interactive bumpers ──────────────────────────────────────────────────
-  // Each live pointer (finger / mouse / touch / gyro tilt) is a circular
-  // bumper. The ball keeps its deterministic path; the frame it crosses into a
-  // bumper we play a bip (pitch from the bumper's height) and emit a flash.
-  // Edge-triggered per pointer index so holding the ball inside a bumper
-  // doesn't machine-gun the sound.
-  const interaction = o.interaction ?? {};
-  const bumperOptions = o.bumpers ?? {};
-  const bumperRadius = bumperOptions.radius ?? 80;
-  const pointers = getPointers( interaction );
-
-  pointers.forEach( (
-    pointer, index
-  ) => {
-    const inside = p.dist(
-      x,
-      y,
-      pointer.x,
-      pointer.y
-    ) <= radius + bumperRadius;
-
-    if ( inside && !state.bumperInside[ index ] ) {
+    // A wall hit happened when the traversal count increased since last frame.
+    // Counts also *drop* when the preview loop wraps back to t=0 — resync
+    // silently in that case instead of firing a phantom bip.
+    if ( state.bouncesX !== null && xState.bounces > state.bouncesX ) {
       triggerBounce(
         audioOptions,
-        p.constrain(
-          pointer.y / p.height,
-          0,
-          1
-        )
+        yState.pos / rangeY
       );
       state.flashes.push( {
-        x: pointer.x,
-        y: pointer.y,
+        x: autoX,
+        y: autoY,
         at: time
       } );
     }
 
-    state.bumperInside[ index ] = inside;
+    if ( state.bouncesY !== null && yState.bounces > state.bouncesY ) {
+      triggerBounce(
+        audioOptions,
+        xState.pos / rangeX
+      );
+      state.flashes.push( {
+        x: autoX,
+        y: autoY,
+        at: time
+      } );
+    }
+  }
+
+  // Keep the deterministic counters advancing even while the auto ball is
+  // hidden, so switching back to it doesn't fire a phantom bip.
+  state.bouncesX = xState.bounces;
+  state.bouncesY = yState.bounces;
+
+  // ── Interactive balls (one per live pointer) ─────────────────────────────
+  // Each pointer (finger / mouse / touch / gyro tilt) becomes an extra ball
+  // that tracks it, clamped to stay fully on the canvas. The clamp is what
+  // makes the boundary a collision: when the pointer reaches an edge the ball
+  // touches the wall and bips (pitch from where along the wall it landed).
+  const pointers = showInteractive ? getPointers( interaction ) : [];
+  const walls = state.interactiveWalls;
+
+  pointers.forEach( (
+    pointer, index
+  ) => {
+    const cx = p.constrain(
+      pointer.x,
+      radius,
+      p.width - radius
+    );
+    const cy = p.constrain(
+      pointer.y,
+      radius,
+      p.height - radius
+    );
+
+    balls.push( {
+      key: `p${ index }`,
+      x: cx,
+      y: cy,
+      r: radius
+    } );
+
+    const onVertWall = pointer.x <= radius || pointer.x >= p.width - radius;
+    const onHorizWall = pointer.y <= radius || pointer.y >= p.height - radius;
+    const prev = walls[ index ] ?? {
+      x: false,
+      y: false
+    };
+
+    if ( onVertWall && !prev.x ) {
+      triggerBounce(
+        audioOptions,
+        cy / p.height
+      );
+      state.flashes.push( {
+        x: cx,
+        y: cy,
+        at: time
+      } );
+    }
+
+    if ( onHorizWall && !prev.y ) {
+      triggerBounce(
+        audioOptions,
+        cx / p.width
+      );
+      state.flashes.push( {
+        x: cx,
+        y: cy,
+        at: time
+      } );
+    }
+
+    walls[ index ] = {
+      x: onVertWall,
+      y: onHorizWall
+    };
   } );
 
-  // Drop stale flags once pointers disappear so a new pointer reusing that
-  // index starts fresh and can bip immediately on entry.
-  state.bumperInside.length = pointers.length;
+  // Drop stale wall memory once pointers disappear so a reused index starts
+  // fresh (and can bip immediately if it spawns against an edge).
+  walls.length = pointers.length;
 
+  // ── Ball-to-ball collisions (optional sound) ─────────────────────────────
+  // Balls pass through each other — the only effect is an optional bip when two
+  // first overlap, edge-triggered via the set of currently-colliding pairs.
+  if ( ballCollisions ) {
+    const colliding = new Set();
+
+    for ( let i = 0; i < balls.length; i++ ) {
+      for ( let j = i + 1; j < balls.length; j++ ) {
+        const a = balls[ i ];
+        const b = balls[ j ];
+
+        if ( p.dist(
+          a.x,
+          a.y,
+          b.x,
+          b.y
+        ) > a.r + b.r ) {
+          continue;
+        }
+
+        const pairKey = `${ a.key }|${ b.key }`;
+
+        colliding.add( pairKey );
+
+        if ( !state.collidingPairs.has( pairKey ) ) {
+          const mx = ( a.x + b.x ) / 2;
+          const my = ( a.y + b.y ) / 2;
+
+          triggerBounce(
+            audioOptions,
+            my / p.height
+          );
+          state.flashes.push( {
+            x: mx,
+            y: my,
+            at: time
+          } );
+        }
+      }
+    }
+
+    state.collidingPairs = colliding;
+  } else if ( state.collidingPairs.size > 0 ) {
+    state.collidingPairs.clear();
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
   p.clear();
   p.background( ...( o.background?.color ?? [
     0,
@@ -193,7 +299,7 @@ sketch.draw( ( time ) => {
     0
   ] ) );
 
-  // Wall-hit ripples: expanding, fading rings.
+  // Collision ripples: expanding, fading rings (walls + ball-to-ball).
   if ( flashOptions.show !== false ) {
     const flashDuration = flashOptions.duration ?? 0.35;
 
@@ -229,38 +335,7 @@ sketch.draw( ( time ) => {
     }
   }
 
-  // Bumper rings: where each pointer is, brighter while the ball is inside it.
-  if ( bumperOptions.show !== false && pointers.length > 0 ) {
-    const ballColor = ballOptions.color ?? [
-      255,
-      255,
-      255
-    ];
-
-    pointers.forEach( (
-      pointer, index
-    ) => {
-      const hit = state.bumperInside[ index ];
-
-      p.push();
-      p.noFill();
-      p.stroke(
-        ...ballColor.slice(
-          0,
-          3
-        ),
-        hit ? 230 : 90
-      );
-      p.strokeWeight( hit ? 4 : 2 );
-      p.circle(
-        pointer.x,
-        pointer.y,
-        bumperRadius * 2
-      );
-      p.pop();
-    } );
-  }
-
+  // Every ball (auto + interactive) drawn the same.
   p.push();
   p.noStroke();
   p.fill( ...( ballOptions.color ?? [
@@ -268,11 +343,15 @@ sketch.draw( ( time ) => {
     255,
     255
   ] ) );
-  p.circle(
-    x,
-    y,
-    radius * 2
-  );
+
+  for ( const ball of balls ) {
+    p.circle(
+      ball.x,
+      ball.y,
+      ball.r * 2
+    );
+  }
+
   p.pop();
 
   // Debug overlay (crosshairs / pointer markers / finger chains / webcam

--- a/src/templates/p5/sketches/audio/ping-pong/index.js
+++ b/src/templates/p5/sketches/audio/ping-pong/index.js
@@ -3,18 +3,37 @@ import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
 import audio from "@/p5/utils/audio.js";
+import {
+  initInteraction,
+  getPointers,
+  disposeInteraction
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
 
 /**
  * Audio demo sketch: a ball bounces around the canvas and every wall hit
  * triggers a synthesised bip (see utils/audio.js). The trajectory is a pure
  * function of time, so the same beat plays in preview, realtime recording
  * and (later) deterministic offline audio rendering.
+ *
+ * On top of that deterministic beat sits an optional interactive layer: each
+ * live pointer from the shared interaction module — fingers (camera), mouse,
+ * touch and gyroscope tilt — becomes a circular bumper. The ball keeps its
+ * time-based path, but the frame it enters a bumper it plays a bip (pitch
+ * mapped to height) and emits a flash, so you can "play" the ball by hand.
+ * Every interaction source defaults OFF, so until one is enabled the sketch
+ * renders exactly as before.
  */
 
 const state = {
   bouncesX: null,
   bouncesY: null,
-  flashes: [] // { x, y, at } — wall-hit ripples, `at` in sketch seconds
+  flashes: [], // { x, y, at } — wall-hit + bumper ripples, `at` in sketch seconds
+  // Per-pointer "ball was inside this bumper last frame", indexed to match the
+  // getPointers() order, so a bumper bips once on entry instead of every frame.
+  bumperInside: []
 };
 
 /**
@@ -61,10 +80,13 @@ function triggerBounce(
   );
 }
 
-sketch.setup( () => {
+sketch.setup( async() => {
   state.bouncesX = null;
   state.bouncesY = null;
   state.flashes = [];
+  state.bumperInside = [];
+
+  await initInteraction( options.sketch?.interaction ?? {} );
 } );
 
 sketch.draw( ( time ) => {
@@ -120,6 +142,50 @@ sketch.draw( ( time ) => {
   state.bouncesX = xState.bounces;
   state.bouncesY = yState.bounces;
 
+  // ── Interactive bumpers ──────────────────────────────────────────────────
+  // Each live pointer (finger / mouse / touch / gyro tilt) is a circular
+  // bumper. The ball keeps its deterministic path; the frame it crosses into a
+  // bumper we play a bip (pitch from the bumper's height) and emit a flash.
+  // Edge-triggered per pointer index so holding the ball inside a bumper
+  // doesn't machine-gun the sound.
+  const interaction = o.interaction ?? {};
+  const bumperOptions = o.bumpers ?? {};
+  const bumperRadius = bumperOptions.radius ?? 80;
+  const pointers = getPointers( interaction );
+
+  pointers.forEach( (
+    pointer, index
+  ) => {
+    const inside = p.dist(
+      x,
+      y,
+      pointer.x,
+      pointer.y
+    ) <= radius + bumperRadius;
+
+    if ( inside && !state.bumperInside[ index ] ) {
+      triggerBounce(
+        audioOptions,
+        p.constrain(
+          pointer.y / p.height,
+          0,
+          1
+        )
+      );
+      state.flashes.push( {
+        x: pointer.x,
+        y: pointer.y,
+        at: time
+      } );
+    }
+
+    state.bumperInside[ index ] = inside;
+  } );
+
+  // Drop stale flags once pointers disappear so a new pointer reusing that
+  // index starts fresh and can bip immediately on entry.
+  state.bumperInside.length = pointers.length;
+
   p.clear();
   p.background( ...( o.background?.color ?? [
     0,
@@ -163,6 +229,38 @@ sketch.draw( ( time ) => {
     }
   }
 
+  // Bumper rings: where each pointer is, brighter while the ball is inside it.
+  if ( bumperOptions.show !== false && pointers.length > 0 ) {
+    const ballColor = ballOptions.color ?? [
+      255,
+      255,
+      255
+    ];
+
+    pointers.forEach( (
+      pointer, index
+    ) => {
+      const hit = state.bumperInside[ index ];
+
+      p.push();
+      p.noFill();
+      p.stroke(
+        ...ballColor.slice(
+          0,
+          3
+        ),
+        hit ? 230 : 90
+      );
+      p.strokeWeight( hit ? 4 : 2 );
+      p.circle(
+        pointer.x,
+        pointer.y,
+        bumperRadius * 2
+      );
+      p.pop();
+    } );
+  }
+
   p.push();
   p.noStroke();
   p.fill( ...( ballOptions.color ?? [
@@ -176,4 +274,12 @@ sketch.draw( ( time ) => {
     radius * 2
   );
   p.pop();
+
+  // Debug overlay (crosshairs / pointer markers / finger chains / webcam
+  // preview / legend) — all gated by interaction.visualization, off by default.
+  drawInteractionOverlay( interaction );
+} );
+
+sketch.cleanup?.( () => {
+  disposeInteraction();
 } );

--- a/src/templates/p5/sketches/audio/ping-pong/options.ts
+++ b/src/templates/p5/sketches/audio/ping-pong/options.ts
@@ -5,19 +5,21 @@ import {
 
 // ── Interaction (fingers / mouse / touch / gyroscope) ──────────────────────
 // Reuse the shared interaction layer but expose only the four sources this
-// sketch reacts to. Every source starts OFF so the deterministic ball + beat
-// are byte-for-byte identical until the user opts in; flip one on and its live
-// pointers become bumpers the ball plays a bip off of.
+// sketch reacts to. Each live pointer drives an extra ball (see the "Balls"
+// mode select). Mouse + touch are on so switching the mode to interactive
+// works instantly; vision (camera) and gyro stay off until granted. While the
+// mode is "auto" (default) the pointers are ignored, so the deterministic ball
+// and beat are byte-for-byte identical until the user opts in.
 
 const interactionDefaults = {
   enabled: interactionFormValues.enabled,
   mouse: {
     ...interactionFormValues.mouse,
-    enabled: false
+    enabled: true
   },
   touch: {
     ...interactionFormValues.touch,
-    enabled: false
+    enabled: true
   },
   vision: {
     ...interactionFormValues.vision,
@@ -78,6 +80,21 @@ const SOUND_OPTIONS = [
   }
 ];
 
+const BALL_MODE_OPTIONS = [
+  {
+    label: "Only automatic ball",
+    value: "auto"
+  },
+  {
+    label: "Auto ball + interactive",
+    value: "both"
+  },
+  {
+    label: "Interactive only",
+    value: "interactive"
+  }
+];
+
 export const formValues = {
   ball: {
     radius: 186,
@@ -111,9 +128,9 @@ export const formValues = {
       255
     ] as number[]
   },
-  bumpers: {
-    show: true,
-    radius: 80
+  mode: {
+    composition: "auto",
+    ballCollisions: false
   },
   interaction: interactionDefaults
 };
@@ -227,20 +244,18 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
-  bumpers: {
+  mode: {
     component: "nested-object",
-    label: "Interactive bumpers",
+    label: "Balls",
     fields: {
-      show: {
-        label: "Show bumper rings",
-        component: "checkbox"
+      composition: {
+        label: "Mode",
+        component: "select",
+        options: BALL_MODE_OPTIONS
       },
-      radius: {
-        label: "Bumper radius (px)",
-        component: "slider",
-        min: 10,
-        max: 300,
-        step: 1
+      ballCollisions: {
+        label: "Ball-to-ball collision sound",
+        component: "checkbox"
       }
     }
   },

--- a/src/templates/p5/sketches/audio/ping-pong/options.ts
+++ b/src/templates/p5/sketches/audio/ping-pong/options.ts
@@ -1,3 +1,68 @@
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+// ── Interaction (fingers / mouse / touch / gyroscope) ──────────────────────
+// Reuse the shared interaction layer but expose only the four sources this
+// sketch reacts to. Every source starts OFF so the deterministic ball + beat
+// are byte-for-byte identical until the user opts in; flip one on and its live
+// pointers become bumpers the ball plays a bip off of.
+
+const interactionDefaults = {
+  enabled: interactionFormValues.enabled,
+  mouse: {
+    ...interactionFormValues.mouse,
+    enabled: false
+  },
+  touch: {
+    ...interactionFormValues.touch,
+    enabled: false
+  },
+  vision: {
+    ...interactionFormValues.vision,
+    enabled: false,
+    // When the camera is switched on, track fingers (not the whole hand).
+    fingers: {
+      ...interactionFormValues.vision.fingers,
+      enabled: true
+    }
+  },
+  gyroscope: {
+    ...interactionFormValues.gyroscope,
+    enabled: false
+  },
+  visualization: {
+    ...interactionFormValues.visualization,
+    enabled: false
+  }
+};
+
+// A fingers-focused slice of the shared Vision panel (drop hands/face/body).
+const visionFingersConfiguration = {
+  component: "nested-object",
+  label: "Vision (Camera) — fingers",
+  fields: {
+    enabled: interactionFormConfiguration.fields.vision.fields.enabled,
+    source: interactionFormConfiguration.fields.vision.fields.source,
+    fingers: interactionFormConfiguration.fields.vision.fields.fingers,
+    performance: interactionFormConfiguration.fields.vision.fields.performance
+  }
+};
+
+const interactionConfiguration = {
+  component: "nested-object",
+  label: "Interaction",
+  fields: {
+    enabled: interactionFormConfiguration.fields.enabled,
+    mouse: interactionFormConfiguration.fields.mouse,
+    touch: interactionFormConfiguration.fields.touch,
+    vision: visionFingersConfiguration,
+    gyroscope: interactionFormConfiguration.fields.gyroscope,
+    visualization: interactionFormConfiguration.fields.visualization
+  }
+};
+
 const SOUND_OPTIONS = [
   {
     label: "Bounce (triangle, pitch drop)",
@@ -45,7 +110,12 @@ export const formValues = {
       0,
       255
     ] as number[]
-  }
+  },
+  bumpers: {
+    show: true,
+    radius: 80
+  },
+  interaction: interactionDefaults
 };
 
 export const formConfiguration: Record<string, any> = {
@@ -156,5 +226,23 @@ export const formConfiguration: Record<string, any> = {
         label: "Background color"
       }
     }
-  }
+  },
+  bumpers: {
+    component: "nested-object",
+    label: "Interactive bumpers",
+    fields: {
+      show: {
+        label: "Show bumper rings",
+        component: "checkbox"
+      },
+      radius: {
+        label: "Bumper radius (px)",
+        component: "slider",
+        min: 10,
+        max: 300,
+        step: 1
+      }
+    }
+  },
+  interaction: interactionConfiguration
 };

--- a/src/templates/p5/sketches/flowers-shaders/flowers-shaders-v2-pipes/index.js
+++ b/src/templates/p5/sketches/flowers-shaders/flowers-shaders-v2-pipes/index.js
@@ -328,9 +328,7 @@ sketch.draw( () => {
   // (braidRadius·pulse·pulseFreq). A 10% margin keeps the march from overshooting.
   const maxR = braidRadius * ( 1 + radiusPulse ) + pipeRadius;
   const pulseSlope = braidRadius * radiusPulse * pulseFreq;
-  const twistLipschitz = Math.sqrt(
-    1 + ( maxR * twist + pulseSlope ) ** 2
-  ) * 1.1;
+  const twistLipschitz = Math.sqrt( 1 + ( maxR * twist + pulseSlope ) ** 2 ) * 1.1;
 
   // Field of view (degrees) → focal length of the pinhole camera.
   const fov = camera.fov ?? 45;

--- a/src/templates/p5/sketches/text-morphing-mask/text-morphing-iris-mask/options.ts
+++ b/src/templates/p5/sketches/text-morphing-mask/text-morphing-iris-mask/options.ts
@@ -1,0 +1,189 @@
+import {
+  fontNames
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
+import {
+  createSingleOrMultipleTextOption
+} from "@/utils/sketchOptionUtils";
+import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
+import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+
+export const formValues = {
+  text: {
+    mode: "single",
+    value: "hello world"
+  },
+  textStyle: {
+    font: "waverseVariable",
+    size: 320,
+    letterSpacing: 0.62,
+    fill: [
+      255,
+      255,
+      255
+    ],
+    stroke: [
+      0,
+      0,
+      0
+    ],
+    strokeWeight: 0
+  },
+  transition: {
+    easing: "easeInOutCubic",
+    pauseRatio: 0.2,
+    overlap: 0.3,
+    onlyChanged: false
+  },
+  circle: {
+    show: true,
+    easing: "easeInOutCubic",
+    maxRadius: 0.55,
+    behindLetters: true,
+    fill: [
+      255,
+      255,
+      255
+    ],
+    fillAlpha: 0,
+    stroke: [
+      255,
+      255,
+      255
+    ],
+    strokeWeight: 2
+  },
+  backgroundColor: [
+    0,
+    0,
+    0
+  ],
+  title: titleDefaultValues
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  text: createSingleOrMultipleTextOption( "text" ),
+  textStyle: {
+    component: "nested-object",
+    label: "Text style",
+    fields: {
+      font: {
+        component: "select",
+        label: "Font name",
+        options: fontNames.map( ( fontName ) => ( {
+          value: fontName,
+          label: fontName
+        } ) )
+      },
+      size: {
+        label: "Size (px)",
+        component: "slider",
+        min: 40,
+        max: 800,
+        step: 1
+      },
+      letterSpacing: {
+        label: "Letter spacing",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      fill: {
+        label: "Fill",
+        component: "color"
+      },
+      stroke: {
+        label: "Stroke",
+        component: "color"
+      },
+      strokeWeight: {
+        label: "Stroke weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      }
+    }
+  },
+  transition: {
+    component: "nested-object",
+    label: "Transition",
+    fields: {
+      easing: {
+        component: "easing",
+        label: "Transition easing function"
+      },
+      pauseRatio: {
+        label: "Pause ratio",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      overlap: {
+        label: "Letter overlap",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      onlyChanged: {
+        label: "Only animate changed letters?",
+        component: "checkbox"
+      }
+    }
+  },
+  circle: {
+    component: "nested-object",
+    label: "Iris circle",
+    fields: {
+      show: {
+        label: "Show circle?",
+        component: "checkbox"
+      },
+      easing: {
+        component: "easing",
+        label: "Circle easing function"
+      },
+      maxRadius: {
+        label: "Max radius (of min dimension)",
+        component: "slider",
+        min: 0.05,
+        max: 1,
+        step: 0.01
+      },
+      behindLetters: {
+        label: "Draw behind letters?",
+        component: "checkbox"
+      },
+      fill: {
+        label: "Fill",
+        component: "color"
+      },
+      fillAlpha: {
+        label: "Fill alpha",
+        component: "slider",
+        min: 0,
+        max: 255,
+        step: 1
+      },
+      stroke: {
+        label: "Stroke",
+        component: "color"
+      },
+      strokeWeight: {
+        label: "Stroke weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  },
+  title: titleFormConfiguration
+};

--- a/src/templates/p5/sketches/text-morphing-mask/text-morphing-letter-mask/options.ts
+++ b/src/templates/p5/sketches/text-morphing-mask/text-morphing-letter-mask/options.ts
@@ -1,0 +1,189 @@
+import {
+  fontNames
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
+import {
+  createSingleOrMultipleTextOption
+} from "@/utils/sketchOptionUtils";
+import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
+import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+
+export const formValues = {
+  text: {
+    mode: "single",
+    value: "hello world"
+  },
+  textStyle: {
+    font: "waverseVariable",
+    size: 320,
+    letterSpacing: 0.62,
+    fill: [
+      255,
+      255,
+      255
+    ],
+    stroke: [
+      0,
+      0,
+      0
+    ],
+    strokeWeight: 0
+  },
+  transition: {
+    easing: "easeInOutCubic",
+    pauseRatio: 0.2,
+    overlap: 0.3,
+    onlyChanged: false
+  },
+  mask: {
+    show: true,
+    easing: "easeInOutCubic",
+    maxScale: 6,
+    behindLetters: true,
+    fill: [
+      255,
+      255,
+      255
+    ],
+    fillAlpha: 0,
+    stroke: [
+      255,
+      255,
+      255
+    ],
+    strokeWeight: 2
+  },
+  backgroundColor: [
+    0,
+    0,
+    0
+  ],
+  title: titleDefaultValues
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  text: createSingleOrMultipleTextOption( "text" ),
+  textStyle: {
+    component: "nested-object",
+    label: "Text style",
+    fields: {
+      font: {
+        component: "select",
+        label: "Font name",
+        options: fontNames.map( ( fontName ) => ( {
+          value: fontName,
+          label: fontName
+        } ) )
+      },
+      size: {
+        label: "Size (px)",
+        component: "slider",
+        min: 40,
+        max: 800,
+        step: 1
+      },
+      letterSpacing: {
+        label: "Letter spacing",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      fill: {
+        label: "Fill",
+        component: "color"
+      },
+      stroke: {
+        label: "Stroke",
+        component: "color"
+      },
+      strokeWeight: {
+        label: "Stroke weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      }
+    }
+  },
+  transition: {
+    component: "nested-object",
+    label: "Transition",
+    fields: {
+      easing: {
+        component: "easing",
+        label: "Transition easing function"
+      },
+      pauseRatio: {
+        label: "Pause ratio",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      overlap: {
+        label: "Letter overlap",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      onlyChanged: {
+        label: "Only animate changed letters?",
+        component: "checkbox"
+      }
+    }
+  },
+  mask: {
+    component: "nested-object",
+    label: "Letter mask",
+    fields: {
+      show: {
+        label: "Show mask letter?",
+        component: "checkbox"
+      },
+      easing: {
+        component: "easing",
+        label: "Mask easing function"
+      },
+      maxScale: {
+        label: "Max scale",
+        component: "slider",
+        min: 1,
+        max: 12,
+        step: 0.5
+      },
+      behindLetters: {
+        label: "Draw behind letters?",
+        component: "checkbox"
+      },
+      fill: {
+        label: "Fill",
+        component: "color"
+      },
+      fillAlpha: {
+        label: "Fill alpha",
+        component: "slider",
+        min: 0,
+        max: 255,
+        step: 1
+      },
+      stroke: {
+        label: "Stroke",
+        component: "color"
+      },
+      strokeWeight: {
+        label: "Stroke weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  },
+  title: titleFormConfiguration
+};

--- a/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v1-melted/options.ts
+++ b/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v1-melted/options.ts
@@ -1,0 +1,208 @@
+import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
+import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+
+const AXIS_OPTIONS = [
+  {
+    label: "Vertical",
+    value: "vertical"
+  },
+  {
+    label: "Horizontal",
+    value: "horizontal"
+  }
+];
+
+export const formValues = {
+  layout: {
+    xCount: 1,
+    yCount: 1,
+    sizeDivisor: 3.5,
+    axis: "vertical"
+  },
+  spiral: {
+    lerpSteps: 200,
+    waveAmplitudeDivisor: 3.5,
+    circleSize: 200,
+    cadenceMin: -4,
+    cadenceMax: 4
+  },
+  motion: {
+    cadenceSpeed: 1,
+    cadenceIndexScale: 0
+  },
+  colors: {
+    hueSpeed: 1,
+    hueSpread: 1,
+    huePhase: 0,
+    indexHueShift: 1,
+    shimmer: 1.5,
+    saturation: 1,
+    brightness: 1
+  },
+  backgroundColor: [
+    0,
+    0,
+    0
+  ],
+  title: {
+    ...titleDefaultValues,
+    show: false
+  }
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  layout: {
+    component: "nested-object",
+    label: "Layout",
+    fields: {
+      xCount: {
+        label: "Columns",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      yCount: {
+        label: "Rows",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      sizeDivisor: {
+        label: "Cell size divisor",
+        component: "slider",
+        min: 0.5,
+        max: 20,
+        step: 0.1
+      },
+      axis: {
+        label: "Spiral axis",
+        component: "select",
+        options: AXIS_OPTIONS
+      }
+    }
+  },
+  spiral: {
+    component: "nested-object",
+    label: "Spiral",
+    fields: {
+      lerpSteps: {
+        label: "Samples",
+        component: "slider",
+        min: 1,
+        max: 320,
+        step: 1
+      },
+      waveAmplitudeDivisor: {
+        label: "Wave amplitude divisor",
+        component: "slider",
+        min: 0.1,
+        max: 20,
+        step: 0.1
+      },
+      circleSize: {
+        label: "Disc size",
+        component: "slider",
+        min: 10,
+        max: 600,
+        step: 1
+      },
+      cadenceMin: {
+        label: "Cadence min",
+        component: "slider",
+        min: -20,
+        max: 0,
+        step: 0.1
+      },
+      cadenceMax: {
+        label: "Cadence max",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  motion: {
+    component: "nested-object",
+    label: "Motion",
+    fields: {
+      cadenceSpeed: {
+        label: "Cadence speed",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      cadenceIndexScale: {
+        label: "Cadence index scale",
+        component: "slider",
+        min: 0,
+        max: 5,
+        step: 0.01
+      }
+    }
+  },
+  colors: {
+    component: "nested-object",
+    label: "Colors",
+    fields: {
+      hueSpeed: {
+        label: "Hue speed",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      hueSpread: {
+        label: "Hue spread",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      huePhase: {
+        label: "Hue phase",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      indexHueShift: {
+        label: "Index hue shift",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      shimmer: {
+        label: "Shimmer",
+        component: "slider",
+        min: 0,
+        max: 5,
+        step: 0.1
+      },
+      saturation: {
+        label: "Saturation",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      brightness: {
+        label: "Brightness",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  },
+  title: titleFormConfiguration
+};

--- a/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v2-rabbit-hole/options.ts
+++ b/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v2-rabbit-hole/options.ts
@@ -1,0 +1,231 @@
+import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
+import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+
+export const formValues = {
+  layout: {
+    xCount: 1,
+    yCount: 1,
+    sizeDivisor: 3
+  },
+  rings: {
+    angleSubdivisions: 14,
+    shadowsCount: 30,
+    shadowIndexStep: 0.05,
+    radiusDivisorMin: 0.2,
+    radiusDivisorMax: 5,
+    weightMin: 20,
+    weightMax: 75,
+    shadowRotationRadians: 7
+  },
+  motion: {
+    spinSpeed: 1,
+    jitterAmount: 0.33
+  },
+  colors: {
+    hueSpeed: 1,
+    hueSpread: 1,
+    huePhase: 0,
+    depthHue: 1,
+    saturation: 1,
+    brightness: 1,
+    opacityCurveSpeed: 5,
+    opacityMin: 1,
+    opacityMax: 15
+  },
+  backgroundColor: [
+    0,
+    0,
+    0
+  ],
+  title: {
+    ...titleDefaultValues,
+    show: false
+  }
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  layout: {
+    component: "nested-object",
+    label: "Layout",
+    fields: {
+      xCount: {
+        label: "Columns",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      yCount: {
+        label: "Rows",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      sizeDivisor: {
+        label: "Cell size divisor",
+        component: "slider",
+        min: 0.5,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  rings: {
+    component: "nested-object",
+    label: "Rings",
+    fields: {
+      angleSubdivisions: {
+        label: "Angle subdivisions",
+        component: "slider",
+        min: 1,
+        max: 64,
+        step: 1
+      },
+      shadowsCount: {
+        label: "Depth (shadows count)",
+        component: "slider",
+        min: 0,
+        max: 200,
+        step: 1
+      },
+      shadowIndexStep: {
+        label: "Shadow index step",
+        component: "slider",
+        min: 0.01,
+        max: 0.5,
+        step: 0.01
+      },
+      radiusDivisorMin: {
+        label: "Radius divisor min",
+        component: "slider",
+        min: 0.05,
+        max: 10,
+        step: 0.05
+      },
+      radiusDivisorMax: {
+        label: "Radius divisor max",
+        component: "slider",
+        min: 0.1,
+        max: 20,
+        step: 0.1
+      },
+      weightMin: {
+        label: "Dot weight min",
+        component: "slider",
+        min: 1,
+        max: 200,
+        step: 1
+      },
+      weightMax: {
+        label: "Dot weight max",
+        component: "slider",
+        min: 1,
+        max: 300,
+        step: 1
+      },
+      shadowRotationRadians: {
+        label: "Shadow rotation",
+        component: "slider",
+        min: -20,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  motion: {
+    component: "nested-object",
+    label: "Motion",
+    fields: {
+      spinSpeed: {
+        label: "Spin speed",
+        component: "slider",
+        min: -10,
+        max: 10,
+        step: 0.1
+      },
+      jitterAmount: {
+        label: "Jitter amount",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  colors: {
+    component: "nested-object",
+    label: "Colors",
+    fields: {
+      hueSpeed: {
+        label: "Hue speed",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      hueSpread: {
+        label: "Hue spread",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      huePhase: {
+        label: "Hue phase",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      depthHue: {
+        label: "Depth hue shift",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      saturation: {
+        label: "Saturation",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      brightness: {
+        label: "Brightness",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      opacityCurveSpeed: {
+        label: "Opacity curve speed",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      },
+      opacityMin: {
+        label: "Opacity min",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.1
+      },
+      opacityMax: {
+        label: "Opacity max",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.1
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  },
+  title: titleFormConfiguration
+};

--- a/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v3-medusa/options.ts
+++ b/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v3-medusa/options.ts
@@ -1,0 +1,349 @@
+import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
+import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+
+export const formValues = {
+  layout: {
+    xCount: 1,
+    yCount: 1,
+    sizeDivisor: 3
+  },
+  rings: {
+    angleSubdivisions: 6,
+    linesCount: 3,
+    shadowsCount: 10,
+    shadowIndexStep: 0.03,
+    radiusDivisorMin: 1,
+    radiusDivisorMax: 5,
+    lineSizeMin: 50,
+    lineSizeMax: 150
+  },
+  motion: {
+    spinSpeed: 1,
+    rotationSpeed: 3,
+    rotationMaxMin: 1,
+    rotationMaxMax: 5
+  },
+  colors: {
+    weightMaxMin: 50,
+    weightMaxMax: 100,
+    hueSpeed: 1,
+    hueSpread: 1,
+    huePhase: 0,
+    depthHue: 1,
+    saturation: 1,
+    brightness: 1,
+    opacityFalloffMin: 1,
+    opacityFalloffMax: 5
+  },
+  endcap: {
+    weight: 4,
+    darken: 32
+  },
+  glow: {
+    enabled: true,
+    ringsCount: 15,
+    sizeMin: 0.166,
+    sizeMax: 1,
+    orbitRadius: 30,
+    orbitSpeed: 5,
+    color: [
+      128,
+      128,
+      255
+    ],
+    strokeWeight: 4
+  },
+  backgroundColor: [
+    0,
+    0,
+    0
+  ],
+  title: {
+    ...titleDefaultValues,
+    show: false
+  }
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  layout: {
+    component: "nested-object",
+    label: "Layout",
+    fields: {
+      xCount: {
+        label: "Columns",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      yCount: {
+        label: "Rows",
+        component: "slider",
+        min: 1,
+        max: 20,
+        step: 1
+      },
+      sizeDivisor: {
+        label: "Cell size divisor",
+        component: "slider",
+        min: 0.5,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  rings: {
+    component: "nested-object",
+    label: "Rings",
+    fields: {
+      angleSubdivisions: {
+        label: "Tentacle directions",
+        component: "slider",
+        min: 1,
+        max: 64,
+        step: 1
+      },
+      linesCount: {
+        label: "Dots per cluster",
+        component: "slider",
+        min: 1,
+        max: 32,
+        step: 1
+      },
+      shadowsCount: {
+        label: "Depth (shadows count)",
+        component: "slider",
+        min: 0,
+        max: 200,
+        step: 1
+      },
+      shadowIndexStep: {
+        label: "Shadow index step",
+        component: "slider",
+        min: 0.01,
+        max: 0.5,
+        step: 0.01
+      },
+      radiusDivisorMin: {
+        label: "Radius divisor min",
+        component: "slider",
+        min: 0.05,
+        max: 10,
+        step: 0.05
+      },
+      radiusDivisorMax: {
+        label: "Radius divisor max",
+        component: "slider",
+        min: 0.1,
+        max: 20,
+        step: 0.1
+      },
+      lineSizeMin: {
+        label: "Line size min",
+        component: "slider",
+        min: 1,
+        max: 400,
+        step: 1
+      },
+      lineSizeMax: {
+        label: "Line size max",
+        component: "slider",
+        min: 1,
+        max: 600,
+        step: 1
+      }
+    }
+  },
+  motion: {
+    component: "nested-object",
+    label: "Motion",
+    fields: {
+      spinSpeed: {
+        label: "Spin speed",
+        component: "slider",
+        min: -10,
+        max: 10,
+        step: 0.1
+      },
+      rotationSpeed: {
+        label: "Rotation speed",
+        component: "slider",
+        min: -10,
+        max: 10,
+        step: 0.1
+      },
+      rotationMaxMin: {
+        label: "Rotation depth min",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      },
+      rotationMaxMax: {
+        label: "Rotation depth max",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  colors: {
+    component: "nested-object",
+    label: "Colors",
+    fields: {
+      weightMaxMin: {
+        label: "Base weight min",
+        component: "slider",
+        min: 1,
+        max: 300,
+        step: 1
+      },
+      weightMaxMax: {
+        label: "Base weight max",
+        component: "slider",
+        min: 1,
+        max: 400,
+        step: 1
+      },
+      hueSpeed: {
+        label: "Hue speed",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      hueSpread: {
+        label: "Hue spread",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      huePhase: {
+        label: "Hue phase",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      depthHue: {
+        label: "Depth hue shift",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      },
+      saturation: {
+        label: "Saturation",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      brightness: {
+        label: "Brightness",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      opacityFalloffMin: {
+        label: "Opacity falloff min",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      },
+      opacityFalloffMax: {
+        label: "Opacity falloff max",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      }
+    }
+  },
+  endcap: {
+    component: "nested-object",
+    label: "Endcap",
+    fields: {
+      weight: {
+        label: "Endcap weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      },
+      darken: {
+        label: "Endcap darken",
+        component: "slider",
+        min: 0,
+        max: 255,
+        step: 1
+      }
+    }
+  },
+  glow: {
+    component: "nested-object",
+    label: "Glow",
+    fields: {
+      enabled: {
+        label: "Enable glow?",
+        component: "checkbox"
+      },
+      ringsCount: {
+        label: "Glow rings count",
+        component: "slider",
+        min: 1,
+        max: 64,
+        step: 1
+      },
+      sizeMin: {
+        label: "Glow size min",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      sizeMax: {
+        label: "Glow size max",
+        component: "slider",
+        min: 0,
+        max: 3,
+        step: 0.01
+      },
+      orbitRadius: {
+        label: "Orbit radius (px)",
+        component: "slider",
+        min: 0,
+        max: 300,
+        step: 1
+      },
+      orbitSpeed: {
+        label: "Orbit speed",
+        component: "slider",
+        min: 0,
+        max: 20,
+        step: 0.1
+      },
+      color: {
+        label: "Glow color",
+        component: "color"
+      },
+      strokeWeight: {
+        label: "Glow stroke weight",
+        component: "slider",
+        min: 0,
+        max: 50,
+        step: 0.5
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  },
+  title: titleFormConfiguration
+};


### PR DESCRIPTION
## Summary

Wires the shared interaction layer (`@/p5/utils/interaction`) into the `audio/ping-pong` sketch so it responds to **fingers (camera), mouse, touch, and gyroscope tilt**.

Each live pointer drives an **extra ball** that simply tracks it, clamped to the canvas. The **canvas boundary is the only collision that always makes a sound**: whenever any ball — the automatic one or an interactive one — reaches a wall it plays a bip (pitch mapped to where along the wall it landed) and emits a flash. Optionally, ball-to-ball contact can play a bip too.

## What changed

**`options.ts`**
- New **"Balls"** category:
  - **Mode** select — `Only automatic ball` (default) · `Auto ball + interactive` · `Interactive only`. In `auto` mode pointers are ignored, so the deterministic ball and beat are byte-for-byte unchanged.
  - **Ball-to-ball collision sound** toggle (default off).
- **Interaction** panel curated to the four requested sources (Vision trimmed to *fingers*), plus the debug Visualization block. **Mouse + touch default on** so switching the mode to interactive works instantly; **vision + gyro stay off** until permission is granted.

**`index.js`**
- `initInteraction(...)` in setup, `getPointers(...)` in draw, `disposeInteraction()` on cleanup (matching the `audio/audio-features` sibling).
- Builds a per-frame ball list (auto + one per pointer); wall hits and ball-to-ball overlaps are **edge-triggered** so they bip once on contact, not every frame.

## How it behaves

- **Auto (default):** unchanged deterministic ball + wall beat.
- **Auto + interactive / Interactive only:** move a pointer to drive a ball; shove it into an edge to play a wall bip. Enable *Ball-to-ball collision sound* for bips when balls meet.
- Camera (fingers) and gyroscope can be enabled in the Interaction panel when you want them.

## Testing

- `eslint` clean on both files.
- `jest src/templates/__tests__/sketches.test.ts` → 908 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sqo7CA7iAs36xpwApVYx2