### PR TITLE
feat(interaction): hand/face gesture channels for the binding system

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
@@ -456,6 +456,25 @@ export function interactionEnablePaths( source: string ): string[] {
     ];
   }
 
+  // Semantic hand gesture scalars (hands.openness, hands.fingers, hands.pinch …):
+  // camera on + the hand tracker (the gesture metrics read its landmarks).
+  if ( source.startsWith( "hands." ) ) {
+    return [
+      "enabled",
+      "vision.enabled",
+      "vision.hands.enabled"
+    ];
+  }
+
+  // Semantic face gesture scalars (face.count, face.depth): camera + face tracker.
+  if ( source.startsWith( "face." ) ) {
+    return [
+      "enabled",
+      "vision.enabled",
+      "vision.face.enabled"
+    ];
+  }
+
   switch ( source ) {
     case "hands":
     case "fingers":

--- a/src/templates/p5/utils/interaction/__tests__/gestureMath.test.ts
+++ b/src/templates/p5/utils/interaction/__tests__/gestureMath.test.ts
@@ -1,0 +1,352 @@
+import {
+  clamp,
+  countFingersUp,
+  faceDepthFromBox,
+  GESTURE_SOURCE_IDS,
+  gestureChannelValues,
+  handMetricsFromLandmarks,
+  mapClamp
+} from "../gestureMath.js";
+import {
+  INTERACTION_SOURCES
+} from "../sources.js";
+
+type Pt = { x: number;
+  y: number;
+  z: number };
+
+// Build a 21-entry landmark array, overriding the indices the math reads.
+function hand( overrides: Record<number, [number, number]> ): Pt[] {
+  const points: Pt[] = Array.from(
+    {
+      length: 21
+    },
+    () => ( {
+      x: 0.5,
+      y: 0.5,
+      z: 0
+    } )
+  );
+
+  for ( const [
+    index,
+    [
+      x,
+      y
+    ]
+  ] of Object.entries( overrides ) ) {
+    points[ Number( index ) ] = {
+      x,
+      y,
+      z: 0
+    };
+  }
+
+  return points;
+}
+
+// Wrist (0) and palm ref (9) give a hand "scale" of 0.30 → near the camera.
+const COMMON = {
+  0: [
+    0.5,
+    0.95
+  ] as [number, number],
+  9: [
+    0.5,
+    0.65
+  ] as [number, number],
+  5: [
+    0.44,
+    0.62
+  ] as [number, number],
+  13: [
+    0.56,
+    0.62
+  ] as [number, number],
+  17: [
+    0.61,
+    0.63
+  ] as [number, number]
+};
+
+const OPEN_HAND = hand( {
+  ...COMMON,
+  8: [
+    0.42,
+    0.30
+  ], // index tip
+  12: [
+    0.50,
+    0.26
+  ], // middle tip
+  16: [
+    0.58,
+    0.30
+  ], // ring tip
+  20: [
+    0.64,
+    0.34
+  ], // pinky tip
+  4: [
+    0.18,
+    0.45
+  ] // thumb tip, out to the side
+} );
+
+const FIST = hand( {
+  ...COMMON,
+  8: [
+    0.45,
+    0.66
+  ], // index tip curled to palm
+  12: [
+    0.50,
+    0.66
+  ],
+  16: [
+    0.55,
+    0.66
+  ],
+  20: [
+    0.60,
+    0.66
+  ],
+  4: [
+    0.46,
+    0.60
+  ] // thumb tucked across the palm
+} );
+
+describe(
+  "handMetricsFromLandmarks",
+  () => {
+    it(
+      "reads an open hand as fully open with five fingers up",
+      () => {
+        const m = handMetricsFromLandmarks( OPEN_HAND );
+
+        expect( m ).not.toBeNull();
+        expect( m!.openness ).toBeGreaterThan( 0.7 );
+        expect( countFingersUp( m!.fingerOpen ) ).toBe( 5 );
+      }
+    );
+
+    it(
+      "reads a fist as closed with no fingers up",
+      () => {
+        const m = handMetricsFromLandmarks( FIST );
+
+        expect( m ).not.toBeNull();
+        expect( m!.openness ).toBeLessThan( 0.3 );
+        expect( countFingersUp( m!.fingerOpen ) ).toBe( 0 );
+      }
+    );
+
+    it(
+      "suggests greater depth for a larger (nearer) hand",
+      () => {
+        const near = handMetricsFromLandmarks( OPEN_HAND )!;
+        // Same pose, half the apparent size (palm ref pulled toward the wrist).
+        const far = handMetricsFromLandmarks( hand( {
+          ...COMMON,
+          9: [
+            0.5,
+            0.80
+          ],
+          8: [
+            0.46,
+            0.62
+          ],
+          12: [
+            0.50,
+            0.60
+          ],
+          16: [
+            0.54,
+            0.62
+          ],
+          20: [
+            0.57,
+            0.64
+          ]
+        } ) )!;
+
+        expect( near.depth ).toBeGreaterThan( far.depth );
+      }
+    );
+
+    it(
+      "returns null for missing or degenerate landmarks",
+      () => {
+        expect( handMetricsFromLandmarks( [] ) ).toBeNull();
+        expect( handMetricsFromLandmarks( null as never ) ).toBeNull();
+      }
+    );
+  }
+);
+
+describe(
+  "mapClamp",
+  () => {
+    it(
+      "remaps within range and clamps outside it",
+      () => {
+        expect( mapClamp(
+          0.5,
+          0,
+          1,
+          0,
+          100
+        ) ).toBe( 50 );
+        expect( mapClamp(
+          -1,
+          0,
+          1,
+          0,
+          100
+        ) ).toBe( 0 );
+        expect( mapClamp(
+          2,
+          0,
+          1,
+          0,
+          100
+        ) ).toBe( 100 );
+      }
+    );
+
+    it(
+      "handles a zero-width input range",
+      () => {
+        expect( mapClamp(
+          5,
+          1,
+          1,
+          10,
+          20
+        ) ).toBe( 10 );
+      }
+    );
+  }
+);
+
+describe(
+  "clamp",
+  () => {
+    it(
+      "constrains to the bounds",
+      () => {
+        expect( clamp( -0.5 ) ).toBe( 0 );
+        expect( clamp( 1.5 ) ).toBe( 1 );
+        expect( clamp( 0.4 ) ).toBe( 0.4 );
+      }
+    );
+  }
+);
+
+describe(
+  "faceDepthFromBox",
+  () => {
+    it(
+      "grows toward 1 as the face fills the frame",
+      () => {
+        expect( faceDepthFromBox(
+          0,
+          320
+        ) ).toBe( 0 );
+        expect( faceDepthFromBox(
+          320,
+          320
+        ) ).toBe( 1 );
+        expect( faceDepthFromBox(
+          0,
+          0
+        ) ).toBe( 0 );
+      }
+    );
+  }
+);
+
+describe(
+  "gestureChannelValues",
+  () => {
+    const metrics = {
+      hands: {
+        count: 2,
+        open: 1,
+        openness: 0.5,
+        fingers: 10,
+        depth: 0.4
+      },
+      hand: {
+        pinch: 0.7,
+        spread: 0.3
+      },
+      face: {
+        count: 4,
+        depth: 0.9
+      }
+    };
+
+    it(
+      "normalizes every channel to 0..1, dividing counts by their maxima",
+      () => {
+        const ch = gestureChannelValues( metrics );
+
+        expect( ch[ "hands.count" ] ).toBe( 1 ); // 2 / 2
+        expect( ch[ "hands.open" ] ).toBe( 0.5 ); // 1 / 2
+        expect( ch[ "hands.openness" ] ).toBe( 0.5 ); // passthrough
+        expect( ch[ "hands.fingers" ] ).toBe( 1 ); // 10 / 10
+        expect( ch[ "hands.depth" ] ).toBe( 0.4 );
+        expect( ch[ "hands.pinch" ] ).toBe( 0.7 );
+        expect( ch[ "hands.spread" ] ).toBe( 0.3 );
+        expect( ch[ "face.count" ] ).toBe( 1 ); // 4 / 4
+        expect( ch[ "face.depth" ] ).toBe( 0.9 );
+
+        for ( const value of Object.values( ch ) ) {
+          expect( value ).toBeGreaterThanOrEqual( 0 );
+          expect( value ).toBeLessThanOrEqual( 1 );
+        }
+      }
+    );
+
+    it(
+      "emits exactly the canonical gesture channel ids",
+      () => {
+        expect( Object.keys( gestureChannelValues( metrics ) ).sort() )
+          .toEqual( [
+            ...GESTURE_SOURCE_IDS
+          ].sort() );
+      }
+    );
+
+    it(
+      "is all zeros for an empty snapshot",
+      () => {
+        const ch = gestureChannelValues( {} );
+
+        for ( const value of Object.values( ch ) ) {
+          expect( value ).toBe( 0 );
+        }
+      }
+    );
+  }
+);
+
+describe(
+  "gesture source manifest parity",
+  () => {
+    it(
+      "exposes every gesture channel id as a scalar source in the manifest",
+      () => {
+        const scalarIds = INTERACTION_SOURCES
+          .filter( ( s ) => s.type === "scalar" )
+          .map( ( s ) => s.id );
+
+        for ( const id of GESTURE_SOURCE_IDS ) {
+          expect( scalarIds ).toContain( id );
+        }
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/interaction/channels.js
+++ b/src/templates/p5/utils/interaction/channels.js
@@ -9,7 +9,8 @@
 // gyroscope, midi, audio, joypad) and tags each with its source name. We just
 // normalize those canvas-space vectors to 0..1 and expose them by source id, so
 // enhancing a handler automatically makes it bindable. Semantic audio scalars
-// (level/bass/treble) come from `getAudio()`.
+// (level/bass/treble) come from `getAudio()`; semantic hand/face gesture scalars
+// (hands.openness/fingers/depth …, face.depth) come from `getInteractionMetrics()`.
 //
 // A lightweight baseline `mouse` channel is always present (its own pointer
 // listener) so sketches WITHOUT an interaction block can still bind the mouse.
@@ -30,6 +31,9 @@ import {
 import {
   clamp01, buildChannelsFromDebug
 } from "./channelsAdapter.js";
+import {
+  gestureChannelValues
+} from "./gestureMath.js";
 
 // Re-export so consumers (and tests) can reach the pure adapter via channels.js.
 export {
@@ -163,6 +167,38 @@ function _collectAudioChannels(
   };
 }
 
+// Semantic hand/face gesture scalar channels from getInteractionMetrics()
+// (each already normalized 0..1 by gestureChannelValues). The metrics read the
+// same MediaPipe results the pointer collectors already drive, so this only
+// adds the open/closed · fingers · depth · pinch · spread derivation on top —
+// no extra inference. Populated when the sketch enabled a hand tracker
+// (hands / fingers) or the face tracker.
+function _collectGestureChannels(
+  interactionOpts, channels
+) {
+  const vision = interactionOpts.vision;
+
+  if ( vision?.enabled === false || !_interaction ) {
+    return;
+  }
+
+  const wantsHands = vision?.hands?.enabled || vision?.fingers?.enabled;
+  const wantsFace = vision?.face?.enabled;
+
+  if ( !wantsHands && !wantsFace ) {
+    return;
+  }
+
+  const values = gestureChannelValues( _interaction.getInteractionMetrics( interactionOpts ) );
+
+  for ( const id in values ) {
+    channels[ id ] = {
+      type: "scalar",
+      value: clamp01( values[ id ] )
+    };
+  }
+}
+
 // ── Per-frame sampling ──────────────────────────────────────────────────────
 // Channels are sampled at most once per rendered frame and cached, so multiple
 // binding reads in the same draw() see a consistent snapshot (and stateful
@@ -219,6 +255,10 @@ export function sampleChannels( interactionOpts ) {
           )
         );
         _collectAudioChannels(
+          interactionOpts,
+          channels
+        );
+        _collectGestureChannels(
           interactionOpts,
           channels
         );

--- a/src/templates/p5/utils/interaction/gestureMath.js
+++ b/src/templates/p5/utils/interaction/gestureMath.js
@@ -1,0 +1,307 @@
+/**
+ * Pure gesture math — turns raw MediaPipe landmarks into intuitive, bindable
+ * scalars (hand openness, fingers raised, suggested depth, pinch, spread …).
+ *
+ * Deliberately free of any p5 / MediaPipe / runtime imports so it stays cheap
+ * to unit-test and to pull into either the sketch runtime or the React options
+ * bundle. The stateful smoothing / per-frame caching lives in `gestures.js`;
+ * everything here is a deterministic function of its inputs.
+ *
+ * Hand landmark indices follow the MediaPipe Hand Landmarker model (21 points
+ * per hand, see HAND_FINGER_JOINT_INDICES in ./index.js).
+ */
+
+// Apparent hand size (wrist → middle-finger MCP, in normalized 0..1 space) maps
+// to a 0..1 "suggested depth": small/far hand → 0, large/near hand → 1. The
+// span is roughly invariant to where the hand is in frame, so it reads as
+// distance-to-camera. Tunable if a camera's field of view differs a lot.
+export const HAND_DEPTH_NEAR = 0.30;
+export const HAND_DEPTH_FAR = 0.06;
+
+// Finger "extension ratio" = (tip→wrist) / (knuckle→wrist). A curled finger
+// sits near its knuckle (~1.0); a fully extended one reaches ~1.9× further.
+const FINGER_CURLED_RATIO = 1.0;
+const FINGER_EXTENDED_RATIO = 1.9;
+
+// Non-thumb fingers, as { knuckle (MCP), tip } landmark indices.
+const FINGER_DEFS = [
+  {
+    name: "index",
+    mcp: 5,
+    tip: 8
+  },
+  {
+    name: "middle",
+    mcp: 9,
+    tip: 12
+  },
+  {
+    name: "ring",
+    mcp: 13,
+    tip: 16
+  },
+  {
+    name: "pinky",
+    mcp: 17,
+    tip: 20
+  }
+];
+
+export const FINGER_KEYS = [
+  "thumb",
+  "index",
+  "middle",
+  "ring",
+  "pinky"
+];
+
+const WRIST = 0;
+const PALM_SCALE_REF = 9; // middle-finger MCP
+const THUMB_TIP = 4;
+const INDEX_TIP = 8;
+const MIDDLE_TIP = 12;
+const RING_TIP = 16;
+const PINKY_TIP = 20;
+const INDEX_MCP = 5;
+
+export function clamp(
+  value, lo = 0, hi = 1
+) {
+  if ( value < lo ) {
+    return lo;
+  }
+
+  if ( value > hi ) {
+    return hi;
+  }
+
+  return value;
+}
+
+/**
+ * Linearly remap `value` from [inMin, inMax] to [outMin, outMax], clamped to the
+ * output range. The workhorse behind every gesture → parameter binding.
+ */
+export function mapClamp(
+  value, inMin, inMax, outMin, outMax
+) {
+  if ( inMax === inMin ) {
+    return outMin;
+  }
+
+  const t = clamp(
+    ( value - inMin ) / ( inMax - inMin ),
+    0,
+    1
+  );
+
+  return outMin + t * ( outMax - outMin );
+}
+
+function dist(
+  a, b
+) {
+  return Math.hypot(
+    a.x - b.x,
+    a.y - b.y
+  );
+}
+
+/**
+ * Per-hand metrics from one hand's 21 landmarks. Returns null when the landmark
+ * set is missing/degenerate so callers can simply skip it.
+ *
+ * @param {Array<{x:number,y:number,z?:number}>} lm
+ * @returns {null | {
+ *   fingerOpen: Record<string, number>,  // 0..1 per finger
+ *   openness: number,                    // 0..1 (mean of the four non-thumb fingers)
+ *   pinch: number,                       // 0..1 (1 = thumb & index touching)
+ *   spread: number,                      // 0..1 (fingertips splayed apart)
+ *   depth: number,                       // 0..1 (suggested proximity to camera)
+ *   scale: number                        // raw apparent hand size (normalized)
+ * }}
+ */
+export function handMetricsFromLandmarks( lm ) {
+  if ( !Array.isArray( lm ) || lm.length < 21 ) {
+    return null;
+  }
+
+  const wrist = lm[ WRIST ];
+  const scale = dist(
+    wrist,
+    lm[ PALM_SCALE_REF ]
+  );
+
+  if ( !( scale > 0 ) ) {
+    return null;
+  }
+
+  const fingerOpen = {};
+
+  for ( const finger of FINGER_DEFS ) {
+    const knuckleSpan = Math.max(
+      dist(
+        lm[ finger.mcp ],
+        wrist
+      ),
+      1e-6
+    );
+    const ratio = dist(
+      lm[ finger.tip ],
+      wrist
+    ) / knuckleSpan;
+
+    fingerOpen[ finger.name ] = clamp( ( ratio - FINGER_CURLED_RATIO ) /
+      ( FINGER_EXTENDED_RATIO - FINGER_CURLED_RATIO ) );
+  }
+
+  // Thumb opens sideways, not along the wrist axis: measure how far its tip sits
+  // from the index knuckle (tucked across the palm in a fist → small).
+  const thumbRatio = dist(
+    lm[ THUMB_TIP ],
+    lm[ INDEX_MCP ]
+  ) / scale;
+
+  fingerOpen.thumb = clamp( ( thumbRatio - 0.6 ) / ( 1.4 - 0.6 ) );
+
+  const openness = ( fingerOpen.index +
+    fingerOpen.middle +
+    fingerOpen.ring +
+    fingerOpen.pinky ) / 4;
+
+  const pinchRatio = dist(
+    lm[ THUMB_TIP ],
+    lm[ INDEX_TIP ]
+  ) / scale;
+  const pinch = 1 - clamp( ( pinchRatio - 0.2 ) / ( 0.9 - 0.2 ) );
+
+  const tipGap = ( dist(
+    lm[ INDEX_TIP ],
+    lm[ MIDDLE_TIP ]
+  ) + dist(
+    lm[ MIDDLE_TIP ],
+    lm[ RING_TIP ]
+  ) + dist(
+    lm[ RING_TIP ],
+    lm[ PINKY_TIP ]
+  ) ) / 3 / scale;
+  const spread = clamp( ( tipGap - 0.15 ) / ( 0.7 - 0.15 ) );
+
+  const depth = clamp( ( scale - HAND_DEPTH_FAR ) /
+    ( HAND_DEPTH_NEAR - HAND_DEPTH_FAR ) );
+
+  return {
+    fingerOpen,
+    openness,
+    pinch,
+    spread,
+    depth,
+    scale
+  };
+}
+
+/**
+ * Count how many fingers read as "raised", given per-finger openness 0..1.
+ */
+export function countFingersUp(
+  fingerOpen, threshold = 0.5
+) {
+  if ( !fingerOpen ) {
+    return 0;
+  }
+
+  return FINGER_KEYS.reduce(
+    (
+      total, key
+    ) => total + ( ( fingerOpen[ key ] ?? 0 ) >= threshold ? 1 : 0 ),
+    0
+  );
+}
+
+/**
+ * Suggested depth 0..1 for a detected face from its bounding-box width relative
+ * to the capture width (a bigger box → closer → 1).
+ */
+export function faceDepthFromBox(
+  boxWidth, captureWidth
+) {
+  if ( !( captureWidth > 0 ) ) {
+    return 0;
+  }
+
+  return clamp( ( boxWidth / captureWidth - 0.15 ) / ( 0.6 - 0.15 ) );
+}
+
+// ── Bindable gesture channels ───────────────────────────────────────────────
+// The scalar gesture sources exposed to the interactive-bindings system. Each
+// `id` is the binding source id (see ../sources.js) and groups under its family
+// ("hands" / "face") in the binding picker, exactly like the audio.* scalars.
+// Declared here, in the pure module, so the source manifest and the channel
+// builder stay in sync (parity-tested).
+export const GESTURE_SOURCES = [
+  {
+    id: "hands.count",
+    label: "Hands · Count"
+  },
+  {
+    id: "hands.open",
+    label: "Hands · Open count"
+  },
+  {
+    id: "hands.openness",
+    label: "Hands · Openness"
+  },
+  {
+    id: "hands.fingers",
+    label: "Hands · Fingers up"
+  },
+  {
+    id: "hands.depth",
+    label: "Hands · Depth (near)"
+  },
+  {
+    id: "hands.pinch",
+    label: "Hands · Pinch"
+  },
+  {
+    id: "hands.spread",
+    label: "Hands · Spread"
+  },
+  {
+    id: "face.count",
+    label: "Face · Count"
+  },
+  {
+    id: "face.depth",
+    label: "Face · Depth (near)"
+  }
+];
+
+export const GESTURE_SOURCE_IDS = GESTURE_SOURCES.map( ( source ) => source.id );
+
+/**
+ * Normalize a gesture metrics snapshot (see ./gestures.js → computeInteractionMetrics)
+ * into 0..1 channel values keyed by the GESTURE_SOURCES ids — the contract the
+ * binding system expects (every channel publishes 0..1; counts are divided by
+ * their natural maxima so the mapping range stays uniform).
+ *
+ * @param {object} metrics - { hands, hand, face } snapshot
+ * @returns {Record<string, number>} keyed by GESTURE_SOURCE_IDS, each 0..1
+ */
+export function gestureChannelValues( metrics ) {
+  const hands = metrics?.hands ?? {};
+  const hand = metrics?.hand ?? {};
+  const face = metrics?.face ?? {};
+
+  return {
+    "hands.count": clamp( ( hands.count ?? 0 ) / 2 ),
+    "hands.open": clamp( ( hands.open ?? 0 ) / 2 ),
+    "hands.openness": clamp( hands.openness ?? 0 ),
+    "hands.fingers": clamp( ( hands.fingers ?? 0 ) / 10 ),
+    "hands.depth": clamp( hands.depth ?? 0 ),
+    "hands.pinch": clamp( hand.pinch ?? 0 ),
+    "hands.spread": clamp( hand.spread ?? 0 ),
+    "face.count": clamp( ( face.count ?? 0 ) / 4 ),
+    "face.depth": clamp( face.depth ?? 0 )
+  };
+}

--- a/src/templates/p5/utils/interaction/gestures.js
+++ b/src/templates/p5/utils/interaction/gestures.js
@@ -1,0 +1,334 @@
+/**
+ * Gesture snapshot — the live, semantic view of what the camera sees: how many
+ * hands/fingers are raised, whether a hand is open or closed (a fist), how near
+ * a hand is to the screen (suggested depth), pinch, spread, and basic face
+ * presence/depth.
+ *
+ * Built on the raw landmark math in ./gestureMath.js, this layer adds the
+ * runtime concerns: reading the latest MediaPipe results, temporal smoothing so
+ * bound parameters don't jitter, finger-up hysteresis so counts don't flicker,
+ * and a once-per-frame cache.
+ *
+ * It feeds the interactive-bindings system: index.js re-exports
+ * getInteractionMetrics(), channels.js normalizes the snapshot into 0..1
+ * `hands.*` / `face.*` scalar channels (via gestureChannelValues), and the
+ * binding picker lists them from the source manifest (./sources.js).
+ */
+
+import mediapipe, {
+  getTaskResult
+} from "@/p5/utils/mediapipe/mediapipe.js";
+import {
+  getP5
+} from "@/p5/utils/sketch.js";
+import {
+  faceDepthFromBox,
+  FINGER_KEYS,
+  handMetricsFromLandmarks,
+  HAND_DEPTH_FAR,
+  HAND_DEPTH_NEAR,
+  mapClamp
+} from "@/p5/utils/interaction/gestureMath.js";
+
+// Results older than this read as "nothing detected" (mirrors the collectors in
+// ./index.js) so a stalled pipeline never freezes a stale gesture.
+const VISION_RESULT_TTL_MS = 1500;
+
+// EMA factor for smoothing (0..1): higher reacts faster, lower is calmer.
+const SMOOTH_ALPHA = 0.4;
+
+// Finger-up hysteresis: rises past the high band, falls below the low band, and
+// holds its previous state in between — kills single-frame count flicker.
+const FINGER_UP_HIGH = 0.6;
+const FINGER_UP_LOW = 0.4;
+
+const _smooth = new Map(); // key → smoothed scalar
+const _up = new Map(); // "h{i}:{finger}:up" → boolean
+const _cache = {
+  frame: -1,
+  metrics: null
+};
+
+function _ema(
+  key, value
+) {
+  const prev = _smooth.get( key );
+  const next = prev == null ? value : prev + SMOOTH_ALPHA * ( value - prev );
+
+  _smooth.set(
+    key,
+    next
+  );
+
+  return next;
+}
+
+/** Drop per-hand smoothing/up state for hands no longer on screen. */
+function _pruneHandState( seen ) {
+  for ( const key of _smooth.keys() ) {
+    if ( /^h\d+:/.test( key ) && !seen.has( key ) ) {
+      _smooth.delete( key );
+    }
+  }
+
+  for ( const key of _up.keys() ) {
+    if ( !seen.has( key ) ) {
+      _up.delete( key );
+    }
+  }
+}
+
+function _emptyMetrics() {
+  return {
+    hands: {
+      count: 0,
+      open: 0,
+      closed: 0,
+      openness: 0,
+      fingers: 0,
+      depth: 0
+    },
+    hand: {
+      present: 0,
+      openness: 0,
+      fingers: 0,
+      depth: 0,
+      pinch: 0,
+      spread: 0
+    },
+    face: {
+      count: 0,
+      present: 0,
+      depth: 0
+    }
+  };
+}
+
+function _collectHandMetrics( opts ) {
+  const vision = opts?.vision ?? {};
+  const handsCfg = vision.hands ?? {};
+  const maxHands = handsCfg.maxHands ?? 2;
+  const results = vision.enabled === false
+    ? []
+    : getTaskResult(
+      "hands",
+      VISION_RESULT_TTL_MS
+    )?.landmarks ?? [];
+
+  const perHand = [];
+  const seen = new Set();
+
+  results.slice(
+    0,
+    maxHands
+  ).forEach( (
+    lm, i
+  ) => {
+    const raw = handMetricsFromLandmarks( lm );
+
+    if ( !raw ) {
+      return;
+    }
+
+    const smoothedFingers = {};
+
+    FINGER_KEYS.forEach( ( finger ) => {
+      const key = `h${ i }:${ finger }`;
+
+      seen.add( key );
+      smoothedFingers[ finger ] = _ema(
+        key,
+        raw.fingerOpen[ finger ] ?? 0
+      );
+    } );
+
+    // Finger-up count with hysteresis on the smoothed openness.
+    let fingersUp = 0;
+
+    FINGER_KEYS.forEach( ( finger ) => {
+      const upKey = `h${ i }:${ finger }:up`;
+      const prev = _up.get( upKey ) ?? false;
+      const value = smoothedFingers[ finger ];
+      const up = value > FINGER_UP_HIGH
+        ? true
+        : value < FINGER_UP_LOW ? false : prev;
+
+      _up.set(
+        upKey,
+        up
+      );
+      seen.add( upKey );
+
+      if ( up ) {
+        fingersUp += 1;
+      }
+    } );
+
+    const scaleKey = `h${ i }:scale`;
+    const pinchKey = `h${ i }:pinch`;
+    const spreadKey = `h${ i }:spread`;
+
+    seen.add( scaleKey );
+    seen.add( pinchKey );
+    seen.add( spreadKey );
+
+    const scale = _ema(
+      scaleKey,
+      raw.scale
+    );
+    const openness = ( smoothedFingers.index +
+      smoothedFingers.middle +
+      smoothedFingers.ring +
+      smoothedFingers.pinky ) / 4;
+
+    perHand.push( {
+      openness,
+      fingersUp,
+      depth: mapClamp(
+        scale,
+        HAND_DEPTH_FAR,
+        HAND_DEPTH_NEAR,
+        0,
+        1
+      ),
+      pinch: _ema(
+        pinchKey,
+        raw.pinch
+      ),
+      spread: _ema(
+        spreadKey,
+        raw.spread
+      ),
+      scale
+    } );
+  } );
+
+  _pruneHandState( seen );
+
+  return perHand;
+}
+
+function _collectFaceMetrics( opts ) {
+  const vision = opts?.vision ?? {};
+  const faceCfg = vision.face ?? {};
+  const maxFaces = faceCfg.maxFaces ?? 1;
+  const minConf = faceCfg.confidence ?? 0.5;
+  const detections = vision.enabled === false
+    ? []
+    : getTaskResult(
+      "faces",
+      VISION_RESULT_TTL_MS
+    )?.detections ?? [];
+
+  const capW = mediapipe.capture?.size?.width ?? 320;
+  const faces = detections
+    .filter( ( det ) => ( det.categories?.[ 0 ]?.score ?? 1 ) >= minConf )
+    .slice(
+      0,
+      maxFaces
+    );
+
+  let depth = 0;
+
+  faces.forEach( ( det ) => {
+    depth = Math.max(
+      depth,
+      faceDepthFromBox(
+        det.boundingBox?.width ?? 0,
+        capW
+      )
+    );
+  } );
+
+  return {
+    count: faces.length,
+    present: faces.length > 0 ? 1 : 0,
+    // Persisted key (never pruned): decays smoothly to 0 when faces leave.
+    depth: _ema(
+      "face:depth",
+      depth
+    )
+  };
+}
+
+/**
+ * Compute the gesture snapshot for `opts` (the sketch's `interaction` block).
+ * Cached per frame. Reads the latest vision results; does NOT start the camera
+ * (the caller — getInteractionMetrics in ./index.js, or the channels sampler —
+ * has already ensured the pipeline is running).
+ *
+ * @param {object} [opts] - interaction options
+ * @returns {ReturnType<typeof _emptyMetrics>}
+ */
+export function computeInteractionMetrics( opts ) {
+  const p = getP5();
+  const frame = p?.frameCount ?? 0;
+
+  if ( _cache.frame === frame && _cache.metrics ) {
+    return _cache.metrics;
+  }
+
+  if ( !opts || opts.enabled === false ) {
+    _cache.frame = frame;
+    _cache.metrics = _emptyMetrics();
+
+    return _cache.metrics;
+  }
+
+  const perHand = _collectHandMetrics( opts );
+  const count = perHand.length;
+  const fingers = perHand.reduce(
+    (
+      total, hand
+    ) => total + hand.fingersUp,
+    0
+  );
+  const open = perHand.filter( ( hand ) => hand.openness > 0.5 ).length;
+  const closed = perHand.filter( ( hand ) => hand.openness < 0.3 ).length;
+  const opennessAgg = count
+    ? perHand.reduce(
+      (
+        sum, hand
+      ) => sum + hand.openness,
+      0
+    ) / count
+    : 0;
+  const depthAgg = count
+    ? Math.max( ...perHand.map( ( hand ) => hand.depth ) )
+    : 0;
+  // The closest (largest) hand drives the single-hand pinch / spread values.
+  const primary = count
+    ? perHand.reduce( (
+      best, hand
+    ) => ( hand.scale > best.scale ? hand : best ) )
+    : null;
+
+  const metrics = _emptyMetrics();
+
+  metrics.hands = {
+    count,
+    open,
+    closed,
+    openness: opennessAgg,
+    fingers,
+    depth: depthAgg
+  };
+
+  if ( primary ) {
+    metrics.hand = {
+      present: 1,
+      openness: primary.openness,
+      fingers: primary.fingersUp,
+      depth: primary.depth,
+      pinch: primary.pinch,
+      spread: primary.spread
+    };
+  }
+
+  metrics.face = _collectFaceMetrics( opts );
+
+  _cache.frame = frame;
+  _cache.metrics = metrics;
+
+  return metrics;
+}

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -21,6 +21,9 @@ import {
   getP5
 } from "@/p5/utils/sketch.js";
 import {
+  computeInteractionMetrics
+} from "@/p5/utils/interaction/gestures.js";
+import {
   createVideoSync
 } from "@/lib/assets/kinds/videos/createVideoSync";
 import {
@@ -2463,6 +2466,31 @@ function _runAudioFeatures( audio ) {
  */
 export function getAudio() {
   return _audioFeatures;
+}
+
+/**
+ * Live "gesture" snapshot derived from the vision pipeline — the semantic view
+ * of what the camera sees this frame:
+ *
+ *   hands: { count, open, closed, openness, fingers, depth }  // all hands
+ *   hand:  { present, openness, fingers, depth, pinch, spread } // closest hand
+ *   face:  { count, present, depth }
+ *
+ * Openness/depth/pinch/spread are 0..1; counts are integers; `depth` rises as a
+ * hand nears the camera (apparent size grows). Values are smoothed and cached
+ * per frame. Ensures the vision pipeline is running, then delegates the math to
+ * gestures.js. The binding system reads this through channels.js, which
+ * normalizes it into `hands.*` / `face.*` scalar channels.
+ *
+ * @param {object} [opts] - the `interaction` section of sketch options
+ * @returns {ReturnType<typeof computeInteractionMetrics>}
+ */
+export function getInteractionMetrics( opts = options.sketch?.interaction ?? {} ) {
+  if ( opts && opts.enabled !== false ) {
+    _ensureVision( opts );
+  }
+
+  return computeInteractionMetrics( opts );
 }
 
 function _collectJoypad(

--- a/src/templates/p5/utils/interaction/sources.js
+++ b/src/templates/p5/utils/interaction/sources.js
@@ -117,6 +117,59 @@ export const INTERACTION_SOURCES = [
     id: "audio.presence",
     type: "scalar",
     label: "Audio · Presence"
+  },
+
+  // ── Semantic hand/face gesture scalars (from getInteractionMetrics()) ──────
+  // Derived, intuitive values about what the camera sees — open vs closed hand,
+  // fingers/hands raised, suggested depth (nearness), pinch, spread, face
+  // presence/depth. Each is published 0..1 by channels.js (gestureChannelValues)
+  // and grouped under the existing "Hands" / "Face" families in the picker. The
+  // canonical id list + normalization live in ./gestureMath.js (GESTURE_SOURCES)
+  // — kept in sync by a parity test.
+  {
+    id: "hands.count",
+    type: "scalar",
+    label: "Hands · Count"
+  },
+  {
+    id: "hands.open",
+    type: "scalar",
+    label: "Hands · Open count"
+  },
+  {
+    id: "hands.openness",
+    type: "scalar",
+    label: "Hands · Openness"
+  },
+  {
+    id: "hands.fingers",
+    type: "scalar",
+    label: "Hands · Fingers up"
+  },
+  {
+    id: "hands.depth",
+    type: "scalar",
+    label: "Hands · Depth (near)"
+  },
+  {
+    id: "hands.pinch",
+    type: "scalar",
+    label: "Hands · Pinch"
+  },
+  {
+    id: "hands.spread",
+    type: "scalar",
+    label: "Hands · Spread"
+  },
+  {
+    id: "face.count",
+    type: "scalar",
+    label: "Face · Count"
+  },
+  {
+    id: "face.depth",
+    type: "scalar",
+    label: "Face · Depth (near)"
   }
 ];
 


### PR DESCRIPTION
## What & why

Rebased onto `main` (the interactive parameter bindings system, #193). This adds semantic **gesture** scalar channels to that system, so any sketch parameter can be driven by what the camera sees — exactly the way the `audio.*` band scalars already work. Bind a circle's radius to hand openness, a polygon's sides to fingers raised, a value to how near a hand is, etc.

> The source manifest even invited this: *"richer per-source channels (hands.pinch, gyro.tilt, …) follow the same pattern."* These are those.

## New bindable sources

In the binding picker, under the existing **Hands** / **Face** groups (each published `0..1`):

| Source | Meaning |
| --- | --- |
| `hands.count` | number of hands |
| `hands.open` | how many hands are open |
| `hands.openness` | average open/closed (fist → open) |
| `hands.fingers` | total fingers raised |
| `hands.depth` | nearest hand's suggested depth/nearness |
| `hands.pinch` | thumb↔index pinch (closest hand) |
| `hands.spread` | finger spread (closest hand) |
| `face.count` / `face.depth` | face presence and nearness |

- **Open vs closed** is a continuous openness (mean finger extension), not binary — a bound parameter moves smoothly between fist and open hand.
- **Fingers-up** uses per-finger hysteresis so counts don't flicker at the threshold.
- **Suggested depth** reads the hand's apparent size as nearness to the screen.
- Counts are normalized by their natural maxima (so every channel stays `0..1`, like audio); values are smoothed and cached per frame.

## How it's wired (mirrors the audio-scalar path)

- `interaction/gestureMath.js` — pure, unit-tested landmark math + `gestureChannelValues()` (snapshot → normalized `0..1` channels) + `GESTURE_SOURCES` manifest.
- `interaction/gestures.js` — smoothing + per-frame snapshot from the live MediaPipe results.
- `interaction/index.js` — `getInteractionMetrics()` (ensures vision is running, delegates to gestures.js).
- `interaction/channels.js` — `_collectGestureChannels()` publishes the scalars alongside the audio ones.
- `interaction/sources.js` — gesture entries in the source manifest (parity-tested against the canonical id list).
- `BindingAffordance/bindingUtils.ts` — picking a `hands.*` / `face.*` source auto-enables the camera + the matching tracker ("pick a source → it works").

**No extra inference**: the gesture metrics read the same hand/face results the pointer collectors already drive — just adding the open/closed · fingers · depth · pinch · spread derivation on top.

## Try it

With the bindings plugin on (`INTERACTION_BINDINGS=true`), open any sketch, click a numeric parameter's binding affordance, pick e.g. **Hands · Openness** for a radius (it auto-enables the camera + hand tracker), and set the output range. Layer **Hands · Fingers up** onto another parameter, etc.

## Note on eyes open/closed

True eyelid open/closed needs MediaPipe **FaceLandmarker** (blendshapes), whose model isn't bundled — the current **BlazeFace** detector only gives face position/size. So this ships `face.count` / `face.depth` and leaves a clean extension point. Happy to wire eye-openness as a follow-up once the model is added.

## Validation

- `npm test` → **37 suites / 1310 tests pass** (incl. new gesture math, channel-normalization, and manifest-parity tests).
- `npm run lint` → 0 errors.
- TypeScript: no errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n7Djs6Uk65WqCcnWmKhfb