### PR TITLE
feat(sound): click feedback on value changes — specs overlay + template options panel

### DIFF
--- a/docs/SOUND_FEEDBACK.md
+++ b/docs/SOUND_FEEDBACK.md
@@ -1,0 +1,127 @@
+# Sound Feedback on Value Changes
+
+Two surfaces now click pleasingly when a value changes:
+
+1. **The template options panel (editor UI)** — every option edit ticks, and
+   the action buttons (reset / randomize / save defaults / generate
+   thumbnail / preview) give an audible confirmation.
+2. **The `specs` content item (on-canvas overlay)** — whenever a spec line's
+   value changes, the sketch itself clicks. Because this routes through the
+   sketch audio engine, the clicks are also **baked into recordings**
+   (realtime and deterministic/server captures alike).
+
+Both share one synthesiser: `src/lib/clickSynth.ts`.
+
+---
+
+## Shared click synth (`src/lib/clickSynth.ts`)
+
+Context-agnostic Web Audio voices — they run identically against a live
+`AudioContext` and an `OfflineAudioContext` (which is what makes the specs
+clicks render into deterministic captures).
+
+| Preset       | Character                                             |
+| ------------ | ----------------------------------------------------- |
+| `click`      | Soft camera-shutter tick (noise snap + faint sine)    |
+| `tick`       | Bright, dry metronome tick                            |
+| `blip`       | Rounded triangle "bip"                                |
+| `pop`        | Bubble pop (downward pitch sweep)                     |
+| `beep`       | Plain sine confirmation                               |
+| `wood`       | Woodblock knock                                       |
+| `typewriter` | Two-part mechanical key strike                        |
+
+Every preset takes `{ gain, rate }` — `rate` transposes the whole recipe
+(2 = octave up), which is what all the pitch options below are built on.
+
+---
+
+## Specs content item: `sound` option group
+
+New `sound` group on the `specs` item (`SpecsItemSchema.sound`), edited in the
+content panel under **Sound on change**. Disabled by default; existing decks
+parse unchanged.
+
+| Option            | Default   | What it does                                                                  |
+| ----------------- | --------- | ----------------------------------------------------------------------------- |
+| `enabled`         | `false`   | Master switch.                                                                 |
+| `preset`          | `click`   | Voice from the shared synth.                                                   |
+| `volume`          | `0.5`     | Click gain (0–1).                                                              |
+| `pitch`           | `1`       | Global pitch multiplier (0.25–4).                                              |
+| `pitchVariation`  | `0.1`     | Random per-click detune ("humanize", 1 ≈ ±half an octave).                     |
+| `linePitchSpread` | `0`       | Pitch offset by line index, in octaves across the list — each line gets a tone.|
+| `minInterval`     | `0.05` s  | Simultaneous changes are *staggered* by this gap (slot-machine cascade).       |
+| `lineCooldown`    | `0.15` s  | A line changing every frame (montage morph) clicks at most once per window.   |
+| `maxBurst`        | `12`      | Hard cap on queued clicks.                                                     |
+| `repeat`          | `once`    | See below.                                                                     |
+
+### Repeat modes
+
+- **`once`** — one click per change.
+- **`count`** — a burst: `times` clicks (2–16), `interval` seconds apart, with
+  an optional `pitchStep` ramp in octaves per click (rising/falling spin-up).
+- **`while-highlighted`** — Geiger-style: keeps clicking every `interval`
+  seconds for as long as the highlight effect stays hot (bounded by the
+  highlight's `duration`). Works with the highlight set to `off` too (falls
+  back to the default 0.9 s window).
+
+### How it plays — and records
+
+Change detection rides the same tracker as the visual highlight
+(`specsChanges.js`). Clicks fire through `audio.trigger("click", …)`
+(`src/templates/p5/utils/audio.js`), so:
+
+- **Live editing / playback**: clicks play through the sketch's audio engine
+  (first pointer/key gesture unlocks the AudioContext, per autoplay policy).
+- **Realtime browser recording**: the engine's master output is mixed into
+  the MediaRecorder — clicks land in the `.webm`.
+- **Deterministic / server capture**: triggers are logged with sketch-time
+  timestamps and rendered offline, sample-accurate against the frame-stepped
+  timeline — clicks land in the exported video.
+
+Scheduling is polled per drawn frame on the sketch clock (`time.seconds()`),
+never `setTimeout`, which is what keeps captures deterministic. The scheduler
+also resets itself when the clock jumps backwards (capture restart).
+
+---
+
+## Editor UI sounds (`src/lib/uiSound.ts`)
+
+A separate, editor-only sound path: it owns its own `AudioContext` and is
+**never** registered on the audio bridge, so panel feedback cannot leak into
+a recording.
+
+- **Value ticks** — hooked into the options form (`useFormState`): any field
+  edit (sliders, inputs, content items, per-slide sketch settings) ticks.
+  Form-level events (reset, initial populate) stay silent.
+- **Action clicks** — the sketch-settings actions row (reset / randomize /
+  save defaults / …) plays a slightly lower confirmation click.
+
+Settings live in the 🔊 button in the sketch-settings actions row and persist
+in `localStorage` (`p5templates.uiSound.v1`):
+
+| Setting                | Default | What it does                                                        |
+| ---------------------- | ------- | ------------------------------------------------------------------- |
+| Sound on value change  | off     | Master switch.                                                      |
+| Sound on action buttons| on      | Confirmation click on the actions row.                              |
+| Click sound            | `click` | Preset from the shared synth.                                       |
+| Volume                 | `0.4`   | Click gain.                                                         |
+| Pitch (×)              | `1`     | Global pitch multiplier.                                            |
+| Humanize               | `0.08`  | Random per-click detune.                                            |
+| Pitch varies by field  | on      | Stable per-field tone (hash of the field path, ±0.35 octaves) — the same slider always ticks at the same pitch. |
+| Min gap (ms)           | `45`    | Throttle: slider drags tick at a musical rate instead of machine-gunning. |
+| Clicks per change      | `1`     | >1 turns each change into a small burst (the repeating option).     |
+| Repeat interval (ms)   | `70`    | Gap between burst clicks.                                           |
+| Pitch ramp (oct/click) | `0.08`  | Rising/falling burst.                                               |
+| Test sound             | —       | Preview the current settings.                                       |
+
+---
+
+## Tests
+
+- `src/types/__tests__/specsSound.test.ts` — schema defaults, healing of
+  pre-sound decks, repeat-mode defaults, schema ↔ form-config ↔ synth-preset
+  alignment.
+- `src/templates/p5/utils/slides/common/__tests__/specsSound.test.ts` —
+  scheduler behaviour: staggering, per-line cooldown, burst cap, both repeat
+  modes, line pitch spread, backwards-clock reset, and the
+  `computeSpecsHeats` change callback.

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config.ts
@@ -8,7 +8,9 @@ import {
   ImageItemAnimations,
   ImagesStackAnimations,
   PatternSchema,
+  SPECS_SOUND_PRESETS,
   SpecsHighlightSchema,
+  SpecsSoundRepeatSchema,
   SpecsVisibilitySchema,
   VerticalAlign,
   VisualOptions
@@ -786,6 +788,134 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
 
       // @ts-expect-error schema carries a .default() wrapper, like VisualOptions
       schema: SpecsHighlightSchema
+    },
+    sound: {
+      label: "Sound on change",
+      component: "nested-object",
+      fields: {
+        enabled: {
+          label: "Enabled",
+          component: "checkbox"
+        },
+        preset: {
+          label: "Click sound",
+          component: "select",
+          options: SPECS_SOUND_PRESETS.map( ( presetName ) => ( {
+            value: presetName,
+            label: presetName
+          } ) )
+        },
+        volume: {
+          label: "Volume",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.05
+        },
+        pitch: {
+          label: "Pitch (×)",
+          component: "slider",
+          min: 0.25,
+          max: 4,
+          step: 0.05
+        },
+        pitchVariation: {
+          label: "Humanize (random pitch)",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.05
+        },
+        linePitchSpread: {
+          label: "Pitch spread by line (octaves)",
+          component: "slider",
+          min: -1,
+          max: 1,
+          step: 0.05
+        },
+        minInterval: {
+          label: "Stagger between clicks (s)",
+          component: "slider",
+          min: 0,
+          max: 0.5,
+          step: 0.01
+        },
+        lineCooldown: {
+          label: "Per-line cooldown (s)",
+          component: "slider",
+          min: 0,
+          max: 2,
+          step: 0.05
+        },
+        maxBurst: {
+          label: "Max queued clicks",
+          component: "slider",
+          min: 1,
+          max: 32,
+          step: 1
+        },
+        repeat: {
+          label: "Repeat",
+          component: "conditional-group",
+          conditionalOn: "mode",
+          hideNone: true,
+          typeSelector: {
+            label: "Mode",
+            options: [
+              {
+                value: "once",
+                label: "Once per change"
+              },
+              {
+                value: "count",
+                label: "Burst (N clicks)"
+              },
+              {
+                value: "while-highlighted",
+                label: "While highlighted"
+              }
+            ]
+          },
+          configs: {
+            once: {},
+            count: {
+              times: {
+                label: "Clicks per change",
+                component: "slider",
+                min: 2,
+                max: 16,
+                step: 1
+              },
+              interval: {
+                label: "Interval (s)",
+                component: "slider",
+                min: 0.02,
+                max: 2,
+                step: 0.01
+              },
+              pitchStep: {
+                label: "Pitch ramp per click (octaves)",
+                component: "slider",
+                min: -0.5,
+                max: 0.5,
+                step: 0.01
+              }
+            },
+            "while-highlighted": {
+              interval: {
+                label: "Interval (s)",
+                component: "slider",
+                min: 0.02,
+                max: 2,
+                step: 0.01
+              }
+            }
+          },
+
+          // @ts-expect-error schema carries a .default() wrapper, like VisualOptions
+          schema: SpecsSoundRepeatSchema
+        }
+      }
     }
   },
   hud: {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/SketchSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/SketchSettings.tsx
@@ -14,6 +14,10 @@ import ResetSettingsButton from "@/components/ResetSettingsButton";
 import SaveDefaultsButton from "./SaveDefaultsButton";
 import GenerateThumbnailButton from "./GenerateThumbnailButton";
 import GeneratePreviewButton from "./GeneratePreviewButton";
+import UiSoundSettingsButton from "./UiSoundSettingsButton";
+import {
+  playAction
+} from "@/lib/uiSound";
 import GenericObjectForm
   from "@/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm";
 import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
@@ -96,22 +100,35 @@ export function SketchSettingsActions( {
 } ) {
   return (
     <>
-      <ResetSettingsButton
-        basePath={ basePath }
-        className={ HEADER_ACTION_CLASS }
-      />
+      {/* Outside the capture wrapper below so tweaking sound settings doesn't
+          itself fire action clicks. */}
+      <UiSoundSettingsButton className={ HEADER_ACTION_CLASS } />
 
-      <RandomizeSettingsButton
-        config={ config }
-        basePath={ basePath }
-        className={ HEADER_ACTION_CLASS }
-      />
+      {/* display:contents keeps the row layout untouched while catching every
+          action click for the audible confirmation (see @/lib/uiSound). */}
+      <span
+        style={ {
+          display: "contents"
+        } }
+        onClickCapture={ () => playAction() }
+      >
+        <ResetSettingsButton
+          basePath={ basePath }
+          className={ HEADER_ACTION_CLASS }
+        />
 
-      <SaveDefaultsButton />
+        <RandomizeSettingsButton
+          config={ config }
+          basePath={ basePath }
+          className={ HEADER_ACTION_CLASS }
+        />
 
-      <GenerateThumbnailButton />
+        <SaveDefaultsButton />
 
-      <GeneratePreviewButton />
+        <GenerateThumbnailButton />
+
+        <GeneratePreviewButton />
+      </span>
     </>
   );
 }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import React, {
+  useEffect, useRef, useState, useSyncExternalStore
+} from "react";
+import {
+  Volume2, VolumeX
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  UI_SOUND_PRESETS,
+  type UiSoundSettings,
+  getUiSoundSettings,
+  playPreview,
+  setUiSoundSettings,
+  subscribeUiSoundSettings
+} from "@/lib/uiSound";
+
+/**
+ * Toggle + settings popover for the editor's value-change click feedback.
+ * Lives in the sketch-settings actions row (desktop panel and mobile drawer),
+ * next to reset / randomize — the actions it also gives a voice to.
+ */
+export default function UiSoundSettingsButton( {
+  className
+}: {
+  className?: string;
+} ) {
+  const settings = useSyncExternalStore(
+    subscribeUiSoundSettings,
+    getUiSoundSettings,
+    getUiSoundSettings
+  );
+  const [
+    open,
+    setOpen
+  ] = useState( false );
+  const containerRef = useRef<HTMLDivElement>( null );
+
+  // Close on outside pointerdown.
+  useEffect(
+    () => {
+      if ( !open ) {
+        return;
+      }
+
+      const onPointerDown = ( event: PointerEvent ) => {
+        if ( !containerRef.current?.contains( event.target as Node ) ) {
+          setOpen( false );
+        }
+      };
+
+      document.addEventListener(
+        "pointerdown",
+        onPointerDown
+      );
+
+      return () => document.removeEventListener(
+        "pointerdown",
+        onPointerDown
+      );
+    },
+    [
+      open
+    ]
+  );
+
+  const update = ( patch: Partial<UiSoundSettings> ) => {
+    setUiSoundSettings( patch );
+  };
+
+  const sliderRow = (
+    label: string,
+    value: number,
+    min: number,
+    max: number,
+    step: number,
+    onChange: ( next: number ) => void
+  ) => (
+    <label className="flex flex-col gap-0.5">
+      <span className="flex justify-between">
+        <span>{label}</span>
+        <span className="opacity-60">{value}</span>
+      </span>
+      <input
+        type="range"
+        min={ min }
+        max={ max }
+        step={ step }
+        value={ value }
+        onChange={ ( e ) => onChange( Number( e.target.value ) ) }
+      />
+    </label>
+  );
+
+  const checkboxRow = (
+    label: string,
+    checked: boolean,
+    onChange: ( next: boolean ) => void
+  ) => (
+    <label className="flex items-center justify-between gap-2">
+      <span>{label}</span>
+      <input
+        type="checkbox"
+        checked={ checked }
+        onChange={ ( e ) => onChange( e.target.checked ) }
+      />
+    </label>
+  );
+
+  return (
+    <div
+      ref={ containerRef }
+      className="relative"
+      onClick={ ( e ) => e.stopPropagation() }
+    >
+      <button
+        type="button"
+        className={ clsx(
+          className,
+          !settings.enabled && "opacity-50"
+        ) }
+        title={
+          settings.enabled
+            ? "UI sound feedback (on) — click for options"
+            : "UI sound feedback (off) — click for options"
+        }
+        aria-label="UI sound feedback settings"
+        onClick={ () => setOpen( ( wasOpen ) => !wasOpen ) }
+      >
+        {settings.enabled ? (
+          <Volume2 className="h-4 w-4" />
+        ) : (
+          <VolumeX className="h-4 w-4" />
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 flex w-64 flex-col gap-2 rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg">
+          {checkboxRow(
+            "Sound on value change",
+            settings.enabled,
+            ( enabled ) => update( {
+              enabled
+            } )
+          )}
+
+          {checkboxRow(
+            "Sound on action buttons",
+            settings.actionSounds,
+            ( actionSounds ) => update( {
+              actionSounds
+            } )
+          )}
+
+          <label className="flex items-center justify-between gap-2">
+            <span>Click sound</span>
+            <select
+              className="rounded border border-theme bg-transparent px-1 py-0.5"
+              value={ settings.preset }
+              onChange={ ( e ) =>
+                update( {
+                  preset: e.target.value as UiSoundSettings[ "preset" ]
+                } ) }
+            >
+              {UI_SOUND_PRESETS.map( ( presetName ) => (
+                <option
+                  key={ presetName }
+                  value={ presetName }
+                >
+                  {presetName}
+                </option>
+              ) )}
+            </select>
+          </label>
+
+          {sliderRow(
+            "Volume",
+            settings.volume,
+            0,
+            1,
+            0.05,
+            ( volume ) => update( {
+              volume
+            } )
+          )}
+
+          {sliderRow(
+            "Pitch (×)",
+            settings.pitch,
+            0.5,
+            2,
+            0.05,
+            ( pitch ) => update( {
+              pitch
+            } )
+          )}
+
+          {sliderRow(
+            "Humanize",
+            settings.pitchVariation,
+            0,
+            1,
+            0.05,
+            ( pitchVariation ) => update( {
+              pitchVariation
+            } )
+          )}
+
+          {checkboxRow(
+            "Pitch varies by field",
+            settings.pitchByField,
+            ( pitchByField ) => update( {
+              pitchByField
+            } )
+          )}
+
+          {sliderRow(
+            "Min gap (ms)",
+            settings.minGapMs,
+            0,
+            300,
+            5,
+            ( minGapMs ) => update( {
+              minGapMs
+            } )
+          )}
+
+          {sliderRow(
+            "Clicks per change",
+            settings.repeatTimes,
+            1,
+            8,
+            1,
+            ( repeatTimes ) => update( {
+              repeatTimes
+            } )
+          )}
+
+          {settings.repeatTimes > 1 && (
+            <>
+              {sliderRow(
+                "Repeat interval (ms)",
+                settings.repeatIntervalMs,
+                20,
+                300,
+                5,
+                ( repeatIntervalMs ) => update( {
+                  repeatIntervalMs
+                } )
+              )}
+
+              {sliderRow(
+                "Pitch ramp (oct/click)",
+                settings.repeatPitchStep,
+                -0.5,
+                0.5,
+                0.01,
+                ( repeatPitchStep ) => update( {
+                  repeatPitchStep
+                } )
+              )}
+            </>
+          )}
+
+          <button
+            type="button"
+            className="mt-1 rounded-lg border border-theme px-2 py-1 hover:bg-hover"
+            onClick={ () => playPreview() }
+          >
+            Test sound
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useFormState.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useFormState.ts
@@ -9,6 +9,9 @@ import {
 } from "react-hook-form";
 import initOptions from "@/utils/initOptions";
 import {
+  playValueChange
+} from "@/lib/uiSound";
+import {
   useInterval
 } from "@/hooks/useInterval";
 import {
@@ -56,7 +59,16 @@ export function useFormState( {
 
   useEffect(
     () => {
-      const subscription = watch( ( value ) => {
+      const subscription = watch( (
+        value, info
+      ) => {
+        // Audible tick on real value edits (sliders, inputs, action buttons).
+        // Form-level events (reset, initial populate) carry no field name and
+        // stay silent. Muting/throttling lives inside the sound module.
+        if ( info?.name ) {
+          playValueChange( info.name );
+        }
+
         latestValueRef.current = value as SketchOption;
 
         if ( rafRef.current === null ) {

--- a/src/lib/clickSynth.ts
+++ b/src/lib/clickSynth.ts
@@ -1,0 +1,395 @@
+/**
+ * Shared "pleasing click" synthesiser.
+ *
+ * One preset table, two consumers:
+ *   - the sketch audio engine (`@/p5/utils/audio.js`) exposes them through
+ *     `audio.trigger("click", { preset, ... })`, so a specs overlay click is
+ *     heard live AND rendered sample-accurately into deterministic captures;
+ *   - the editor UI sound module (`@/lib/uiSound.ts`) plays them on template
+ *     option changes through its own AudioContext, so panel feedback can
+ *     never bleed into a recording.
+ *
+ * Every voice is context-agnostic — it only ever touches the `ctx` and
+ * `destination` it is handed — which is what lets the same code run against a
+ * live AudioContext and an OfflineAudioContext.
+ */
+
+export const CLICK_PRESET_NAMES = [
+  "click",
+  "tick",
+  "blip",
+  "pop",
+  "beep",
+  "wood",
+  "typewriter"
+] as const;
+
+export type ClickPresetName = ( typeof CLICK_PRESET_NAMES )[ number ];
+
+export interface ClickParams {
+  /** Peak gain of the click, 0..1. */
+  gain?: number;
+  /**
+   * Pitch multiplier applied to every frequency of the preset (1 = as
+   * designed, 2 = one octave up, 0.5 = one octave down).
+   */
+  rate?: number;
+}
+
+export function isClickPreset( name: unknown ): name is ClickPresetName {
+  return (
+    typeof name === "string" &&
+    ( CLICK_PRESET_NAMES as readonly string[] ).includes( name )
+  );
+}
+
+// exponentialRamp cannot reach true zero.
+const MIN_GAIN = 0.0001;
+
+type AnyAudioContext = BaseAudioContext;
+
+/* ------------------------------------------------------------------ */
+/*  Primitive voices                                                   */
+/* ------------------------------------------------------------------ */
+
+interface ToneSpec {
+  type?: OscillatorType;
+  freq: number;
+  endFreq?: number;
+  duration?: number;
+  attack?: number;
+  gain?: number;
+  delay?: number;
+}
+
+function tone(
+  ctx: AnyAudioContext,
+  destination: AudioNode,
+  when: number,
+  {
+    type = "sine",
+    freq,
+    endFreq,
+    duration = 0.05,
+    attack = 0.001,
+    gain = 0.5,
+    delay = 0
+  }: ToneSpec
+) {
+  const startTime = when + delay;
+  const osc = ctx.createOscillator();
+  const envelope = ctx.createGain();
+
+  osc.type = type;
+  osc.frequency.setValueAtTime(
+    Math.max(
+      1,
+      freq
+    ),
+    startTime
+  );
+
+  if ( endFreq && endFreq > 0 ) {
+    osc.frequency.exponentialRampToValueAtTime(
+      Math.max(
+        1,
+        endFreq
+      ),
+      startTime + duration
+    );
+  }
+
+  envelope.gain.setValueAtTime(
+    MIN_GAIN,
+    startTime
+  );
+  envelope.gain.exponentialRampToValueAtTime(
+    Math.max(
+      MIN_GAIN,
+      gain
+    ),
+    startTime + attack
+  );
+  envelope.gain.exponentialRampToValueAtTime(
+    MIN_GAIN,
+    startTime + duration
+  );
+
+  osc.connect( envelope );
+  envelope.connect( destination );
+
+  osc.start( startTime );
+  osc.stop( startTime + duration + 0.05 );
+
+  osc.onended = () => {
+    osc.disconnect();
+    envelope.disconnect();
+  };
+}
+
+interface NoiseSpec {
+  freq: number;
+  q?: number;
+  duration?: number;
+  gain?: number;
+  delay?: number;
+}
+
+function noiseHit(
+  ctx: AnyAudioContext,
+  destination: AudioNode,
+  when: number,
+  {
+    freq,
+    q = 1,
+    duration = 0.03,
+    gain = 0.3,
+    delay = 0
+  }: NoiseSpec
+) {
+  const startTime = when + delay;
+  const frameCount = Math.max(
+    1,
+    Math.floor( ctx.sampleRate * duration )
+  );
+  const buffer = ctx.createBuffer(
+    1,
+    frameCount,
+    ctx.sampleRate
+  );
+  const data = buffer.getChannelData( 0 );
+
+  for ( let i = 0; i < frameCount; i++ ) {
+    data[ i ] = ( Math.random() * 2 - 1 ) * ( 1 - i / frameCount );
+  }
+
+  const source = ctx.createBufferSource();
+  const filter = ctx.createBiquadFilter();
+  const envelope = ctx.createGain();
+
+  source.buffer = buffer;
+  filter.type = "bandpass";
+  filter.frequency.value = Math.max(
+    1,
+    freq
+  );
+  filter.Q.value = q;
+  envelope.gain.value = gain;
+
+  source.connect( filter );
+  filter.connect( envelope );
+  envelope.connect( destination );
+
+  source.start( startTime );
+
+  source.onended = () => {
+    source.disconnect();
+    filter.disconnect();
+    envelope.disconnect();
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Presets                                                            */
+/* ------------------------------------------------------------------ */
+
+type PresetVoice = (
+  ctx: AnyAudioContext,
+  destination: AudioNode,
+  when: number,
+  gain: number,
+  rate: number
+) => void;
+
+// Each preset is a tiny "recipe" over the two primitives above. Frequencies
+// are the designed pitch; `rate` transposes the whole recipe.
+const PRESETS: Record<ClickPresetName, PresetVoice> = {
+  // Soft camera-shutter tick: filtered noise snap plus a faint sine body.
+  click: (
+    ctx, destination, when, gain, rate
+  ) => {
+    noiseHit(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 2400 * rate,
+        q: 3,
+        duration: 0.025,
+        gain
+      }
+    );
+    tone(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 1800 * rate,
+        duration: 0.02,
+        gain: gain * 0.35
+      }
+    );
+  },
+
+  // Bright, dry metronome tick (pure filtered noise).
+  tick: (
+    ctx, destination, when, gain, rate
+  ) => {
+    noiseHit(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 3200 * rate,
+        q: 1.5,
+        duration: 0.03,
+        gain
+      }
+    );
+  },
+
+  // Short rounded triangle blip — friendly UI "bip".
+  blip: (
+    ctx, destination, when, gain, rate
+  ) => {
+    tone(
+      ctx,
+      destination,
+      when,
+      {
+        type: "triangle",
+        freq: 1300 * rate,
+        duration: 0.05,
+        attack: 0.002,
+        gain
+      }
+    );
+  },
+
+  // Bubble pop: fast downward pitch sweep.
+  pop: (
+    ctx, destination, when, gain, rate
+  ) => {
+    tone(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 520 * rate,
+        endFreq: 160 * rate,
+        duration: 0.09,
+        attack: 0.002,
+        gain
+      }
+    );
+  },
+
+  // Plain sine beep — longest of the set, reads as a confirmation.
+  beep: (
+    ctx, destination, when, gain, rate
+  ) => {
+    tone(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 880 * rate,
+        duration: 0.12,
+        attack: 0.004,
+        gain
+      }
+    );
+  },
+
+  // Woodblock: resonant low noise knock over a short thump.
+  wood: (
+    ctx, destination, when, gain, rate
+  ) => {
+    noiseHit(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 950 * rate,
+        q: 8,
+        duration: 0.06,
+        gain
+      }
+    );
+    tone(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 220 * rate,
+        endFreq: 180 * rate,
+        duration: 0.05,
+        gain: gain * 0.5
+      }
+    );
+  },
+
+  // Two-part mechanical key strike: hammer then rebound.
+  typewriter: (
+    ctx, destination, when, gain, rate
+  ) => {
+    noiseHit(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 2000 * rate,
+        q: 2,
+        duration: 0.02,
+        gain
+      }
+    );
+    noiseHit(
+      ctx,
+      destination,
+      when,
+      {
+        freq: 1400 * rate,
+        q: 2,
+        duration: 0.03,
+        gain: gain * 0.6,
+        delay: 0.03
+      }
+    );
+  }
+};
+
+/**
+ * Schedule one click of `preset` at `when` (in the context's time base).
+ * Works against a live AudioContext (when = ctx.currentTime + offset) and an
+ * OfflineAudioContext (when = event timestamp) alike.
+ */
+export function scheduleClick(
+  ctx: AnyAudioContext,
+  destination: AudioNode,
+  when: number,
+  preset: string,
+  {
+    gain = 0.5,
+    rate = 1
+  }: ClickParams = {}
+): void {
+  const voice = PRESETS[ isClickPreset( preset ) ? preset : "click" ];
+
+  voice(
+    ctx,
+    destination,
+    when,
+    Math.max(
+      0,
+      Math.min(
+        1,
+        gain
+      )
+    ),
+    Math.max(
+      0.05,
+      rate
+    )
+  );
+}

--- a/src/lib/uiSound.ts
+++ b/src/lib/uiSound.ts
@@ -1,0 +1,356 @@
+/**
+ * Editor UI sound feedback — a pleasing click whenever a template option
+ * value changes in the options panel, plus a confirmation click on the
+ * action buttons (reset / randomize / save defaults / …).
+ *
+ * Deliberately separate from the sketch audio engine: this module owns its
+ * own AudioContext that is NEVER registered on the audio bridge, so panel
+ * feedback can't leak into browser or server recordings. The DSP itself is
+ * shared with the sketch side through `@/lib/clickSynth`.
+ *
+ * Settings persist in localStorage and are observable through `subscribe`,
+ * so React components can bind with useSyncExternalStore.
+ */
+
+import {
+  CLICK_PRESET_NAMES,
+  type ClickPresetName,
+  scheduleClick
+} from "@/lib/clickSynth";
+
+export interface UiSoundSettings {
+  /** Master switch for value-change clicks. */
+  enabled: boolean;
+  /** Also click when an action button (reset / randomize / …) is pressed. */
+  actionSounds: boolean;
+  /** Voice from the shared click synth. */
+  preset: ClickPresetName;
+  /** 0..1 master volume. */
+  volume: number;
+  /** Global pitch multiplier (0.5..2 is the sensible range). */
+  pitch: number;
+  /** Random per-click detune 0..1 (1 ≈ ±half an octave). */
+  pitchVariation: number;
+  /**
+   * Derive a stable pitch offset from the field's path, so dragging the same
+   * slider always ticks at the same tone and different fields sound distinct.
+   */
+  pitchByField: boolean;
+  /** Minimum gap between clicks in ms — throttles slider drags. */
+  minGapMs: number;
+  /** Clicks per change event: 1 = single click, >1 = a small burst. */
+  repeatTimes: number;
+  /** Gap between burst clicks in ms. */
+  repeatIntervalMs: number;
+  /** Pitch ramp per burst click, in octaves. */
+  repeatPitchStep: number;
+}
+
+export const UI_SOUND_PRESETS = CLICK_PRESET_NAMES;
+
+export const UI_SOUND_DEFAULTS: UiSoundSettings = {
+  enabled: false,
+  actionSounds: true,
+  preset: "click",
+  volume: 0.4,
+  pitch: 1,
+  pitchVariation: 0.08,
+  pitchByField: true,
+  minGapMs: 45,
+  repeatTimes: 1,
+  repeatIntervalMs: 70,
+  repeatPitchStep: 0.08
+};
+
+const STORAGE_KEY = "p5templates.uiSound.v1";
+
+let settings: UiSoundSettings | null = null;
+const listeners = new Set<() => void>();
+
+function sanitize( raw: unknown ): UiSoundSettings {
+  const candidate = ( raw ?? {} ) as Partial<UiSoundSettings>;
+  const clamp = (
+    value: unknown, min: number, max: number, fallback: number
+  ) =>
+    typeof value === "number" && Number.isFinite( value )
+      ? Math.min(
+        max,
+        Math.max(
+          min,
+          value
+        )
+      )
+      : fallback;
+
+  return {
+    enabled:
+      typeof candidate.enabled === "boolean"
+        ? candidate.enabled
+        : UI_SOUND_DEFAULTS.enabled,
+    actionSounds:
+      typeof candidate.actionSounds === "boolean"
+        ? candidate.actionSounds
+        : UI_SOUND_DEFAULTS.actionSounds,
+    preset: ( CLICK_PRESET_NAMES as readonly string[] ).includes( candidate.preset as string )
+      ? ( candidate.preset as ClickPresetName )
+      : UI_SOUND_DEFAULTS.preset,
+    volume: clamp(
+      candidate.volume,
+      0,
+      1,
+      UI_SOUND_DEFAULTS.volume
+    ),
+    pitch: clamp(
+      candidate.pitch,
+      0.25,
+      4,
+      UI_SOUND_DEFAULTS.pitch
+    ),
+    pitchVariation: clamp(
+      candidate.pitchVariation,
+      0,
+      1,
+      UI_SOUND_DEFAULTS.pitchVariation
+    ),
+    pitchByField:
+      typeof candidate.pitchByField === "boolean"
+        ? candidate.pitchByField
+        : UI_SOUND_DEFAULTS.pitchByField,
+    minGapMs: clamp(
+      candidate.minGapMs,
+      0,
+      500,
+      UI_SOUND_DEFAULTS.minGapMs
+    ),
+    repeatTimes: Math.round( clamp(
+      candidate.repeatTimes,
+      1,
+      8,
+      UI_SOUND_DEFAULTS.repeatTimes
+    ) ),
+    repeatIntervalMs: clamp(
+      candidate.repeatIntervalMs,
+      20,
+      500,
+      UI_SOUND_DEFAULTS.repeatIntervalMs
+    ),
+    repeatPitchStep: clamp(
+      candidate.repeatPitchStep,
+      -0.5,
+      0.5,
+      UI_SOUND_DEFAULTS.repeatPitchStep
+    )
+  };
+}
+
+export function getUiSoundSettings(): UiSoundSettings {
+  if ( settings ) {
+    return settings;
+  }
+
+  let stored: unknown = null;
+
+  if ( typeof window !== "undefined" ) {
+    try {
+      const raw = window.localStorage.getItem( STORAGE_KEY );
+
+      stored = raw ? JSON.parse( raw ) : null;
+    } catch {
+      stored = null;
+    }
+  }
+
+  settings = sanitize( stored );
+
+  return settings;
+}
+
+export function setUiSoundSettings( patch: Partial<UiSoundSettings> ): UiSoundSettings {
+  settings = sanitize( {
+    ...getUiSoundSettings(),
+    ...patch
+  } );
+
+  if ( typeof window !== "undefined" ) {
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify( settings )
+      );
+    } catch {
+      // Private mode / quota — settings just won't persist.
+    }
+  }
+
+  for ( const listener of listeners ) {
+    listener();
+  }
+
+  return settings;
+}
+
+/** useSyncExternalStore-compatible subscription. */
+export function subscribeUiSoundSettings( listener: () => void ): () => void {
+  listeners.add( listener );
+
+  return () => {
+    listeners.delete( listener );
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Playback                                                           */
+/* ------------------------------------------------------------------ */
+
+let _context: AudioContext | null = null;
+let _masterGain: GainNode | null = null;
+let _lastClickAt = -Infinity;
+
+function ensureContext(): AudioContext | null {
+  if ( typeof window === "undefined" ) {
+    return null;
+  }
+
+  if ( _context ) {
+    // The panel click always happens inside a user gesture, so resuming a
+    // suspended context here satisfies autoplay policy.
+    if ( _context.state === "suspended" ) {
+      _context.resume().catch( () => {
+        // Retried on the next click.
+      } );
+    }
+
+    return _context;
+  }
+
+  const Ctx =
+    window.AudioContext ??
+    ( window as unknown as {
+      webkitAudioContext?: typeof AudioContext;
+    } ).webkitAudioContext;
+
+  if ( !Ctx ) {
+    return null;
+  }
+
+  _context = new Ctx();
+  _masterGain = _context.createGain();
+  _masterGain.gain.value = 1;
+  _masterGain.connect( _context.destination );
+
+  return _context;
+}
+
+// Small stable hash → pitch offset, so "slides.0.sketch.magnitude" always
+// ticks at the same tone and neighbouring fields sound distinct.
+function fieldPitchOffset( fieldPath: string ): number {
+  let hash = 0;
+
+  for ( let i = 0; i < fieldPath.length; i++ ) {
+    hash = ( hash * 31 + fieldPath.charCodeAt( i ) ) | 0;
+  }
+
+  // Map to ±0.35 octaves.
+  return ( ( ( hash % 1000 ) + 1000 ) % 1000 / 1000 - 0.5 ) * 0.7;
+}
+
+function playClicks(
+  current: UiSoundSettings,
+  baseRate: number,
+  times: number
+): void {
+  const ctx = ensureContext();
+
+  if ( !ctx || !_masterGain ) {
+    return;
+  }
+
+  for ( let i = 0; i < times; i++ ) {
+    const humanize =
+      ( Math.random() * 2 - 1 ) * current.pitchVariation * 0.5;
+    const rate =
+      baseRate *
+      Math.pow(
+        2,
+        humanize + current.repeatPitchStep * i
+      );
+
+    scheduleClick(
+      ctx,
+      _masterGain,
+      ctx.currentTime + ( i * current.repeatIntervalMs ) / 1000,
+      current.preset,
+      {
+        gain: current.volume,
+        rate
+      }
+    );
+  }
+}
+
+/**
+ * A template option value changed in the panel. Throttled by `minGapMs`;
+ * pitch derives from the field path when `pitchByField` is on.
+ */
+export function playValueChange( fieldPath?: string ): void {
+  const current = getUiSoundSettings();
+
+  if ( !current.enabled ) {
+    return;
+  }
+
+  const now =
+    typeof performance !== "undefined" ? performance.now() : Date.now();
+
+  if ( now - _lastClickAt < current.minGapMs ) {
+    return;
+  }
+
+  _lastClickAt = now;
+
+  const fieldOffset =
+    current.pitchByField && fieldPath ? fieldPitchOffset( fieldPath ) : 0;
+  const baseRate = current.pitch * Math.pow(
+    2,
+    fieldOffset
+  );
+
+  playClicks(
+    current,
+    baseRate,
+    current.repeatTimes
+  );
+}
+
+/**
+ * An action button (reset / randomize / save defaults / …) was pressed.
+ * Slightly lower-pitched single click so it reads as "did something" rather
+ * than "value ticked".
+ */
+export function playAction(): void {
+  const current = getUiSoundSettings();
+
+  if ( !current.enabled || !current.actionSounds ) {
+    return;
+  }
+
+  playClicks(
+    current,
+    current.pitch * 0.8,
+    1
+  );
+}
+
+/** Preview the current settings from the settings popover. */
+export function playPreview(): void {
+  const current = getUiSoundSettings();
+
+  playClicks(
+    current,
+    current.pitch,
+    Math.max(
+      1,
+      current.repeatTimes
+    )
+  );
+}

--- a/src/templates/p5/utils/audio.js
+++ b/src/templates/p5/utils/audio.js
@@ -1,6 +1,9 @@
 import {
   registerAudioBridge
 } from "@/lib/audioBridge";
+import {
+  scheduleClick
+} from "@/lib/clickSynth";
 import time from "./time.js";
 
 /**
@@ -250,6 +253,18 @@ function scheduleOn(
   }
 
   switch ( name ) {
+    // UI-style click presets (specs overlay, value-change feedback). The
+    // concrete voice is picked by `params.preset` inside the shared synth so
+    // live playback and offline capture render the exact same sound.
+    case "click":
+      scheduleClick(
+        ctx,
+        destination,
+        startTime,
+        params?.preset ?? "click",
+        params
+      );
+      break;
     case "tick":
       playTickOn(
         ctx,
@@ -325,6 +340,23 @@ function playTickLive( params ) {
     handles.filter.disconnect();
     handles.envelope.disconnect();
   };
+}
+
+function playClickLive( params ) {
+  const ctx = ensureContext();
+
+  if ( !ctx ) {
+    return;
+  }
+
+  // The shared synth cleans its own nodes up via onended.
+  scheduleClick(
+    ctx,
+    _masterGain,
+    ctx.currentTime,
+    params?.preset ?? "click",
+    params
+  );
 }
 
 function playSampleLive(
@@ -522,6 +554,9 @@ const audio = {
     }
 
     switch ( name ) {
+      case "click":
+        playClickLive( params );
+        break;
       case "tick":
         playTickLive( params );
         break;

--- a/src/templates/p5/utils/slides/common/__tests__/specsSound.test.ts
+++ b/src/templates/p5/utils/slides/common/__tests__/specsSound.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Behavioural tests for the specs sound scheduler: staggering, per-line
+ * cooldown, burst cap, repeat modes and the backwards-clock reset that keeps
+ * deterministic captures from being silenced by editing-session state.
+ *
+ * The scheduler polls a caller-provided clock and takes an injected trigger,
+ * so no Web Audio (or audio engine import) is needed here.
+ */
+
+// The module under test imports the audio engine only for its default
+// instance; stub it so the sketch/p5 import chain never loads in node.
+jest.mock(
+  "../../../audio.js",
+  () => ( {
+    __esModule: true,
+    default: {
+      trigger: jest.fn()
+    }
+  } )
+);
+
+import {
+  createSpecsSoundScheduler
+} from "../specsSound.js";
+import computeSpecsHeats from "../specsChanges.js";
+
+const baseOption = {
+  enabled: true,
+  preset: "click",
+  volume: 0.5,
+  pitch: 1,
+  pitchVariation: 0,
+  linePitchSpread: 0,
+  minInterval: 0.05,
+  lineCooldown: 0.15,
+  maxBurst: 12,
+  repeat: {
+    mode: "once"
+  }
+};
+
+function makeScheduler() {
+  const fired: any[] = [];
+  const scheduler = createSpecsSoundScheduler(
+    ( params: any ) => fired.push( params ),
+    () => 0.5 // deterministic "random"
+  );
+
+  return {
+    fired,
+    scheduler
+  };
+}
+
+describe(
+  "createSpecsSoundScheduler",
+  () => {
+    it(
+      "fires one click per change once due",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 4,
+            now: 1
+          }
+        );
+
+        expect( fired ).toHaveLength( 0 );
+
+        scheduler.update( 1 );
+
+        expect( fired ).toHaveLength( 1 );
+        expect( fired[ 0 ] ).toMatchObject( {
+          preset: "click",
+          gain: 0.5,
+          rate: 1
+        } );
+      }
+    );
+
+    it(
+      "staggers simultaneous changes by minInterval",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        for ( const label of [
+          "A",
+          "B",
+          "C"
+        ] ) {
+          scheduler.noteChange(
+            baseOption,
+            {
+              label,
+              index: 0,
+              lineCount: 3,
+              now: 1
+            }
+          );
+        }
+
+        scheduler.update( 1 );
+        expect( fired ).toHaveLength( 1 );
+
+        scheduler.update( 1.06 );
+        expect( fired ).toHaveLength( 2 );
+
+        scheduler.update( 1.2 );
+        expect( fired ).toHaveLength( 3 );
+      }
+    );
+
+    it(
+      "applies the per-line cooldown to rapid retriggers",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "MORPH",
+            index: 0,
+            lineCount: 1,
+            now: 1
+          }
+        );
+        // Same line changes again on the next frame — inside the cooldown.
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "MORPH",
+            index: 0,
+            lineCount: 1,
+            now: 1.016
+          }
+        );
+        scheduler.update( 1.05 );
+
+        expect( fired ).toHaveLength( 1 );
+
+        // Past the cooldown it clicks again.
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "MORPH",
+            index: 0,
+            lineCount: 1,
+            now: 1.2
+          }
+        );
+        scheduler.update( 1.3 );
+
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+
+    it(
+      "schedules a rising burst in count mode",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.noteChange(
+          {
+            ...baseOption,
+            repeat: {
+              mode: "count",
+              times: 3,
+              interval: 0.1,
+              pitchStep: 1 // one octave per click, easy to assert
+            }
+          },
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 1,
+            now: 0
+          }
+        );
+
+        scheduler.update( 0.25 );
+
+        expect( fired ).toHaveLength( 3 );
+        expect( fired.map( ( click ) => click.rate ) ).toEqual( [
+          1,
+          2,
+          4
+        ] );
+      }
+    );
+
+    it(
+      "repeats across the highlight window in while-highlighted mode",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.noteChange(
+          {
+            ...baseOption,
+            repeat: {
+              mode: "while-highlighted",
+              interval: 0.3
+            }
+          },
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 1,
+            now: 0,
+            highlightDuration: 0.9
+          }
+        );
+
+        // floor(0.9 / 0.3) + 1 = 4 clicks at 0, 0.3, 0.6, 0.9 — collected by
+        // stepping the clock like the per-frame caller does.
+        for ( let t = 0; t <= 1.05; t += 0.05 ) {
+          scheduler.update( t );
+        }
+
+        expect( fired ).toHaveLength( 4 );
+      }
+    );
+
+    it(
+      "caps the queue at maxBurst",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const option = {
+          ...baseOption,
+          maxBurst: 2
+        };
+
+        for ( let i = 0; i < 5; i++ ) {
+          scheduler.noteChange(
+            option,
+            {
+              label: `L${ i }`,
+              index: i,
+              lineCount: 5,
+              now: 1
+            }
+          );
+        }
+
+        scheduler.update( 1.1 );
+
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+
+    it(
+      "spreads pitch across lines in octaves",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const option = {
+          ...baseOption,
+          linePitchSpread: 1
+        };
+
+        scheduler.noteChange(
+          option,
+          {
+            label: "FIRST",
+            index: 0,
+            lineCount: 3,
+            now: 1
+          }
+        );
+        scheduler.update( 1.05 );
+        scheduler.noteChange(
+          option,
+          {
+            label: "LAST",
+            index: 2,
+            lineCount: 3,
+            now: 2
+          }
+        );
+        scheduler.update( 2.05 );
+
+        expect( fired[ 0 ].rate ).toBeCloseTo( 1 );
+        expect( fired[ 1 ].rate ).toBeCloseTo( 2 );
+      }
+    );
+
+    it(
+      "drops clicks that went stale while the overlay wasn't drawn",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 1,
+            now: 1
+          }
+        );
+
+        // Next update only happens much later (fade-out window, hidden tab):
+        // the queued click is dropped instead of fired late.
+        scheduler.update( 5 );
+
+        expect( fired ).toHaveLength( 0 );
+        expect( scheduler.pending() ).toBe( 0 );
+      }
+    );
+
+    it(
+      "resets itself when the clock jumps backwards (capture restart)",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        // Editing session state far in the future…
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 1,
+            now: 500
+          }
+        );
+        scheduler.update( 500 );
+        expect( fired ).toHaveLength( 1 );
+
+        // …then the deterministic capture resets the sketch clock to 0.
+        scheduler.noteChange(
+          baseOption,
+          {
+            label: "SEED",
+            index: 0,
+            lineCount: 1,
+            now: 0.1
+          }
+        );
+        scheduler.update( 0.1 );
+
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+  }
+);
+
+describe(
+  "computeSpecsHeats onChange callback",
+  () => {
+    it(
+      "reports value changes but not first sightings",
+      () => {
+        const changes: Array<[string, number]> = [];
+        const onChange = (
+          label: string, index: number
+        ) => changes.push( [
+          label,
+          index
+        ] );
+        const lines = ( value: string ) => [
+          {
+            label: "SPECS-SOUND-TEST",
+            value
+          }
+        ];
+
+        computeSpecsHeats(
+          lines( "a" ),
+          0.9,
+          onChange
+        );
+        expect( changes ).toHaveLength( 0 );
+
+        computeSpecsHeats(
+          lines( "b" ),
+          0.9,
+          onChange
+        );
+        expect( changes ).toEqual( [
+          [
+            "SPECS-SOUND-TEST",
+            0
+          ]
+        ] );
+
+        // Unchanged value stays silent.
+        computeSpecsHeats(
+          lines( "b" ),
+          0.9,
+          onChange
+        );
+        expect( changes ).toHaveLength( 1 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/slides/common/drawSlideSpecs.js
+++ b/src/templates/p5/utils/slides/common/drawSlideSpecs.js
@@ -3,8 +3,10 @@ import sketch, {
   getP5
 } from "../../sketch.js";
 import animation from "../../animation.js";
+import time from "../../time.js";
 import buildSpecsLines from "./specsData.js";
 import computeSpecsHeats from "./specsChanges.js";
+import specsSound from "./specsSound.js";
 
 /**
  * Technical / BIOS-style overlay that reveals the current sketch settings.
@@ -80,13 +82,52 @@ export default function drawSlideSpecs( specsOption ) {
     duration: 0.9,
     background: specsOption.fill
   };
-  const heats =
-    highlight.style && highlight.style !== "off"
-      ? computeSpecsHeats(
-        lines,
-        highlight.duration ?? 0.9
-      )
-      : null;
+  const highlightActive = Boolean( highlight.style ) && highlight.style !== "off";
+  const highlightDuration = highlight.duration ?? 0.9;
+
+  // Sound on change rides the same change tracker as the highlight, so it
+  // works with the highlight off too. Single computeSpecsHeats call per frame:
+  // the tracker mutates on read, so a second call would swallow the change.
+  const sound = specsOption.sound;
+  const soundEnabled = Boolean( sound?.enabled );
+  const changedLines = [];
+
+  let heats = null;
+
+  if ( highlightActive || soundEnabled ) {
+    const computed = computeSpecsHeats(
+      lines,
+      highlightDuration,
+      soundEnabled
+        ? (
+          label, index
+        ) => changedLines.push( {
+          label,
+          index
+        } )
+        : undefined
+    );
+
+    heats = highlightActive ? computed : null;
+  }
+
+  if ( soundEnabled ) {
+    const now = time.seconds();
+
+    for ( const change of changedLines ) {
+      specsSound.noteChange(
+        sound,
+        {
+          ...change,
+          lineCount: lines.length,
+          now,
+          highlightDuration
+        }
+      );
+    }
+
+    specsSound.update( now );
+  }
 
   const size = specsOption.size ?? 22;
   const lineStep = size * ( specsOption.lineHeight ?? 1.4 );

--- a/src/templates/p5/utils/slides/common/specsChanges.js
+++ b/src/templates/p5/utils/slides/common/specsChanges.js
@@ -15,10 +15,13 @@ const tracker = new Map();
  *
  * @param {{ label: string, value: string }[]} lines
  * @param {number} durationSeconds  How long a highlight takes to fade out.
+ * @param {(label: string, index: number) => void} [onChange]  Called once per
+ *   line whose value just changed on THIS call (not for first sightings) —
+ *   the seam the sound feedback hangs off.
  * @returns {Map<string, number>} label -> heat (0..1)
  */
 export default function computeSpecsHeats(
-  lines, durationSeconds
+  lines, durationSeconds, onChange
 ) {
   const now = performance.now();
   const durationMs = Math.max(
@@ -27,9 +30,10 @@ export default function computeSpecsHeats(
   );
   const heats = new Map();
 
-  for ( const {
-    label, value
-  } of lines ) {
+  for ( let index = 0; index < lines.length; index++ ) {
+    const {
+      label, value
+    } = lines[ index ];
     const previous = tracker.get( label );
 
     if ( previous === undefined ) {
@@ -44,6 +48,10 @@ export default function computeSpecsHeats(
     } else if ( previous.value !== value ) {
       previous.value = value;
       previous.changedAt = now;
+      onChange?.(
+        label,
+        index
+      );
     }
 
     const entry = tracker.get( label );

--- a/src/templates/p5/utils/slides/common/specsSound.js
+++ b/src/templates/p5/utils/slides/common/specsSound.js
@@ -1,0 +1,230 @@
+import audio from "../../audio.js";
+
+/**
+ * Turns specs-overlay value changes into clicks through the sketch audio
+ * engine. Because everything routes through `audio.trigger("click", …)`, a
+ * click that plays live while editing is also logged during deterministic
+ * capture and baked into the exported video's soundtrack.
+ *
+ * Scheduling is polled, not timer-based: `drawSlideSpecs` calls `update(now)`
+ * once per frame with the sketch clock (`time.seconds()`), so due clicks fire
+ * on real frames — which is exactly what keeps them deterministic when the
+ * recorder steps frames faster or slower than the wall clock.
+ *
+ * Behaviour knobs all come from the specs item's `sound` options
+ * (SpecsSoundSchema):
+ *   - simultaneous changes are STAGGERED by `minInterval` (slot-machine
+ *     cascade) instead of stacking into one transient;
+ *   - a line that keeps changing every frame (montage morph) retriggers at
+ *     most once per `lineCooldown`;
+ *   - the queue is capped at `maxBurst` pending clicks;
+ *   - `repeat` turns one change into a burst ("count", with per-repeat pitch
+ *     ramp) or a Geiger-style stream ("while-highlighted").
+ */
+
+const DEFAULTS = {
+  preset: "click",
+  volume: 0.5,
+  pitch: 1,
+  pitchVariation: 0.1,
+  linePitchSpread: 0,
+  minInterval: 0.05,
+  lineCooldown: 0.15,
+  maxBurst: 12
+};
+
+export function createSpecsSoundScheduler(
+  trigger = ( params ) => audio.trigger(
+    "click",
+    params
+  ),
+  random = Math.random
+) {
+  // Pending clicks: { at, preset, gain, rate }, kept sorted by insertion —
+  // near enough, fire order only matters within a frame anyway.
+  let queue = [];
+  // Stagger anchor: the time the latest initial click was scheduled at.
+  let lastScheduledAt = -Infinity;
+  // label -> sketch time of its last accepted change (cooldown gate).
+  const lineLastChangeAt = new Map();
+  // Backwards-clock detection (capture restart, deck reset).
+  let lastNow = -Infinity;
+
+  const reset = () => {
+    queue = [];
+    lastScheduledAt = -Infinity;
+    lineLastChangeAt.clear();
+    lastNow = -Infinity;
+  };
+
+  // 2^x pitch algebra keeps every knob musical (octaves, not raw Hz).
+  const computeRate = (
+    option, index, lineCount, repeatIndex, pitchStep
+  ) => {
+    const spread = option.linePitchSpread ?? DEFAULTS.linePitchSpread;
+    const variation = option.pitchVariation ?? DEFAULTS.pitchVariation;
+    const lineOffset =
+      lineCount > 1 ? spread * ( index / ( lineCount - 1 ) ) : 0;
+    const humanize = ( random() * 2 - 1 ) * variation * 0.5;
+    const ramp = pitchStep * repeatIndex;
+
+    return (
+      ( option.pitch ?? DEFAULTS.pitch ) *
+      Math.pow(
+        2,
+        lineOffset + humanize + ramp
+      )
+    );
+  };
+
+  const syncClock = ( now ) => {
+    // The sketch clock resets on capture start / deck reset. Any state keyed
+    // to the old timeline would silence (or mis-time) every future click.
+    if ( now + 0.5 < lastNow ) {
+      reset();
+    }
+
+    lastNow = now;
+  };
+
+  return {
+    reset,
+
+    /**
+     * Register one changed line. `now` is the sketch clock in seconds;
+     * `highlightDuration` bounds the "while-highlighted" repeat mode.
+     */
+    noteChange(
+      option, {
+        label, index, lineCount, now, highlightDuration = 0.9
+      }
+    ) {
+      syncClock( now );
+
+      const cooldown = option.lineCooldown ?? DEFAULTS.lineCooldown;
+      const lastChange = lineLastChangeAt.get( label );
+
+      if ( lastChange !== undefined && now - lastChange < cooldown ) {
+        return;
+      }
+
+      lineLastChangeAt.set(
+        label,
+        now
+      );
+
+      const minInterval = option.minInterval ?? DEFAULTS.minInterval;
+      const maxBurst = option.maxBurst ?? DEFAULTS.maxBurst;
+      const firstAt = Math.max(
+        now,
+        lastScheduledAt + minInterval
+      );
+
+      lastScheduledAt = firstAt;
+
+      const repeat = option.repeat ?? {
+        mode: "once"
+      };
+      // [offset seconds, repeat index] pairs for this change's click series.
+      let series = [
+        [
+          0,
+          0
+        ]
+      ];
+      let pitchStep = 0;
+
+      if ( repeat.mode === "count" ) {
+        const times = repeat.times ?? 3;
+        const interval = repeat.interval ?? 0.08;
+
+        pitchStep = repeat.pitchStep ?? 0;
+        series = Array.from(
+          {
+            length: times
+          },
+          (
+            _, i
+          ) => [
+            i * interval,
+            i
+          ]
+        );
+      } else if ( repeat.mode === "while-highlighted" ) {
+        const interval = repeat.interval ?? 0.12;
+        const count = Math.max(
+          1,
+          Math.floor( highlightDuration / interval ) + 1
+        );
+
+        series = Array.from(
+          {
+            length: count
+          },
+          (
+            _, i
+          ) => [
+            i * interval,
+            i
+          ]
+        );
+      }
+
+      for ( const [
+        offset,
+        repeatIndex
+      ] of series ) {
+        if ( queue.length >= maxBurst ) {
+          break;
+        }
+
+        queue.push( {
+          at: firstAt + offset,
+          preset: option.preset ?? DEFAULTS.preset,
+          gain: option.volume ?? DEFAULTS.volume,
+          rate: computeRate(
+            option,
+            index,
+            lineCount,
+            repeatIndex,
+            pitchStep
+          )
+        } );
+      }
+    },
+
+    /** Fire every queued click that is due. Call once per drawn frame. */
+    update( now ) {
+      syncClock( now );
+
+      if ( !queue.length ) {
+        return;
+      }
+
+      // Clicks that went stale while the overlay wasn't drawn (fade-out
+      // window, hidden tab) are dropped, not fired: releasing them all in
+      // one frame would stack into a single loud transient.
+      const staleBefore = now - 0.25;
+      const due = queue.filter( ( click ) => click.at <= now && click.at >= staleBefore );
+
+      queue = queue.filter( ( click ) => click.at > now );
+
+      for ( const click of due ) {
+        trigger( {
+          preset: click.preset,
+          gain: click.gain,
+          rate: click.rate
+        } );
+      }
+    },
+
+    /** Number of queued clicks (test / debug seam). */
+    pending() {
+      return queue.length;
+    }
+  };
+}
+
+// Shared instance for the specs overlay renderer. Like the change tracker in
+// specsChanges.js, module scope is fine: specs is in practice a single item.
+export default createSpecsSoundScheduler();

--- a/src/types/__tests__/specsSound.test.ts
+++ b/src/types/__tests__/specsSound.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Guards the specs "sound on change" option group.
+ *
+ * Same drift-protection idea as qrCodeItem.test.ts: the Zod schema, the specs
+ * item, and the form field-config must stay in agreement, and pre-existing
+ * decks (persisted before the sound group existed) must heal to a silent
+ * default instead of failing to parse.
+ */
+
+import {
+  SPECS_SOUND_PRESETS,
+  SpecsItemSchema,
+  SpecsSoundRepeatSchema,
+  SpecsSoundSchema
+} from "@/types/sketch.types";
+import {
+  CLICK_PRESET_NAMES
+} from "@/lib/clickSynth";
+import {
+  formConfig
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
+
+describe(
+  "specs sound option group",
+  () => {
+    it(
+      "defaults to disabled with a single pleasing click",
+      () => {
+        const sound = SpecsSoundSchema.parse( undefined );
+
+        expect( sound ).toEqual( {
+          enabled: false,
+          preset: "click",
+          volume: 0.5,
+          pitch: 1,
+          pitchVariation: 0.1,
+          linePitchSpread: 0,
+          minInterval: 0.05,
+          lineCooldown: 0.15,
+          maxBurst: 12,
+          repeat: {
+            mode: "once"
+          }
+        } );
+      }
+    );
+
+    it(
+      "heals pre-sound specs items to the silent default",
+      () => {
+        const item = SpecsItemSchema.parse( {
+          type: "specs"
+        } );
+
+        expect( item.sound.enabled ).toBe( false );
+        expect( item.sound.repeat ).toEqual( {
+          mode: "once"
+        } );
+      }
+    );
+
+    it(
+      "fills per-mode repeat defaults",
+      () => {
+        expect( SpecsSoundRepeatSchema.parse( {
+          mode: "count"
+        } ) ).toEqual( {
+          mode: "count",
+          times: 3,
+          interval: 0.08,
+          pitchStep: 0.08
+        } );
+
+        expect( SpecsSoundRepeatSchema.parse( {
+          mode: "while-highlighted"
+        } ) ).toEqual( {
+          mode: "while-highlighted",
+          interval: 0.12
+        } );
+      }
+    );
+
+    it(
+      "keeps the schema presets aligned with the click synth",
+      () => {
+        expect( [
+          ...SPECS_SOUND_PRESETS
+        ] ).toEqual( [
+          ...CLICK_PRESET_NAMES
+        ] );
+      }
+    );
+
+    it(
+      "exposes every schema field in the specs form config",
+      () => {
+        const soundConfig = formConfig.specs.sound;
+
+        expect( soundConfig ).toBeDefined();
+
+        if ( soundConfig?.component !== "nested-object" ) {
+          throw new Error( "specs.sound should be a nested-object group" );
+        }
+
+        const schemaKeys = Object.keys( SpecsSoundSchema.removeDefault().shape );
+        const configKeys = Object.keys( soundConfig.fields );
+
+        expect( configKeys.sort() ).toEqual( schemaKeys.sort() );
+      }
+    );
+  }
+);

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -267,6 +267,102 @@ export const SpecsHighlightSchema = z
     ]
   } );
 
+/* ---------------- specs sound-on-change --------------------------- */
+
+// Synth presets from @/lib/clickSynth — duplicated as a plain list so the
+// schema layer stays free of audio imports (zod enums want literals anyway).
+export const SPECS_SOUND_PRESETS = [
+  "click",
+  "tick",
+  "blip",
+  "pop",
+  "beep",
+  "wood",
+  "typewriter"
+] as const;
+
+const soundRepeatInterval = z.number().min( 0.02 )
+  .max( 2 );
+
+// How a changed line clicks: once, an N-times burst (with optional pitch
+// ramp, for a "spin-up" feel), or repeated for as long as the highlight
+// effect stays hot (Geiger-counter style). Discriminated union so the panel
+// shows only the controls the picked mode uses — same pattern as highlight.
+export const SpecsSoundRepeatSchema = z
+  .discriminatedUnion(
+    "mode",
+    [
+      z.object( {
+        mode: z.literal( "once" )
+      } ),
+      z.object( {
+        mode: z.literal( "count" ),
+        // total clicks per change (first one included)
+        times: z.number().int()
+          .min( 2 )
+          .max( 16 )
+          .default( 3 ),
+        // seconds between clicks of the burst
+        interval: soundRepeatInterval.default( 0.08 ),
+        // pitch ramp per repeat, in octaves ( + rises, - falls, 0 = flat )
+        pitchStep: z.number().min( -0.5 )
+          .max( 0.5 )
+          .default( 0.08 )
+      } ),
+      z.object( {
+        mode: z.literal( "while-highlighted" ),
+        // seconds between clicks while the line's highlight is still hot
+        interval: soundRepeatInterval.default( 0.12 )
+      } )
+    ]
+  )
+  .default( {
+    mode: "once"
+  } );
+
+export const SpecsSoundSchema = z
+  .object( {
+    // Master switch — off by default so existing decks stay silent.
+    enabled: z.boolean().default( false ),
+    // Voice from the shared click synth.
+    preset: z.enum( SPECS_SOUND_PRESETS ).default( "click" ),
+    volume: z.number().min( 0 )
+      .max( 1 )
+      .default( 0.5 ),
+    // Global pitch multiplier (1 = as designed, 2 = octave up).
+    pitch: z.number().min( 0.25 )
+      .max( 4 )
+      .default( 1 ),
+    // Random per-click detune, 0..1 (1 ≈ ±half an octave) — "humanize".
+    pitchVariation: z.number().min( 0 )
+      .max( 1 )
+      .default( 0.1 ),
+    // Pitch offset by line index, in octaves across the whole list, so each
+    // spec line gets its own recognisable tone ( + = lower lines are higher ).
+    linePitchSpread: z.number().min( -1 )
+      .max( 1 )
+      .default( 0 ),
+    // Minimum spacing between clicks (seconds). Simultaneous changes (e.g. a
+    // randomize) are staggered by this amount — the slot-machine cascade —
+    // instead of stacking into one loud transient.
+    minInterval: z.number().min( 0 )
+      .max( 0.5 )
+      .default( 0.05 ),
+    // Per-line retrigger cooldown (seconds): a value that changes every frame
+    // (montage morphs) clicks at most once per this window.
+    lineCooldown: z.number().min( 0 )
+      .max( 2 )
+      .default( 0.15 ),
+    // Hard cap on queued clicks — keeps a deck-wide randomize from becoming a
+    // machine gun.
+    maxBurst: z.number().int()
+      .min( 1 )
+      .max( 32 )
+      .default( 12 ),
+    repeat: SpecsSoundRepeatSchema
+  } )
+  .default( {} );
+
 export const SpecsItemSchema = z.object( {
   type: z.literal( "specs" ),
   style: z.enum( [
@@ -324,7 +420,8 @@ export const SpecsItemSchema = z.object( {
       "sketch"
     ] ),
   visibility: SpecsVisibilitySchema,
-  highlight: SpecsHighlightSchema
+  highlight: SpecsHighlightSchema,
+  sound: SpecsSoundSchema
 } );
 
 export const TextItemSchema = z.object( {


### PR DESCRIPTION
# Sound feedback on value changes

A pleasing click whenever a value changes — on both surfaces, with a full set of options (see `docs/SOUND_FEEDBACK.md`).

## Shared synth — `src/lib/clickSynth.ts`
7 context-agnostic Web Audio presets (`click`, `tick`, `blip`, `pop`, `beep`, `wood`, `typewriter`), each taking `{ gain, rate }`. Context-agnostic so the exact same DSP runs live and through `OfflineAudioContext`.

## 1. `specs` content item — new **Sound on change** group (off by default)

| Option | What it does |
| --- | --- |
| preset / volume / pitch | voice, gain, global pitch multiplier |
| humanize | random per-click detune |
| pitch spread by line | each spec line gets its own tone (octaves across the list) |
| stagger (`minInterval`) | simultaneous changes cascade like a slot machine instead of stacking |
| per-line cooldown | a value morphing every frame clicks at most once per window |
| max queued clicks | hard cap against machine-gunning |
| repeat: **once / burst / while-highlighted** | burst = N clicks with per-click pitch ramp; while-highlighted = Geiger-style stream for the highlight duration |

Change detection rides the existing highlight tracker (`specsChanges.js` gains an `onChange` callback). Clicks route through `audio.trigger("click", …)`, so they play live **and render sample-accurately into recordings** (realtime MediaRecorder mix and deterministic/server offline render). Scheduling is polled per frame on the sketch clock — no timers — with a backwards-clock reset (capture restart) and stale-click dropping (fade-out window / hidden tab).

## 2. Template options panel (template actions)

Editor-only sound path (`src/lib/uiSound.ts`) with its **own AudioContext, never registered on the audio bridge** — panel feedback can't leak into recordings.

- Tick on every form value edit (sliders, inputs, content items, per-slide sketch settings) via the `useFormState` watch subscription; form-level events (reset/populate) stay silent.
- Confirmation click on the actions row (reset / randomize / save defaults / …).
- New 🔊 settings popover in the actions row (desktop panel + mobile drawer), persisted in `localStorage`: enable switches, preset, volume, pitch, humanize, stable **pitch-by-field** (same slider always ticks at the same tone), min-gap throttle, clicks-per-change burst + interval + pitch ramp, and a test button.

## Tests
- `src/types/__tests__/specsSound.test.ts` — schema defaults, healing of pre-sound decks, repeat-mode defaults, schema ↔ form-config ↔ synth-preset alignment.
- `src/templates/p5/utils/slides/common/__tests__/specsSound.test.ts` — scheduler behaviour: stagger, cooldown, burst cap, both repeat modes, pitch spread, stale-click drop, backwards-clock reset, change-callback semantics.

`npx jest`: 40 suites / 1364 tests pass. ESLint clean on all touched files. `tsc --noEmit` reports no errors in touched files (pre-existing errors elsewhere are from the skipped Prisma generate and an old test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AENMVgKqV3GpMnox9uWPbw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AENMVgKqV3GpMnox9uWPbw)_