### PR TITLE
feat(slides): montage staggering + dip transition style

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SlideTransitionSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SlideTransitionSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {
-  useState
+  Fragment, useState
 } from "react";
 import {
   ChevronDown
@@ -13,10 +13,12 @@ import {
   SketchOptionInput,
   SlideTransitionSchema,
   TRANSITION_LOOP_MODES,
-  TRANSITION_SOURCE_MODES
+  TRANSITION_SOURCE_MODES,
+  TRANSITION_STYLES
 } from "@/types/sketch.types";
 import ControlledEasingInput from "./ContentItems/components/ControlledEasingInput/ControlledEasingInput";
 import ControlledSliderInput from "./ContentItems/components/ControlledSliderInput/ControlledSliderInput";
+import ControlledColorInput from "./ContentItems/components/ControlledColorInput/ControlledColorInput";
 import ControlledSlideMultiSelect from "./ContentItems/components/ControlledSlideMultiSelect/ControlledSlideMultiSelect";
 import {
   BarLabelSegment
@@ -36,6 +38,11 @@ const LOOP_LABELS: Record<( typeof TRANSITION_LOOP_MODES )[ number ], string> = 
   cyclic: "Cyclic (loops)",
   pingpong: "Ping-pong",
   once: "Once (hold last)"
+};
+
+const STYLE_LABELS: Record<( typeof TRANSITION_STYLES )[ number ], string> = {
+  morph: "Morph (interpolate)",
+  dip: "Dip (fade + snap)"
 };
 
 /** One-line native <select> sharing the control-bar chrome. */
@@ -156,6 +163,7 @@ export default function SlideTransitionSettings( {
 
   const enabled = Boolean( transition?.enabled );
   const sources = ( transition?.sources as string ) ?? "all";
+  const style = ( transition?.style as string ) ?? "morph";
 
   const handleToggle = ( on: boolean ) => {
     if ( on ) {
@@ -216,6 +224,15 @@ export default function SlideTransitionSettings( {
             />
           )}
 
+          <BarSelect
+            name={ `${ base }.style` }
+            label="Style"
+            options={ TRANSITION_STYLES.map( ( value ) => ( {
+              value,
+              label: STYLE_LABELS[ value ]
+            } ) ) }
+          />
+
           <ControlledEasingInput name={ `${ base }.easing` } label="Easing" />
 
           <ControlledSliderInput
@@ -235,13 +252,39 @@ export default function SlideTransitionSettings( {
             } ) ) }
           />
 
-          <SnapKeysInput name={ `${ base }.snapKeys` } />
+          {style === "morph" ? (
+            <Fragment>
+              <ControlledSliderInput
+                name={ `${ base }.stagger` }
+                label="Stagger"
+                min={ 0 }
+                max={ 0.9 }
+                step={ 0.05 }
+              />
 
-          <p className="px-1 pt-0.5 text-[0.65rem] leading-snug text-label">
-            Morphs the source slides&apos; parameters over this slide&apos;s
-            duration. Numbers &amp; colours interpolate; discrete params (seed,
-            modes) should be listed under Snap.
-          </p>
+              <SnapKeysInput name={ `${ base }.snapKeys` } />
+
+              <p className="px-1 pt-0.5 text-[0.65rem] leading-snug text-label">
+                Morphs the source slides&apos; parameters over this slide&apos;s
+                duration. Numbers &amp; colours interpolate; discrete params
+                (seed, modes) should be listed under Snap. Stagger offsets each
+                param group so they don&apos;t all move at once.
+              </p>
+            </Fragment>
+          ) : (
+            <Fragment>
+              <ControlledColorInput
+                name={ `${ base }.dipColor` }
+                label="Dip color"
+              />
+
+              <p className="px-1 pt-0.5 text-[0.65rem] leading-snug text-label">
+                Snaps between source slides, fading through the dip colour at
+                each switch. Use for variants too different to interpolate
+                (seed, layout).
+              </p>
+            </Fragment>
+          )}
         </div>
       )}
     </div>

--- a/src/templates/p5/utils/__tests__/lerpParams.test.ts
+++ b/src/templates/p5/utils/__tests__/lerpParams.test.ts
@@ -1,4 +1,6 @@
-import lerpParamsImpl from "@/p5/utils/slides/morph/lerpParams.js";
+import lerpParamsImpl, {
+  lerpParamsStaggered as lerpParamsStaggeredImpl
+} from "@/p5/utils/slides/morph/lerpParams.js";
 
 // The util is untyped JS; give it a call signature so the assertions below can
 // read the dynamic result shape.
@@ -7,6 +9,14 @@ const lerpParams = lerpParamsImpl as (
   to: Record<string, unknown>,
   t: number,
   snapKeys?: string[]
+) => any;
+
+const lerpParamsStaggered = lerpParamsStaggeredImpl as (
+  from: Record<string, unknown>,
+  to: Record<string, unknown>,
+  t: number,
+  snapKeys?: string[],
+  spread?: number
 ) => any;
 
 describe(
@@ -296,6 +306,136 @@ describe(
 
         expect( out.only ).toBe( 5 );
         expect( out.other ).toBe( 9 );
+      }
+    );
+  }
+);
+
+describe(
+  "lerpParamsStaggered",
+  () => {
+    test(
+      "matches a plain lerp when spread is 0",
+      () => {
+        expect( lerpParamsStaggered(
+          {
+            a: 0,
+            b: 0
+          },
+          {
+            a: 10,
+            b: 10
+          },
+          0.5,
+          [],
+          0
+        ) ).toEqual( {
+          a: 5,
+          b: 5
+        } );
+      }
+    );
+
+    test(
+      "falls back to a plain lerp with a single group",
+      () => {
+        expect( lerpParamsStaggered(
+          {
+            a: 0
+          },
+          {
+            a: 10
+          },
+          0.5,
+          [],
+          0.5
+        ) ).toEqual( {
+          a: 5
+        } );
+      }
+    );
+
+    test(
+      "offsets groups so the leading one is ahead of the trailing one",
+      () => {
+        // keys [a, b], spread 0.5, global 0.5 → a done, b not started.
+        expect( lerpParamsStaggered(
+          {
+            a: 0,
+            b: 0
+          },
+          {
+            a: 10,
+            b: 10
+          },
+          0.5,
+          [],
+          0.5
+        ) ).toEqual( {
+          a: 10,
+          b: 0
+        } );
+      }
+    );
+
+    test(
+      "all groups settle at the segment endpoints",
+      () => {
+        const from = {
+          a: 0,
+          b: 0
+        };
+        const to = {
+          a: 10,
+          b: 10
+        };
+
+        expect( lerpParamsStaggered(
+          from,
+          to,
+          0,
+          [],
+          0.5
+        ) ).toEqual( {
+          a: 0,
+          b: 0
+        } );
+        expect( lerpParamsStaggered(
+          from,
+          to,
+          1,
+          [],
+          0.5
+        ) ).toEqual( {
+          a: 10,
+          b: 10
+        } );
+      }
+    );
+
+    test(
+      "still honours snapKeys within a staggered group",
+      () => {
+        // keys [x, seed]; at global 0.6 the trailing seed group is < 0.5 so it
+        // snaps to `from`, while x has already completed.
+        const out = lerpParamsStaggered(
+          {
+            x: 0,
+            seed: 1
+          },
+          {
+            x: 10,
+            seed: 9
+          },
+          0.6,
+          [
+            "seed"
+          ],
+          0.5
+        );
+
+        expect( out.x ).toBe( 10 );
+        expect( out.seed ).toBe( 1 );
       }
     );
   }

--- a/src/templates/p5/utils/__tests__/staggeredProgress.test.ts
+++ b/src/templates/p5/utils/__tests__/staggeredProgress.test.ts
@@ -1,0 +1,80 @@
+import staggeredProgress from "@/p5/utils/slides/morph/staggeredProgress.js";
+
+describe(
+  "staggeredProgress",
+  () => {
+    test(
+      "is the identity when spread is 0",
+      () => {
+        expect( staggeredProgress(
+          0.5,
+          0.3,
+          0
+        ) ).toBe( 0.5 );
+      }
+    );
+
+    test(
+      "leading group (keyPos 0) runs ahead, trailing group (keyPos 1) lags",
+      () => {
+        // spread 0.5 → span 0.5.
+        // keyPos 0: start 0   → (0.25)/0.5 = 0.5
+        expect( staggeredProgress(
+          0.25,
+          0,
+          0.5
+        ) ).toBeCloseTo( 0.5 );
+
+        // keyPos 1: start 0.5 → (0.5-0.5)/0.5 = 0 at global 0.5, 0.5 at global 0.75
+        expect( staggeredProgress(
+          0.5,
+          1,
+          0.5
+        ) ).toBe( 0 );
+        expect( staggeredProgress(
+          0.75,
+          1,
+          0.5
+        ) ).toBeCloseTo( 0.5 );
+      }
+    );
+
+    test(
+      "every group settles to 0 at global 0 and 1 at global 1",
+      () => {
+        for ( const keyPos of [
+          0,
+          0.5,
+          1
+        ] ) {
+          expect( staggeredProgress(
+            0,
+            keyPos,
+            0.5
+          ) ).toBe( 0 );
+          expect( staggeredProgress(
+            1,
+            keyPos,
+            0.5
+          ) ).toBe( 1 );
+        }
+      }
+    );
+
+    test(
+      "spread of 1 degenerates to a step at the group's start",
+      () => {
+        expect( staggeredProgress(
+          0.4,
+          0.5,
+          1
+        ) ).toBe( 0 );
+        expect( staggeredProgress(
+          0.6,
+          0.5,
+          1
+        ) ).toBe( 1 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -11,6 +11,7 @@ import {
 } from "./layouts";
 
 import getMontageSketch from "./morph/index.js";
+import drawMontageDip from "./morph/drawMontageDip.js";
 
 import {
   coerceFramerate
@@ -43,6 +44,7 @@ const slides = {
       () => {
         slides.renderCurrentSlide();
         slides.render( options );
+        slides.renderMontageOverlay();
       }
     );
 
@@ -202,6 +204,19 @@ const slides = {
       return;
     }
     this.render( slide );
+  },
+
+  // Draw the montage "dip" fade on top of everything when the current slide is
+  // a dip-style montage. Morph-style montages need no overlay.
+  renderMontageOverlay() {
+    const slide = this.current;
+
+    if ( slide?.transition?.enabled && slide.transition.style === "dip" ) {
+      drawMontageDip(
+        slide,
+        options?.slides || []
+      );
+    }
   },
 
   /**

--- a/src/templates/p5/utils/slides/morph/drawMontageDip.js
+++ b/src/templates/p5/utils/slides/morph/drawMontageDip.js
@@ -1,0 +1,81 @@
+import sketch, {
+  getP5
+} from "../../sketch.js";
+import animation from "../../animation.js";
+import resolveMontageSources from "./resolveMontageSources.js";
+import {
+  mapProgressionToSegment
+} from "./segmentMapper.js";
+
+/**
+ * Draw the "dip" overlay for a montage slide whose style is "dip": a full-canvas
+ * fade to dipColor that peaks at each segment's midpoint, hiding the hard param
+ * switch underneath (see getMontageSketch, which snaps params at the same
+ * midpoint). Drawn last, on top of the sketch and its content overlays.
+ *
+ * No-op for non-dip montages or when fewer than two sources resolve.
+ */
+export default function drawMontageDip(
+  montageSlide, allSlides
+) {
+  const transition = montageSlide?.transition;
+
+  if ( !transition?.enabled || transition.style !== "dip" ) {
+    return;
+  }
+
+  const sources = resolveMontageSources(
+    montageSlide,
+    allSlides
+  );
+
+  if ( sources.length < 2 ) {
+    return;
+  }
+
+  const {
+    localT
+  } = mapProgressionToSegment(
+    animation.progression,
+    sources.length,
+    transition
+  );
+
+  // 0 at the segment edges (and through the hold), full at the midpoint switch.
+  const alpha = Math.sin( Math.PI * localT ) * 255;
+
+  if ( alpha <= 0 ) {
+    return;
+  }
+
+  const p = getP5();
+  const color = Array.isArray( transition.dipColor ) ? transition.dipColor : [
+    0,
+    0,
+    0
+  ];
+
+  p.push();
+
+  if ( sketch.sketchOptions?.type === "webgl" ) {
+    p.translate(
+      -p.width / 2,
+      -p.height / 2
+    );
+  }
+
+  p.noStroke();
+  p.fill(
+    color[ 0 ],
+    color[ 1 ],
+    color[ 2 ],
+    alpha
+  );
+  p.rect(
+    0,
+    0,
+    p.width,
+    p.height
+  );
+  p.pop();
+}

--- a/src/templates/p5/utils/slides/morph/index.js
+++ b/src/templates/p5/utils/slides/morph/index.js
@@ -3,7 +3,9 @@ import resolveMontageSources from "./resolveMontageSources.js";
 import {
   mapProgressionToSegment
 } from "./segmentMapper.js";
-import lerpParams from "./lerpParams.js";
+import lerpParams, {
+  lerpParamsStaggered
+} from "./lerpParams.js";
 
 /**
  * Compute the effective sketch settings for a montage (transition) slide at the
@@ -65,10 +67,30 @@ export default function getMontageSketch(
     ...( sources[ toIndex ].sketch ?? {} )
   };
 
+  // Dip style: don't interpolate — snap at the segment midpoint (where the fade
+  // to dipColor peaks, drawn separately by drawMontageDip). Robust for variants
+  // whose structure is too different to morph.
+  if ( transition.style === "dip" ) {
+    return localT < 0.5 ? fromSketch : toSketch;
+  }
+
+  const snapKeys = Array.isArray( transition.snapKeys ) ? transition.snapKeys : [];
+  const stagger = transition.stagger ?? 0;
+
+  if ( stagger > 0 ) {
+    return lerpParamsStaggered(
+      fromSketch,
+      toSketch,
+      localT,
+      snapKeys,
+      stagger
+    );
+  }
+
   return lerpParams(
     fromSketch,
     toSketch,
     localT,
-    Array.isArray( transition.snapKeys ) ? transition.snapKeys : []
+    snapKeys
   );
 }

--- a/src/templates/p5/utils/slides/morph/lerpParams.js
+++ b/src/templates/p5/utils/slides/morph/lerpParams.js
@@ -17,6 +17,8 @@
  * Pure: no p5 / DOM dependency, so it is unit-testable in node.
  */
 
+import staggeredProgress from "./staggeredProgress.js";
+
 function isPlainObject( value ) {
   return value != null && typeof value === "object" && !Array.isArray( value );
 }
@@ -125,6 +127,60 @@ export default function lerpParams(
       snapKeys
     );
   }
+
+  return out;
+}
+
+/**
+ * Like lerpParams, but each TOP-LEVEL param group gets its own phase-shifted
+ * progress so groups don't morph in lockstep (`spread` 0..~0.9). Group order
+ * follows key order: the first leads, the last trails. Falls back to a plain
+ * lerp when there is nothing to stagger.
+ */
+export function lerpParamsStaggered(
+  from, to, t, snapKeys = [], spread = 0
+) {
+  const source = from ?? {};
+  const target = to ?? {};
+  const keys = [
+    ...new Set( [
+      ...Object.keys( source ),
+      ...Object.keys( target )
+    ] )
+  ];
+
+  if ( spread <= 0 || keys.length <= 1 ) {
+    return lerpParams(
+      source,
+      target,
+      t,
+      snapKeys
+    );
+  }
+
+  const denom = keys.length - 1;
+  const out = {};
+
+  keys.forEach( (
+    key, index
+  ) => {
+    const groupT = staggeredProgress(
+      t,
+      index / denom,
+      spread
+    );
+
+    out[ key ] = lerpParams(
+      {
+        [ key ]: source[ key ]
+      },
+      {
+        [ key ]: target[ key ]
+      },
+      groupT,
+      snapKeys
+    )[ key ];
+  } );
 
   return out;
 }

--- a/src/templates/p5/utils/slides/morph/staggeredProgress.js
+++ b/src/templates/p5/utils/slides/morph/staggeredProgress.js
@@ -1,0 +1,33 @@
+function clamp01( value ) {
+  if ( !Number.isFinite( value ) ) {
+    return 0;
+  }
+
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
+/**
+ * Remap a global 0..1 morph progress to a per-group progress, so groups don't
+ * all move in lockstep. `keyPos` is the group's normalised position (0..1):
+ * group 0 leads, the last group trails by `spread`. Mirrors the
+ * `staggeredProgress` used elsewhere in the sketches (spline-text/_shared.js).
+ *
+ * At global 0 every group is at 0; at global 1 every group is at 1, so segment
+ * boundaries always settle cleanly.
+ */
+export default function staggeredProgress(
+  global, keyPos, spread
+) {
+  if ( spread <= 0 ) {
+    return clamp01( global );
+  }
+
+  const start = keyPos * spread;
+  const span = 1 - spread;
+
+  if ( span <= 0 ) {
+    return global >= start ? 1 : 0;
+  }
+
+  return clamp01( ( global - start ) / span );
+}

--- a/src/types/__tests__/slideTransition.test.ts
+++ b/src/types/__tests__/slideTransition.test.ts
@@ -40,10 +40,17 @@ describe(
         expect( t.enabled ).toBe( false );
         expect( t.sources ).toBe( "all" );
         expect( t.slideIds ).toEqual( [] );
+        expect( t.style ).toBe( "morph" );
         expect( t.loop ).toBe( "cyclic" );
         expect( t.holdRatio ).toBeGreaterThanOrEqual( 0 );
+        expect( t.stagger ).toBe( 0 );
         expect( t.snapKeys ).toEqual( [
           "seed"
+        ] );
+        expect( t.dipColor ).toEqual( [
+          0,
+          0,
+          0
         ] );
       }
     );

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -823,6 +823,11 @@ export const TRANSITION_LOOP_MODES = [
   "once"
 ] as const;
 
+export const TRANSITION_STYLES = [
+  "morph",
+  "dip"
+] as const;
+
 // A "montage" slide morphs the sketch parameters of several OTHER slides into
 // one another over its own duration, in a loop. Only the sources' `sketch`
 // params are interpolated — the montage keeps its own size/animation, so source
@@ -839,6 +844,12 @@ export const SlideTransitionSchema = z.object( {
   // are filtered at runtime. Ignored when sources === "all".
   slideIds: z.array( z.string() ).default( [] ),
 
+  // "morph" = interpolate params between sources (numbers/colours lerp).
+  // "dip"   = snap params at the segment midpoint, hidden behind a fade to
+  //           dipColor — the robust choice for non-morphable variants whose
+  //           seed/layout/structure differ too much to interpolate.
+  style: z.enum( TRANSITION_STYLES ).default( "morph" ),
+
   // Easing key from easing.js (e.g. "linear", "easeInOutCubic").
   easing: z.string().default( "easeInOutCubic" ),
 
@@ -850,11 +861,26 @@ export const SlideTransitionSchema = z.object( {
 
   loop: z.enum( TRANSITION_LOOP_MODES ).default( "cyclic" ),
 
-  // Param paths (dotted, or a leaf name like "seed") that SNAP at the segment
-  // boundary instead of interpolating — for discrete params (random seeds,
-  // enums, integer counts) or params that invalidate a heavy per-frame cache.
+  // morph only — spread [0..0.9] of the per-group phase offset, so top-level
+  // param groups don't all morph in lockstep (e.g. colours lead, geometry
+  // follows). 0 = every group morphs together.
+  stagger: z.number().min( 0 )
+    .max( 0.9 )
+    .default( 0 ),
+
+  // morph only — param paths (dotted, or a leaf name like "seed") that SNAP at
+  // the segment boundary instead of interpolating: discrete params (random
+  // seeds, enums, integer counts) or params that invalidate a heavy per-frame
+  // cache.
   snapKeys: z.array( z.string() ).default( [
     "seed"
+  ] ),
+
+  // dip only — the colour the canvas fades through while params switch.
+  dipColor: RGBA.default( [
+    0,
+    0,
+    0
   ] )
 } );
 


### PR DESCRIPTION
## What & why

Phase 3 refinements on top of the merged montage slide (#182). Two of the three follow-ups we discussed — the **feasible** ones. True crossfade (a real A→B dissolve) is intentionally **not** here: it would need offscreen rendering of two variants per frame (a cross-cutting refactor of every sketch), so it stays a separate, larger effort. The **dip** style below covers the same need — transitioning between variants too different to interpolate — without that cost.

## 1. Staggering (morph style)

A `stagger` knob (0–0.9) offsets each **top-level param group**'s morph in time, so groups don't all move in lockstep — e.g. colours lead, geometry follows. Richer than a monolithic morph.

- New pure `lerpParamsStaggered` phase-shifts each group via a `staggeredProgress` helper (mirrors the existing one in `spline-text/_shared.js`).
- Every group still settles exactly at the segment boundaries (0 at the start, 1 at the end), so loops stay seamless.
- `snapKeys` are still honoured per group.

## 2. Dip transition (`style: "dip"`)

For variants whose seed/layout/structure differ too much to interpolate, params **snap** at the segment midpoint, hidden behind a full-canvas **fade through `dipColor`** that peaks exactly at the switch.

- `drawMontageDip` draws the fade last in `post-draw` (over the sketch and its overlays); alpha follows `sin(π·localT)` so it's 0 at the segment edges and through the hold, full at the midpoint.
- Param snap and fade peak read the same `localT`, so they're always in sync.
- **Single render per frame** — no offscreen buffers, unlike a true crossfade.

## Schema & UI

- `SlideTransitionSchema` gains `style`, `stagger`, `dipColor` — all defaulted, so existing montages heal to `style: "morph"` on load (no behaviour change).
- The slide panel gets a **Style** picker and swaps the morph-only controls (Stagger, Snap) for the **Dip color** picker when dip is selected.

## Behaviour notes

- `easing`, `hold` and `loop` apply to both styles; `stagger`/`snapKeys` are morph-only, `dipColor` is dip-only.
- Default montage behaviour is unchanged (`style: "morph"`, `stagger: 0` → the same plain lerp as before).

## Files

- Runtime: `slides/morph/{staggeredProgress,drawMontageDip}.js` (new), `lerpParams.js` (+`lerpParamsStaggered`), `morph/index.js`, `slides/index.js` (dip overlay hook)
- Schema/UI: `sketch.types.ts`, `SlideTransitionSettings.tsx`

## Testing

- New unit tests: `staggeredProgress` (windowing, endpoints, degenerate spread) and `lerpParamsStaggered` (group offset, endpoints, snap-within-group); schema defaults extended.
- Full suite green: **1217 tests pass**; lint and `tsc` clean on all changed files.
- Not yet exercised in-browser (deps install is network-limited here). Suggested visual pass: morph + Stagger > 0 (groups move at offset times); a deck with very different seeds → Dip style (clean fade-through-colour switches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc68H7Po3FePV3PWS3okSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc68H7Po3FePV3PWS3okSY)_