### PR TITLE
Show screenshot action on mobile in engine controls

### DIFF
--- a/src/components/TemplateSketchPage/EngineControls.tsx
+++ b/src/components/TemplateSketchPage/EngineControls.tsx
@@ -233,7 +233,7 @@ export function EngineControls( ) {
           disabled={ thumbnailSaveState === "saving" }
           onClick={ handleCaptureClick }
           onDoubleClick={ handleSaveCanvasAsThumbnail }
-          className="hidden md:inline-flex h-full px-3 hover:bg-hover transition-colors group items-center justify-center"
+          className="inline-flex h-full px-3 hover:bg-hover transition-colors border-r border-border md:border-r-0 group items-center justify-center"
         >
           {thumbnailSaveState === "saving" ? (
             <Loader2 className="h-4 w-4 text-yellow-400/70 animate-spin" />


### PR DESCRIPTION
## Summary

The engine controls toolbar previously hid **both** the GitHub link and the screenshot (camera) action on mobile. The screenshot action is genuinely useful on mobile, so this change keeps only the GitHub link hidden and lets the screenshot action through.

With the GitHub icon gone on mobile there's room for the camera button alongside the existing record/export shortcut, so the mobile toolbar now reads **Play | Screenshot | Record**.

## Changes

- `src/components/TemplateSketchPage/EngineControls.tsx`: the screenshot button now uses `inline-flex` instead of `hidden md:inline-flex`, so it shows on all viewports.
- Added a mobile-only right divider (`border-r border-border md:border-r-0`) so the screenshot button sits cleanly between the play and record shortcuts on mobile, while the desktop layout (where it's the last button) stays clean.
- The GitHub link keeps its `hidden md:inline-flex` and remains hidden on mobile.

## Testing

CSS-class-only change. Lint could not run in the fresh container (`@stylistic/eslint-plugin` not installed), but no logic was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgXNnATe98GqZwKjoaabX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgXNnATe98GqZwKjoaabX6)_