### PR TITLE
feat(interaction): reusable on-canvas drag layer + draggable content items

### DIFF
--- a/src/templates/p5/sketches/splines/splines-v2-draggable/index.js
+++ b/src/templates/p5/sketches/splines/splines-v2-draggable/index.js
@@ -2,7 +2,6 @@ import options from "@/p5/utils/options.js";
 import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
-import events from "@/p5/utils/events.js";
 import {
   setSketchOptions
 } from "@/p5/shared/syncSketchOptions.js";
@@ -10,6 +9,9 @@ import {
   initInteraction,
   getPointerGroups
 } from "@/p5/utils/interaction/index.js";
+import {
+  createDraggable
+} from "@/p5/utils/interaction/draggable.js";
 import {
   drawInteractionCameraPreview
 } from "@/p5/utils/interaction/overlay.js";
@@ -24,27 +26,17 @@ import {
 //   1. The points are stored NORMALIZED (0..1) in options.sketch.points.items,
 //      so they survive canvas resizes and are saved/exported with the template.
 //      Random by default (seeded); `count`/`seed` regenerate the layout.
-//   2. Dragging never pans the viewport. Touch is claimed by enabling
-//      `interaction.touch` (TemplateSketchPage flips disableTouchGestures), and
-//      the mouse drag is kept off the pan by tagging the canvas `data-no-drag`
-//      while a point is under the cursor (the viewport cancels its pan on that
-//      hook BEFORE it would pause the loop, so the drag stays live).
-//   3. Pointer positions come from the shared interaction layer
-//      (getPointerGroups), which converts client → canvas space correctly even
-//      when the viewport is zoomed/panned. Mouse press state comes from the
-//      engine's wired canvas events; a touch counts as "pressed" while present.
-//
-// The grab → move → release state machine is source-agnostic, so all three
-// inputs feed the same path as one { x, y, pressed } pointer:
-//   - touch  → present finger, always "pressed"
-//   - camera → enable Vision → Hands; the thumb+index midpoint is the pointer
-//              and a PINCH (the two tips closer than the threshold) is "pressed",
-//              so you literally pinch a point and move it. No viewport conflict —
-//              the camera emits no pointer events.
-//   - mouse  → cursor position + button state.
-// Every pointer is independent and keyed by a stable id, so several can drag at
-// once: multi-touch (one point per finger) and multi-hand (one point per
-// pinching hand). The mouse is ignored while fingers are down.
+//   2. The grab → move → release state machine, pointer collection (mouse +
+//      touch) and the keep-off-the-viewport-pan affordance all come from the
+//      shared draggable layer (utils/interaction/draggable.js) — the same
+//      helper that makes the template content items draggable.
+//   3. On top of the built-in mouse/touch pointers, the sketch feeds the
+//      draggable layer camera pointers: enable Vision → Hands and the
+//      thumb+index midpoint is the pointer, a PINCH (the two tips closer than
+//      the threshold) is "pressed" — so you literally pinch a point and move
+//      it. Every pointer is independent, so several can drag at once:
+//      multi-touch (one point per finger) and multi-hand (one point per
+//      pinching hand).
 
 const state = {
   // Working copy of the control points, normalized [0..1].
@@ -54,16 +46,6 @@ const state = {
   // JSON of the items we last took from / wrote to the store, so we can tell an
   // external edit (form, reload) apart from our own drag write.
   syncHash: null,
-  // Mouse button state, fed by the engine's wired canvas events.
-  mouseDown: false,
-  // Active drags, one entry per pointer currently holding a point:
-  // pointer key ("mouse" / "touch-<id>" / "cam-<handId>") → point index. Several
-  // at once = multi-touch and multi-hand dragging in parallel.
-  drags: new Map(),
-  // Point indices to highlight as "hovered" this frame.
-  hovers: new Set(),
-  // Whether the canvas currently carries the `data-no-drag` attribute.
-  noDrag: false,
   // Per-hand camera feedback for drawing: handId → { thumb, index, mid, pinching }.
   cameras: new Map(),
   // Per-hand EMA-smoothed pinch midpoint (camera landmarks are jittery), kept
@@ -72,6 +54,10 @@ const state = {
   // Per-hand pinch latch (hysteresis) so a borderline gap doesn't flicker.
   pinching: new Map()
 };
+
+// Shared grab → move → release drag layer (mouse + touch built in, camera
+// pointers fed per frame).
+const draggable = createDraggable();
 
 function clamp01( value ) {
   return Math.min(
@@ -250,58 +236,6 @@ function syncPoints( cfg ) {
   }
 }
 
-function nearestIndex(
-  pointsPx, x, y, radius
-) {
-  let best = -1;
-  let bestDistance = radius * radius;
-
-  for ( let i = 0; i < pointsPx.length; i++ ) {
-    const dx = pointsPx[ i ].x - x;
-    const dy = pointsPx[ i ].y - y;
-    const distance = dx * dx + dy * dy;
-
-    if ( distance < bestDistance ) {
-      bestDistance = distance;
-      best = i;
-    }
-  }
-
-  return best;
-}
-
-// Tag the canvas so the viewport's gesture layer cancels a mouse pan when the
-// cursor is over (or dragging) a point, and reflect the grab state in the
-// cursor. Touch never needs this — its gestures are already disabled.
-function updateCanvasAffordance(
-  wantNoDrag, grabbing
-) {
-  const element = sketch.getCanvasElement?.();
-
-  if ( !element ) {
-    return;
-  }
-
-  if ( wantNoDrag !== state.noDrag ) {
-    if ( wantNoDrag ) {
-      element.setAttribute(
-        "data-no-drag",
-        ""
-      );
-    } else {
-      element.removeAttribute( "data-no-drag" );
-    }
-
-    state.noDrag = wantNoDrag;
-  }
-
-  const cursor = grabbing ? "grabbing" : wantNoDrag ? "grab" : "";
-
-  if ( element.style.cursor !== cursor ) {
-    element.style.cursor = cursor;
-  }
-}
-
 function drawHighlight(
   p, pointsPx, hovers, grabbed, baseSize
 ) {
@@ -343,32 +277,6 @@ function drawHighlight(
   } );
 
   p.pop();
-}
-
-// Nearest point within `radius`, skipping any already held by another pointer
-// so two fingers / two hands can't fight over the same point.
-function nearestFreeIndex(
-  pointsPx, x, y, radius, taken
-) {
-  let best = -1;
-  let bestDistance = radius * radius;
-
-  for ( let i = 0; i < pointsPx.length; i++ ) {
-    if ( taken.has( i ) ) {
-      continue;
-    }
-
-    const dx = pointsPx[ i ].x - x;
-    const dy = pointsPx[ i ].y - y;
-    const distance = dx * dx + dy * dy;
-
-    if ( distance < bestDistance ) {
-      bestDistance = distance;
-      best = i;
-    }
-  }
-
-  return best;
 }
 
 // One hand's thumb + index pinch. The hands group is ordered
@@ -451,26 +359,13 @@ function resolveHandPinch(
   };
 }
 
-// Every active pointer this frame as { key, x, y, pressed, kind }. All sources
-// coexist — multi-touch + multi-hand + mouse — and each grabs its own point. The
-// mouse is dropped while any finger is down (its position is stale on a
-// touchscreen). Stale per-hand camera state for hands that left is pruned here.
-function collectPointers(
+// Camera pointers for the draggable layer, one per tracked hand: pinch midpoint
+// as position, "pinching" as pressed. Stale per-hand state for hands that left
+// is pruned here.
+function collectCameraPointers(
   o, groups
 ) {
   const pointers = [];
-  const touchGroups = groups.filter( ( group ) => group.source === "touch" );
-
-  touchGroups.forEach( ( group ) => {
-    pointers.push( {
-      key: group.id,
-      x: group.points[ 0 ].x,
-      y: group.points[ 0 ].y,
-      pressed: true,
-      kind: "touch"
-    } );
-  } );
-
   const vision = o.interaction?.vision;
 
   if ( vision?.enabled && vision.hands?.enabled ) {
@@ -508,20 +403,6 @@ function collectPointers(
     state.cameras.clear();
     state.cameraSmooth.clear();
     state.pinching.clear();
-  }
-
-  if ( touchGroups.length === 0 ) {
-    const mouse = groups.find( ( group ) => group.source === "mouse" );
-
-    if ( mouse ) {
-      pointers.push( {
-        key: "mouse",
-        x: mouse.points[ 0 ].x,
-        y: mouse.points[ 0 ].y,
-        pressed: state.mouseDown,
-        kind: "mouse"
-      } );
-    }
   }
 
   return pointers;
@@ -592,28 +473,13 @@ sketch.setup( async() => {
   state.points = [];
   state.signature = null;
   state.syncHash = null;
-  state.mouseDown = false;
-  state.drags = new Map();
-  state.hovers = new Set();
-  state.noDrag = false;
   state.cameras = new Map();
   state.cameraSmooth = new Map();
   state.pinching = new Map();
 
-  // Press / release of the mouse button. Press is canvas-scoped (don't grab when
-  // clicking UI); release is global so letting go off-canvas still ends a drag.
-  events.register(
-    "engine-canvas-mouse-pressed",
-    () => {
-      state.mouseDown = true;
-    }
-  );
-  events.register(
-    "engine-mouse-released",
-    () => {
-      state.mouseDown = false;
-    }
-  );
+  // Re-arm the drag layer's listeners (the engine's event registry is cleared
+  // on reset).
+  draggable.attach();
 
   await initInteraction( options.sketch?.interaction ?? {} );
 } );
@@ -627,7 +493,7 @@ sketch.draw( () => {
 
   // Re-sync from the store only when nothing is being dragged, so a live drag is
   // never snapped back to a stale value.
-  if ( state.drags.size === 0 ) {
+  if ( !draggable.dragging ) {
     syncPoints( cfg );
   }
 
@@ -646,120 +512,41 @@ sketch.draw( () => {
     n.y * p.height
   ) );
 
-  const pointers = collectPointers(
-    o,
-    getPointerGroups( interaction )
-  );
-  const activeKeys = new Set( pointers.map( ( pointer ) => pointer.key ) );
-  let released = false;
+  // One groups fetch per frame, shared by the drag layer (mouse + touch) and
+  // the camera pinch pointers.
+  const groups = getPointerGroups( interaction );
 
-  // Release any drag whose pointer vanished (finger lifted, hand left the frame).
-  for ( const key of [
-    ...state.drags.keys()
-  ] ) {
-    if ( !activeKeys.has( key ) ) {
-      state.drags.delete( key );
-      released = true;
-    }
-  }
+  const {
+    hovers,
+    grabbed,
+    released
+  } = draggable.update( {
+    targets: pointsPx,
+    radius: grabRadius,
+    groups,
+    extraPointers: collectCameraPointers(
+      o,
+      groups
+    ),
+    onMove: (
+      index, pointer
+    ) => {
+      const moved = {
+        x: clamp01( pointer.x / p.width ),
+        y: clamp01( pointer.y / p.height )
+      };
 
-  // Indices currently held, so no two pointers fight over the same point.
-  const grabbed = new Set( state.drags.values() );
-  const hovers = new Set();
-
-  const moveTo = (
-    index, pointer
-  ) => {
-    const moved = {
-      x: clamp01( pointer.x / p.width ),
-      y: clamp01( pointer.y / p.height )
-    };
-
-    state.points[ index ] = moved;
-    pointsPx[ index ] = p.createVector(
-      moved.x * p.width,
-      moved.y * p.height
-    );
-  };
-
-  pointers.forEach( ( pointer ) => {
-    if ( state.drags.has( pointer.key ) ) {
-      const index = state.drags.get( pointer.key );
-
-      if ( pointer.pressed ) {
-        moveTo(
-          index,
-          pointer
-        );
-      } else {
-        state.drags.delete( pointer.key );
-        grabbed.delete( index );
-        released = true;
-      }
-
-      return;
-    }
-
-    if ( pointer.pressed ) {
-      const index = nearestFreeIndex(
-        pointsPx,
-        pointer.x,
-        pointer.y,
-        grabRadius,
-        grabbed
+      state.points[ index ] = moved;
+      pointsPx[ index ] = p.createVector(
+        moved.x * p.width,
+        moved.y * p.height
       );
-
-      if ( index !== -1 ) {
-        state.drags.set(
-          pointer.key,
-          index
-        );
-        grabbed.add( index );
-        moveTo(
-          index,
-          pointer
-        );
-      }
-
-      return;
-    }
-
-    // Aiming (not pressed): highlight the point the mouse / open hand is over.
-    if ( pointer.kind === "mouse" || pointer.kind === "camera" ) {
-      const index = nearestIndex(
-        pointsPx,
-        pointer.x,
-        pointer.y,
-        grabRadius
-      );
-
-      if ( index !== -1 ) {
-        hovers.add( index );
-      }
     }
   } );
-
-  state.hovers = hovers;
 
   if ( released ) {
     persistPoints();
   }
-
-  // Mouse-only: keep the canvas off the viewport pan while it hovers/holds a
-  // point, and mirror the grab in the cursor.
-  const mousePointer = pointers.find( ( pointer ) => pointer.kind === "mouse" );
-  const mouseDragging = state.drags.has( "mouse" );
-  const mouseOverPoint = !!mousePointer && !mouseDragging && nearestIndex(
-    pointsPx,
-    mousePointer.x,
-    mousePointer.y,
-    grabRadius
-  ) !== -1;
-
-  updateCanvasAffordance(
-    mouseDragging || mouseOverPoint,
-    mouseDragging
-  );
 
   if ( pointsPx.length >= 2 ) {
     renderSplines(
@@ -777,7 +564,7 @@ sketch.draw( () => {
   drawHighlight(
     p,
     pointsPx,
-    state.hovers,
+    hovers,
     grabbed,
     o.overlay?.points?.size ?? 16
   );

--- a/src/templates/p5/utils/events.js
+++ b/src/templates/p5/utils/events.js
@@ -36,8 +36,12 @@ const events = {
     events.registeredEvents[ eventName ][ eventId ] = eventFunction;
     events.lastEventId++;
 
+    // Tolerates a registry that was cleared (sketch reset) since this
+    // unregister was handed out.
     return () => {
-      delete events.registeredEvents[ eventName ][ eventId ];
+      if ( events.registeredEvents[ eventName ] ) {
+        delete events.registeredEvents[ eventName ][ eventId ];
+      }
     };
   },
   // GENERAL SKETCH EVENTS

--- a/src/templates/p5/utils/interaction/__tests__/dragMath.test.ts
+++ b/src/templates/p5/utils/interaction/__tests__/dragMath.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Unit tests for the pure drag state machine (`dragMath.js`) shared by the
+ * on-canvas draggable layers (splines-v2-draggable, the content-item drag).
+ */
+import {
+  nearestTargetIndex,
+  stepDrag
+} from "../dragMath.js";
+
+type Pointer = {
+  key: string;
+  x: number;
+  y: number;
+  pressed: boolean;
+  kind: string;
+};
+
+const pointer = (
+  key: string,
+  x: number,
+  y: number,
+  pressed: boolean,
+  kind = "mouse"
+): Pointer => ( {
+  key,
+  x,
+  y,
+  pressed,
+  kind
+} );
+
+const targetsOf = ( ...coords: Array<[number, number]> ) =>
+  coords.map( ( [
+    x,
+    y
+  ] ) => ( {
+    x,
+    y
+  } ) );
+
+describe(
+  "nearestTargetIndex",
+  () => {
+    const targets = targetsOf(
+      [
+        100,
+        100
+      ],
+      [
+        200,
+        100
+      ],
+      [
+        105,
+        100
+      ]
+    );
+
+    it(
+      "returns the closest target within the radius",
+      () => {
+        expect( nearestTargetIndex(
+          targets,
+          104,
+          100,
+          44
+        ) ).toBe( 2 );
+      }
+    );
+
+    it(
+      "returns -1 when nothing is within the radius",
+      () => {
+        expect( nearestTargetIndex(
+          targets,
+          500,
+          500,
+          44
+        ) ).toBe( -1 );
+      }
+    );
+
+    it(
+      "skips indices already taken by another pointer",
+      () => {
+        expect( nearestTargetIndex(
+          targets,
+          104,
+          100,
+          44,
+          new Set( [
+            2
+          ] )
+        ) ).toBe( 0 );
+      }
+    );
+  }
+);
+
+describe(
+  "stepDrag",
+  () => {
+    it(
+      "grabs the nearest free target on press and moves it",
+      () => {
+        const drags = new Map<string, number>();
+        const targets = targetsOf( [
+          100,
+          100
+        ] );
+        const moves: Array<[number, Pointer]> = [];
+
+        const result = stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              110,
+              95,
+              true
+            )
+          ],
+          targets,
+          44,
+          (
+            index: number, ptr: Pointer
+          ) => moves.push( [
+            index,
+            ptr
+          ] )
+        );
+
+        expect( drags.get( "mouse" ) ).toBe( 0 );
+        expect( moves ).toEqual( [
+          [
+            0,
+            expect.objectContaining( {
+              x: 110,
+              y: 95
+            } )
+          ]
+        ] );
+        expect( result.grabbed.has( 0 ) ).toBe( true );
+        expect( result.released ).toBe( false );
+      }
+    );
+
+    it(
+      "does not grab targets outside the radius",
+      () => {
+        const drags = new Map<string, number>();
+
+        const result = stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              300,
+              300,
+              true
+            )
+          ],
+          targetsOf( [
+            100,
+            100
+          ] ),
+          44,
+          () => {
+            throw new Error( "should not move" );
+          }
+        );
+
+        expect( drags.size ).toBe( 0 );
+        expect( result.grabbed.size ).toBe( 0 );
+      }
+    );
+
+    it(
+      "keeps an in-flight drag glued to its pointer even far from the target",
+      () => {
+        const drags = new Map<string, number>( [
+          [
+            "mouse",
+            0
+          ]
+        ] );
+        const moves: number[] = [];
+
+        stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              900,
+              900,
+              true
+            )
+          ],
+          targetsOf( [
+            100,
+            100
+          ] ),
+          44,
+          ( index: number ) => moves.push( index )
+        );
+
+        expect( drags.get( "mouse" ) ).toBe( 0 );
+        expect( moves ).toEqual( [
+          0
+        ] );
+      }
+    );
+
+    it(
+      "releases when the pointer un-presses and reports it",
+      () => {
+        const drags = new Map<string, number>( [
+          [
+            "mouse",
+            0
+          ]
+        ] );
+
+        const result = stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              100,
+              100,
+              false
+            )
+          ],
+          targetsOf( [
+            100,
+            100
+          ] ),
+          44,
+          () => {
+            throw new Error( "should not move" );
+          }
+        );
+
+        expect( drags.size ).toBe( 0 );
+        expect( result.released ).toBe( true );
+      }
+    );
+
+    it(
+      "releases when the pointer vanishes (finger lifted)",
+      () => {
+        const drags = new Map<string, number>( [
+          [
+            "touch-0",
+            0
+          ]
+        ] );
+
+        const result = stepDrag(
+          drags,
+          [],
+          targetsOf( [
+            100,
+            100
+          ] ),
+          44,
+          () => {
+            throw new Error( "should not move" );
+          }
+        );
+
+        expect( drags.size ).toBe( 0 );
+        expect( result.released ).toBe( true );
+      }
+    );
+
+    it(
+      "releases when the grabbed target no longer exists (item removed)",
+      () => {
+        const drags = new Map<string, number>( [
+          [
+            "mouse",
+            3
+          ]
+        ] );
+
+        const result = stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              100,
+              100,
+              true
+            )
+          ],
+          targetsOf( [
+            100,
+            100
+          ] ),
+          44,
+          () => {
+            // The pointer is free again — it may immediately re-grab target 0.
+          }
+        );
+
+        expect( result.released ).toBe( true );
+        expect( drags.get( "mouse" ) ).toBe( 0 );
+      }
+    );
+
+    it(
+      "lets several pointers drag different targets without fighting",
+      () => {
+        const drags = new Map<string, number>();
+        const targets = targetsOf(
+          [
+            100,
+            100
+          ],
+          [
+            120,
+            100
+          ]
+        );
+        const moves: Array<[number, string]> = [];
+
+        stepDrag(
+          drags,
+          [
+            pointer(
+              "touch-0",
+              102,
+              100,
+              true,
+              "touch"
+            ),
+            pointer(
+              "touch-1",
+              104,
+              100,
+              true,
+              "touch"
+            )
+          ],
+          targets,
+          44,
+          (
+            index: number, ptr: Pointer
+          ) => moves.push( [
+            index,
+            ptr.key
+          ] )
+        );
+
+        // Both fingers are closest to target 0, but the second finger must
+        // fall back to the free target 1.
+        expect( drags.get( "touch-0" ) ).toBe( 0 );
+        expect( drags.get( "touch-1" ) ).toBe( 1 );
+        expect( moves ).toEqual( [
+          [
+            0,
+            "touch-0"
+          ],
+          [
+            1,
+            "touch-1"
+          ]
+        ] );
+      }
+    );
+
+    it(
+      "hovers unpressed mouse/camera pointers but never touch",
+      () => {
+        const drags = new Map<string, number>();
+        const targets = targetsOf( [
+          100,
+          100
+        ] );
+
+        const hovered = stepDrag(
+          drags,
+          [
+            pointer(
+              "mouse",
+              105,
+              100,
+              false
+            ),
+            pointer(
+              "cam-hand-0",
+              104,
+              100,
+              false,
+              "camera"
+            )
+          ],
+          targets,
+          44,
+          () => {
+            throw new Error( "should not move" );
+          }
+        );
+
+        expect( hovered.hovers.has( 0 ) ).toBe( true );
+
+        const touched = stepDrag(
+          drags,
+          [
+            pointer(
+              "touch-0",
+              105,
+              100,
+              false,
+              "touch"
+            )
+          ],
+          targets,
+          44,
+          () => {
+            throw new Error( "should not move" );
+          }
+        );
+
+        expect( touched.hovers.size ).toBe( 0 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/interaction/dragMath.js
+++ b/src/templates/p5/utils/interaction/dragMath.js
@@ -1,0 +1,148 @@
+/**
+ * Pure drag math — the grab → move → release state machine shared by every
+ * on-canvas draggable layer (splines-v2-draggable's control points, the
+ * template content items in slides/contentDrag.js, …).
+ *
+ * Deliberately free of any p5 / DOM / runtime imports so it stays cheap to
+ * unit-test. The stateful wiring (pointer collection, canvas affordance,
+ * engine events) lives in `draggable.js`; everything here is a deterministic
+ * function of its inputs.
+ */
+
+/**
+ * Nearest target within `radius` of (x, y), skipping indices in `taken` so two
+ * pointers can't fight over the same target. Returns -1 when nothing is close.
+ *
+ * @param {Array<{x: number, y: number}>} targets
+ * @param {number} x
+ * @param {number} y
+ * @param {number} radius
+ * @param {Set<number>} [taken]
+ */
+export function nearestTargetIndex(
+  targets, x, y, radius, taken = null
+) {
+  let best = -1;
+  let bestDistance = radius * radius;
+
+  for ( let i = 0; i < targets.length; i++ ) {
+    if ( taken?.has( i ) ) {
+      continue;
+    }
+
+    const dx = targets[ i ].x - x;
+    const dy = targets[ i ].y - y;
+    const distance = dx * dx + dy * dy;
+
+    if ( distance < bestDistance ) {
+      bestDistance = distance;
+      best = i;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * One step of the drag state machine. Pointers are source-agnostic — mouse,
+ * finger, camera pinch all feed the same path as one { key, x, y, pressed,
+ * kind } record. Every pointer is independent and keyed by a stable id, so
+ * several can drag at once (one target per pointer, no two pointers on the
+ * same target).
+ *
+ * Reads/writes only `drags` (mutated in place) and reports what happened.
+ *
+ * @param {Map<string, number>} drags - Active drags, pointer key → target index.
+ * @param {Array<{key: string, x: number, y: number, pressed: boolean, kind: string}>} pointers
+ * @param {Array<{x: number, y: number}>} targets - Pixel-space targets.
+ * @param {number} radius - Pick-up radius (px).
+ * @param {(index: number, pointer: object) => void} onMove - Called for every
+ *   grabbed target that should follow its pointer this step. May mutate
+ *   `targets[index]` so later pointers in the same step see the new position.
+ * @returns {{ hovers: Set<number>, grabbed: Set<number>, released: boolean }}
+ */
+export function stepDrag(
+  drags, pointers, targets, radius, onMove
+) {
+  const activeKeys = new Set( pointers.map( ( pointer ) => pointer.key ) );
+  let released = false;
+
+  // Release any drag whose pointer vanished (finger lifted, hand left the
+  // frame) or whose target index no longer exists (item removed mid-drag).
+  for ( const key of [
+    ...drags.keys()
+  ] ) {
+    if ( !activeKeys.has( key ) || drags.get( key ) >= targets.length ) {
+      drags.delete( key );
+      released = true;
+    }
+  }
+
+  // Indices currently held, so no two pointers fight over the same target.
+  const grabbed = new Set( drags.values() );
+  const hovers = new Set();
+
+  pointers.forEach( ( pointer ) => {
+    if ( drags.has( pointer.key ) ) {
+      const index = drags.get( pointer.key );
+
+      if ( pointer.pressed ) {
+        onMove(
+          index,
+          pointer
+        );
+      } else {
+        drags.delete( pointer.key );
+        grabbed.delete( index );
+        released = true;
+      }
+
+      return;
+    }
+
+    if ( pointer.pressed ) {
+      const index = nearestTargetIndex(
+        targets,
+        pointer.x,
+        pointer.y,
+        radius,
+        grabbed
+      );
+
+      if ( index !== -1 ) {
+        drags.set(
+          pointer.key,
+          index
+        );
+        grabbed.add( index );
+        onMove(
+          index,
+          pointer
+        );
+      }
+
+      return;
+    }
+
+    // Aiming (not pressed): highlight the target the mouse / open hand is
+    // over. Touch can't hover — a finger is always a press.
+    if ( pointer.kind !== "touch" ) {
+      const index = nearestTargetIndex(
+        targets,
+        pointer.x,
+        pointer.y,
+        radius
+      );
+
+      if ( index !== -1 ) {
+        hovers.add( index );
+      }
+    }
+  } );
+
+  return {
+    hovers,
+    grabbed,
+    released
+  };
+}

--- a/src/templates/p5/utils/interaction/draggable.js
+++ b/src/templates/p5/utils/interaction/draggable.js
@@ -1,0 +1,333 @@
+import events from "../events.js";
+import sketch from "../sketch.js";
+// pointerTracking, NOT ./index.js: this module is reachable from the core
+// engine chain (slides/contentDrag.js), and the full interaction module would
+// drag MediaPipe into module-eval (options.js loads it lazily on purpose).
+import {
+  getBasicPointerGroups,
+  clientToCanvas
+} from "./pointerTracking.js";
+import {
+  nearestTargetIndex,
+  stepDrag
+} from "./dragMath.js";
+
+export {
+  nearestTargetIndex,
+  stepDrag
+};
+
+// ── Reusable grab → move → release drag layer ───────────────────────────────
+// Extracted from splines-v2-draggable so any sketch (or engine layer, like the
+// content-item drag in slides/contentDrag.js) can make on-canvas points
+// draggable with the mouse, a finger, or any custom pointer (camera pinch, …)
+// without re-implementing the state machine. What an instance handles:
+//
+//   - Pointer collection. Touch fingers and the mouse come from the shared
+//     interaction layer (canvas-space, correct under viewport zoom/pan). Every
+//     pointer is independent and keyed by a stable id, so several can drag at
+//     once (one point per finger / per custom pointer). The mouse is ignored
+//     while fingers are down — its position is stale on a touchscreen.
+//   - Mouse press state via the engine's wired canvas events: press is
+//     canvas-scoped (don't grab when clicking UI), release is global so
+//     letting go off-canvas still ends a drag.
+//   - The grab → move → release state machine itself: the nearest free target
+//     within `radius` is grabbed on press, follows the pointer while pressed,
+//     and is released when the pointer lifts or vanishes.
+//   - Keeping drags off the viewport pan. While the mouse hovers/holds a
+//     target the canvas carries `data-no-drag` (the viewport cancels a mouse
+//     pan on that hook) plus a grab/grabbing cursor. Touch can't hover, so a
+//     capture-phase pointerdown listener hit-tests the press BEFORE the
+//     viewport's gesture layer sees it and tags the canvas in time — that way
+//     touch dragging works even when the sketch didn't claim the touchscreen
+//     through `interaction.touch`.
+
+// Several draggable layers can be live on the same canvas at once (a sketch's
+// own points plus the engine's content items), so the `data-no-drag` tag and
+// the cursor reflect the union of every instance's wish, not the last writer.
+const _instances = new Set();
+
+function _applyAffordance() {
+  const element = sketch.getCanvasElement?.();
+
+  if ( !element ) {
+    return;
+  }
+
+  let wantNoDrag = false;
+  let grabbing = false;
+
+  _instances.forEach( ( instance ) => {
+    wantNoDrag = wantNoDrag || instance._wantNoDrag;
+    grabbing = grabbing || instance._grabbing;
+  } );
+
+  if ( wantNoDrag ) {
+    if ( !element.hasAttribute( "data-no-drag" ) ) {
+      element.setAttribute(
+        "data-no-drag",
+        ""
+      );
+    }
+  } else {
+    element.removeAttribute( "data-no-drag" );
+  }
+
+  const cursor = grabbing ? "grabbing" : wantNoDrag ? "grab" : "";
+
+  if ( element.style.cursor !== cursor ) {
+    element.style.cursor = cursor;
+  }
+}
+
+/**
+ * Detach every live instance. Called at sketch start (registerContentDrag)
+ * so an instance belonging to the PREVIOUS sketch can't leave a stale
+ * `data-no-drag` / grab cursor on the fresh canvas — a sketch that stopped
+ * drawing never gets another update() to clear its flags. Instances of the
+ * new sketch re-attach afterwards (their setup runs later).
+ */
+export function detachAllDraggables() {
+  [
+    ..._instances
+  ].forEach( ( instance ) => instance.detach() );
+}
+
+/**
+ * Create a draggable layer. Call `attach()` from sketch setup (or any per-
+ * sketch-start hook — the engine's event registry is cleared on reset, so the
+ * listeners must be re-armed each start), then `update({...})` every frame.
+ */
+export function createDraggable() {
+  const instance = {
+    // Active drags: pointer key ("mouse" / "touch-<n>" / custom) → target index.
+    drags: new Map(),
+    // Mouse button state, fed by the engine's wired canvas events.
+    mouseDown: false,
+    // What this instance wants the canvas affordance to be (see above).
+    _wantNoDrag: false,
+    _grabbing: false,
+    // Last frame's targets/radius, kept for the pointerdown capture hit-test.
+    _lastTargets: [],
+    _lastRadius: 0,
+    _unregisters: [],
+    _pointerDownListener: null,
+
+    get dragging() {
+      return instance.drags.size > 0;
+    },
+
+    /**
+     * Arm the listeners. Idempotent per instance — safe to call on every
+     * sketch start (it re-arms after events.registeredEvents was cleared).
+     */
+    attach() {
+      instance.detach();
+
+      // Press / release of the mouse button. Press is canvas-scoped (don't
+      // grab when clicking UI); release is global so letting go off-canvas
+      // still ends a drag.
+      instance._unregisters.push( events.register(
+        "engine-canvas-mouse-pressed",
+        () => {
+          instance.mouseDown = true;
+        }
+      ) );
+      instance._unregisters.push( events.register(
+        "engine-mouse-released",
+        () => {
+          instance.mouseDown = false;
+        }
+      ) );
+
+      // Tag the canvas BEFORE the viewport's gesture layer sees the press:
+      // its onDragStart cancels the pan when the event target carries
+      // `data-no-drag` — the only chance a touch drag has, since touch can't
+      // hover its way to the attribute like the mouse does. Capture phase runs
+      // ahead of the viewport's bubble-phase handlers in the same dispatch.
+      if ( typeof window !== "undefined" ) {
+        instance._pointerDownListener = ( event ) => {
+          if ( instance._lastTargets.length === 0 ) {
+            return;
+          }
+
+          const element = sketch.getCanvasElement?.();
+
+          if ( !element || event.target !== element ) {
+            return;
+          }
+
+          const point = clientToCanvas(
+            event.clientX,
+            event.clientY
+          );
+
+          if ( !point ) {
+            return;
+          }
+
+          const hit = nearestTargetIndex(
+            instance._lastTargets,
+            point.x,
+            point.y,
+            instance._lastRadius
+          );
+
+          if ( hit !== -1 ) {
+            instance._wantNoDrag = true;
+            _applyAffordance();
+          }
+        };
+        window.addEventListener(
+          "pointerdown",
+          instance._pointerDownListener,
+          {
+            capture: true
+          }
+        );
+      }
+
+      _instances.add( instance );
+    },
+
+    detach() {
+      instance._unregisters.forEach( ( unregister ) => unregister() );
+      instance._unregisters = [];
+
+      if ( instance._pointerDownListener && typeof window !== "undefined" ) {
+        window.removeEventListener(
+          "pointerdown",
+          instance._pointerDownListener,
+          {
+            capture: true
+          }
+        );
+        instance._pointerDownListener = null;
+      }
+
+      instance.drags.clear();
+      instance.mouseDown = false;
+      instance._wantNoDrag = false;
+      instance._grabbing = false;
+      instance._lastTargets = [];
+      _instances.delete( instance );
+    },
+
+    /**
+     * Nothing to drag this frame (e.g. every item was removed): drop any
+     * in-flight drags and clear this instance's share of the canvas
+     * affordance without detaching the listeners.
+     */
+    idle() {
+      instance.drags.clear();
+      instance._lastTargets = [];
+
+      if ( instance._wantNoDrag || instance._grabbing ) {
+        instance._wantNoDrag = false;
+        instance._grabbing = false;
+        _applyAffordance();
+      }
+    },
+
+    /**
+     * Run one frame of the drag layer.
+     *
+     * @param {object} config
+     * @param {Array<{x: number, y: number}>} config.targets - Pixel-space
+     *   grab targets. `onMove` may mutate entries in place so later pointers
+     *   in the same frame see updated positions.
+     * @param {number} [config.radius=44] - Pick-up radius (px).
+     * @param {(index: number, pointer: object) => void} config.onMove -
+     *   Called for every grabbed target that follows its pointer this frame.
+     * @param {Array} [config.groups] - Pre-fetched getPointerGroups() result.
+     *   Pass it when the sketch already collects groups (avoids re-running
+     *   per-frame collectors); omitted, mouse + touch are collected with the
+     *   basic always-on config.
+     * @param {Array<{key, x, y, pressed, kind}>} [config.extraPointers] -
+     *   Custom pointers merged in (e.g. camera pinches), one drag each.
+     * @returns {{ hovers: Set<number>, grabbed: Set<number>,
+     *   released: boolean, dragging: boolean, pointers: Array }}
+     */
+    update( {
+      targets,
+      radius = 44,
+      onMove,
+      groups = null,
+      extraPointers = []
+    } ) {
+      const pointerGroups = groups ?? getBasicPointerGroups();
+      const pointers = [];
+      const touchGroups = pointerGroups.filter( ( group ) => group.source === "touch" );
+
+      touchGroups.forEach( ( group ) => {
+        pointers.push( {
+          key: group.id,
+          x: group.points[ 0 ].x,
+          y: group.points[ 0 ].y,
+          pressed: true,
+          kind: "touch"
+        } );
+      } );
+
+      // The mouse is dropped while any finger is down (its position is stale
+      // on a touchscreen).
+      if ( touchGroups.length === 0 ) {
+        const mouse = pointerGroups.find( ( group ) => group.source === "mouse" );
+
+        if ( mouse ) {
+          pointers.push( {
+            key: "mouse",
+            x: mouse.points[ 0 ].x,
+            y: mouse.points[ 0 ].y,
+            pressed: instance.mouseDown,
+            kind: "mouse"
+          } );
+        }
+      }
+
+      pointers.push( ...extraPointers );
+
+      const {
+        hovers,
+        grabbed,
+        released
+      } = stepDrag(
+        instance.drags,
+        pointers,
+        targets,
+        radius,
+        onMove
+      );
+
+      // Mouse-only affordance: keep the canvas off the viewport pan while the
+      // mouse hovers/holds a target, and mirror the grab in the cursor. Any
+      // active drag (touch included) keeps the tag on so a pan can't start
+      // mid-drag.
+      const mousePointer = pointers.find( ( pointer ) => pointer.kind === "mouse" );
+      const mouseDragging = instance.drags.has( "mouse" );
+      const mouseOverTarget = !!mousePointer && !mouseDragging && nearestTargetIndex(
+        targets,
+        mousePointer.x,
+        mousePointer.y,
+        radius
+      ) !== -1;
+
+      instance._wantNoDrag = mouseDragging || mouseOverTarget || instance.drags.size > 0;
+      instance._grabbing = mouseDragging;
+      _applyAffordance();
+
+      instance._lastTargets = targets;
+      instance._lastRadius = radius;
+
+      return {
+        hovers,
+        grabbed,
+        released,
+        dragging: instance.drags.size > 0,
+        pointers
+      };
+    }
+  };
+
+  return instance;
+}

--- a/src/templates/p5/utils/interaction/index.js
+++ b/src/templates/p5/utils/interaction/index.js
@@ -32,6 +32,21 @@ import {
 import {
   resolveAssetURL
 } from "@/lib/assets/resolveAssetURL";
+import {
+  ensurePointerTracking,
+  removePointerTracking,
+  getRawMouse,
+  getRawTouches
+} from "@/p5/utils/interaction/pointerTracking.js";
+
+// Re-exported so existing consumers keep one import site; the implementation
+// lives in pointerTracking.js (kept MediaPipe-free so lightweight layers can
+// import it without loading this module).
+export {
+  ensurePointerTracking,
+  clientToCanvas,
+  getBasicPointerGroups
+} from "@/p5/utils/interaction/pointerTracking.js";
 
 // ── Hand landmark indices ──────────────────────────────────────────────────
 // Fingertip indices: thumb, index, middle, ring, pinky
@@ -146,14 +161,6 @@ const FACE_KEYPOINT_ORDER = [
 
 // ── Module-level state ─────────────────────────────────────────────────────
 
-// Raw mouse/touch: tracked via window listeners so coordinates are correct
-// even when the canvas is panned/zoomed inside ScalableViewport (CSS transform).
-const _rawMouse = {
-  clientX: null,
-  clientY: null
-};
-let _rawTouches = []; // Array of { clientX, clientY }
-
 let _noiseOffset = 0;
 // Frame guards for collectors that mutate global state. Without them, every
 // extra call inside the same frame (e.g. the debug overlay running
@@ -178,8 +185,6 @@ const _gyro = {
 let _gyroInitialized = false;
 let _gyroListener = null;
 let _gyroPermissionListener = null;
-let _pointerMoveListener = null;
-let _touchListeners = null;
 
 // MIDI state
 let _midiInitialized = false;
@@ -606,81 +611,11 @@ export async function initInteraction( opts = {} ) {
   _disposeGyro();
 
   // ── Raw mouse / touch tracking ───────────────────────────────────────────
-  // We track raw clientX/Y ourselves so _clientToCanvas() can give correct
-  // canvas-space coordinates regardless of CSS transforms in ScalableViewport.
-  if ( typeof window !== "undefined" ) {
-    // Remove stale listeners from a previous initInteraction call
-    if ( _pointerMoveListener ) {
-      window.removeEventListener(
-        "pointermove",
-        _pointerMoveListener
-      );
-    }
-
-    _rawMouse.clientX = null;
-    _rawMouse.clientY = null;
-
-    _pointerMoveListener = ( e ) => {
-      _rawMouse.clientX = e.clientX;
-      _rawMouse.clientY = e.clientY;
-    };
-    window.addEventListener(
-      "pointermove",
-      _pointerMoveListener,
-      {
-        passive: true
-      }
-    );
-
-    if ( _touchListeners ) {
-      window.removeEventListener(
-        "touchstart",
-        _touchListeners.fn
-      );
-      window.removeEventListener(
-        "touchmove",
-        _touchListeners.fn
-      );
-      window.removeEventListener(
-        "touchend",
-        _touchListeners.fn
-      );
-    }
-
-    _rawTouches = [];
-
-    const _onTouch = ( e ) => {
-      _rawTouches = Array.from( e.touches ).map( ( t ) => ( {
-        clientX: t.clientX,
-        clientY: t.clientY
-      } ) );
-    };
-
-    _touchListeners = {
-      fn: _onTouch
-    };
-    window.addEventListener(
-      "touchstart",
-      _onTouch,
-      {
-        passive: true
-      }
-    );
-    window.addEventListener(
-      "touchmove",
-      _onTouch,
-      {
-        passive: true
-      }
-    );
-    window.addEventListener(
-      "touchend",
-      _onTouch,
-      {
-        passive: true
-      }
-    );
-  }
+  // Raw clientX/Y is tracked (in pointerTracking.js) so _clientToCanvas() can
+  // give correct canvas-space coordinates regardless of CSS transforms in
+  // ScalableViewport. Re-wire from scratch so a fresh sketch starts clean.
+  removePointerTracking();
+  ensurePointerTracking();
 
   // ── MIDI reset (lazy init triggered by _collectMidi) ─────────────────────
   if ( _midiAccess ) {
@@ -726,36 +661,8 @@ export function disposeInteraction() {
   // Gyroscope
   _disposeGyro();
 
-  // Mouse
-  if ( _pointerMoveListener ) {
-    window.removeEventListener(
-      "pointermove",
-      _pointerMoveListener
-    );
-    _pointerMoveListener = null;
-  }
-
-  _rawMouse.clientX = null;
-  _rawMouse.clientY = null;
-
-  // Touch
-  if ( _touchListeners ) {
-    window.removeEventListener(
-      "touchstart",
-      _touchListeners.fn
-    );
-    window.removeEventListener(
-      "touchmove",
-      _touchListeners.fn
-    );
-    window.removeEventListener(
-      "touchend",
-      _touchListeners.fn
-    );
-    _touchListeners = null;
-  }
-
-  _rawTouches = [];
+  // Mouse + touch
+  removePointerTracking();
 
   // MIDI
   if ( _midiAccess ) {
@@ -1061,16 +968,17 @@ function _collectMouse(
   // Use raw client coordinates converted through getBoundingClientRect() so
   // the result is correct even when ScalableViewport has panned/zoomed the
   // canvas (CSS transform on the parent doesn't affect the formula).
+  const rawMouse = getRawMouse();
   let rawX, rawY;
 
-  if ( _rawMouse.clientX === null ) {
+  if ( rawMouse.clientX === null ) {
     // No pointermove yet — fall back to p5's values for the first frame
     rawX = p.mouseX;
     rawY = p.mouseY;
   } else {
     const coords = _clientToCanvas(
-      _rawMouse.clientX,
-      _rawMouse.clientY,
+      rawMouse.clientX,
+      rawMouse.clientY,
       p
     );
 
@@ -1117,9 +1025,10 @@ function _collectTouch(
     return;
   }
 
+  const rawTouches = getRawTouches();
   const maxTouches = touch.maxTouches ?? 5;
   const count = Math.min(
-    _rawTouches.length,
+    rawTouches.length,
     maxTouches
   );
 
@@ -1127,8 +1036,8 @@ function _collectTouch(
     const {
       x, y
     } = _clientToCanvas(
-      _rawTouches[ i ].clientX,
-      _rawTouches[ i ].clientY,
+      rawTouches[ i ].clientX,
+      rawTouches[ i ].clientY,
       p
     );
 

--- a/src/templates/p5/utils/interaction/pointerTracking.js
+++ b/src/templates/p5/utils/interaction/pointerTracking.js
@@ -1,0 +1,243 @@
+import {
+  getP5
+} from "../sketch.js";
+
+// ── Raw mouse / touch tracking + canvas-space conversion ───────────────────
+// The window-listener layer that feeds every pointer consumer. Split out of
+// interaction/index.js so lightweight users (the draggable helper, the
+// engine's content-item drag) can track pointers WITHOUT pulling the full
+// interaction module — and its MediaPipe import — into the core module-eval
+// chain (see initInteractionForOptions in options.js, which loads that module
+// lazily for the same reason).
+//
+// Raw clientX/Y is tracked here and converted through getBoundingClientRect()
+// so canvas-space coordinates are correct even when the canvas is panned /
+// zoomed inside ScalableViewport (CSS transform on the parent doesn't affect
+// the formula).
+
+const _rawMouse = {
+  clientX: null,
+  clientY: null
+};
+let _rawTouches = []; // Array of { clientX, clientY }
+
+let _pointerMoveListener = null;
+let _touchListeners = null;
+
+// Read by interaction/index.js' mouse/touch collectors.
+export function getRawMouse() {
+  return _rawMouse;
+}
+
+export function getRawTouches() {
+  return _rawTouches;
+}
+
+/**
+ * Wire the raw mouse/touch window listeners if they aren't wired yet.
+ * Idempotent — safe to call every frame.
+ */
+export function ensurePointerTracking() {
+  if ( typeof window === "undefined" ) {
+    return;
+  }
+
+  if ( !_pointerMoveListener ) {
+    _pointerMoveListener = ( e ) => {
+      _rawMouse.clientX = e.clientX;
+      _rawMouse.clientY = e.clientY;
+    };
+    window.addEventListener(
+      "pointermove",
+      _pointerMoveListener,
+      {
+        passive: true
+      }
+    );
+  }
+
+  if ( !_touchListeners ) {
+    const _onTouch = ( e ) => {
+      _rawTouches = Array.from( e.touches ).map( ( t ) => ( {
+        clientX: t.clientX,
+        clientY: t.clientY
+      } ) );
+    };
+
+    _touchListeners = {
+      fn: _onTouch
+    };
+    window.addEventListener(
+      "touchstart",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+    window.addEventListener(
+      "touchmove",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+    window.addEventListener(
+      "touchend",
+      _onTouch,
+      {
+        passive: true
+      }
+    );
+  }
+}
+
+/**
+ * Remove the listeners and clear the tracked state. Called when a sketch is
+ * torn down (disposeInteraction) and before initInteraction re-wires so a
+ * fresh sketch starts clean.
+ */
+export function removePointerTracking() {
+  if ( typeof window === "undefined" ) {
+    return;
+  }
+
+  if ( _pointerMoveListener ) {
+    window.removeEventListener(
+      "pointermove",
+      _pointerMoveListener
+    );
+    _pointerMoveListener = null;
+  }
+
+  _rawMouse.clientX = null;
+  _rawMouse.clientY = null;
+
+  if ( _touchListeners ) {
+    window.removeEventListener(
+      "touchstart",
+      _touchListeners.fn
+    );
+    window.removeEventListener(
+      "touchmove",
+      _touchListeners.fn
+    );
+    window.removeEventListener(
+      "touchend",
+      _touchListeners.fn
+    );
+    _touchListeners = null;
+  }
+
+  _rawTouches = [];
+}
+
+/**
+ * Convert viewport-space client coordinates to p5 canvas-space coordinates,
+ * honouring the ScalableViewport pan/zoom. The rect is resolved fresh — this
+ * is meant for DOM event handlers, which run between frames when a per-frame
+ * cache may be stale (e.g. a paused loop). Returns null when no canvas is
+ * available.
+ */
+export function clientToCanvas(
+  clientX, clientY
+) {
+  const p = getP5();
+  const rect = _canvasRect();
+
+  if ( !p || !rect ) {
+    return null;
+  }
+
+  return _convert(
+    rect,
+    p,
+    clientX,
+    clientY
+  );
+}
+
+function _canvasRect() {
+  if ( typeof document === "undefined" ) {
+    return null;
+  }
+
+  const canvas = document.querySelector( "canvas.p5Canvas" );
+  const rect = canvas?.getBoundingClientRect();
+
+  if ( !rect || rect.width === 0 || rect.height === 0 ) {
+    return null;
+  }
+
+  return rect;
+}
+
+function _convert(
+  rect, p, clientX, clientY
+) {
+  return {
+    x: ( clientX - rect.left ) * ( p.width / rect.width ),
+    y: ( clientY - rect.top ) * ( p.height / rect.height )
+  };
+}
+
+/**
+ * Mouse + touch pointer groups, always on, in the same shape as the full
+ * interaction layer's getPointerGroups() (no smoothing, no offsets).
+ * Deliberately does NOT touch the vision/MIDI/audio machinery — that stays
+ * reconciled by the sketch's own interaction options — so engine-level layers
+ * can call this every frame without fighting the sketch. The mouse is omitted
+ * until it has moved at least once (no phantom pointer at 0,0).
+ */
+export function getBasicPointerGroups() {
+  const p = getP5();
+
+  if ( !p ) {
+    return [];
+  }
+
+  ensurePointerTracking();
+
+  // One rect for every pointer this call — getBoundingClientRect can force a
+  // layout pass, so it isn't resolved per pointer.
+  const rect = _canvasRect();
+
+  if ( !rect ) {
+    return [];
+  }
+
+  const groups = [];
+
+  if ( _rawMouse.clientX !== null ) {
+    groups.push( {
+      source: "mouse",
+      id: "mouse-0",
+      points: [
+        _convert(
+          rect,
+          p,
+          _rawMouse.clientX,
+          _rawMouse.clientY
+        )
+      ]
+    } );
+  }
+
+  _rawTouches.forEach( (
+    touch, index
+  ) => {
+    groups.push( {
+      source: "touch",
+      id: `touch-${ index }`,
+      points: [
+        _convert(
+          rect,
+          p,
+          touch.clientX,
+          touch.clientY
+        )
+      ]
+    } );
+  } );
+
+  return groups;
+}

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -1,0 +1,478 @@
+import events from "../events.js";
+import {
+  getP5
+} from "../sketch.js";
+import {
+  getSketchOptions,
+  setSketchOptions
+} from "../../shared/syncSketchOptions.js";
+import {
+  createDraggable,
+  detachAllDraggables
+} from "../interaction/draggable.js";
+
+// ── On-canvas drag for template content items ──────────────────────────────
+// Every positioned content item — the global "content" list edited in the
+// template options AND the per-slide lists edited in the slide editor — can be
+// grabbed at its anchor point and moved with the mouse or a finger, exactly
+// like the control points of splines-v2-draggable (same shared draggable
+// layer). Engine-level: registered from slides/index.js for every template,
+// no per-sketch code.
+//
+// How it fits together, mirroring the splines sketch:
+//   - Item positions are stored NORMALIZED (0..1) in item.position, so a drag
+//     writes resize-proof values that are saved/exported with the template.
+//   - While a drag is live the moved position lives in an override map that
+//     freeLayout consults when it renders (via resolveDraggedItem) — the store
+//     is only written on RELEASE, so the form isn't re-rendered at 60fps.
+//   - The write goes through setSketchOptions with origin "p5": the options
+//     module skips its own change handler (no feedback loop) while React
+//     still picks the new values up in the form.
+//   - The shared draggable layer keeps the viewport pan/zoom off a drag
+//     (data-no-drag + capture-phase pointerdown hit-test), so this works with
+//     mouse and touch on any template without claiming `interaction.touch`.
+
+// Content item types that carry a normalized `position` and render anchored to
+// it ("meta", "background", "hud" and "images" are laid out differently).
+const DRAGGABLE_TYPES = new Set( [
+  "text",
+  "image",
+  "images-stack",
+  "visual",
+  "qrcode",
+  "specs"
+] );
+
+// Pick-up radius (px) around an item's anchor point.
+const GRAB_RADIUS = 44;
+
+export const GLOBAL_CONTENT_SCOPE = "global";
+
+export function slideContentScope( index ) {
+  return `slide:${ index }`;
+}
+
+// Live drag overrides: `${scope}:${contentIndex}` → normalized { x, y }
+// position. Consulted by freeLayout while a drag is in flight; flushed into
+// the option store on release.
+const overrides = new Map();
+
+const draggable = createDraggable();
+
+function clamp01( value ) {
+  return Math.min(
+    1,
+    Math.max(
+      0,
+      value
+    )
+  );
+}
+
+// The renderers' fallback anchors when an item has no position yet (matching
+// drawSlideQrCode / drawSlideSpecs defaults; everything else centres).
+function positionDefaults( type ) {
+  switch ( type ) {
+    case "qrcode":
+      return {
+        x: 0.5,
+        y: 0.82
+      };
+    case "specs":
+      return {
+        x: 0.05,
+        y: 0.06
+      };
+    default:
+      return {
+        x: 0.5,
+        y: 0.5
+      };
+  }
+}
+
+// Text renders at (margin + position) * size (see drawSlideText), so its grab
+// anchor is offset by the margin — and a drag writes position = pointer − margin.
+function textMargin( item ) {
+  const horizontal = Number.parseFloat( item.margin?.horizontal );
+  const vertical = Number.parseFloat( item.margin?.vertical );
+
+  return {
+    h: Number.isFinite( horizontal ) ? horizontal : 0.015,
+    v: Number.isFinite( vertical ) ? vertical : 0.015
+  };
+}
+
+function overrideKey(
+  scope, index
+) {
+  return `${ scope }:${ index }`;
+}
+
+/**
+ * The item as it should render this frame: while it is being dragged, its
+ * live (not yet persisted) position replaces the stored one. Called by
+ * freeLayout for every content item; returns the item untouched when no drag
+ * is in flight.
+ */
+export function resolveDraggedItem(
+  scope, index, item
+) {
+  if ( overrides.size === 0 || !scope || !item ) {
+    return item;
+  }
+
+  const override = overrides.get( overrideKey(
+    scope,
+    index
+  ) );
+
+  if ( !override ) {
+    return item;
+  }
+
+  return {
+    ...item,
+    position: {
+      ...( item.position ?? {} ),
+      x: override.x,
+      y: override.y
+    }
+  };
+}
+
+// Same wrap as slides/index.js uses to resolve the rendered slide, so the
+// scope written here always matches the scope freeLayout renders with.
+function currentSlideIndex( count ) {
+  const raw = typeof window !== "undefined"
+    ? window.getCurrentSlide?.()?.index
+    : 0;
+  const index = Number( raw ) || 0;
+
+  return ( ( index % count ) + count ) % count;
+}
+
+// Every draggable content item on screen this frame, as pixel-space grab
+// targets carrying where they came from (scope + index) so a move knows where
+// to write back. Current slide items first, then the global list — freeLayout
+// draws them in that order too.
+function collectTargets( p ) {
+  const store = getSketchOptions();
+  const targets = [];
+
+  const add = (
+    scope, content
+  ) => {
+    if ( !Array.isArray( content ) ) {
+      return;
+    }
+
+    content.forEach( (
+      item, index
+    ) => {
+      if ( !item || !DRAGGABLE_TYPES.has( item.type ) ) {
+        return;
+      }
+
+      const defaults = positionDefaults( item.type );
+      const override = overrides.get( overrideKey(
+        scope,
+        index
+      ) );
+      const position = override ?? item.position ?? {};
+      const margin = item.type === "text" ? textMargin( item ) : {
+        h: 0,
+        v: 0
+      };
+
+      targets.push( {
+        x: ( ( position.x ?? defaults.x ) + margin.h ) * p.width,
+        y: ( ( position.y ?? defaults.y ) + margin.v ) * p.height,
+        scope,
+        index,
+        marginX: margin.h,
+        marginY: margin.v
+      } );
+    } );
+  };
+
+  const slidesArray = Array.isArray( store.slides ) ? store.slides : [];
+
+  if ( slidesArray.length > 0 ) {
+    const slideIndex = currentSlideIndex( slidesArray.length );
+
+    add(
+      slideContentScope( slideIndex ),
+      slidesArray[ slideIndex ]?.content
+    );
+  }
+
+  add(
+    GLOBAL_CONTENT_SCOPE,
+    store.content
+  );
+
+  return targets;
+}
+
+function moveTarget(
+  p, target, pointer
+) {
+  if ( !target ) {
+    return;
+  }
+
+  const moved = {
+    x: clamp01( pointer.x / p.width - target.marginX ),
+    y: clamp01( pointer.y / p.height - target.marginY )
+  };
+
+  overrides.set(
+    overrideKey(
+      target.scope,
+      target.index
+    ),
+    moved
+  );
+
+  // Keep the pixel anchor in step so a second pointer this frame can't grab
+  // the item at its stale position.
+  target.x = ( moved.x + target.marginX ) * p.width;
+  target.y = ( moved.y + target.marginY ) * p.height;
+}
+
+// Apply the pending overrides to one content list. Returns the new list, or
+// null when nothing in it was dragged.
+function applyToContent(
+  scope, content
+) {
+  if ( !Array.isArray( content ) ) {
+    return null;
+  }
+
+  let changed = false;
+
+  const next = content.map( (
+    item, index
+  ) => {
+    const override = overrides.get( overrideKey(
+      scope,
+      index
+    ) );
+
+    if ( !override || !item ) {
+      return item;
+    }
+
+    changed = true;
+
+    return {
+      ...item,
+      position: {
+        ...( item.position ?? {} ),
+        x: override.x,
+        y: override.y
+      }
+    };
+  } );
+
+  return changed ? next : null;
+}
+
+// Persist the dragged positions into the saved options so they survive
+// reloads and are exported with the template. Origin "p5" so the options
+// module skips its own change handler (no feedback loop), while React still
+// picks the new values up in the form. Overrides for a drag that is still in
+// flight are flushed too (they hold the item's current position) and simply
+// start accumulating again next frame.
+function persistOverrides() {
+  if ( overrides.size === 0 ) {
+    return;
+  }
+
+  const store = getSketchOptions();
+  const update = {};
+
+  const nextContent = applyToContent(
+    GLOBAL_CONTENT_SCOPE,
+    store.content
+  );
+
+  if ( nextContent ) {
+    update.content = nextContent;
+  }
+
+  const slidesArray = Array.isArray( store.slides ) ? store.slides : [];
+  let slidesChanged = false;
+
+  const nextSlides = slidesArray.map( (
+    slide, slideIndex
+  ) => {
+    const next = applyToContent(
+      slideContentScope( slideIndex ),
+      slide?.content
+    );
+
+    if ( !next ) {
+      return slide;
+    }
+
+    slidesChanged = true;
+
+    return {
+      ...slide,
+      content: next
+    };
+  } );
+
+  if ( slidesChanged ) {
+    update.slides = nextSlides;
+  }
+
+  overrides.clear();
+
+  if ( Object.keys( update ).length > 0 ) {
+    setSketchOptions(
+      update,
+      "p5"
+    );
+  }
+}
+
+// Hover / grab rings at the item anchors, mirroring the splines highlight so
+// the grab handles read the same across the app.
+function drawAffordance(
+  p, targets, hovers, grabbed
+) {
+  if ( hovers.size === 0 && grabbed.size === 0 ) {
+    return;
+  }
+
+  p.push();
+  p.noFill();
+
+  hovers.forEach( ( index ) => {
+    const target = targets[ index ];
+
+    if ( !target || grabbed.has( index ) ) {
+      return;
+    }
+
+    p.stroke(
+      255,
+      255,
+      255,
+      170
+    );
+    p.strokeWeight( 2 );
+    p.circle(
+      target.x,
+      target.y,
+      34
+    );
+  } );
+
+  grabbed.forEach( ( index ) => {
+    const target = targets[ index ];
+
+    if ( !target ) {
+      return;
+    }
+
+    p.stroke(
+      120,
+      200,
+      255,
+      230
+    );
+    p.strokeWeight( 3 );
+    p.circle(
+      target.x,
+      target.y,
+      40
+    );
+    p.noStroke();
+    p.fill(
+      120,
+      200,
+      255,
+      230
+    );
+    p.circle(
+      target.x,
+      target.y,
+      6
+    );
+  } );
+
+  p.pop();
+}
+
+function handleFrame() {
+  const p = getP5();
+
+  if ( !p ) {
+    return;
+  }
+
+  const targets = collectTargets( p );
+
+  if ( targets.length === 0 ) {
+    // Nothing draggable on screen (or every item was just removed): drop any
+    // in-flight drag and release the canvas affordance instead of leaving a
+    // stale grab cursor behind.
+    overrides.clear();
+    draggable.idle();
+
+    return;
+  }
+
+  const {
+    hovers,
+    grabbed,
+    released
+  } = draggable.update( {
+    targets,
+    radius: GRAB_RADIUS,
+    onMove: (
+      index, pointer
+    ) => moveTarget(
+      p,
+      targets[ index ],
+      pointer
+    )
+  } );
+
+  if ( released ) {
+    persistOverrides();
+  }
+
+  drawAffordance(
+    p,
+    targets,
+    hovers,
+    grabbed
+  );
+}
+
+/**
+ * Called from slides.registerEvents() on every sketch start (the engine event
+ * registry is cleared on reset). Registration order matters: slides registers
+ * its render handlers first, so this post-draw runs after the content items
+ * were drawn and the affordance rings stack on top.
+ */
+export function registerContentDrag() {
+  overrides.clear();
+
+  // The previous sketch's draggable layers (its own points AND this one) are
+  // orphaned at this point — their update() will never run again, so detach
+  // them before re-arming, or a stale hover flag would keep `data-no-drag` /
+  // the grab cursor on the fresh canvas forever.
+  detachAllDraggables();
+
+  draggable.attach();
+  events.register(
+    "post-draw",
+    handleFrame
+  );
+}

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -15,6 +15,12 @@ import drawMontageDip from "./morph/drawMontageDip.js";
 import drawMontageTitle from "./montageTitle/index.js";
 
 import {
+  registerContentDrag,
+  slideContentScope,
+  GLOBAL_CONTENT_SCOPE
+} from "./contentDrag.js";
+
+import {
   coerceFramerate
 } from "../framerate.js";
 
@@ -49,6 +55,10 @@ const slides = {
         slides.renderMontageTitle();
       }
     );
+
+    // After the render handler above so the drag layer hit-tests / draws on
+    // top of the content items it makes draggable (mouse + touch, engine-wide).
+    registerContentDrag();
 
     events.register(
       "post-draw",
@@ -190,13 +200,19 @@ const slides = {
     );
   },
 
-  render( source ) {
+  render(
+    source, scope = GLOBAL_CONTENT_SCOPE
+  ) {
     // Pass the source straight through. For global content `source` is the
     // live options proxy; destructuring/spreading it would drop every key
     // (its target is empty and it has only a get trap), silently discarding
     // global `content`. freeLayout reads `.content` via the get trap instead.
+    // `scope` tells the content-drag layer which list is rendering.
     // ( _layouts[ source?.layout ] ?? _layouts.auto )( source );
-    _layouts.free( source );
+    _layouts.free(
+      source,
+      scope
+    );
   },
 
   renderCurrentSlide() {
@@ -205,7 +221,15 @@ const slides = {
     if ( !slide ) {
       return;
     }
-    this.render( slide );
+
+    // Wrapped like getSlide() so the scope matches what contentDrag targets.
+    this.render(
+      slide,
+      slideContentScope( wrap(
+        Number( this.index ) || 0,
+        this.count
+      ) )
+    );
   },
 
   // Draw the montage "dip" fade on top of everything when the current slide is

--- a/src/templates/p5/utils/slides/layouts/freeLayout.js
+++ b/src/templates/p5/utils/slides/layouts/freeLayout.js
@@ -8,9 +8,25 @@ import drawSlideImages from "../common/drawSlideImages.js";
 import drawSlideBackground from "../common/drawSlideBackground.js";
 import drawSlideImagesStack from "../common/drawSlideImagesStack.js";
 import drawSlideQrCode from "../common/drawSlideQrCode.js";
+import {
+  resolveDraggedItem
+} from "../contentDrag.js";
 
-export default function freeLayout( options ) {
-  options?.content?.forEach( ( item ) => {
+// `scope` says which content list is being rendered ("global" or "slide:<n>")
+// so an in-flight on-canvas drag (see contentDrag.js) can substitute the live
+// position of the grabbed item without touching the option store every frame.
+export default function freeLayout(
+  options, scope
+) {
+  options?.content?.forEach( (
+    rawItem, index
+  ) => {
+    const item = resolveDraggedItem(
+      scope,
+      index,
+      rawItem
+    );
+
     switch ( item?.type ) {
       case "background":
         drawSlideBackground( item );


### PR DESCRIPTION
Extract the grab → move → release state machine from splines-v2-draggable
into a shared draggable layer, then use it to make every positioned content
item (global template options content AND per-slide content from the slide
editor) draggable on the canvas with the mouse or touch.

- utils/interaction/dragMath.js: pure, unit-tested drag state machine
  (nearest-free-target grabbing, multi-pointer, hover vs press).
- utils/interaction/draggable.js: createDraggable() — pointer collection
  (mouse + touch, custom pointers like camera pinch), engine mouse press
  wiring, data-no-drag / cursor affordance shared across instances, and a
  capture-phase pointerdown hit-test so a touch drag cancels the viewport
  pan without the sketch claiming interaction.touch.
- utils/interaction/pointerTracking.js: raw mouse/touch window listeners +
  client→canvas conversion split out of interaction/index.js so the engine
  chain can use them without pulling MediaPipe into module eval.
- utils/slides/contentDrag.js: engine-wide content-item drag (text, image,
  images-stack, visual, qrcode, specs). Live position override consumed by
  freeLayout while dragging; persisted to options.content /
  slides[i].content on release via setSketchOptions origin "p5".
- splines-v2-draggable now consumes the shared layer (camera pinch kept as
  extra pointers).
- events.js: unregister closures tolerate a cleared registry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lqv1B8hQ645eMYgPunSX3i