### PR TITLE
fix(content-drag): make draggable content items grabbable by touch on mobile

### DIFF
--- a/src/templates/p5/utils/interaction/pointerTracking.js
+++ b/src/templates/p5/utils/interaction/pointerTracking.js
@@ -181,6 +181,29 @@ function _convert(
 }
 
 /**
+ * How many canvas-internal pixels one on-screen (CSS) pixel spans right now —
+ * i.e. `canvasInternalWidth / canvasDisplayWidth`. On a phone the canvas is a
+ * 1080-wide buffer squeezed into ~380 CSS px, so this is ~2.8; on desktop
+ * unzoomed it's ~1; zoomed in it drops below 1. Multiply a desired SCREEN-space
+ * hit radius by this to get the equivalent radius in the canvas-pixel space
+ * that the drag math works in, so a grab target stays the same physical size on
+ * every device instead of collapsing to a few pixels on mobile. Returns 1 when
+ * no canvas is measurable (harmless no-op scaling).
+ */
+export function getCanvasDisplayScale() {
+  const p = getP5();
+  const rect = _canvasRect();
+
+  if ( !p || !rect ) {
+    return 1;
+  }
+
+  // Width and height scale together under the viewport's uniform transform;
+  // width alone is representative.
+  return p.width / rect.width;
+}
+
+/**
  * Mouse + touch pointer groups, always on, in the same shape as the full
  * interaction layer's getPointerGroups() (no smoothing, no offsets).
  * Deliberately does NOT touch the vision/MIDI/audio machinery — that stays

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -10,6 +10,9 @@ import {
   createDraggable,
   detachAllDraggables
 } from "../interaction/draggable.js";
+import {
+  getCanvasDisplayScale
+} from "../interaction/pointerTracking.js";
 
 // ── On-canvas drag for template content items ──────────────────────────────
 // Every positioned content item — the global "content" list edited in the
@@ -43,8 +46,13 @@ const DRAGGABLE_TYPES = new Set( [
   "specs"
 ] );
 
-// Pick-up radius (px) around an item's anchor point.
-const GRAB_RADIUS = 44;
+// Pick-up radius around an item's anchor point, in ON-SCREEN (CSS) pixels.
+// Converted to canvas-pixel space per frame (see grabRadius) so the touch
+// target stays the same physical size on every device — a fixed canvas-pixel
+// radius collapses to a handful of screen pixels on a phone (a 1080-wide buffer
+// shown ~380px wide), which is what made items feel un-grabbable on mobile and
+// let the tap fall through to a viewport pan instead.
+const GRAB_RADIUS_SCREEN_PX = 44;
 
 export const GLOBAL_CONTENT_SCOPE = "global";
 
@@ -427,13 +435,18 @@ function handleFrame() {
     return;
   }
 
+  // Keep the grab zone a constant physical size on screen: a CSS-pixel radius
+  // scaled into the canvas-pixel space the drag math (and the capture-phase
+  // pan-cancel hit-test) both work in.
+  const grabRadius = GRAB_RADIUS_SCREEN_PX * getCanvasDisplayScale();
+
   const {
     hovers,
     grabbed,
     released
   } = draggable.update( {
     targets,
-    radius: GRAB_RADIUS,
+    radius: grabRadius,
     onMove: (
       index, pointer
     ) => moveTarget(


### PR DESCRIPTION
Follow-up to #204 (which added on-canvas dragging of content items). That shipped, but the feature was effectively unusable **on mobile**.

## The bug

The grab radius was a fixed **44 canvas pixels**. Content items live on a high-resolution canvas buffer (e.g. 1080px wide) that the viewport scales *down* to fit the screen. On a phone (~380 CSS px wide) that's a ~2.8× reduction, so 44 canvas px became **~15 screen px**:

- Items were nearly impossible to grab — you had to tap within ~15px of the exact anchor point.
- A near-miss fell through to a **viewport pan** (the capture-phase `data-no-drag` pan-cancel hit-test uses the same radius), so the whole canvas moved instead — reading as "drag doesn't work."

Desktop unzoomed is ~1× scale, so the problem was invisible there.

## The fix

Size the grab zone in **screen (CSS) space** and convert to canvas-pixel space each frame:

- New `getCanvasDisplayScale()` in `pointerTracking.js` returns `canvasInternalWidth / canvasDisplayWidth`.
- `contentDrag.js` multiplies the 44px screen radius by that scale before handing it to the drag layer.

Result: a constant physical touch target on every device. Because the capture-phase pan-cancel test reads the same radius, this also makes touch reliably win over the viewport pan when a finger lands on an item. Desktop behaviour is unchanged (~1× scale); zoomed-in/out views scale correctly.

## Verification

- `npm test` — 42 suites / 1380 tests pass.
- `npm run lint` — 0 errors (2 pre-existing warnings in untouched files).
- Not device-tested from this environment; the change is a coordinate-space correction reasoned from the viewport's scaling math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lqv1B8hQ645eMYgPunSX3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lqv1B8hQ645eMYgPunSX3i)_