### PR TITLE
fix(animation): make sketch duration actually drive the live p5 cadence

### DIFF
--- a/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v3-medusa/index.js
+++ b/src/templates/p5/sketches/torsade-shaders/torsade-shaders-v3-medusa/index.js
@@ -2,6 +2,7 @@ import options from "@/p5/utils/options.js";
 import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
+import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 import {
   createInstancedFieldRenderer
@@ -219,8 +220,12 @@ sketch.setup(
   {}
 );
 
-sketch.draw( ( time ) => {
+sketch.draw( () => {
   const p = getP5();
+  // Duration-driven loop clock (canonical), replacing the legacy `draw(time)`
+  // argument. Same value as before at the default duration, but now the whole
+  // animation rescales with the sketch duration.
+  const time = animation.loopTime;
   const o = options.sketch ?? {};
   const layout = o.layout ?? {};
   const rings = o.rings ?? {};

--- a/src/templates/p5/utils/__tests__/durationLoopClock.test.ts
+++ b/src/templates/p5/utils/__tests__/durationLoopClock.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression tests for the duration-scaled loop clock.
+ *
+ * The bug: changing the animation duration in Template Options did nothing to
+ * the live sketch. Sketches drive their motion off the first `draw(time, …)`
+ * argument, which used to be raw, unbounded `time.seconds()` — a value with no
+ * `duration` term — so the duration only ever affected the progression bar
+ * label and the recorded frame count, never the on-canvas cadence.
+ *
+ * The fix makes that argument the loop phase scaled by the baseline duration
+ * (`time.drawSeconds()`), so the whole animation completes within `duration`:
+ * a 1s loop runs the same motion the 12s default shows, only 12x faster, and
+ * the live preview matches the recorded clip frame-for-frame.
+ */
+
+export {};
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const time = require( "@/p5/utils/time.js" ).default;
+const animation = require( "@/p5/utils/animation.js" ).default;
+const sketch = require( "@/p5/utils/sketch.js" ).default;
+const {
+  DURATION_DEFAULT
+} = require( "@/lib/animationConfig" );
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function setDuration( duration: number ): void {
+  sketch.sketchOptions = {
+    size: {
+      width: 1080,
+      height: 1350
+    },
+    animation: {
+      framerate: 60,
+      duration
+    }
+  };
+}
+
+describe(
+  "duration-scaled loop clock",
+  () => {
+    beforeEach( () => {
+      window.disableRecordingMode!();
+      time.reset();
+    } );
+
+    test(
+      "at the default duration the draw clock equals real seconds within a loop",
+      () => {
+        setDuration( DURATION_DEFAULT );
+        time.elapsed = 5000; // 5s into a 12s loop
+
+        expect( time.drawSeconds() ).toBeCloseTo(
+          5,
+          6
+        );
+        expect( animation.progression ).toBeCloseTo(
+          5 / DURATION_DEFAULT,
+          6
+        );
+      }
+    );
+
+    test(
+      "a 1s loop is 12x faster: half the loop is reached in 0.5s, not 6s",
+      () => {
+        // 12s loop: phase 0.5 (mid-animation) is reached after 6 real seconds.
+        setDuration( 12 );
+        time.elapsed = 6000;
+        const drawAt12s = time.drawSeconds();
+
+        // 1s loop: the SAME mid-animation point is reached after only 0.5s.
+        setDuration( 1 );
+        time.elapsed = 500;
+        const drawAt1s = time.drawSeconds();
+
+        // Both sit at the same point in the animation (phase 0.5 → 6 draw-seconds)…
+        expect( drawAt1s ).toBeCloseTo(
+          drawAt12s,
+          6
+        );
+        expect( drawAt1s ).toBeCloseTo(
+          0.5 * DURATION_DEFAULT,
+          6
+        );
+
+        // …but the 1s loop advances the draw clock 12x faster in wall-clock
+        // terms: DURATION_DEFAULT draw-seconds per `duration` real seconds.
+        const ratePerSecondAt1s = drawAt1s / 0.5;
+        const ratePerSecondAt12s = drawAt12s / 6;
+
+        expect( ratePerSecondAt12s ).toBeCloseTo(
+          DURATION_DEFAULT / 12,
+          6
+        );
+        expect( ratePerSecondAt1s ).toBeCloseTo(
+          DURATION_DEFAULT / 1,
+          6
+        );
+        expect( ratePerSecondAt1s ).toBeCloseTo(
+          ratePerSecondAt12s * 12,
+          6
+        );
+      }
+    );
+
+    test(
+      "the draw clock wraps every `duration` seconds during live playback",
+      () => {
+        setDuration( 4 );
+
+        time.elapsed = 1000; // 1s → quarter way
+        expect( time.drawSeconds() ).toBeCloseTo(
+          0.25 * DURATION_DEFAULT,
+          6
+        );
+
+        time.elapsed = 5000; // 5s → one full loop + 1s → back to quarter way
+        expect( time.drawSeconds() ).toBeCloseTo(
+          0.25 * DURATION_DEFAULT,
+          6
+        );
+      }
+    );
+
+    test(
+      "progression delegates to the canonical phase",
+      () => {
+        setDuration( 8 );
+        time.elapsed = 2000; // 2s into an 8s loop → phase 0.25
+
+        expect( animation.progression ).toBeCloseTo(
+          time.phase(),
+          10
+        );
+        expect( time.phase() ).toBeCloseTo(
+          0.25,
+          6
+        );
+      }
+    );
+
+    test(
+      "during recording the phase does not wrap (matches the frame index)",
+      () => {
+        setDuration( 4 );
+        window.enableRecordingMode!();
+
+        // Recording clock is pinned to frame / framerate; the last frame of a
+        // 4s @60fps loop sits just under a full loop (no wrap).
+        const totalFrames = 4 * 60;
+
+        window.setRecordingFrame!( totalFrames - 1 );
+        time.incrementElapsedTime();
+
+        expect( time.phase() ).toBeCloseTo(
+          ( totalFrames - 1 ) / totalFrames,
+          6
+        );
+        expect( time.phase() ).toBeLessThan( 1 );
+        // The draw clock spans the full baseline within the clip.
+        expect( time.drawSeconds() ).toBeLessThan( DURATION_DEFAULT );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/animation.js
+++ b/src/templates/p5/utils/animation.js
@@ -40,6 +40,17 @@ const animation = {
     // derives from one source and can never drift apart.
     return time.phase();
   },
+  // Duration-driven loop seconds — the canonical replacement for the legacy
+  // `draw(time, …)` first argument. It is the loop phase scaled so one whole
+  // loop spans the baseline duration (`progression × DURATION_DEFAULT`), so a
+  // sketch that thinks in seconds (e.g. feeds a shader `uT`) reads this instead
+  // of the draw argument: it stays duration-driven AND stops depending on the
+  // draw signature. New sketches should prefer `animation.progression` directly;
+  // this exists so the seconds-based sketches migrate as a one-line change with
+  // no visual difference. Backed by the same `time.phase()` as everything else.
+  get loopTime() {
+    return time.drawSeconds();
+  },
   get circularProgression() {
     return mappers.circular(
       animation.progression,

--- a/src/templates/p5/utils/animation.js
+++ b/src/templates/p5/utils/animation.js
@@ -5,7 +5,7 @@ import {
   getP5
 } from "./sketch.js";
 import {
-  resolveAnimation, totalFramesFor
+  totalFramesFor
 } from "@/lib/animationConfig";
 
 const animation = {
@@ -35,18 +35,10 @@ const animation = {
   },
 
   get progression() {
-    const {
-      duration
-    } = resolveAnimation( sketch.sketchOptions?.animation );
-    const seconds = time.seconds();
-
-    // During recording, don't wrap and don't cap - progression should match frame count
-    if ( time.isRecording ) {
-      return seconds / duration;
-    }
-
-    // Normal playback: wrap around for continuous loop
-    return ( seconds % duration ) / duration;
+    // Delegate to the single canonical loop phase so every progression reader
+    // (this getter, the bridge, the per-frame draw clock, the progression bar)
+    // derives from one source and can never drift apart.
+    return time.phase();
   },
   get circularProgression() {
     return mappers.circular(

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -294,9 +294,14 @@ const sketch = {
 
           events.handle( "pre-draw" );
 
-          // Call the user's draw function with the same args as before
+          // Call the user's draw function. The first arg is the duration-scaled
+          // loop clock (time.drawSeconds), NOT raw elapsed seconds: a sketch
+          // that animates off it completes its whole loop within `duration`, so
+          // changing the duration rescales the live preview and the recording
+          // identically. At the default duration it equals the old real-seconds
+          // value, so existing sketches are unchanged there.
           await sketch._drawFn?.(
-            time.seconds(),
+            time.drawSeconds(),
             sketch.getCanvasCenter(),
             sketch.favoriteColors.purple,
             p
@@ -491,35 +496,15 @@ const sketch = {
           return;
         }
 
-        const {
-          duration
-        } = resolveAnimation( sketch.sketchOptions?.animation );
-        const seconds = time.seconds();
-        const progression = time.isRecording
-          ? Math.min(
-            seconds / duration,
-            1.0
-          )
-          : ( seconds % duration ) / duration;
-
-        subscribers.forEach( ( cb ) => cb( progression ) );
+        // Read the single canonical loop phase (same source as
+        // animation.progression and the draw clock) so subscribers never see a
+        // position that disagrees with the running sketch.
+        subscribers.forEach( ( cb ) => cb( time.phase() ) );
       }
     );
 
     registerAnimationBridge( {
-      getProgression: () => {
-        const {
-          duration
-        } = resolveAnimation( sketch.sketchOptions?.animation );
-        const seconds = time.seconds();
-
-        return time.isRecording
-          ? Math.min(
-            seconds / duration,
-            1.0
-          )
-          : ( seconds % duration ) / duration;
-      },
+      getProgression: () => time.phase(),
 
       setProgression: ( value ) => {
         const clamped = Math.max(

--- a/src/templates/p5/utils/time.js
+++ b/src/templates/p5/utils/time.js
@@ -1,6 +1,6 @@
 import sketch from "./sketch.js";
 import {
-  resolveAnimation
+  resolveAnimation, DURATION_DEFAULT
 } from "@/lib/animationConfig";
 
 const time = {
@@ -13,6 +13,36 @@ const time = {
   },
   milliSeconds: function() {
     return time.elapsed;
+  },
+  // The canonical loop phase in [0, 1): how far through one `duration`-long loop
+  // we are. This is THE single value the engine derives looping motion from —
+  // `animation.progression`, the animation bridge and the per-frame
+  // `draw(time, …)` clock all read it, so the live preview, the progression bar
+  // and the recorded file can never resolve a different loop position. During
+  // deterministic capture `elapsed` is pinned to frame / framerate, so this is
+  // exactly frame / totalFrames.
+  phase: function() {
+    const {
+      duration
+    } = resolveAnimation( sketch?.sketchOptions?.animation );
+    const seconds = time.seconds();
+
+    // During recording we must NOT wrap: progression climbs monotonically with
+    // the frame index so the final frame sits just under a full loop.
+    return time.isRecording
+      ? seconds / duration
+      : ( seconds % duration ) / duration;
+  },
+  // The seconds value handed to every sketch's `draw(time, …)`. It is the loop
+  // phase scaled by the baseline duration, so a sketch authored against it
+  // completes its WHOLE animation within `duration` — i.e. the duration is the
+  // loop's period. Changing the duration therefore rescales the live preview and
+  // the recorded clip identically (WYSIWYG). Scaled by DURATION_DEFAULT so that
+  // at the default duration this equals the historical real-seconds clock: every
+  // existing sketch looks unchanged at the default duration and simply runs
+  // faster at a shorter duration / slower at a longer one.
+  drawSeconds: function() {
+    return time.phase() * DURATION_DEFAULT;
   },
   every: function(
     second, callback
@@ -117,37 +147,13 @@ window.setAnimationProgression = function( progression ) {
 let lastDispatchedProgression = -1;
 
 window.getAnimationProgression = function() {
-  // Resolve the loop length through the shared resolver (same default as the
-  // encode loop) so progression and the recorded frame count never disagree.
-  const {
-    duration
-  } = resolveAnimation( sketch?.sketchOptions?.animation );
-  const seconds = time.seconds();
+  // Read the canonical loop phase — the same value `animation.progression`, the
+  // bridge and the per-frame draw clock use — so every consumer agrees and the
+  // recorded frame count can never disagree with the live position. `phase()`
+  // already handles the recording branch (no wrap, matches the frame index).
+  const progression = time.phase();
 
-  // During recording, don't wrap and don't cap - progression should match frame count
-  if ( time.isRecording ) {
-    const progression = seconds / duration;
-
-    // Dispatch event only when progression changes significantly (every 0.01 or so)
-    if ( Math.abs( progression - lastDispatchedProgression ) > 0.01 ) {
-      lastDispatchedProgression = progression;
-      window.dispatchEvent( new CustomEvent(
-        "animation-progression-changed",
-        {
-          detail: {
-            progression
-          }
-        }
-      ) );
-    }
-
-    return progression;
-  }
-
-  // Normal playback: wrap around for continuous loop
-  const progression = ( seconds % duration ) / duration;
-
-  // Dispatch event only when progression changes significantly
+  // Dispatch event only when progression changes significantly (every 0.01 or so)
   if ( Math.abs( progression - lastDispatchedProgression ) > 0.01 ) {
     lastDispatchedProgression = progression;
     window.dispatchEvent( new CustomEvent(


### PR DESCRIPTION
## The bug

Changing the animation **Duration** in Template Options did nothing to the live sketch. The progression‑bar label and the recorded file length changed, but the on‑canvas motion ran at the **same cadence** — a 1‑second sketch looked identical to the 12‑second default.

## Root cause

p5 sketches drive their motion off the **first `draw(time, …)` argument**, which was raw, unbounded `time.seconds()` — a value with **no `duration` term**. So duration could never affect those sketches live.

- **88 sketches** animate off this `time` argument (the shader / neon families: `uT: time`, `shape.draw(time)`, `sin(time * speed)`).
- The duration‑normalized `animation.progression` path *did* respond — which is why other sketches worked and the propagation looked fine.
- The recording engine was a **red herring**: it reads duration from the store, so the file length changed while the live preview didn't. (Verified: the committed `durationRecording` / `effectiveSlideDuration` tests already prove duration propagates to the live clock for the reported global‑edit case — the propagation was never the bug.)

GSAP was never affected: its timeline is built to `duration` and scrubbed `elapsed % duration`, so it already behaves as "duration = the loop's period." This PR brings p5 in line with that model.

## The fix — one canonical loop clock

Unify the time model around a single phase, so live preview, the progression bar and the recorded file can never disagree:

- **`time.phase()`** — the loop position in `[0, 1)`. `animation.progression`, the animation bridge and `window.getAnimationProgression` now all delegate to it, removing **four copies** of the same `(seconds % duration) / duration` formula.
- **`time.drawSeconds()`** — the loop phase scaled by the baseline duration, handed to every sketch's `draw(time, …)`. A sketch authored against it completes its **whole animation within `duration`**, so the duration is the loop's period: a 1s loop runs the motion the 12s default shows, 12× faster, and the live preview matches the recorded clip frame‑for‑frame.

Scaled by `DURATION_DEFAULT` (12) so that **at the default duration the value equals the old real‑seconds clock** — every existing sketch is unchanged at 12s and simply rescales at other durations. Audio and the HUD keep raw `time.seconds()`, which is correct for scheduling / telemetry.

## Behaviour change to be aware of

For raw‑`time` sketches, the live preview now **loops at `duration`** (the seam the exported clip already has becomes visible — WYSIWYG), and non‑default durations now rescale the **recorded** clip's motion (the whole point). At the default 12s, output is unchanged.

## Tests

- New `durationLoopClock.test.ts` (5 tests) locks the duration‑scaling + single‑phase contract.
- Existing `recordingClock`, `durationRecording`, `effectiveSlideDuration` suites unchanged — **1264 tests green**, lint clean.

Net **−17 lines** of production code (four duplicated progression formulas collapsed into one phase).

## Follow‑up (out of scope)

A separate, narrow propagation fragility exists for **multi‑slide decks with per‑slide duration overrides**: the live p5 clock reads `sketch.sketchOptions.animation` (a synced snapshot) and the p5 runtime's `slides.index` isn't wired to the UI's active slide for live editing. Not the reported symptom; can be addressed later by routing the live read through `getEffectiveSlideSettings(getSketchOptions(), index)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4ybWFojDjLVjXAp4PcsGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4ybWFojDjLVjXAp4PcsGh)_