### PR TITLE
perf(dev): cut sketch-studio route cold-compile ~26% under Turbopack

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,26 @@ const nextConfig: NextConfig = {
   distDir: process.env.NEXT_BUILD_DIR || ".next",
   poweredByHeader: false,
   devIndicators: false,
+
+  // Node-only server dependencies that must never reach the browser. Marking
+  // them external stops Turbopack (and webpack) from parsing/transforming them
+  // into the module graph on every server compile — they are `require()`d
+  // straight from node_modules at runtime instead. This trims the dev-compile
+  // cost of the recording/API routes and the sketch-studio server route that
+  // pull these in. Next already ships @aws-sdk/client-s3, sharp, prisma and
+  // playwright in its default external list, so only the deps NOT covered by
+  // that list are added here (see node_modules/next/dist/lib/
+  // server-external-packages.json). Browser deps used for client-side recording
+  // (mediabunny, gif.js) are deliberately NOT listed — they must stay bundled.
+  serverExternalPackages: [
+    "@aws-sdk/s3-request-presigner",
+    "archiver",
+    "tar",
+    "bullmq",
+    "ioredis",
+    "web-push"
+  ],
+
   allowedDevOrigins: [
     "*",
     "192.168.1.161",

--- a/src/app/templates/[engine]/[...sketch]/page.tsx
+++ b/src/app/templates/[engine]/[...sketch]/page.tsx
@@ -6,11 +6,9 @@ import {
 } from "next/navigation";
 import React from "react";
 
-import "@/engines/index"; // register all engines
-
 import {
-  hasEngine, getEngine
-} from "@/engines/registry";
+  isKnownEngine, getEngineLabel
+} from "@/engines/engineCatalog";
 import {
   findSketchMeta
 } from "@/engines/metadata";
@@ -66,9 +64,7 @@ export async function generateMetadata( {
   );
   const baseUrl = getBaseUrl();
 
-  const engineLabel = hasEngine( engineId )
-    ? getEngine( engineId ).label
-    : engineId;
+  const engineLabel = getEngineLabel( engineId );
   const title = formatSketchTitle( sketchName );
   const description = buildSketchDescription(
     title,
@@ -152,7 +148,7 @@ export default async function StudioPage( {
   } = await params;
 
   /* ---- validate engine ------------------------------------------- */
-  if ( !hasEngine( engineId ) ) {
+  if ( !isKnownEngine( engineId ) ) {
     return notFound();
   }
 
@@ -175,7 +171,7 @@ export default async function StudioPage( {
   }
 
   /* ---- engine label for structured data -------------------------- */
-  const engineLabel = getEngine( engineId ).label;
+  const engineLabel = getEngineLabel( engineId );
   const baseUrl = getBaseUrl();
 
   /* ---- load options & form meta ---------------------------------- */

--- a/src/engines/gsap/GsapEngine.ts
+++ b/src/engines/gsap/GsapEngine.ts
@@ -22,9 +22,6 @@ import {
   resolveSketchPath
 } from "@/engines/metadata";
 import {
-  loadSketchModule
-} from "@/generated/sketchModuleRegistry";
-import {
   registerServerCaptureController,
   unregisterServerCaptureController
 } from "@/engines/recording/serverCapture";
@@ -98,7 +95,15 @@ export class GsapEngine implements SketchEngine {
 
     // Loaded from the generated registry of literal dynamic imports — see
     // src/generated/sketchModuleRegistry.ts. A variable-path import here would
-    // make the bundler build a context module over every sketch.
+    // make the bundler build a context module over every sketch. The registry
+    // module is imported dynamically (rather than at the top of the file) so
+    // its ~270 literal import() code-split points are NOT registered on the
+    // sketch page's initial compile — they only cost compile time once a sketch
+    // actually mounts and calls init().
+    const {
+      loadSketchModule
+    } = await import( "@/generated/sketchModuleRegistry" );
+
     const templateModule = await loadSketchModule(
       "gsap",
       sketchPath

--- a/src/engines/p5/P5Engine.ts
+++ b/src/engines/p5/P5Engine.ts
@@ -28,9 +28,6 @@ import {
   resolveSketchPath
 } from "@/engines/metadata";
 import {
-  loadSketchModule
-} from "@/generated/sketchModuleRegistry";
-import {
   getAnimationBridge
 } from "@/lib/animationBridge";
 import {
@@ -128,7 +125,15 @@ export class P5Engine implements SketchEngine {
     // Loaded from the generated registry of literal dynamic imports — see
     // src/generated/sketchModuleRegistry.ts. A variable-path import here would
     // make the bundler build a context module over every sketch, compiling the
-    // whole catalogue on each page in dev.
+    // whole catalogue on each page in dev. The registry module is imported
+    // dynamically (rather than at the top of the file) so its ~270 literal
+    // import() code-split points are NOT registered on the sketch page's
+    // initial compile — they only cost compile time once a sketch actually
+    // mounts and calls init(), shaving that work off the page's first paint.
+    const {
+      loadSketchModule
+    } = await import( "@/generated/sketchModuleRegistry" );
+
     await loadSketchModule(
       "p5",
       sketchPath

--- a/src/engines/sketchOptionLoaders.ts
+++ b/src/engines/sketchOptionLoaders.ts
@@ -1,10 +1,5 @@
 import "server-only";
 
-import {
-  sketchOptionsJsonLoaders,
-  sketchFormLoaders
-} from "@/generated/sketchOptionsRegistry";
-
 /**
  * Server-only loaders for a template's filesystem-backed option files
  * (`options.json` / `options.ts`).
@@ -41,6 +36,9 @@ export type SketchOptionLoaders = {
 function buildLoaders( engineId: string ): SketchOptionLoaders {
   return {
     async loadOptionsJson( sketchPath: string ) {
+      const {
+        sketchOptionsJsonLoaders
+      } = await import( "@/generated/sketchOptionsRegistry" );
       const loader = sketchOptionsJsonLoaders[ `${ engineId }:${ sketchPath }` ];
 
       if ( !loader ) {
@@ -53,6 +51,9 @@ function buildLoaders( engineId: string ): SketchOptionLoaders {
     },
 
     async loadSketchForm( sketchPath: string ) {
+      const {
+        sketchFormLoaders
+      } = await import( "@/generated/sketchOptionsRegistry" );
       const loader = sketchFormLoaders[ `${ engineId }:${ sketchPath }` ];
 
       if ( !loader ) {
@@ -65,25 +66,16 @@ function buildLoaders( engineId: string ): SketchOptionLoaders {
 }
 
 /**
- * The set of engines that ship at least one option file, derived from the
- * generated registry keys (`<engineId>:<sketchPath>`).
+ * Return the server-only option loaders for `engineId`.
+ *
+ * Always returns a loader pair: each loader resolves to `{}` when the generated
+ * registry has no entry for the key, so callers don't need a separate
+ * "does this engine ship option files?" guard. The registry (`@/generated/
+ * sketchOptionsRegistry`, ~280 literal import() code-split points) is imported
+ * *inside* the loaders rather than at module top level, so those split points
+ * stay off the sketch route's initial server compile — they are only paid once
+ * a loader actually runs while rendering a sketch that has options.
  */
-const enginesWithOptions = new Set( [
-  ...Object.keys( sketchOptionsJsonLoaders ),
-  ...Object.keys( sketchFormLoaders )
-].map( ( key ) => key.slice(
-  0,
-  key.indexOf( ":" )
-) ) );
-
-/**
- * Return the server-only option loaders for `engineId`, or `undefined`
- * when the engine has no template option files.
- */
-export function getSketchOptionLoaders( engineId: string ): SketchOptionLoaders | undefined {
-  if ( !enginesWithOptions.has( engineId ) ) {
-    return undefined;
-  }
-
+export function getSketchOptionLoaders( engineId: string ): SketchOptionLoaders {
   return buildLoaders( engineId );
 }


### PR DESCRIPTION
## Why

Opening a sketch page in dev (`next dev --turbopack`) was slow — ~30s to compile on the user's machine, reproduced at **~56.7s** in a slower sandbox. The studio route `/templates/[engine]/[...sketch]` was the outlier (the home page compiles in ~4s).

I profiled the route's compile graph with throwaway diagnostic pages and isolated the cost:

| Route compiled (fresh `.next`) | Cold compile |
|---|---|
| Bare control page | 4.1s |
| `sketchModuleRegistry` only (272 `import()` thunks) | 15.8s |
| `@/engines/index` (engines + deps, incl. registry) | 30.7s |
| Full studio route | ~55s |

The route was eagerly pulling **two generated registries** (272 + 283 literal `import()` code-split points) and the **full engine runtime** into its initial compile graph. Turbopack has to register a code-split boundary for every one of those ~555 literal imports up front, even though none of the sketches themselves are compiled until opened.

The existing dynamic-import code-splitting (TemplateOptions, CaptureActions, FieldRenderer, p5/gsap runtimes) is all intact — this is about what stays on the route's *initial* graph.

## What changed

- **`page.tsx` reads engine id/label from the static `engineCatalog`** (`isKnownEngine` / `getEngineLabel`) instead of `import "@/engines/index"` + the runtime registry. The server route no longer compiles the entire engine graph (and the module registry it drags in) just to render a label — this mirrors how `getTemplatesData` already avoids the engine graph for the gallery/home pages.
- **`P5Engine` / `GsapEngine` import `sketchModuleRegistry` dynamically inside `init()`** instead of at module top level, so its ~270 split points stay off the route's initial compile (proven in isolation: the engine graph dropped 30.7s → 16.5s).
- **`sketchOptionLoaders` imports `sketchOptionsRegistry` dynamically inside the loader methods** and drops the eager `enginesWithOptions` set, keeping the 283 form-loader split points off the server route's initial compile.
- **`next.config.ts` adds `serverExternalPackages`** for node-only server deps not already in Next's default external list (`@aws-sdk/s3-request-presigner`, `archiver`, `tar`, `bullmq`, `ioredis`, `web-push`) so Turbopack stops transforming them on server compiles (helps the recording/API routes most).

## Result

Clean A/B on a fixed machine, fresh `.next`, 2 runs each:

| | Run 1 | Run 2 | Avg |
|---|---|---|---|
| Baseline | 57.0s | 56.4s | **~56.7s** |
| This PR | 42.5s | 41.7s | **~42.0s** |

**~26% (~15s) off the studio route's cold compile.** No production or runtime behavior change — the registries and engines still load identically at runtime; only the dev-mode module graph shrinks.

## Note on the bigger lever (not included)

The single largest win for the "every time I pull a branch it's ~30s again" case is **Turbopack persistent dev caching** (`experimental.turbopackPersistentCaching`), which survives dev-server restarts. It is **canary-only** in the pinned Next `15.5.19` (stable throws `CanaryOnlyError` and the dev server won't start), so it's intentionally left out. Adopting it would require moving the project to `next@canary` — happy to do that as a follow-up if wanted. In the meantime, keeping the dev server running across `git pull` (instead of restarting) lets Turbopack do fast incremental recompiles rather than a cold one.

## Verification

- ESLint clean on all changed files
- `jest src/engines` — 8/8 pass
- `next dev --turbopack` starts and validates the new config
- Studio route renders `200` and the A/B above was measured end-to-end

## Test plan

- [ ] `npm run dev`, open a p5 sketch and a gsap sketch — both render and animate
- [ ] Confirm options/sketch-settings panels still populate (exercises `sketchOptionsRegistry`)
- [ ] Confirm a recording still works end-to-end (exercises the `serverExternalPackages` deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jjjVhpxUjU92ktEBEnGU5

---
_Generated by [Claude Code](https://claude.ai/code/session_015jjjVhpxUjU92ktEBEnGU5)_