### PR TITLE
feat(slides): sequence individual params during montage transitions

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
@@ -939,8 +939,8 @@ export default function SlideTransitionSettings( {
                 name={ `${ base }.stagger` }
                 label="Stagger"
                 min={ 0 }
-                max={ 0.9 }
-                step={ 0.05 }
+                max={ 1 }
+                step={ 0.1 }
               />
 
               <SnapKeysInput name={ `${ base }.snapKeys` } />
@@ -948,8 +948,9 @@ export default function SlideTransitionSettings( {
               <p className="px-1 pt-0.5 text-[0.65rem] leading-snug text-label">
                 Morphs the source slides&apos; parameters over this slide&apos;s
                 duration. Numbers &amp; colours interpolate; discrete params
-                (seed, modes) should be listed under Snap. Stagger offsets each
-                param group so they don&apos;t all move at once.
+                (seed, modes) should be listed under Snap. Stagger 0 = every
+                changing param moves together; 1 = they change one at a time,
+                each over its own slice of the transition.
               </p>
             </Fragment>
           ) : (

--- a/src/sketches/p5/utils/__tests__/lerpParams.test.ts
+++ b/src/sketches/p5/utils/__tests__/lerpParams.test.ts
@@ -1,5 +1,5 @@
 import lerpParamsImpl, {
-  lerpParamsStaggered as lerpParamsStaggeredImpl
+  lerpParamsSequenced as lerpParamsSequencedImpl
 } from "@/p5/utils/slides/morph/lerpParams.js";
 
 // The util is untyped JS; give it a call signature so the assertions below can
@@ -11,7 +11,7 @@ const lerpParams = lerpParamsImpl as (
   snapKeys?: string[]
 ) => any;
 
-const lerpParamsStaggered = lerpParamsStaggeredImpl as (
+const lerpParamsSequenced = lerpParamsSequencedImpl as (
   from: Record<string, unknown>,
   to: Record<string, unknown>,
   t: number,
@@ -312,12 +312,12 @@ describe(
 );
 
 describe(
-  "lerpParamsStaggered",
+  "lerpParamsSequenced",
   () => {
     test(
       "matches a plain lerp when spread is 0",
       () => {
-        expect( lerpParamsStaggered(
+        expect( lerpParamsSequenced(
           {
             a: 0,
             b: 0
@@ -337,29 +337,35 @@ describe(
     );
 
     test(
-      "falls back to a plain lerp with a single group",
+      "falls back to a plain lerp when only one param changes",
       () => {
-        expect( lerpParamsStaggered(
+        // `b` is identical on both sides, so only `a` changes → nothing to
+        // sequence, `a` morphs across the whole window.
+        expect( lerpParamsSequenced(
           {
-            a: 0
+            a: 0,
+            b: 5
           },
           {
-            a: 10
+            a: 10,
+            b: 5
           },
           0.5,
           [],
-          0.5
+          1
         ) ).toEqual( {
-          a: 5
+          a: 5,
+          b: 5
         } );
       }
     );
 
     test(
-      "offsets groups so the leading one is ahead of the trailing one",
+      "spread 1 changes params one at a time: the first finishes before the next starts",
       () => {
-        // keys [a, b], spread 0.5, global 0.5 → a done, b not started.
-        expect( lerpParamsStaggered(
+        // changing leaves [a, b], spread 1, t 0.5 → a's [0,0.5] slice is done,
+        // b's [0.5,1] slice hasn't started.
+        expect( lerpParamsSequenced(
           {
             a: 0,
             b: 0
@@ -370,7 +376,7 @@ describe(
           },
           0.5,
           [],
-          0.5
+          1
         ) ).toEqual( {
           a: 10,
           b: 0
@@ -379,7 +385,63 @@ describe(
     );
 
     test(
-      "all groups settle at the segment endpoints",
+      "sequences leaves nested in the same group independently",
+      () => {
+        // The case top-level grouping missed: two leaves under one object still
+        // change one after another.
+        const out = lerpParamsSequenced(
+          {
+            sites: {
+              count: 0,
+              speed: 0
+            }
+          },
+          {
+            sites: {
+              count: 10,
+              speed: 10
+            }
+          },
+          0.5,
+          [],
+          1
+        );
+
+        expect( out.sites.count ).toBe( 10 );
+        expect( out.sites.speed ).toBe( 0 );
+      }
+    );
+
+    test(
+      "only counts leaves that actually differ toward the slice count",
+      () => {
+        // `b` is unchanged, so a and c split the window in half (not thirds).
+        const out = lerpParamsSequenced(
+          {
+            a: 0,
+            b: 5,
+            c: 0
+          },
+          {
+            a: 10,
+            b: 5,
+            c: 10
+          },
+          0.5,
+          [],
+          1
+        );
+
+        expect( out ).toEqual( {
+          a: 10,
+          b: 5,
+          c: 0
+        } );
+      }
+    );
+
+    test(
+      "every param settles at the transition endpoints",
       () => {
         const from = {
           a: 0,
@@ -390,22 +452,22 @@ describe(
           b: 10
         };
 
-        expect( lerpParamsStaggered(
+        expect( lerpParamsSequenced(
           from,
           to,
           0,
           [],
-          0.5
+          1
         ) ).toEqual( {
           a: 0,
           b: 0
         } );
-        expect( lerpParamsStaggered(
+        expect( lerpParamsSequenced(
           from,
           to,
           1,
           [],
-          0.5
+          1
         ) ).toEqual( {
           a: 10,
           b: 10
@@ -414,11 +476,11 @@ describe(
     );
 
     test(
-      "still honours snapKeys within a staggered group",
+      "still honours snapKeys within the sequence",
       () => {
-        // keys [x, seed]; at global 0.6 the trailing seed group is < 0.5 so it
-        // snaps to `from`, while x has already completed.
-        const out = lerpParamsStaggered(
+        // changing leaves [x, seed]; at t 0.6 the seed slice [0.5,1] is < 0.5 so
+        // it snaps to `from`, while x has already completed.
+        const out = lerpParamsSequenced(
           {
             x: 0,
             seed: 1
@@ -431,7 +493,7 @@ describe(
           [
             "seed"
           ],
-          0.5
+          1
         );
 
         expect( out.x ).toBe( 10 );

--- a/src/sketches/p5/utils/__tests__/sequenceProgress.test.ts
+++ b/src/sketches/p5/utils/__tests__/sequenceProgress.test.ts
@@ -1,0 +1,105 @@
+import sequenceProgress from "@/p5/utils/slides/morph/sequenceProgress.js";
+
+describe(
+  "sequenceProgress",
+  () => {
+    test(
+      "is the identity when spread is 0",
+      () => {
+        expect( sequenceProgress(
+          0.5,
+          0,
+          3,
+          0
+        ) ).toBe( 0.5 );
+      }
+    );
+
+    test(
+      "is the identity with a single item",
+      () => {
+        expect( sequenceProgress(
+          0.4,
+          0,
+          1,
+          1
+        ) ).toBe( 0.4 );
+      }
+    );
+
+    test(
+      "spread 1 gives even, non-overlapping slices (one at a time)",
+      () => {
+        // count 2 → item 0 over [0, 0.5], item 1 over [0.5, 1].
+        expect( sequenceProgress(
+          0.25,
+          0,
+          2,
+          1
+        ) ).toBeCloseTo( 0.5 );
+        expect( sequenceProgress(
+          0.5,
+          0,
+          2,
+          1
+        ) ).toBe( 1 );
+
+        expect( sequenceProgress(
+          0.5,
+          1,
+          2,
+          1
+        ) ).toBe( 0 );
+        expect( sequenceProgress(
+          0.75,
+          1,
+          2,
+          1
+        ) ).toBeCloseTo( 0.5 );
+      }
+    );
+
+    test(
+      "every item settles to 0 at t=0 and 1 at t=1",
+      () => {
+        for ( const index of [
+          0,
+          1,
+          2
+        ] ) {
+          expect( sequenceProgress(
+            0,
+            index,
+            3,
+            1
+          ) ).toBe( 0 );
+          expect( sequenceProgress(
+            1,
+            index,
+            3,
+            1
+          ) ).toBe( 1 );
+        }
+      }
+    );
+
+    test(
+      "intermediate spread keeps the windows partially overlapping",
+      () => {
+        // count 2, spread 0.5 → width 0.75, item 1 starts at 0.25.
+        expect( sequenceProgress(
+          0.25,
+          1,
+          2,
+          0.5
+        ) ).toBe( 0 );
+        expect( sequenceProgress(
+          0.25,
+          0,
+          2,
+          0.5
+        ) ).toBeCloseTo( 1 / 3 );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/morph/index.js
+++ b/src/sketches/p5/utils/slides/morph/index.js
@@ -4,7 +4,7 @@ import {
   mapProgressionToSegment
 } from "./segmentMapper.js";
 import lerpParams, {
-  lerpParamsStaggered
+  lerpParamsSequenced
 } from "./lerpParams.js";
 
 /**
@@ -78,7 +78,7 @@ export default function getMontageSketch(
   const stagger = transition.stagger ?? 0;
 
   if ( stagger > 0 ) {
-    return lerpParamsStaggered(
+    return lerpParamsSequenced(
       fromSketch,
       toSketch,
       localT,

--- a/src/sketches/p5/utils/slides/morph/lerpParams.js
+++ b/src/sketches/p5/utils/slides/morph/lerpParams.js
@@ -17,7 +17,7 @@
  * Pure: no p5 / DOM dependency, so it is unit-testable in node.
  */
 
-import staggeredProgress from "./staggeredProgress.js";
+import sequenceProgress from "./sequenceProgress.js";
 
 function isPlainObject( value ) {
   return value != null && typeof value === "object" && !Array.isArray( value );
@@ -51,50 +51,29 @@ function shouldSnap(
   );
 }
 
-function lerpValue(
-  a, b, t, path, snapKeys
+// A leaf morphs when the two sides differ. Arrays compare component-wise so an
+// unchanged colour doesn't register as a change.
+function leafChanges(
+  a, b
 ) {
-  if ( shouldSnap(
-    a,
-    b,
-    path,
-    snapKeys
-  ) ) {
-    return t < 0.5 ? a : b;
-  }
-
-  if ( typeof a === "number" && typeof b === "number" ) {
-    return a + ( b - a ) * t;
+  if ( a === b ) {
+    return false;
   }
 
   if ( Array.isArray( a ) && Array.isArray( b ) ) {
-    if ( isEqualLengthNumericArray(
-      a,
-      b
-    ) ) {
-      return a.map( (
-        v, i
-      ) => v + ( b[ i ] - v ) * t );
-    }
-
-    return t < 0.5 ? a : b;
+    return a.length !== b.length || a.some( (
+      v, i
+    ) => v !== b[ i ] );
   }
 
-  if ( isPlainObject( a ) && isPlainObject( b ) ) {
-    return lerpParams(
-      a,
-      b,
-      t,
-      snapKeys,
-      path
-    );
-  }
-
-  return t < 0.5 ? a : b;
+  return true;
 }
 
-export default function lerpParams(
-  from, to, t, snapKeys = [], prefix = ""
+// `resolveT( path )` returns the morph progress for the leaf at `path`, so the
+// same walk serves both a uniform morph (constant t) and a per-parameter
+// sequenced one (a different slice of t per changing leaf).
+function lerpNode(
+  from, to, resolveT, snapKeys, prefix
 ) {
   const source = from ?? {};
   const target = to ?? {};
@@ -122,7 +101,7 @@ export default function lerpParams(
     out[ key ] = lerpValue(
       a,
       b,
-      t,
+      resolveT,
       path,
       snapKeys
     );
@@ -131,25 +110,130 @@ export default function lerpParams(
   return out;
 }
 
+function lerpValue(
+  a, b, resolveT, path, snapKeys
+) {
+  if ( shouldSnap(
+    a,
+    b,
+    path,
+    snapKeys
+  ) ) {
+    return resolveT( path ) < 0.5 ? a : b;
+  }
+
+  if ( typeof a === "number" && typeof b === "number" ) {
+    return a + ( b - a ) * resolveT( path );
+  }
+
+  if ( Array.isArray( a ) && Array.isArray( b ) ) {
+    if ( isEqualLengthNumericArray(
+      a,
+      b
+    ) ) {
+      const t = resolveT( path );
+
+      return a.map( (
+        v, i
+      ) => v + ( b[ i ] - v ) * t );
+    }
+
+    return resolveT( path ) < 0.5 ? a : b;
+  }
+
+  if ( isPlainObject( a ) && isPlainObject( b ) ) {
+    return lerpNode(
+      a,
+      b,
+      resolveT,
+      snapKeys,
+      path
+    );
+  }
+
+  return resolveT( path ) < 0.5 ? a : b;
+}
+
+// Ordered list of leaf paths that actually change between `from` and `to`,
+// following the exact traversal order of lerpNode so indices line up.
+function collectChangingLeaves(
+  from, to, prefix, snapKeys, out
+) {
+  const source = from ?? {};
+  const target = to ?? {};
+  const keys = new Set( [
+    ...Object.keys( source ),
+    ...Object.keys( target )
+  ] );
+
+  for ( const key of keys ) {
+    const path = prefix ? `${ prefix }.${ key }` : key;
+    const a = source[ key ];
+    const b = target[ key ];
+
+    if ( a === undefined || b === undefined ) {
+      continue;
+    }
+
+    if (
+      !shouldSnap(
+        a,
+        b,
+        path,
+        snapKeys
+      ) &&
+      isPlainObject( a ) &&
+      isPlainObject( b )
+    ) {
+      collectChangingLeaves(
+        a,
+        b,
+        path,
+        snapKeys,
+        out
+      );
+      continue;
+    }
+
+    if ( leafChanges(
+      a,
+      b
+    ) ) {
+      out.push( path );
+    }
+  }
+
+  return out;
+}
+
+export default function lerpParams(
+  from, to, t, snapKeys = [], prefix = ""
+) {
+  return lerpNode(
+    from,
+    to,
+    () => t,
+    snapKeys,
+    prefix
+  );
+}
+
 /**
- * Like lerpParams, but each TOP-LEVEL param group gets its own phase-shifted
- * progress so groups don't morph in lockstep (`spread` 0..~0.9). Group order
- * follows key order: the first leads, the last trails. Falls back to a plain
- * lerp when there is nothing to stagger.
+ * Like lerpParams, but SEQUENCES the individual parameters that change: each
+ * differing leaf (e.g. `sites.count`, `backgroundColor`, `speed`) gets its own
+ * slice of the morph window, so they change one after another instead of all at
+ * once. `spread` (0..1) sizes the slices — 0 = every changing param moves
+ * together (plain lerp); 1 = strictly one param at a time, each over 1/N of the
+ * window. Only leaves that actually differ count toward N. Falls back to a plain
+ * lerp when 0 or 1 params change.
  */
-export function lerpParamsStaggered(
+export function lerpParamsSequenced(
   from, to, t, snapKeys = [], spread = 0
 ) {
   const source = from ?? {};
   const target = to ?? {};
-  const keys = [
-    ...new Set( [
-      ...Object.keys( source ),
-      ...Object.keys( target )
-    ] )
-  ];
 
-  if ( spread <= 0 || keys.length <= 1 ) {
+  if ( spread <= 0 ) {
     return lerpParams(
       source,
       target,
@@ -158,29 +242,49 @@ export function lerpParamsStaggered(
     );
   }
 
-  const denom = keys.length - 1;
-  const out = {};
+  const order = collectChangingLeaves(
+    source,
+    target,
+    "",
+    snapKeys,
+    []
+  );
 
-  keys.forEach( (
-    key, index
-  ) => {
-    const groupT = staggeredProgress(
+  if ( order.length <= 1 ) {
+    return lerpParams(
+      source,
+      target,
       t,
-      index / denom,
+      snapKeys
+    );
+  }
+
+  const indexOf = new Map( order.map( (
+    path, index
+  ) => [
+    path,
+    index
+  ] ) );
+  const resolveT = ( path ) => {
+    const index = indexOf.get( path );
+
+    if ( index === undefined ) {
+      return t;
+    }
+
+    return sequenceProgress(
+      t,
+      index,
+      order.length,
       spread
     );
+  };
 
-    out[ key ] = lerpParams(
-      {
-        [ key ]: source[ key ]
-      },
-      {
-        [ key ]: target[ key ]
-      },
-      groupT,
-      snapKeys
-    )[ key ];
-  } );
-
-  return out;
+  return lerpNode(
+    source,
+    target,
+    resolveT,
+    snapKeys,
+    ""
+  );
 }

--- a/src/sketches/p5/utils/slides/morph/sequenceProgress.js
+++ b/src/sketches/p5/utils/slides/morph/sequenceProgress.js
@@ -1,0 +1,45 @@
+function clamp01( value ) {
+  if ( !Number.isFinite( value ) ) {
+    return 0;
+  }
+
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
+/**
+ * Per-item morph progress with a SIZED, sliding time window — used by the
+ * montage transition to change the individual parameters that differ one after
+ * another rather than all at once.
+ *
+ * Unlike the shared `staggeredProgress` (overlapping windows of a fixed 1-spread
+ * width), here `spread` (0..1) sizes each window so full-spread slices are even
+ * and non-overlapping:
+ *   - 0 → every item shares the full window: all change together.
+ *   - 1 → items get equal, NON-overlapping slices: item 0 over [0, 1/count],
+ *         item 1 over [1/count, 2/count], … i.e. strictly one at a time.
+ *   - between → the windows shrink and slide apart, partially overlapping.
+ *
+ * `t` is the (already eased) global morph progress 0..1. Every item is at 0 at
+ * t=0 and at 1 at t=1, so segment boundaries always settle cleanly.
+ */
+export default function sequenceProgress(
+  t, index, count, spread
+) {
+  const progress = clamp01( t );
+
+  if ( count <= 1 || spread <= 0 ) {
+    return progress;
+  }
+
+  const s = clamp01( spread );
+  // Window width shrinks from the full range (s=0) to one even slice (s=1).
+  const width = 1 - s * ( 1 - 1 / count );
+  const startSpan = 1 - width;
+  const start = ( index / ( count - 1 ) ) * startSpan;
+
+  if ( width <= 0 ) {
+    return progress >= start ? 1 : 0;
+  }
+
+  return clamp01( ( progress - start ) / width );
+}

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -1437,11 +1437,14 @@ export const SlideTransitionSchema = z.object( {
 
   loop: z.enum( TRANSITION_LOOP_MODES ).default( "cyclic" ),
 
-  // morph only — spread [0..0.9] of the per-group phase offset, so top-level
-  // param groups don't all morph in lockstep (e.g. colours lead, geometry
-  // follows). 0 = every group morphs together.
+  // morph only — how sequentially the individual parameters that differ between
+  // the source slides change [0..1]. 0 = every changing param morphs together;
+  // 1 = they change strictly one after another, each over its own even slice of
+  // the transition (param 1, then 2, then 3, …). In between, the per-param
+  // windows shrink and slide apart. Only leaves that actually differ are
+  // sequenced.
   stagger: z.number().min( 0 )
-    .max( 0.9 )
+    .max( 1 )
     .default( 0 ),
 
   // morph only — param paths (dotted, or a leaf name like "seed") that SNAP at


### PR DESCRIPTION
## What & why

Follow-up to #183. The montage `stagger` option was meant to make a transition change its parameters progressively, but you couldn't see any effect. Two reasons, now fixed:

1. It only nudged each group's *start* inside a heavily overlapping window (barely perceptible).
2. It sequenced by **top-level group** (`sites`, `backgroundColor`, …) — so when the params that differ between two slides all live under one group (e.g. `sites.count` + `sites.speed`), they still changed together.

This reworks it to sequence the **individual parameters that differ**, one after another.

## The model

`stagger` (0..1) now gives each **changing leaf** (`sites.count`, `backgroundColor`, `speed`, …) its own slice of the transition window:

- **0** → every changing param morphs together (plain lerp — unchanged default).
- **1** → params change strictly one at a time, each over `1/N` of the window: param 1, then 2, then 3, … So 3 differing params over a 1s transition = ~0.33s each, in sequence.
- **between** → the per-param windows shrink and slide apart.

Only leaves that **actually differ** count toward `N`, so unchanged params don't waste a slice. Every param settles at the segment boundaries, so loops stay seamless; `snapKeys` still snap (at their own slice).

## Implementation

- `lerpParams` refactored around a `resolveT(path)` engine, so the same deep walk serves both the uniform morph (constant `t`) and the per-parameter sequenced one (a different slice of `t` per changing leaf). Public `lerpParams(from, to, t, …)` behaviour is unchanged.
- `collectChangingLeaves` builds the stable per-leaf order; `lerpParamsSequenced` maps each changing leaf to its windowed slice via `staggeredProgress(t, index, N, spread)`.
- `morph/index.js` calls `lerpParamsSequenced` when `stagger > 0`.

## How to see it

Montage (morph style), ≥ 2 source slides that differ in **2–3 simple numeric params**, **Stagger = 1**, low **Hold**. You'll watch one param finish before the next begins, rather than everything snapping together.

## Testing

- `lerpParamsSequenced` tests: sequential one-at-a-time at spread 1, **nested leaves under one group sequence independently** (the case the old grouping missed), only-differing-leaves counted, endpoints settle, snap-within-sequence, spread-0 = plain lerp.
- Full suite green: **1605 tests pass**; lint and `tsc` clean.
- Rebased onto current `main` (repo reorg `src/templates` → `src/sketches`, `TemplateOptions` → `SketchOptions`).
- Still not driven in-browser here — happy to run a headless visual pass if you want proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc68H7Po3FePV3PWS3okSY