### PR TITLE
perf(template-options): code-split FieldRenderer out of sketch-page i…

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
@@ -1,8 +1,19 @@
+import dynamic from "next/dynamic";
 import {
   FieldConfig
 } from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
 
-import FieldRenderer from "@/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer";
+// FieldRenderer is the heavy hub of the option form: it statically pulls in all
+// nine Controlled* inputs and recurses through ItemListRenderer (a large
+// subtree). Every always-mounted panel — RootSettings (general settings),
+// SketchSettings, and the mobile drawer — reaches it through this single
+// import, so a *static* import here drags the whole subtree into the sketch
+// page's initial compile even though all three panels gate their forms behind a
+// collapsed-by-default CollapsibleItem. Loading it as a separate chunk lets the
+// dev server skip compiling it until a settings section is actually expanded —
+// the same code-split rationale as OptionsPanel's collapsed sections. The
+// CollapsibleItem chrome stays static, so there is no loading flash on open.
+const FieldRenderer = dynamic( () => import( "@/components/ClientProcessingSketch/components/TemplateOptions/components/FieldRenderer" ) );
 
 type GenericObjectFormProps = {
   basePath?: string;


### PR DESCRIPTION
…nitial compile

GenericObjectForm imported FieldRenderer statically. FieldRenderer is the heavy hub of the option form — it statically pulls in all nine Controlled* inputs and recurses through ItemListRenderer (a large subtree). All three always-mounted panels (RootSettings, SketchSettings, mobile drawer) reach it through this single import, so the static edge dragged the whole subtree into the sketch page's initial dev-server compile, even though every panel gates its form behind a collapsed-by-default CollapsibleItem whose content never mounts until expanded.

Load FieldRenderer via next/dynamic so the subtree compiles only when a settings section is actually opened — the same code-split rationale already applied to OptionsPanel's collapsed sections (ContentItems/SlideCarousel/ SlideEditor). The CollapsibleItem chrome stays static, so there is no loading flash on open.