### PR TITLE
fix(letter-grid): freeze the letters against zoom & motion controls

### DIFF
--- a/src/templates/p5/sketches/letter-grid/_grid.js
+++ b/src/templates/p5/sketches/letter-grid/_grid.js
@@ -374,9 +374,21 @@ export function resolveReadingPosition( {
 }
 
 /**
- * Convenience cache wrapper. Owns a `{ key, path, alphabet }` record and only
- * rebuilds the path when an input that shapes it changes. The caller passes the
- * record in so each sketch keeps its own (the engine resets between sketches).
+ * Convenience cache wrapper. Owns a `{ key, path, alphabet }` record and rebuilds
+ * the path only when the letters' IDENTITY changes. The caller passes the record in
+ * so each sketch keeps its own (the engine resets between sketches).
+ *
+ * The cache key is INTENTIONALLY limited to what actually decides which glyphs are
+ * on screen — the word, the resolved alphabet and the seed. Everything the camera
+ * lands on is `cellChar(col, row, seed, alphabet)`, so the letters only *look* like
+ * they change when the path (hence the camera's absolute cell coordinates) moves.
+ * Keeping viewRadius / spread OUT of the key freezes the letters against zoom, cell
+ * size, breathing zoom, view radius, search spread and every other purely visual or
+ * motion control: change any of them and the same letters stay put — which is what
+ * lets them be driven by the binding system and dynamic montage without the field
+ * reshuffling underfoot (a per-frame breathing zoom used to rebuild the path every
+ * frame). viewRadius / spread still SHAPE a freshly built path — they just never
+ * trigger one; the layout re-forms only when the word, alphabet or seed changes.
  */
 export function ensurePath(
   store, {
@@ -394,9 +406,7 @@ export function ensurePath(
   const key = [
     glyphs.join( "" ),
     alphabet,
-    seed,
-    Math.round( viewRadius * 100 ),
-    Math.round( spread * 100 )
+    seed
   ].join( "|" );
 
   if ( key !== store.key ) {

--- a/src/templates/p5/sketches/letter-grid/letter-grid-v1-spell/index.js
+++ b/src/templates/p5/sketches/letter-grid/letter-grid-v1-spell/index.js
@@ -142,12 +142,20 @@ sketch.draw( () => {
     p.width,
     p.height
   );
+  // The breathing zoom modulates only what we DRAW; the base cell size is what the
+  // path build reads, so the word layout never breathes with it.
+  const baseCellSize = minDim / cellsAcross;
   const pulse = ( gridCfg.zoomPulse ?? 0 ) * Math.sin( animation.angle );
-  const cellSize = ( minDim / cellsAcross ) * ( 1 + pulse );
+  const cellSize = baseCellSize * ( 1 + pulse );
 
+  // Draw bounds follow the live (breathing) cell size so the screen always fills…
   const viewCols = p.width / cellSize;
   const viewRows = p.height / cellSize;
-  const viewRadius = 0.5 * Math.sqrt( viewCols * viewCols + viewRows * viewRows );
+  // …while the path's view radius is derived from the steady base size, so a
+  // breathing zoom can't jitter it (the path is cached on word/seed only anyway).
+  const baseCols = p.width / baseCellSize;
+  const baseRows = p.height / baseCellSize;
+  const viewRadius = 0.5 * Math.sqrt( baseCols * baseCols + baseRows * baseRows );
 
   const spread = clamp(
     motionCfg.searchSpread ?? 0.6,


### PR DESCRIPTION
## Problem

On the **Letter Grid** sketches, changing certain parameters — most visibly the **Breathing zoom** (`grid.zoomPulse`) — made the whole field of letters reshuffle at random. That fights the intended workflow of animating these sketches via the binding system and dynamic montage, where the letters should stay put.

## Root cause

The glyphs on screen are `cellChar(col, row, seed, alphabet)` — pure in `(col, row, seed, alphabet)`. They only *look* like they change when the **word path** shifts, because the camera then travels to different absolute grid cells and shows a different slice of the field.

`ensurePath` keyed its path cache on `viewRadius` and `spread` **in addition to** word/seed/alphabet:

```js
const key = [ glyphs.join(""), alphabet, seed,
  Math.round(viewRadius * 100), Math.round(spread * 100) ].join("|");
```

In **v1**, `viewRadius` is derived from `cellSize`, and the breathing zoom multiplies `cellSize` **every frame** (`pulse = zoomPulse · sin(angle)`). So with `zoomPulse > 0` the cache key changed every frame → the path was rebuilt every frame → the entire letter field reshuffled. Changing the cell size, view radius or search spread caused the same reshuffle on each drag.

## Fix

- **Shared engine (`_grid.js`)** — key the path cache **only** on the letters' identity: word glyphs, resolved alphabet, seed. Zoom, cell size, breathing zoom, view radius and search spread no longer reshuffle the field; the letters stay frozen and re-form only when the word, alphabet or seed changes. `viewRadius` / `spread` still *shape* a freshly built path — they just never *trigger* a rebuild. This covers all four variants (v1 spell, v2 extrude, v3 leap, v4 trail) through the shared engine.
- **v1 (`letter-grid-v1-spell`)** — derive the path's view radius from the **base** (non-breathing) cell size so a fresh build is deterministic. The pulse still scales what is *drawn*, and the draw bounds still follow the live cell size so the screen keeps filling.

## Verification

Ran the pure engine functions against a simulated breathing-zoom sequence (viewRadius + spread wobbling for 8 frames):

- Path identical across all 8 breathing frames → letters frozen. ✅
- Changing **only the seed** reshuffles the path → letters change on seed change. ✅
- Changing the **word** reshuffles the path. ✅

`node --check` passes on both changed files. (The full lint/test suite could not run in this environment — `npm ci` kept hitting connection resets on a large dependency download.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK4rYxiavYtzVCDdARy9fw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4rYxiavYtzVCDdARy9fw)_