### PR TITLE
fix(content-drag): grab items by their visible body + own the pointer so the viewport can't pan

### DIFF
--- a/src/templates/p5/utils/interaction/pointerTracking.js
+++ b/src/templates/p5/utils/interaction/pointerTracking.js
@@ -1,4 +1,4 @@
-import {
+import sketch, {
   getP5
 } from "../sketch.js";
 
@@ -161,7 +161,13 @@ function _canvasRect() {
     return null;
   }
 
-  const canvas = document.querySelector( "canvas.p5Canvas" );
+  // Prefer the exact node the running sketch owns, so the rect used for the
+  // hit-test always matches the element the content-drag identity check accepts
+  // (event.target === sketch.getCanvasElement()). Falling back to a class
+  // lookup would risk resolving a DIFFERENT canvas.p5Canvas (an incompletely
+  // torn-down previous sketch, or an attached graphics buffer) — a divergent
+  // rect makes clientToCanvas mis-map the pointer and every hit-test miss.
+  const canvas = sketch.getCanvasElement?.() ?? document.querySelector( "canvas.p5Canvas" );
   const rect = canvas?.getBoundingClientRect();
 
   if ( !rect || rect.width === 0 || rect.height === 0 ) {

--- a/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
+++ b/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
@@ -86,6 +86,11 @@ jest.mock(
 import {
   registerContentDrag
 } from "../contentDrag.js";
+import {
+  beginItemBounds,
+  reportItemBounds,
+  endItemBounds
+} from "../common/itemBoundsRegistry.js";
 
 // window.getCurrentSlide is read to resolve the slide scope; no slides here.
 ( window as unknown as { getCurrentSlide?: () => unknown } ).getCurrentSlide = () => ( {
@@ -316,6 +321,94 @@ describe(
         // Held pointer 1's position, not pointer 2's (0.1, 0.9).
         expect( update.content[ 0 ].position.x ).toBeCloseTo( 0.6 );
         expect( update.content[ 0 ].position.y ).toBeCloseTo( 0.6 );
+      }
+    );
+  }
+);
+
+describe(
+  "content drag — visible-bounds grabbing",
+  () => {
+    it(
+      "grabs by the drawn rectangle even when it is far from the anchor, and drags by offset",
+      () => {
+        // The renderer reports the item's VISIBLE rect at (700..900, 100..200)
+        // while the anchor sits at (500, 500) — the palette-default text
+        // situation (glyphs centred mid-canvas, anchor at the layout origin).
+        beginItemBounds(
+          "global",
+          0
+        );
+        reportItemBounds(
+          700,
+          100,
+          200,
+          100
+        );
+        endItemBounds();
+
+        // Press inside the visible rect (its centre), far from the anchor.
+        const down = pressAt(
+          "pointerdown",
+          800,
+          150
+        );
+
+        expect( down.defaultPrevented ).toBe( true );
+
+        // Drag +100/+200; release.
+        pressAt(
+          "pointermove",
+          900,
+          350
+        );
+        pressAt(
+          "pointerup",
+          900,
+          350
+        );
+
+        expect( setSketchOptions ).toHaveBeenCalledTimes( 1 );
+
+        const [
+          update
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { content: Array<{ position: { x: number;
+            y: number } }> }
+        ];
+
+        // Offset drag: the position moves by the pointer DELTA (+0.1, +0.2)
+        // from its start (0.5, 0.5) — it does not snap the anchor under the
+        // cursor.
+        expect( update.content[ 0 ].position.x ).toBeCloseTo( 0.6 );
+        expect( update.content[ 0 ].position.y ).toBeCloseTo( 0.7 );
+      }
+    );
+
+    it(
+      "does not fall back to the anchor disc when fresh bounds exist elsewhere",
+      () => {
+        beginItemBounds(
+          "global",
+          0
+        );
+        reportItemBounds(
+          700,
+          100,
+          200,
+          100
+        );
+        endItemBounds();
+
+        // Press at the ANCHOR (500,500) — visibly empty, since the item is
+        // drawn at its reported rect. Must fall through to the viewport pan.
+        const down = pressAt(
+          "pointerdown",
+          500,
+          500
+        );
+
+        expect( down.defaultPrevented ).toBe( false );
       }
     );
   }

--- a/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
+++ b/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
@@ -1,0 +1,322 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Integration tests for the content-item drag layer. These drive the REAL
+ * capture-phase pointer flow through jsdom to lock in the behaviour that
+ * matters: a press on an item must be claimed BEFORE the viewport's gesture
+ * recogniser sees it (stopImmediatePropagation), the item must follow the
+ * pointer, the move must persist on release, and a press that misses every
+ * item must fall through untouched so the viewport can still pan.
+ */
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+// A fake p5: fixed 1000×1000 canvas buffer, always looping (so requestRedraw is
+// a no-op), plus a real <canvas> element as the event target.
+const canvasEl = ( () => {
+  const el = document.createElement( "canvas" );
+
+  el.className = "p5Canvas";
+  // jsdom gives 0×0 rects by default; pin one so clientToCanvas isn't needed —
+  // we mock clientToCanvas directly below instead.
+  document.body.appendChild( el );
+
+  return el;
+} )();
+
+const fakeP5 = {
+  width: 1000,
+  height: 1000,
+  isLooping: () => true,
+  redraw: jest.fn(),
+  push: jest.fn(),
+  pop: jest.fn(),
+  noFill: jest.fn(),
+  noStroke: jest.fn(),
+  fill: jest.fn(),
+  stroke: jest.fn(),
+  strokeWeight: jest.fn(),
+  circle: jest.fn()
+};
+
+jest.mock(
+  "../../sketch.js",
+  () => ( {
+    __esModule: true,
+    default: {
+      getCanvasElement: () => canvasEl
+    },
+    getP5: () => fakeP5
+  } )
+);
+
+// A mutable in-memory option store.
+let store: Record<string, unknown> = {};
+const setSketchOptions = jest.fn( ( update: Record<string, unknown> ) => {
+  store = {
+    ...store,
+    ...update
+  };
+} );
+
+jest.mock(
+  "../../../shared/syncSketchOptions.js",
+  () => ( {
+    __esModule: true,
+    getSketchOptions: () => store,
+    setSketchOptions: ( ...args: unknown[] ) => setSketchOptions( ...args as [Record<string, unknown>] )
+  } )
+);
+
+// Display scale 1 (canvas shown 1:1) and a direct client→canvas passthrough:
+// the tests place pointers in canvas coordinates already.
+jest.mock(
+  "../../interaction/pointerTracking.js",
+  () => ( {
+    __esModule: true,
+    getCanvasDisplayScale: () => 1,
+    clientToCanvas: (
+      x: number, y: number
+    ) => ( {
+      x,
+      y
+    } )
+  } )
+);
+
+import {
+  registerContentDrag
+} from "../contentDrag.js";
+
+// window.getCurrentSlide is read to resolve the slide scope; no slides here.
+( window as unknown as { getCurrentSlide?: () => unknown } ).getCurrentSlide = () => ( {
+  index: 0
+} );
+
+// Dispatch a pointer event on the canvas and report whether propagation to the
+// viewport (a bubble/capture listener further down the tree) was stopped. We
+// approximate "the viewport sees it" with a window listener registered AFTER
+// contentDrag's — stopImmediatePropagation on window-capture prevents it.
+function pressAt(
+  type: string, x: number, y: number, pointerId = 1
+) {
+  const event = new Event(
+    type,
+    {
+      bubbles: true,
+      cancelable: true
+    }
+  ) as PointerEvent & { pointerId: number };
+
+  Object.assign(
+    event,
+    {
+      clientX: x,
+      clientY: y,
+      pointerId,
+      pointerType: "mouse",
+      button: 0
+    }
+  );
+
+  canvasEl.dispatchEvent( event );
+
+  return event;
+}
+
+beforeEach( () => {
+  store = {
+    content: [
+      {
+        type: "text",
+        content: "hello",
+        position: {
+          x: 0.5,
+          y: 0.5
+        },
+        margin: {
+          horizontal: 0,
+          vertical: 0
+        }
+      }
+    ]
+  };
+  setSketchOptions.mockClear();
+  fakeP5.redraw.mockClear();
+  registerContentDrag();
+} );
+
+describe(
+  "content drag — pointer flow",
+  () => {
+    it(
+      "claims a press that lands on an item (stops it reaching the viewport)",
+      () => {
+        // Item anchor is at (0.5,0.5)*1000 = (500,500).
+        const down = pressAt(
+          "pointerdown",
+          500,
+          500
+        );
+
+        // stopImmediatePropagation makes the event non-cancelable for later
+        // listeners; the clearest observable is that defaultPrevented is set
+        // (we called preventDefault) and no pan occurred.
+        expect( down.defaultPrevented ).toBe( true );
+      }
+    );
+
+    it(
+      "does NOT claim a press that misses every item (viewport can pan)",
+      () => {
+        const down = pressAt(
+          "pointerdown",
+          50,
+          50
+        );
+
+        expect( down.defaultPrevented ).toBe( false );
+      }
+    );
+
+    it(
+      "hides an on-item press from a later window listener (the viewport)",
+      () => {
+        // contentDrag registered its window-capture handler in beforeEach;
+        // this stand-in for the viewport's recogniser registers AFTER, so
+        // stopImmediatePropagation on the earlier handler must starve it.
+        const viewport = jest.fn();
+
+        window.addEventListener(
+          "pointerdown",
+          viewport,
+          {
+            capture: true
+          }
+        );
+
+        try {
+          pressAt(
+            "pointerdown",
+            500,
+            500
+          ); // on the item
+
+          expect( viewport ).not.toHaveBeenCalled();
+
+          pressAt(
+            "pointerdown",
+            50,
+            50
+          ); // empty canvas
+
+          expect( viewport ).toHaveBeenCalledTimes( 1 );
+        } finally {
+          window.removeEventListener(
+            "pointerdown",
+            viewport,
+            {
+              capture: true
+            }
+          );
+        }
+      }
+    );
+
+    it(
+      "moves the item and persists the new position on release",
+      () => {
+        pressAt(
+          "pointerdown",
+          500,
+          500
+        );
+        pressAt(
+          "pointermove",
+          700,
+          300
+        );
+        pressAt(
+          "pointerup",
+          700,
+          300
+        );
+
+        expect( setSketchOptions ).toHaveBeenCalledTimes( 1 );
+
+        const [
+          update,
+          origin
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { content: Array<{ position: { x: number;
+            y: number } }> },
+          string
+        ];
+
+        expect( origin ).toBe( "p5" );
+        expect( update.content[ 0 ].position.x ).toBeCloseTo( 0.7 );
+        expect( update.content[ 0 ].position.y ).toBeCloseTo( 0.3 );
+      }
+    );
+
+    it(
+      "does not persist until release (no 60fps store writes)",
+      () => {
+        pressAt(
+          "pointerdown",
+          500,
+          500
+        );
+        pressAt(
+          "pointermove",
+          600,
+          400
+        );
+
+        expect( setSketchOptions ).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      "ignores moves from a different pointer id mid-drag",
+      () => {
+        pressAt(
+          "pointerdown",
+          500,
+          500,
+          1
+        );
+        // Pointer 1 drives the drag to (0.6, 0.6)…
+        pressAt(
+          "pointermove",
+          600,
+          600,
+          1
+        );
+        // …a second finger moving elsewhere must NOT steer it.
+        pressAt(
+          "pointermove",
+          100,
+          900,
+          2
+        );
+        pressAt(
+          "pointerup",
+          600,
+          600,
+          1
+        );
+
+        const [
+          update
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { content: Array<{ position: { x: number;
+            y: number } }> }
+        ];
+
+        // Held pointer 1's position, not pointer 2's (0.1, 0.9).
+        expect( update.content[ 0 ].position.x ).toBeCloseTo( 0.6 );
+        expect( update.content[ 0 ].position.y ).toBeCloseTo( 0.6 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/slides/common/drawSlideImage.js
+++ b/src/templates/p5/utils/slides/common/drawSlideImage.js
@@ -4,6 +4,9 @@ import {
 import imageUtils from "../../imageUtils.js";
 import mappers from "../../mappers.js";
 import animation from "../../animation.js";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
 
 export default function drawSlideImage(
   imageOption, slideOptions
@@ -52,6 +55,19 @@ export default function drawSlideImage(
     center: imageOption.center ?? true,
     margin: imageOption.margin ?? 80,
     scale: imageOption.scale,
-    img: image.img
+    img: image.img,
+    // The rectangle actually drawn, for the on-canvas drag's hit-test.
+    callback: (
+      cx, cy, w, h
+    ) => {
+      const centered = imageOption.center ?? true;
+
+      reportItemBounds(
+        centered ? cx - w / 2 : cx,
+        centered ? cy - h / 2 : cy,
+        w,
+        h
+      );
+    }
   } );
 }

--- a/src/templates/p5/utils/slides/common/drawSlideImagesStack.js
+++ b/src/templates/p5/utils/slides/common/drawSlideImagesStack.js
@@ -2,6 +2,9 @@ import imageUtils from "../../imageUtils.js";
 import animation from "../../animation.js";
 import easing from "../../easing.js";
 import * as common from "../../common.js";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
 
 export default function drawSlideImagesStack(
   imagesStackOption, slideOptions
@@ -36,6 +39,34 @@ export default function drawSlideImagesStack(
     images.length,
     easing.easeInOutBack
   );
+
+  // Approximate drawn rectangle for the on-canvas drag's hit-test: the stack
+  // is rendered inside translate(position*size) with each image fitted by
+  // marginImage into (canvas*scale − 2*margin), centred on the origin —
+  // mirror that fit for the first image (rotation ignored on purpose).
+  {
+    const stackScale = scaleValue ?? 1;
+    const stackMargin = imagesStackOption.margin ?? 80;
+    const availableW = width * stackScale - 2 * stackMargin;
+    const availableH = height * stackScale - 2 * stackMargin;
+    const img0 = images[ 0 ].img;
+
+    if ( img0?.width && availableW > 0 && availableH > 0 ) {
+      const fit = Math.min(
+        availableW / img0.width,
+        availableH / img0.height
+      );
+      const w = img0.width * fit * stackScale;
+      const h = img0.height * fit * stackScale;
+
+      reportItemBounds(
+        position.x * width - w / 2,
+        position.y * height - h / 2,
+        w,
+        h
+      );
+    }
+  }
 
   push();
 

--- a/src/templates/p5/utils/slides/common/drawSlideQrCode.js
+++ b/src/templates/p5/utils/slides/common/drawSlideQrCode.js
@@ -7,6 +7,9 @@ import sketch, {
 import {
   buildQrUrl, stripScheme
 } from "./qrCodeUrl.js";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
 
 // Inlined at build time by Next for NEXT_PUBLIC_* vars, so it is readable in
 // the client/headless sketch bundle. Lets a localhost dev machine encode the
@@ -101,6 +104,14 @@ export default function drawSlideQrCode( qrCodeOption ) {
   const centerY = ( qrCodeOption.position?.y ?? 0.82 ) * p.height;
   const left = centerX - side / 2;
   const top = centerY - side / 2;
+
+  // Exact drawn square, for the on-canvas drag's hit-test.
+  reportItemBounds(
+    left,
+    top,
+    side,
+    side
+  );
 
   p.push();
 

--- a/src/templates/p5/utils/slides/common/drawSlideSpecs.js
+++ b/src/templates/p5/utils/slides/common/drawSlideSpecs.js
@@ -7,6 +7,9 @@ import time from "../../time.js";
 import buildSpecsLines from "./specsData.js";
 import computeSpecsHeats from "./specsChanges.js";
 import specsSound from "./specsSound.js";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
 
 /**
  * Technical / BIOS-style overlay that reveals the current sketch settings.
@@ -401,6 +404,23 @@ export default function drawSlideSpecs( specsOption ) {
 
   const originX = p.width * ( specsOption.position?.x ?? 0.05 );
   const originY = p.height * ( specsOption.position?.y ?? 0.06 );
+
+  // Approximate drawn block (origin, stacked lines) for the on-canvas drag's
+  // hit-test. Ticker style shows one line, boot-log all of them — the full
+  // block is a generous, stable grab zone for both.
+  if ( lines.length > 0 ) {
+    const blockW = Math.max(
+      ...lines.map( ( line ) => measureWidth( `${ line.label }: ${ line.value }` ) ),
+      size * 4
+    );
+
+    reportItemBounds(
+      originX,
+      originY - size,
+      blockW,
+      lines.length * lineStep + size * 2
+    );
+  }
 
   if ( specsOption.style === "ticker" ) {
     // Single line cycling through all parameters. In permanent mode the reveal

--- a/src/templates/p5/utils/slides/common/drawSlideText.js
+++ b/src/templates/p5/utils/slides/common/drawSlideText.js
@@ -2,6 +2,9 @@ import string from "../../string.js";
 import {
   getP5
 } from "../../sketch";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
 
 const parseFloatDefault = (
   value, _default = 0.015
@@ -20,22 +23,89 @@ export default function drawSlideText( textOption ) {
   const horizontalMargin = parseFloatDefault( textOption.margin.horizontal );
   const verticalMargin = parseFloatDefault( textOption.margin.vertical );
 
-  string.write(
+  const x = p.width * horizontalMargin + p.width * textOption.position.x;
+  const y = p.height * verticalMargin + p.height * textOption.position.y;
+  const textWidth = p.width - 2 * ( p.width * horizontalMargin );
+  const textHeight = p.height - 2 * ( p.height * verticalMargin );
+  const size = Number( textOption.size );
+  const horizontalAlign = textOption.alignment?.horizontal ?? "center";
+  const verticalAlign = textOption.alignment?.vertical ?? "baseline";
+
+  const box = string.write(
     textOption.content,
-    p.width * horizontalMargin + p.width * textOption.position.x,
-    p.height * verticalMargin + p.height * textOption.position.y,
+    x,
+    y,
     {
-      size: Number( textOption.size ),
+      size,
       font: string.fonts?.[ textOption.font ] ?? string.fonts.martian,
       textAlign: [
-        textOption.alignment?.horizontal ?? "center",
-        textOption.alignment?.vertical ?? "baseline"
+        horizontalAlign,
+        verticalAlign
       ],
       blendMode: textOption.blend,
       fill: p.color( ...textOption.fill ),
       stroke: p.color( ...textOption.stroke ),
-      textWidth: p.width - 2 * ( p.width * horizontalMargin ),
-      textHeight: p.height - 2 * ( p.height * verticalMargin )
+      textWidth,
+      textHeight
     }
+  );
+
+  // Nothing drawn (empty string / missing font) → no grab zone to report.
+  if ( !textOption.content ) {
+    return;
+  }
+
+  // Where the glyphs VISIBLY are — p5 rect-mode text aligns them inside the
+  // (x, y, textWidth, textHeight) layout box, so the drawn pixels can sit far
+  // from the (x, y) anchor the drag layer stores. Report an approximate
+  // glyph rectangle so the item can be grabbed by what the user sees.
+  // Width/height come from the font's measured bounds (clamped to the layout
+  // box — word-wrap never draws wider than it).
+  const glyphW = Math.min(
+    Math.max(
+      box?.w ?? textWidth,
+      size
+    ),
+    textWidth
+  );
+  const glyphH = Math.max(
+    box?.h ?? size,
+    size
+  );
+
+  const left = horizontalAlign === "left"
+    ? x
+    : horizontalAlign === "right"
+      ? x + textWidth - glyphW
+      : x + ( textWidth - glyphW ) / 2;
+
+  // Vertical: rect-mode CENTER/BOTTOM/TOP place the glyphs inside the box;
+  // BASELINE is not honoured in rect mode and behaves like TOP, but older
+  // p5 builds treated it as glyphs-above-y — cover both with a band that
+  // spans one glyph height on each side of y.
+  let top;
+  let boundsH = glyphH;
+
+  switch ( verticalAlign ) {
+    case "center":
+      top = y + ( textHeight - glyphH ) / 2;
+      break;
+    case "bottom":
+      top = y + textHeight - glyphH;
+      break;
+    case "top":
+      top = y;
+      break;
+    default: // "baseline"
+      top = y - glyphH;
+      boundsH = glyphH * 2;
+      break;
+  }
+
+  reportItemBounds(
+    left,
+    top,
+    glyphW,
+    boundsH
   );
 }

--- a/src/templates/p5/utils/slides/common/itemBoundsRegistry.js
+++ b/src/templates/p5/utils/slides/common/itemBoundsRegistry.js
@@ -1,0 +1,109 @@
+import {
+  getP5
+} from "../../sketch.js";
+
+// ── Per-frame registry of where each content item was ACTUALLY drawn ───────
+// The on-canvas drag (slides/contentDrag.js) originally hit-tested a small
+// disc around an item's normalized `position` anchor. But an item's anchor is
+// often nowhere near its visible pixels — rect-mode text centers its glyphs
+// inside a near-full-width layout box, images extend around their anchor, and
+// a freshly added text item (position.x = 0) draws in the middle of the
+// canvas while its anchor sits on the left edge. Grabbing "what you see"
+// (the way splines-v2-draggable works, where the visible dots ARE the
+// anchors) requires knowing the drawn rectangle.
+//
+// freeLayout brackets each item render with beginItemBounds(scope, index) /
+// endItemBounds(), and each renderer reports the rectangle it actually drew
+// (canvas-pixel space) via reportItemBounds(). Entries carry the frame they
+// were reported on so a consumer can ignore stale rects (item removed,
+// renderer bailed early).
+
+const registry = new Map(); // "scope:index" → { x, y, w, h, frame, order }
+
+let currentKey = null;
+let drawOrder = 0;
+
+export function itemBoundsKey(
+  scope, index
+) {
+  return `${ scope }:${ index }`;
+}
+
+/** Called by freeLayout before dispatching one item's renderer. */
+export function beginItemBounds(
+  scope, index
+) {
+  currentKey = scope == null ? null : itemBoundsKey(
+    scope,
+    index
+  );
+}
+
+/** Called by freeLayout after the renderer returns. */
+export function endItemBounds() {
+  currentKey = null;
+}
+
+/**
+ * Called by a renderer with the rectangle it just drew, in canvas pixels.
+ * No-op outside a beginItemBounds/endItemBounds bracket, so renderers can
+ * report unconditionally (they are also used outside content-item rendering).
+ */
+export function reportItemBounds(
+  x, y, w, h
+) {
+  if ( !currentKey || ![
+    x,
+    y,
+    w,
+    h
+  ].every( Number.isFinite ) ) {
+    return;
+  }
+
+  registry.set(
+    currentKey,
+    {
+      x,
+      y,
+      w,
+      h,
+      frame: getP5()?.frameCount ?? 0,
+      order: drawOrder++
+    }
+  );
+}
+
+/**
+ * The rectangle an item was last drawn at, or null when none was reported
+ * recently (renderer bailed, item removed, sketch not yet drawn). `maxAge`
+ * is in frames; a noLoop sketch doesn't advance frameCount, so its last
+ * report stays valid.
+ */
+export function getItemBounds(
+  scope, index, maxAge = 3
+) {
+  const entry = registry.get( itemBoundsKey(
+    scope,
+    index
+  ) );
+
+  if ( !entry ) {
+    return null;
+  }
+
+  const frame = getP5()?.frameCount ?? 0;
+
+  if ( frame - entry.frame > maxAge ) {
+    return null;
+  }
+
+  return entry;
+}
+
+/** Fresh-start hook for sketch (re)initialisation. */
+export function clearItemBounds() {
+  registry.clear();
+  currentKey = null;
+  drawOrder = 0;
+}

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -11,14 +11,28 @@ import {
   clientToCanvas
 } from "../interaction/pointerTracking.js";
 import {
-  nearestTargetIndex
-} from "../interaction/dragMath.js";
+  getItemBounds,
+  clearItemBounds
+} from "./common/itemBoundsRegistry.js";
 
 // ── On-canvas drag for template content items ──────────────────────────────
 // Every positioned content item — the global "content" list edited in the
 // template options AND the per-slide lists edited in the slide editor — can be
-// grabbed at its anchor point and moved with the mouse or a finger. Engine-
+// grabbed BY ITS VISIBLE BODY and moved with the mouse or a finger. Engine-
 // level: registered from slides/index.js for every template, no per-sketch code.
+//
+// Grab what you see. This mirrors why splines-v2-draggable always felt right:
+// there, the visible dots ARE the drag anchors. A content item's normalized
+// `position` anchor, by contrast, is often nowhere near its drawn pixels
+// (rect-mode text centres its glyphs inside a near-full-width layout box, so a
+// fresh text item at position.x = 0 draws mid-canvas while its anchor sits on
+// the left edge). Hit-testing a disc around the anchor therefore missed the
+// item the user was actually clicking, and the press fell through to a
+// viewport pan. Instead, every renderer reports the rectangle it actually
+// drew (itemBoundsRegistry, bracketed per item by freeLayout) and the press
+// is tested against those visible rectangles — topmost first, with the
+// anchor disc kept only as a fallback for items whose renderer reported
+// nothing this frame (e.g. "visual", whose size isn't measurable).
 //
 // Why this owns raw pointer events instead of the shared draggable layer:
 // content templates don't necessarily animate every frame, and the canvas
@@ -214,6 +228,12 @@ function collectTargets( p ) {
       targets.push( {
         x: ( ( position.x ?? defaults.x ) + margin.h ) * p.width,
         y: ( ( position.y ?? defaults.y ) + margin.v ) * p.height,
+        // Where the item was actually drawn (canvas px), when its renderer
+        // reported it — the primary grab surface.
+        bounds: getItemBounds(
+          scope,
+          index
+        ),
         scope,
         index,
         marginX: margin.h,
@@ -246,7 +266,58 @@ function grabRadius() {
   return GRAB_RADIUS_SCREEN_PX * getCanvasDisplayScale();
 }
 
+// Extra forgiveness (canvas px) around a visible rect so near-edge presses
+// still grab; sized in screen pixels like the anchor radius.
+function boundsPadding() {
+  return 10 * getCanvasDisplayScale();
+}
+
+/**
+ * The target under a canvas-space point, or -1. Visible rectangles win; the
+ * anchor disc only catches items whose renderer reported no bounds this
+ * frame. Targets are in draw order (current slide first, then global, each
+ * list front-to-back), so the LAST hit is the one drawn on top.
+ */
+function hitTest(
+  point, targets
+) {
+  const radius = grabRadius();
+  const pad = boundsPadding();
+  let hit = -1;
+
+  targets.forEach( (
+    target, index
+  ) => {
+    const bounds = target.bounds;
+
+    if ( bounds ) {
+      if (
+        point.x >= bounds.x - pad &&
+        point.x <= bounds.x + bounds.w + pad &&
+        point.y >= bounds.y - pad &&
+        point.y <= bounds.y + bounds.h + pad
+      ) {
+        hit = index;
+      }
+
+      return;
+    }
+
+    const dx = target.x - point.x;
+    const dy = target.y - point.y;
+
+    if ( dx * dx + dy * dy <= radius * radius ) {
+      hit = index;
+    }
+  } );
+
+  return hit;
+}
+
 // Write the dragged item's live position from a canvas-space pointer point.
+// The grab offset (anchor − pointer at grab time) is preserved so the item
+// follows the hand from wherever it was picked up instead of snapping its
+// anchor under the cursor.
 function applyMove(
   p, point
 ) {
@@ -260,8 +331,8 @@ function applyMove(
       activeDrag.index
     ),
     {
-      x: clamp01( point.x / p.width - activeDrag.marginX ),
-      y: clamp01( point.y / p.height - activeDrag.marginY )
+      x: clamp01( point.x / p.width + activeDrag.offsetX - activeDrag.marginX ),
+      y: clamp01( point.y / p.height + activeDrag.offsetY - activeDrag.marginY )
     }
   );
 }
@@ -414,11 +485,9 @@ function onPointerDown( event ) {
   }
 
   const targets = collectTargets( p );
-  const hit = nearestTargetIndex(
-    targets,
-    point.x,
-    point.y,
-    grabRadius()
+  const hit = hitTest(
+    point,
+    targets
   );
 
   // Missed every item — let the viewport pan as usual.
@@ -437,7 +506,11 @@ function onPointerDown( event ) {
     scope: target.scope,
     index: target.index,
     marginX: target.marginX,
-    marginY: target.marginY
+    marginY: target.marginY,
+    // Anchor − pointer at grab time (normalized), so the item follows from
+    // where it was picked up instead of jumping its anchor under the cursor.
+    offsetX: target.x / p.width - point.x / p.width,
+    offsetY: target.y / p.height - point.y / p.height
   };
 
   try {
@@ -512,11 +585,9 @@ function onPointerMove( event ) {
   hoverPoint = point;
 
   const targets = collectTargets( p );
-  const hit = nearestTargetIndex(
-    targets,
-    point.x,
-    point.y,
-    grabRadius()
+  const hit = hitTest(
+    point,
+    targets
   );
   const key = hit === -1 ? null : overrideKey(
     targets[ hit ].scope,
@@ -591,11 +662,9 @@ function drawAffordance() {
   } );
 
   if ( !activeDrag && hoverPoint ) {
-    const hit = nearestTargetIndex(
-      targets,
-      hoverPoint.x,
-      hoverPoint.y,
-      grabRadius()
+    const hit = hitTest(
+      hoverPoint,
+      targets
     );
 
     if ( hit !== -1 ) {
@@ -607,41 +676,65 @@ function drawAffordance() {
     return;
   }
 
+  // Outline the grabbable surface itself — the item's visible rectangle —
+  // so the affordance shows exactly what a press will pick up. Anchor circle
+  // only for items without reported bounds (e.g. "visual").
+  const outline = (
+    target, color, weight
+  ) => {
+    p.stroke( ...color );
+    p.strokeWeight( weight );
+
+    if ( target.bounds ) {
+      const pad = boundsPadding() / 2;
+
+      p.rect(
+        target.bounds.x - pad,
+        target.bounds.y - pad,
+        target.bounds.w + pad * 2,
+        target.bounds.h + pad * 2,
+        6
+      );
+    } else {
+      p.circle(
+        target.x,
+        target.y,
+        grabRadius()
+      );
+    }
+  };
+
   p.push();
   p.noFill();
 
   hovers.forEach( ( index ) => {
-    const target = targets[ index ];
-
-    p.stroke(
-      255,
-      255,
-      255,
-      170
-    );
-    p.strokeWeight( 2 );
-    p.circle(
-      target.x,
-      target.y,
-      34
+    outline(
+      targets[ index ],
+      [
+        255,
+        255,
+        255,
+        170
+      ],
+      2
     );
   } );
 
   grabbed.forEach( ( index ) => {
     const target = targets[ index ];
 
-    p.stroke(
-      120,
-      200,
-      255,
-      230
+    outline(
+      target,
+      [
+        120,
+        200,
+        255,
+        230
+      ],
+      3
     );
-    p.strokeWeight( 3 );
-    p.circle(
-      target.x,
-      target.y,
-      40
-    );
+
+    // Anchor dot: the point the stored `position` refers to.
     p.noStroke();
     p.fill(
       120,
@@ -654,6 +747,7 @@ function drawAffordance() {
       target.y,
       6
     );
+    p.noFill();
   } );
 
   p.pop();
@@ -702,6 +796,7 @@ function detachDom() {
  */
 export function registerContentDrag() {
   overrides.clear();
+  clearItemBounds();
   activeDrag = null;
   hoverPoint = null;
   lastHoverKey = null;

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -1,5 +1,5 @@
 import events from "../events.js";
-import {
+import sketch, {
   getP5
 } from "../sketch.js";
 import {
@@ -7,33 +7,37 @@ import {
   setSketchOptions
 } from "../../shared/syncSketchOptions.js";
 import {
-  createDraggable,
-  detachAllDraggables
-} from "../interaction/draggable.js";
-import {
-  getCanvasDisplayScale
+  getCanvasDisplayScale,
+  clientToCanvas
 } from "../interaction/pointerTracking.js";
+import {
+  nearestTargetIndex
+} from "../interaction/dragMath.js";
 
 // ── On-canvas drag for template content items ──────────────────────────────
 // Every positioned content item — the global "content" list edited in the
 // template options AND the per-slide lists edited in the slide editor — can be
-// grabbed at its anchor point and moved with the mouse or a finger, exactly
-// like the control points of splines-v2-draggable (same shared draggable
-// layer). Engine-level: registered from slides/index.js for every template,
-// no per-sketch code.
+// grabbed at its anchor point and moved with the mouse or a finger. Engine-
+// level: registered from slides/index.js for every template, no per-sketch code.
 //
-// How it fits together, mirroring the splines sketch:
-//   - Item positions are stored NORMALIZED (0..1) in item.position, so a drag
-//     writes resize-proof values that are saved/exported with the template.
-//   - While a drag is live the moved position lives in an override map that
-//     freeLayout consults when it renders (via resolveDraggedItem) — the store
-//     is only written on RELEASE, so the form isn't re-rendered at 60fps.
-//   - The write goes through setSketchOptions with origin "p5": the options
-//     module skips its own change handler (no feedback loop) while React
-//     still picks the new values up in the form.
-//   - The shared draggable layer keeps the viewport pan/zoom off a drag
-//     (data-no-drag + capture-phase pointerdown hit-test), so this works with
-//     mouse and touch on any template without claiming `interaction.touch`.
+// Why this owns raw pointer events instead of the shared draggable layer:
+// content templates don't necessarily animate every frame, and the canvas
+// lives inside ScalableViewport, whose @use-gesture drag recogniser treats any
+// press-and-move as a pan. The earlier approach set a `data-no-drag` attribute
+// during hover and hoped the viewport would cancel its own pan — which fails
+// whenever the draw loop isn't tagging in time, so the pan won every gesture.
+// Here a capture-phase `pointerdown` on `window` hit-tests the press and, when
+// it lands on an item, calls `stopImmediatePropagation()` BEFORE the event ever
+// reaches the viewport's listeners — so the pan cannot start at all. The drag
+// then runs entirely from pointer events (mouse + touch + pen unified), so it
+// no longer depends on the p5 loop or on the viewport cooperating.
+//
+// Positions are stored NORMALIZED (0..1) in item.position (resize-proof, saved/
+// exported with the template). While a drag is live the moved position lives in
+// an override map that freeLayout consults when it renders (via
+// resolveDraggedItem); the store is written only on RELEASE (setSketchOptions
+// origin "p5", so the options module skips its own change handler — no feedback
+// loop — while React still picks the new values up in the form).
 
 // Content item types that carry a normalized `position` and render anchored to
 // it ("meta", "background", "hud" and "images" are laid out differently).
@@ -47,11 +51,10 @@ const DRAGGABLE_TYPES = new Set( [
 ] );
 
 // Pick-up radius around an item's anchor point, in ON-SCREEN (CSS) pixels.
-// Converted to canvas-pixel space per frame (see grabRadius) so the touch
-// target stays the same physical size on every device — a fixed canvas-pixel
-// radius collapses to a handful of screen pixels on a phone (a 1080-wide buffer
-// shown ~380px wide), which is what made items feel un-grabbable on mobile and
-// let the tap fall through to a viewport pan instead.
+// Converted to canvas-pixel space per use (see grabRadius) so the touch target
+// stays the same physical size on every device — a fixed canvas-pixel radius
+// collapses to a handful of screen pixels on a phone (a 1080-wide buffer shown
+// ~380px wide), which made items feel un-grabbable on mobile.
 const GRAB_RADIUS_SCREEN_PX = 44;
 
 export const GLOBAL_CONTENT_SCOPE = "global";
@@ -61,11 +64,27 @@ export function slideContentScope( index ) {
 }
 
 // Live drag overrides: `${scope}:${contentIndex}` → normalized { x, y }
-// position. Consulted by freeLayout while a drag is in flight; flushed into
-// the option store on release.
+// position. Consulted by freeLayout while a drag is in flight; flushed into the
+// option store on release.
 const overrides = new Map();
 
-const draggable = createDraggable();
+// The pointer currently dragging an item, or null. `pointerId` scopes every
+// move/up to the exact pointer that grabbed, so multi-touch elsewhere can't
+// hijack the drag.
+let activeDrag = null;
+
+// Last hover position (canvas px) for the mouse, or null. Drives the hover ring
+// and the "move" cursor; touch never hovers.
+let hoverPoint = null;
+
+// The target index the mouse last hovered, so a paused sketch can be nudged to
+// redraw only when the ring should appear/disappear (not on every mouse move).
+let lastHoverKey = null;
+
+// Wired DOM listeners, kept so a re-register (next sketch start) can detach the
+// previous set.
+let domListeners = null;
+let unregisterPostDraw = null;
 
 function clamp01( value ) {
   return Math.min(
@@ -118,10 +137,9 @@ function overrideKey(
 }
 
 /**
- * The item as it should render this frame: while it is being dragged, its
- * live (not yet persisted) position replaces the stored one. Called by
- * freeLayout for every content item; returns the item untouched when no drag
- * is in flight.
+ * The item as it should render this frame: while it is being dragged, its live
+ * (not yet persisted) position replaces the stored one. Called by freeLayout
+ * for every content item; returns the item untouched when no drag is in flight.
  */
 export function resolveDraggedItem(
   scope, index, item
@@ -149,8 +167,8 @@ export function resolveDraggedItem(
   };
 }
 
-// Same wrap as slides/index.js uses to resolve the rendered slide, so the
-// scope written here always matches the scope freeLayout renders with.
+// Same wrap as slides/index.js uses to resolve the rendered slide, so the scope
+// written here always matches the scope freeLayout renders with.
 function currentSlideIndex( count ) {
   const raw = typeof window !== "undefined"
     ? window.getCurrentSlide?.()?.index
@@ -160,10 +178,10 @@ function currentSlideIndex( count ) {
   return ( ( index % count ) + count ) % count;
 }
 
-// Every draggable content item on screen this frame, as pixel-space grab
-// targets carrying where they came from (scope + index) so a move knows where
-// to write back. Current slide items first, then the global list — freeLayout
-// draws them in that order too.
+// Every draggable content item on screen right now, as pixel-space grab targets
+// carrying where they came from (scope + index) so a move knows where to write
+// back. Current slide items first, then the global list — freeLayout draws them
+// in that order too.
 function collectTargets( p ) {
   const store = getSketchOptions();
   const targets = [];
@@ -223,30 +241,29 @@ function collectTargets( p ) {
   return targets;
 }
 
-function moveTarget(
-  p, target, pointer
+// Canvas-pixel pick-up radius for the current display scale.
+function grabRadius() {
+  return GRAB_RADIUS_SCREEN_PX * getCanvasDisplayScale();
+}
+
+// Write the dragged item's live position from a canvas-space pointer point.
+function applyMove(
+  p, point
 ) {
-  if ( !target ) {
+  if ( !activeDrag ) {
     return;
   }
 
-  const moved = {
-    x: clamp01( pointer.x / p.width - target.marginX ),
-    y: clamp01( pointer.y / p.height - target.marginY )
-  };
-
   overrides.set(
     overrideKey(
-      target.scope,
-      target.index
+      activeDrag.scope,
+      activeDrag.index
     ),
-    moved
+    {
+      x: clamp01( point.x / p.width - activeDrag.marginX ),
+      y: clamp01( point.y / p.height - activeDrag.marginY )
+    }
   );
-
-  // Keep the pixel anchor in step so a second pointer this frame can't grab
-  // the item at its stale position.
-  target.x = ( moved.x + target.marginX ) * p.width;
-  target.y = ( moved.y + target.marginY ) * p.height;
 }
 
 // Apply the pending overrides to one content list. Returns the new list, or
@@ -287,12 +304,8 @@ function applyToContent(
   return changed ? next : null;
 }
 
-// Persist the dragged positions into the saved options so they survive
-// reloads and are exported with the template. Origin "p5" so the options
-// module skips its own change handler (no feedback loop), while React still
-// picks the new values up in the form. Overrides for a drag that is still in
-// flight are flushed too (they hold the item's current position) and simply
-// start accumulating again next frame.
+// Persist the dragged positions into the saved options so they survive reloads
+// and are exported with the template.
 function persistOverrides() {
   if ( overrides.size === 0 ) {
     return;
@@ -347,11 +360,249 @@ function persistOverrides() {
   }
 }
 
-// Hover / grab rings at the item anchors, mirroring the splines highlight so
-// the grab handles read the same across the app.
-function drawAffordance(
-  p, targets, hovers, grabbed
-) {
+// A static (noLoop) sketch won't redraw on its own, so nudge it once so the
+// moved item and its ring show immediately. A looping sketch redraws anyway —
+// don't double-draw it.
+function requestRedraw( p ) {
+  if (
+    p &&
+    typeof p.isLooping === "function" &&
+    !p.isLooping() &&
+    typeof p.redraw === "function"
+  ) {
+    p.redraw();
+  }
+}
+
+function setCursor( value ) {
+  const element = sketch.getCanvasElement?.();
+
+  if ( element && element.style.cursor !== value ) {
+    element.style.cursor = value;
+  }
+}
+
+// ── Pointer handlers (capture phase on window, ahead of the viewport) ───────
+
+function onPointerDown( event ) {
+  const p = getP5();
+
+  if ( !p ) {
+    return;
+  }
+
+  const element = sketch.getCanvasElement?.();
+
+  // Only presses that land directly on the sketch canvas are ours; UI chrome
+  // and empty page area fall through untouched so normal panning still works.
+  if ( !element || event.target !== element ) {
+    return;
+  }
+
+  // Left button / primary pointer only.
+  if ( event.pointerType === "mouse" && event.button !== 0 ) {
+    return;
+  }
+
+  const point = clientToCanvas(
+    event.clientX,
+    event.clientY
+  );
+
+  if ( !point ) {
+    return;
+  }
+
+  const targets = collectTargets( p );
+  const hit = nearestTargetIndex(
+    targets,
+    point.x,
+    point.y,
+    grabRadius()
+  );
+
+  // Missed every item — let the viewport pan as usual.
+  if ( hit === -1 ) {
+    return;
+  }
+
+  // We own this gesture: stop it before the viewport's recogniser sees it.
+  event.stopImmediatePropagation();
+  event.preventDefault();
+
+  const target = targets[ hit ];
+
+  activeDrag = {
+    pointerId: event.pointerId,
+    scope: target.scope,
+    index: target.index,
+    marginX: target.marginX,
+    marginY: target.marginY
+  };
+
+  try {
+    element.setPointerCapture?.( event.pointerId );
+  } catch {
+    // Capture is best-effort; window listeners already see every move.
+  }
+
+  applyMove(
+    p,
+    point
+  );
+  setCursor( "grabbing" );
+  requestRedraw( p );
+}
+
+function onPointerMove( event ) {
+  // Active drag: follow the exact pointer that grabbed.
+  if ( activeDrag && event.pointerId === activeDrag.pointerId ) {
+    event.stopImmediatePropagation();
+
+    const p = getP5();
+    const point = p && clientToCanvas(
+      event.clientX,
+      event.clientY
+    );
+
+    if ( p && point ) {
+      applyMove(
+        p,
+        point
+      );
+      requestRedraw( p );
+    }
+
+    return;
+  }
+
+  if ( activeDrag ) {
+    return;
+  }
+
+  // Hover (mouse/pen only): update the ring + cursor. Never stops the event, so
+  // panning empty canvas still works.
+  if ( event.pointerType === "touch" ) {
+    return;
+  }
+
+  const p = getP5();
+  const element = sketch.getCanvasElement?.();
+
+  if ( !p || !element || event.target !== element ) {
+    if ( hoverPoint ) {
+      hoverPoint = null;
+      lastHoverKey = null;
+      setCursor( "" );
+      requestRedraw( p );
+    }
+
+    return;
+  }
+
+  const point = clientToCanvas(
+    event.clientX,
+    event.clientY
+  );
+
+  if ( !point ) {
+    return;
+  }
+
+  hoverPoint = point;
+
+  const targets = collectTargets( p );
+  const hit = nearestTargetIndex(
+    targets,
+    point.x,
+    point.y,
+    grabRadius()
+  );
+  const key = hit === -1 ? null : overrideKey(
+    targets[ hit ].scope,
+    targets[ hit ].index
+  );
+
+  setCursor( hit === -1 ? "" : "move" );
+
+  // Only force a redraw when the hovered item actually changes, so a paused
+  // sketch shows/hides the ring without redrawing on every mouse move.
+  if ( key !== lastHoverKey ) {
+    lastHoverKey = key;
+    requestRedraw( p );
+  }
+}
+
+function onPointerUp( event ) {
+  if ( !activeDrag || event.pointerId !== activeDrag.pointerId ) {
+    return;
+  }
+
+  event.stopImmediatePropagation();
+
+  const element = sketch.getCanvasElement?.();
+
+  try {
+    element?.releasePointerCapture?.( event.pointerId );
+  } catch {
+    // Ignore — the capture may already be gone.
+  }
+
+  persistOverrides();
+  activeDrag = null;
+  setCursor( "" );
+  requestRedraw( getP5() );
+}
+
+// ── Ring affordance (drawn on top of the content items each draw) ───────────
+
+function drawAffordance() {
+  const p = getP5();
+
+  if ( !p ) {
+    return;
+  }
+
+  const targets = collectTargets( p );
+
+  if ( targets.length === 0 ) {
+    // Nothing draggable on screen — drop stale overrides so a removed item's
+    // ghost position can't resurface if items are re-added.
+    if ( !activeDrag ) {
+      overrides.clear();
+    }
+
+    return;
+  }
+
+  const hovers = new Set();
+  const grabbed = new Set();
+
+  targets.forEach( (
+    target, index
+  ) => {
+    if (
+      activeDrag &&
+      target.scope === activeDrag.scope &&
+      target.index === activeDrag.index
+    ) {
+      grabbed.add( index );
+    }
+  } );
+
+  if ( !activeDrag && hoverPoint ) {
+    const hit = nearestTargetIndex(
+      targets,
+      hoverPoint.x,
+      hoverPoint.y,
+      grabRadius()
+    );
+
+    if ( hit !== -1 ) {
+      hovers.add( hit );
+    }
+  }
+
   if ( hovers.size === 0 && grabbed.size === 0 ) {
     return;
   }
@@ -361,10 +612,6 @@ function drawAffordance(
 
   hovers.forEach( ( index ) => {
     const target = targets[ index ];
-
-    if ( !target || grabbed.has( index ) ) {
-      return;
-    }
 
     p.stroke(
       255,
@@ -382,10 +629,6 @@ function drawAffordance(
 
   grabbed.forEach( ( index ) => {
     const target = targets[ index ];
-
-    if ( !target ) {
-      return;
-    }
 
     p.stroke(
       120,
@@ -416,76 +659,95 @@ function drawAffordance(
   p.pop();
 }
 
-function handleFrame() {
-  const p = getP5();
-
-  if ( !p ) {
-    return;
+function detachDom() {
+  if ( domListeners && typeof window !== "undefined" ) {
+    window.removeEventListener(
+      "pointerdown",
+      domListeners.down,
+      {
+        capture: true
+      }
+    );
+    window.removeEventListener(
+      "pointermove",
+      domListeners.move,
+      {
+        capture: true
+      }
+    );
+    window.removeEventListener(
+      "pointerup",
+      domListeners.up,
+      {
+        capture: true
+      }
+    );
+    window.removeEventListener(
+      "pointercancel",
+      domListeners.up,
+      {
+        capture: true
+      }
+    );
   }
 
-  const targets = collectTargets( p );
-
-  if ( targets.length === 0 ) {
-    // Nothing draggable on screen (or every item was just removed): drop any
-    // in-flight drag and release the canvas affordance instead of leaving a
-    // stale grab cursor behind.
-    overrides.clear();
-    draggable.idle();
-
-    return;
-  }
-
-  // Keep the grab zone a constant physical size on screen: a CSS-pixel radius
-  // scaled into the canvas-pixel space the drag math (and the capture-phase
-  // pan-cancel hit-test) both work in.
-  const grabRadius = GRAB_RADIUS_SCREEN_PX * getCanvasDisplayScale();
-
-  const {
-    hovers,
-    grabbed,
-    released
-  } = draggable.update( {
-    targets,
-    radius: grabRadius,
-    onMove: (
-      index, pointer
-    ) => moveTarget(
-      p,
-      targets[ index ],
-      pointer
-    )
-  } );
-
-  if ( released ) {
-    persistOverrides();
-  }
-
-  drawAffordance(
-    p,
-    targets,
-    hovers,
-    grabbed
-  );
+  domListeners = null;
 }
 
 /**
  * Called from slides.registerEvents() on every sketch start (the engine event
  * registry is cleared on reset). Registration order matters: slides registers
  * its render handlers first, so this post-draw runs after the content items
- * were drawn and the affordance rings stack on top.
+ * were drawn and the ring stacks on top.
  */
 export function registerContentDrag() {
   overrides.clear();
+  activeDrag = null;
+  hoverPoint = null;
+  lastHoverKey = null;
 
-  // The previous sketch's draggable layers (its own points AND this one) are
-  // orphaned at this point — their update() will never run again, so detach
-  // them before re-arming, or a stale hover flag would keep `data-no-drag` /
-  // the grab cursor on the fresh canvas forever.
-  detachAllDraggables();
+  // Re-arm from a clean slate: the previous sketch's listeners are orphaned.
+  detachDom();
 
-  draggable.attach();
-  events.register(
+  if ( typeof window !== "undefined" ) {
+    domListeners = {
+      down: onPointerDown,
+      move: onPointerMove,
+      up: onPointerUp
+    };
+    window.addEventListener(
+      "pointerdown",
+      domListeners.down,
+      {
+        capture: true
+      }
+    );
+    window.addEventListener(
+      "pointermove",
+      domListeners.move,
+      {
+        capture: true
+      }
+    );
+    window.addEventListener(
+      "pointerup",
+      domListeners.up,
+      {
+        capture: true
+      }
+    );
+    window.addEventListener(
+      "pointercancel",
+      domListeners.up,
+      {
+        capture: true
+      }
+    );
+  }
+
+  unregisterPostDraw?.();
+  unregisterPostDraw = events.register(
     "post-draw",
-    handleFrame
+    drawAffordance
   );
 }

--- a/src/templates/p5/utils/slides/layouts/freeLayout.js
+++ b/src/templates/p5/utils/slides/layouts/freeLayout.js
@@ -11,10 +11,17 @@ import drawSlideQrCode from "../common/drawSlideQrCode.js";
 import {
   resolveDraggedItem
 } from "../contentDrag.js";
+import {
+  beginItemBounds,
+  endItemBounds
+} from "../common/itemBoundsRegistry.js";
 
 // `scope` says which content list is being rendered ("global" or "slide:<n>")
 // so an in-flight on-canvas drag (see contentDrag.js) can substitute the live
 // position of the grabbed item without touching the option store every frame.
+// Each item's render is bracketed with begin/endItemBounds so the renderer's
+// reportItemBounds() call lands on the right (scope, index) — that visible
+// rectangle is what the drag layer hit-tests.
 export default function freeLayout(
   options, scope
 ) {
@@ -25,6 +32,11 @@ export default function freeLayout(
       scope,
       index,
       rawItem
+    );
+
+    beginItemBounds(
+      scope,
+      index
     );
 
     switch ( item?.type ) {
@@ -74,5 +86,7 @@ export default function freeLayout(
         );
         break;
     }
+
+    endItemBounds();
   } );
 }


### PR DESCRIPTION
Follow-up to #204 / #205. Fixes "dragging a content item pans the canvas instead of moving the item" — on desktop and mobile. Two independent defects compounded; both are fixed here, and **the failing case was reproduced and re-verified end-to-end in the running app with real mouse events** this time.

## Root cause 1 — the grab zone wasn't where the item visibly is (the big one)

An item's normalized `position` anchor is often **nowhere near its drawn pixels**. Rect-mode text centres its glyphs inside a near-full-width layout box, so a freshly added text item (`position.x = 0`, the palette default) renders **mid-canvas** while its grab anchor sits on the **left edge**. Clicking the text you see missed the 44px anchor disc every time → the press fell through → the viewport panned. This is exactly why splines-v2 always worked: its visible dots ARE their anchors — you grab what you see.

**Fix: grab what you see.**
- New `itemBoundsRegistry.js`: per-frame registry of each item's actually-drawn rectangle; `freeLayout` brackets every item render with `begin/endItemBounds` so each renderer's report lands on the right `(scope, index)`.
- `drawSlideText` / `Image` / `ImagesStack` / `QrCode` / `Specs` report the rect they draw (text derives its glyph band from measured bounds + rect-mode alignment; image uses `marginImage`'s exact callback rect; qrcode is exact; stack/specs are close approximations).
- `contentDrag` hit-tests the visible rectangles (topmost drawn wins, ~10 screen-px forgiveness), keeps the anchor disc only for items with no reported bounds (e.g. `visual`), drags by **grab offset** (item follows from where you picked it up — no snap), and the hover/grab affordance now outlines the actual grabbable rectangle.

## Root cause 2 — the viewport could still win the gesture

The original implementation relied on the p5 draw loop tagging `data-no-drag` during hover and on `@use-gesture` cancelling its own pan. Fixed by owning the input: capture-phase `pointerdown` on `window` hit-tests the press and, on a hit, `stopImmediatePropagation()` runs **before** the viewport's recogniser ever sees the event. A miss falls through so normal panning keeps working. (Also: hit-test rect resolved from the sketch's own canvas node so a stale `canvas.p5Canvas` can never skew coordinates.)

## Verification

- **Reproduced the bug first**: real `next dev` + Chromium + real mouse events, clicking the *visible* glyphs of a palette-default text item → no grab, viewport panned (the reported behaviour).
- **After the fix, same script**: hover cursor appears, item grabs and moves by exactly the pointer delta, position persists to options on release, viewport does **not** pan. Same for slide-scoped items. Dragging empty canvas still pans.
- `npm test` — 43 suites / 1388 tests (bounds-grab, offset drag, no-anchor-fallback, pointer-ownership all covered).
- `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lqv1B8hQ645eMYgPunSX3i