### PR TITLE
feat(content): per-item render phase — place items behind or in front of the sketch

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -311,6 +311,26 @@ export const blendSelectOptions: SelectOption[] = Blend.options.map( ( blendOpti
   label: blendOption
 } ) );
 
+// Shared render-phase selector (schema: RenderPhase in sketch.types.ts).
+// Every content-item type carries it, so it must appear in every formConfig
+// entry below or GenericItemForm hides the field with a console warning.
+// "Behind" only shows through where the sketch leaves transparency, unless
+// the template sets sketch.delegateBackground.
+const phaseField: FieldConfig = {
+  label: "Layer",
+  component: "select",
+  options: [
+    {
+      value: "front",
+      label: "In front of the sketch"
+    },
+    {
+      value: "back",
+      label: "Behind the sketch"
+    }
+  ]
+};
+
 /* ---------------- HUD widget field fragments -------------------- */
 const hudAnchorField: FieldConfig = {
   label: "Anchor",
@@ -532,6 +552,7 @@ const dotsPatternFields: ItemFormConfig = {
 // The top-level keys MUST match the 'type' in your Zod discriminated union
 export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
   meta: {
+    phase: phaseField,
     fill: {
       label: "Fill",
       component: "color"
@@ -586,6 +607,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   specs: {
+    phase: phaseField,
     style: {
       label: "Style",
       component: "select",
@@ -948,6 +970,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   hud: {
+    phase: phaseField,
     fill: {
       label: "Default fill",
       component: "color"
@@ -1123,6 +1146,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   text: {
+    phase: phaseField,
     content: {
       label: "Content",
       component: "textarea"
@@ -1213,6 +1237,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     // We can add more fields here and they will auto-generate
   },
   background: {
+    phase: phaseField,
     background: {
       label: "Background color",
       component: "color"
@@ -1249,6 +1274,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   image: {
+    phase: phaseField,
     source: {
       label: "Source",
       component: "image"
@@ -1328,6 +1354,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   "images-stack": {
+    phase: phaseField,
     sources: {
       label: "Sources",
       component: "images-stack"
@@ -1398,6 +1425,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   visual: {
+    phase: phaseField,
     position: {
       label: "Position",
       component: "vector2d",
@@ -1448,6 +1476,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     }
   },
   qrcode: {
+    phase: phaseField,
     domainOverride: {
       label: "Domain override",
       component: "text",

--- a/src/templates/p5/utils/__tests__/renderPhase.test.ts
+++ b/src/templates/p5/utils/__tests__/renderPhase.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Tests for the per-item render phase ("back" = behind the sketch, "front" =
+ * on top — the historical default) and the opt-in delegated background.
+ *
+ * freeLayout draws one phase per pass: the pre-draw pass renders "back" items
+ * under the sketch, the post-draw pass renders "front" (and legacy unphased)
+ * items on top. backgroundLayer captures a delegated sketch's first opaque
+ * background() call so the engine can repaint it under back-phase items
+ * instead of letting it erase them.
+ */
+
+jest.mock(
+  "../slides/common/drawSlideVisual.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideMeta.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideSpecs.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideHud.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideText.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideImage.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideImages.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideBackground.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideImagesStack.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+jest.mock(
+  "../slides/common/drawSlideQrCode.js",
+  () => ( {
+    __esModule: true,
+    default: jest.fn()
+  } )
+);
+
+// backgroundLayer reads the delegation flag from the live options proxy; a
+// mutable mock lets each test flip it without the real store machinery.
+const mockLiveOptions: {
+  sketch: Record<string, unknown>;
+} = {
+  sketch: {}
+};
+
+jest.mock(
+  "../options.js",
+  () => ( {
+    __esModule: true,
+    default: mockLiveOptions
+  } )
+);
+
+import freeLayout from "../slides/layouts/freeLayout.js";
+import drawSlideSpecs from "../slides/common/drawSlideSpecs.js";
+import drawSlideText from "../slides/common/drawSlideText.js";
+import drawSlideBackground from "../slides/common/drawSlideBackground.js";
+
+import {
+  install,
+  beginSketchDraw,
+  endSketchDraw,
+  paintBase,
+  isDelegated
+} from "../backgroundLayer.js";
+
+function createFakeP5() {
+  const calls: unknown[][] = [];
+
+  const p: any = {
+    background: ( ...args: unknown[] ) => {
+      calls.push( args );
+    }
+  };
+
+  return {
+    p,
+    calls
+  };
+}
+
+describe(
+  "freeLayout render phases",
+  () => {
+    beforeEach( () => {
+      jest.clearAllMocks();
+    } );
+
+    const content = [
+      {
+        type: "background",
+        phase: "back"
+      },
+      {
+        type: "specs",
+        phase: "back"
+      },
+      {
+        type: "text"
+      }, // legacy item without a phase
+      {
+        type: "specs",
+        phase: "front"
+      }
+    ];
+
+    it(
+      "defaults to the front pass: unphased + front items only",
+      () => {
+        freeLayout( {
+          content
+        } );
+
+        expect( drawSlideBackground ).not.toHaveBeenCalled();
+        expect( drawSlideText ).toHaveBeenCalledTimes( 1 );
+        expect( drawSlideSpecs ).toHaveBeenCalledTimes( 1 );
+        expect( drawSlideSpecs ).toHaveBeenCalledWith( content[ 3 ] );
+      }
+    );
+
+    it(
+      "back pass renders only back items",
+      () => {
+        freeLayout(
+          {
+            content
+          },
+          "back"
+        );
+
+        expect( drawSlideBackground ).toHaveBeenCalledTimes( 1 );
+        expect( drawSlideText ).not.toHaveBeenCalled();
+        expect( drawSlideSpecs ).toHaveBeenCalledTimes( 1 );
+        expect( drawSlideSpecs ).toHaveBeenCalledWith( content[ 1 ] );
+      }
+    );
+
+    it(
+      "tolerates empty options",
+      () => {
+        expect( () => freeLayout( undefined as any ) ).not.toThrow();
+        expect( () => freeLayout(
+          {},
+          "back"
+        ) ).not.toThrow();
+      }
+    );
+  }
+);
+
+describe(
+  "backgroundLayer delegated background",
+  () => {
+    beforeEach( () => {
+      mockLiveOptions.sketch = {};
+      endSketchDraw();
+    } );
+
+    it(
+      "is inert without the flag: background paints as usual",
+      () => {
+        const {
+          p, calls
+        } = createFakeP5();
+
+        install( p );
+        expect( isDelegated() ).toBe( false );
+
+        beginSketchDraw();
+        p.background(
+          10,
+          20,
+          30
+        );
+        endSketchDraw();
+
+        expect( calls ).toEqual( [
+          [
+            10,
+            20,
+            30
+          ]
+        ] );
+      }
+    );
+
+    it(
+      "captures the first opaque call and repaints it via paintBase",
+      () => {
+        const {
+          p, calls
+        } = createFakeP5();
+
+        install( p );
+        mockLiveOptions.sketch = {
+          delegateBackground: true
+        };
+
+        beginSketchDraw();
+        p.background(
+          10,
+          20,
+          30
+        );
+        endSketchDraw();
+
+        // Suppressed inside the sketch draw…
+        expect( calls ).toEqual( [] );
+
+        // …and repainted by the engine at the bottom of the next frame.
+        paintBase();
+        expect( calls ).toEqual( [
+          [
+            10,
+            20,
+            30
+          ]
+        ] );
+      }
+    );
+
+    it(
+      "lets translucent (trail) backgrounds through, including array form",
+      () => {
+        const {
+          p, calls
+        } = createFakeP5();
+
+        install( p );
+        mockLiveOptions.sketch = {
+          delegateBackground: true
+        };
+
+        beginSketchDraw();
+        p.background(
+          0,
+          0,
+          0,
+          40
+        );
+        p.background( [
+          0,
+          0,
+          0,
+          40
+        ] );
+        endSketchDraw();
+
+        expect( calls ).toHaveLength( 2 );
+
+        // Nothing captured — paintBase stays a no-op.
+        paintBase();
+        expect( calls ).toHaveLength( 2 );
+      }
+    );
+
+    it(
+      "passes later opaque calls through (intentional mid-frame repaints)",
+      () => {
+        const {
+          p, calls
+        } = createFakeP5();
+
+        install( p );
+        mockLiveOptions.sketch = {
+          delegateBackground: true
+        };
+
+        beginSketchDraw();
+        p.background( 0 ); // captured
+        p.background( 255 ); // mid-frame repaint, painted
+        endSketchDraw();
+
+        expect( calls ).toEqual( [
+          [
+            255
+          ]
+        ] );
+
+        // Next frame captures again.
+        beginSketchDraw();
+        p.background( 0 );
+        endSketchDraw();
+        expect( calls ).toHaveLength( 1 );
+      }
+    );
+
+    it(
+      "leaves content items untouched outside the sketch-draw window",
+      () => {
+        const {
+          p, calls
+        } = createFakeP5();
+
+        install( p );
+        mockLiveOptions.sketch = {
+          delegateBackground: true
+        };
+
+        // e.g. drawSlideBackground running in a freeLayout pass
+        p.background(
+          1,
+          2,
+          3
+        );
+
+        expect( calls ).toEqual( [
+          [
+            1,
+            2,
+            3
+          ]
+        ] );
+      }
+    );
+
+    it(
+      "install rebinds cleanly on a fresh p5 instance",
+      () => {
+        const first = createFakeP5();
+
+        install( first.p );
+        mockLiveOptions.sketch = {
+          delegateBackground: true
+        };
+
+        beginSketchDraw();
+        first.p.background( 7 );
+        endSketchDraw();
+
+        const second = createFakeP5();
+
+        install( second.p );
+
+        // The capture from the previous instance is dropped with the rebind.
+        paintBase();
+        expect( second.calls ).toEqual( [] );
+        expect( first.calls ).toEqual( [] );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/__tests__/renderPhase.test.ts
+++ b/src/templates/p5/utils/__tests__/renderPhase.test.ts
@@ -1,4 +1,6 @@
 /**
+ * @jest-environment jsdom
+ *
  * Tests for the per-item render phase ("back" = behind the sketch, "front" =
  * on top — the historical default) and the opt-in delegated background.
  *
@@ -7,6 +9,10 @@
  * items on top. backgroundLayer captures a delegated sketch's first opaque
  * background() call so the engine can repaint it under back-phase items
  * instead of letting it erase them.
+ *
+ * freeLayout's real signature is (options, scope, phase) — scope drives the
+ * on-canvas drag system (contentDrag.js) and is irrelevant here, so these
+ * tests pass it through as undefined and target phase explicitly.
  */
 
 jest.mock(
@@ -170,6 +176,7 @@ describe(
           {
             content
           },
+          undefined,
           "back"
         );
 
@@ -186,6 +193,7 @@ describe(
         expect( () => freeLayout( undefined as any ) ).not.toThrow();
         expect( () => freeLayout(
           {},
+          undefined,
           "back"
         ) ).not.toThrow();
       }

--- a/src/templates/p5/utils/backgroundLayer.js
+++ b/src/templates/p5/utils/backgroundLayer.js
@@ -1,0 +1,96 @@
+import options from "./options.js";
+
+/**
+ * Opt-in engine ownership of a sketch's background, so "back"-phase content
+ * items (drawn before the sketch — see freeLayout) stay visible under it.
+ *
+ * The problem: most sketches open their draw with an opaque p.background(),
+ * which repaints the whole canvas and erases anything rendered before the
+ * sketch. With `delegateBackground: true` in a template's sketch settings,
+ * the FIRST opaque background() call inside the sketch's draw is captured
+ * instead of painted; the engine repaints that color at the very bottom of
+ * the next frame (paintBase, before back-phase items). Translucent calls
+ * (alpha < 255 — trail/accumulation effects) and any further opaque calls in
+ * the same frame (intentional mid-frame repaints) pass through untouched.
+ *
+ * Designed for 2D sketches whose draw starts with an opaque background().
+ * Sketches that clear() manually or accumulate without a background call
+ * should keep the flag off.
+ */
+
+const state = {
+  original: null,
+  baseArgs: null,
+  inSketchDraw: false,
+  consumed: false
+};
+
+export function isDelegated() {
+  return options.sketch?.delegateBackground === true;
+}
+
+// Best-effort alpha detection over p5's background() signatures. Anything not
+// recognizably translucent (color strings, p5.Color, single gray, r/g/b) is
+// treated as opaque.
+function alphaOf( args ) {
+  if ( args.length === 1 && Array.isArray( args[ 0 ] ) ) {
+    return args[ 0 ][ 3 ] ?? 255;
+  }
+
+  if ( args.length === 2 && typeof args[ 0 ] === "number" && typeof args[ 1 ] === "number" ) {
+    return args[ 1 ];
+  }
+
+  if ( args.length === 4 && typeof args[ 3 ] === "number" ) {
+    return args[ 3 ];
+  }
+
+  return 255;
+}
+
+// Called from p.setup on every fresh p5 instance — always rebinds so a reset
+// never leaves the wrapper pointing at a destroyed instance.
+export function install( p ) {
+  state.original = p.background.bind( p );
+  state.baseArgs = null;
+  state.inSketchDraw = false;
+  state.consumed = false;
+
+  p.background = ( ...args ) => {
+    if ( !state.inSketchDraw || !isDelegated() ) {
+      return state.original( ...args );
+    }
+
+    if ( alphaOf( args ) < 255 ) {
+      return state.original( ...args );
+    }
+
+    if ( !state.consumed ) {
+      state.consumed = true;
+      state.baseArgs = args;
+      return;
+    }
+
+    return state.original( ...args );
+  };
+}
+
+export function beginSketchDraw() {
+  state.inSketchDraw = true;
+  state.consumed = false;
+}
+
+export function endSketchDraw() {
+  state.inSketchDraw = false;
+}
+
+// Repaint the captured base color at the bottom of the frame (pre-draw, after
+// the engine clear, before back-phase content). No-op until the sketch's
+// first draw has captured a color — one transparent frame at load.
+export function paintBase() {
+  if ( !isDelegated() || !state.baseArgs || !state.original ) {
+    return;
+  }
+
+  state.original( ...state.baseArgs );
+}

--- a/src/templates/p5/utils/sketch.js
+++ b/src/templates/p5/utils/sketch.js
@@ -19,6 +19,7 @@ import {
 import {
   resolveAnimation
 } from "@/lib/animationConfig";
+import * as backgroundLayer from "./backgroundLayer.js";
 
 let _p5 = null;
 let _container = null;
@@ -208,6 +209,10 @@ const sketch = {
             p.setCamera( sketch.camera );
           }
 
+          // Wrap p.background so templates with sketch.delegateBackground can
+          // let back-phase content items show under the sketch.
+          backgroundLayer.install( p );
+
           p.frameRate( coerceFramerate( sketchOptions?.animation?.framerate ) ?? 60 );
           p.smooth();
 
@@ -294,18 +299,28 @@ const sketch = {
 
           events.handle( "pre-draw" );
 
-          // Call the user's draw function. The first arg is the duration-scaled
-          // loop clock (time.drawSeconds), NOT raw elapsed seconds: a sketch
-          // that animates off it completes its whole loop within `duration`, so
-          // changing the duration rescales the live preview and the recording
-          // identically. At the default duration it equals the old real-seconds
-          // value, so existing sketches are unchanged there.
-          await sketch._drawFn?.(
-            time.drawSeconds(),
-            sketch.getCanvasCenter(),
-            sketch.favoriteColors.purple,
-            p
-          );
+          // The sketch-draw window scopes the delegated-background capture to
+          // the user's own background() calls — content items (e.g. the
+          // background item) paint through untouched. finally: a throwing
+          // sketch must not leave the window open.
+          backgroundLayer.beginSketchDraw();
+
+          try {
+            // Call the user's draw function. The first arg is the duration-scaled
+            // loop clock (time.drawSeconds), NOT raw elapsed seconds: a sketch
+            // that animates off it completes its whole loop within `duration`, so
+            // changing the duration rescales the live preview and the recording
+            // identically. At the default duration it equals the old real-seconds
+            // value, so existing sketches are unchanged there.
+            await sketch._drawFn?.(
+              time.drawSeconds(),
+              sketch.getCanvasCenter(),
+              sketch.favoriteColors.purple,
+              p
+            );
+          } finally {
+            backgroundLayer.endSketchDraw();
+          }
 
           events.handle( "post-draw" );
 

--- a/src/templates/p5/utils/slides/common/drawSlideHud.js
+++ b/src/templates/p5/utils/slides/common/drawSlideHud.js
@@ -10,7 +10,10 @@ import {
  * gauge, sparkline, counter, crosshairs, swatch, boundingBox), each toggled and
  * configured independently. Widgets bind to a data source (a built-in live key
  * or a sketch-settings key-path) — see hud/sources.js. Drawn on the canvas via
- * freeLayout's post-draw pass, so it is captured by recordings.
+ * freeLayout (post-draw for "front" items, pre-draw for "back" items placed
+ * behind the sketch), so it is captured by recordings either way. Note a
+ * "back" HUD only shows where the sketch leaves transparency, unless the
+ * template sets sketch.delegateBackground.
  */
 
 // Draw order (later = on top).

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -29,6 +29,11 @@ import {
   mergeSlideOverride
 } from "@/lib/effectiveSlideSettings";
 
+import {
+  paintBase,
+  isDelegated as isBackgroundDelegated
+} from "../backgroundLayer.js";
+
 // Safe modulo that wraps negatives too
 const wrap = (
   i, n
@@ -41,17 +46,45 @@ const slides = {
     events.register(
       "pre-draw",
       () => {
-        if ( options?.slides && options?.slides.length ) {
+        // The engine owns the per-frame clear whenever something must survive
+        // under the sketch: slides (historical), back-phase content (would
+        // smear over the previous frame otherwise), or a delegated background
+        // (the sketch's own clearing background() is suppressed).
+        if (
+          ( options?.slides && options?.slides.length ) ||
+          slides.hasBackPhaseContent ||
+          isBackgroundDelegated()
+        ) {
           getP5()?.clear();
         }
+      }
+    );
+
+    // Back pass: registered after the clear handler so back items land on the
+    // freshly cleared canvas, and running in pre-draw so the sketch draws on
+    // top of them.
+    events.register(
+      "pre-draw",
+      () => {
+        paintBase();
+        slides.renderCurrentSlide( "back" );
+        slides.render(
+          options,
+          GLOBAL_CONTENT_SCOPE,
+          "back"
+        );
       }
     );
 
     events.register(
       "post-draw",
       () => {
-        slides.renderCurrentSlide();
-        slides.render( options );
+        slides.renderCurrentSlide( "front" );
+        slides.render(
+          options,
+          GLOBAL_CONTENT_SCOPE,
+          "front"
+        );
         slides.renderMontageOverlay();
         slides.renderMontageTitle();
         slides.updateMontageSound();
@@ -101,6 +134,15 @@ const slides = {
 
   get hasSlides() {
     return this.count > 0;
+  },
+
+  // True when any back-phase item exists in global content or on the current
+  // slide — those need the engine clear to avoid smearing across frames.
+  get hasBackPhaseContent() {
+    const hasBack = ( list ) =>
+      Array.isArray( list ) && list.some( ( item ) => item?.phase === "back" );
+
+    return hasBack( options?.content ) || hasBack( this.current?.content );
   },
 
   get previous() {
@@ -203,21 +245,23 @@ const slides = {
   },
 
   render(
-    source, scope = GLOBAL_CONTENT_SCOPE
+    source, scope = GLOBAL_CONTENT_SCOPE, phase = "front"
   ) {
     // Pass the source straight through. For global content `source` is the
     // live options proxy; destructuring/spreading it would drop every key
     // (its target is empty and it has only a get trap), silently discarding
     // global `content`. freeLayout reads `.content` via the get trap instead.
-    // `scope` tells the content-drag layer which list is rendering.
+    // `scope` tells the content-drag layer which list is rendering; `phase`
+    // selects the front/back pass (see freeLayout).
     // ( _layouts[ source?.layout ] ?? _layouts.auto )( source );
     _layouts.free(
       source,
-      scope
+      scope,
+      phase
     );
   },
 
-  renderCurrentSlide() {
+  renderCurrentSlide( phase = "front" ) {
     const slide = this.current;
 
     if ( !slide ) {
@@ -230,7 +274,8 @@ const slides = {
       slideContentScope( wrap(
         Number( this.index ) || 0,
         this.count
-      ) )
+      ) ),
+      phase
     );
   },
 

--- a/src/templates/p5/utils/slides/layouts/freeLayout.js
+++ b/src/templates/p5/utils/slides/layouts/freeLayout.js
@@ -19,15 +19,22 @@ import {
 // `scope` says which content list is being rendered ("global" or "slide:<n>")
 // so an in-flight on-canvas drag (see contentDrag.js) can substitute the live
 // position of the grabbed item without touching the option store every frame.
-// Each item's render is bracketed with begin/endItemBounds so the renderer's
+// `phase` selects which items this pass draws: "front" (default) runs in
+// post-draw on top of the sketch, "back" runs in pre-draw behind it. Items
+// without a phase are treated as "front" (the historical stacking). Each
+// item's render is bracketed with begin/endItemBounds so the renderer's
 // reportItemBounds() call lands on the right (scope, index) — that visible
 // rectangle is what the drag layer hit-tests.
 export default function freeLayout(
-  options, scope
+  options, scope, phase = "front"
 ) {
   options?.content?.forEach( (
     rawItem, index
   ) => {
+    if ( ( rawItem?.phase ?? "front" ) !== phase ) {
+      return;
+    }
+
     const item = resolveDraggedItem(
       scope,
       index,

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -127,8 +127,20 @@ export const PatternSchema = z
     borders: false
   } );
 
+// Render phase of a content item relative to the sketch draw. "front" items
+// render after the sketch (on top — the historical behavior, hence the
+// default), "back" items render before it (behind). A "back" item only shows
+// through where the sketch leaves transparency, unless the template delegates
+// its background to the engine (options.sketch.delegateBackground — see
+// templates/p5/utils/backgroundLayer.js).
+export const RenderPhase = z.enum( [
+  "back",
+  "front"
+] ).default( "front" );
+
 export const BackgroundItemSchema = z.object( {
   type: z.literal( "background" ),
+  phase: RenderPhase,
   background: RGBA.default( [
     246,
     235,
@@ -139,6 +151,7 @@ export const BackgroundItemSchema = z.object( {
 
 export const MetaItemSchema = z.object( {
   type: z.literal( "meta" ),
+  phase: RenderPhase,
   topLeft: z.string().default( "@costardrouge.jpg" ),
   topRight: z.string().default( "" ),
   bottomLeft: z.string().default( "" ),
@@ -365,6 +378,7 @@ export const SpecsSoundSchema = z
 
 export const SpecsItemSchema = z.object( {
   type: z.literal( "specs" ),
+  phase: RenderPhase,
   style: z.enum( [
     "boot-log",
     "ticker"
@@ -426,6 +440,7 @@ export const SpecsItemSchema = z.object( {
 
 export const TextItemSchema = z.object( {
   type: z.literal( "text" ),
+  phase: RenderPhase,
   content: z.string().default( "" ),
 
   size: z.number().positive()
@@ -503,6 +518,7 @@ export const ImagesStackAnimations = z.discriminatedUnion(
 
 export const ImageItemSchema = z.object( {
   type: z.literal( "image" ),
+  phase: RenderPhase,
   source: z.string().default( "" ),
   margin: z.number().min( 0 )
     .max( 1000 )
@@ -537,6 +553,7 @@ const NonEmptyPath = z.string().trim()
 
 export const ImagesStackItemSchema = z.object( {
   type: z.literal( "images-stack" ),
+  phase: RenderPhase,
   sources: z.preprocess(
     ( v ) =>
       Array.isArray( v )
@@ -589,6 +606,7 @@ export const VisualOptions = z
 
 export const VisualItemSchema = z.object( {
   type: z.literal( "visual" ),
+  phase: RenderPhase,
   visual: VisualOptions.optional(),
 
   position: Vec2.default( {
@@ -601,6 +619,7 @@ export const VisualItemSchema = z.object( {
 
 export const QrCodeItemSchema = z.object( {
   type: z.literal( "qrcode" ),
+  phase: RenderPhase,
   // Origin to encode. Empty -> NEXT_PUBLIC_SITE_URL (the production domain),
   // falling back to the live page origin. Set it to point at the public
   // domain when generating content from a localhost / capture URL. A bare
@@ -882,6 +901,7 @@ export const HudBoundingBoxSchema = z
 
 export const HudItemSchema = z.object( {
   type: z.literal( "hud" ),
+  phase: RenderPhase,
   fill: RGBA.default( [
     0,
     255,


### PR DESCRIPTION
## What

Every content item (background, meta, specs, text, image, images-stack, visual, qrcode, **hud**) gains a **`phase`** field — a "Layer" select in the editor:

- **`front`** (default) — rendered after the sketch, on top. This is the historical stacking, so every existing template renders identically (Zod `.default("front")` heals saved options on parse).
- **`back`** — rendered before the sketch, behind it. Lets you put e.g. a `specs` or `hud` overlay behind the sketch visual.

Works for both **global content** (authored once, applies across all slides) and per-slide content.

## How

- `freeLayout(options, phase)` draws one phase per pass (items without a phase count as `front`).
- `slides/index.js` runs the **back pass in pre-draw** (right after the engine clear, before the sketch draws) and the front pass in post-draw as before. The per-frame clear now also fires when back-phase items exist or a delegated background is active — not only when slides exist.
- **`backgroundLayer.js` (new)** — opt-in per template via `sketch.delegateBackground: true`. Most sketches open their draw with an opaque `p.background()`, which would erase anything behind them. When delegated, the first opaque `background()` call inside the sketch-draw window is *captured* instead of painted, and the engine repaints that color at the bottom of the next frame, under back-phase items. Translucent fills (alpha < 255 — trail effects) and any further opaque calls in the same frame (intentional mid-frame repaints) pass through untouched. Content items (e.g. the `background` item) are outside the window and never intercepted.

## Notes / limitations

- Without `delegateBackground`, a `back` item only shows through where the sketch leaves transparency.
- Delegation is designed for 2D sketches whose draw starts with an opaque `background()`; keep it off for WEBGL or manual-`clear()`/accumulation sketches.
- `phase` applies to the whole item (a HUD goes behind or in front as a unit — split into two hud items to straddle).

## Tests

- New `renderPhase.test.ts` (9 tests): freeLayout phase filtering + backgroundLayer capture/passthrough/rebind semantics.
- Full suite: 39 suites, 1358 tests green. Lint clean (2 pre-existing warnings elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdvDG1ZmK4qiTkfuzxCJxM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdvDG1ZmK4qiTkfuzxCJxM)_