### PR TITLE
refactor(kinetic): adopt shared interaction system across all kinetic sketches

### DIFF
--- a/src/templates/p5/sketches/kinetic/kinetic-grid-spheres/index.js
+++ b/src/templates/p5/sketches/kinetic/kinetic-grid-spheres/index.js
@@ -6,40 +6,31 @@ import easing from "@/p5/utils/easing.js";
 import grid from "@/p5/utils/grid.js";
 import graphics from "@/p5/utils/graphics.js";
 import colors from "@/p5/utils/colors.js";
-import * as common from "@/p5/utils/common.js";
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 
-import addScreenPositionFunction from "@/utils/addScreenPositionFunction.js";
-
-import mediapipe, {
-  init as mediapipeInit, setEnabled as setMediapipeEnabled
-} from "@/p5/utils/mediapipe/mediapipe.js"; // Key landmarks for interaction (fingertips)
-
-// Key landmarks for interaction (fingertips)
-const interactionIndices = [
-  4,
-  8,
-  12,
-  16,
-  20
-];
+import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
 
 const sketchState = {
-  interactive: {
-    image: null
-  },
   shape: {
-    graphics: null
-  },
-  webcam: {
     graphics: null
   }
 };
 
-sketch.setup( async( {
-  canvas
-} ) => {
+const getBackgroundColor = () =>
+  options.sketch?.backgroundColor ?? [
+    246,
+    235,
+    225
+  ];
+
+sketch.setup( async() => {
   const p = getP5();
 
   p.background( ...getBackgroundColor() );
@@ -50,40 +41,35 @@ sketch.setup( async( {
     "webgl"
   );
 
-  addScreenPositionFunction( sketchState.shape.graphics );
-
-  sketchState.webcam.graphics = p.createGraphics(
-    p.width,
-    p.height
-  );
-
-  await mediapipeInit( {
-    worker: false,
-    tasks: [
-      "hands"
-    ]
-  } );
+  // One call boots every enabled interaction source (mouse, vision, orbit…)
+  // declared in the shared `interaction` options.
+  await initInteraction( options.sketch?.interaction ?? {} );
 } );
 
-const getBackgroundColor = () =>
-  options.sketch?.backgroundColor ?? [
-    246,
-    235,
-    225
-  ];
+// Interaction pointers arrive in top-left canvas space; the grid lives in
+// centered WEBGL model space, so shift each pointer by half the canvas. This
+// replaces the old per-source screenPosition round-trip (≈ identity at the base
+// camera) with a deterministic, camera-independent conversion.
+const toModelSpace = ( pointers ) => {
+  const p = getP5();
+
+  return pointers.map( ( v ) =>
+    p.createVector(
+      v.x - p.width / 2,
+      v.y - p.height / 2
+    ) );
+};
 
 sketch.draw( () => {
   const p = getP5();
+  const g = sketchState.shape.graphics;
+  const interaction = options.sketch?.interaction ?? {};
+  const render = options.sketch?.animation ?? {};
 
   p.clear();
   p.background( ...getBackgroundColor() );
 
   renderTitle( options.sketch?.title );
-
-  // Dynamically enable/disable mediapipe based on useHands option
-  const useHands = options.sketch.animation.useHands ?? true;
-
-  setMediapipeEnabled( useHands );
 
   const columns = options.sketch?.grid?.columns ?? 65;
   const rows = ( columns * p.height ) / p.width;
@@ -118,83 +104,31 @@ sketch.draw( () => {
   const fillAlphaEnd = options.sketch?.color?.fillAlphaEnd ?? 0;
   const strokeAlpha = options.sketch?.color?.strokeAlpha ?? 200;
 
-  const maxInfluenceDistance =
-    options.sketch.animation.maxInfluenceDistance ?? 150;
+  const maxInfluenceDistance = render.maxInfluenceDistance ?? 150;
 
-  const targetVectors = [];
+  // Every enabled source — mouse, hands, orbit, … — merged into one flat list
+  // and mapped into the grid's centered coordinate space.
+  const targetVectors = toModelSpace( getPointers( interaction ) );
 
-  if ( options.sketch.animation.useMouse ?? true ) {
-    sketchState.shape.graphics.screenPosition( p.createVector(
-      p.mouseX - p.width / 2,
-      p.mouseY - p.height / 2
-    ) );
-  }
-
-  if ( options.sketch.animation.useHands ?? true ) {
-    mediapipe.tasks?.hands?.result?.landmarks?.forEach( ( hand ) => {
-      const interactionPoints = interactionIndices
-        .map( ( i ) => hand[ i ] )
-        .filter( Boolean );
-
-      interactionPoints.forEach( ( point ) => {
-        if ( point ) {
-          const x = common.inverseX( point.x ) * p.width;
-          const y = point.y * p.height;
-
-          targetVectors.push( sketchState.shape.graphics.screenPosition( p.createVector(
-            x - p.width / 2,
-            y - p.height / 2
-          ) ) );
-        }
-      } );
-    } );
-  }
-
-  const margin = 150;
-  const W = p.width / 2 - margin;
-  const H = p.height / 2 - margin;
-  const targetsCount = options.sketch.animation.spheresCount ?? 3;
-
-  for ( let i = 0; i < targetsCount; i++ ) {
-    const targetProgression = i / targetsCount;
-
-    targetVectors.push( ( p.createVector(
-      p.map(
-        Math.sin( animation.angle + i * 2 ),
-        -1,
-        1,
-        -W,
-        W
-      ),
-      p.map(
-        Math.cos( animation.angle + i * targetProgression ),
-        -1,
-        1,
-        -H,
-        H
-      )
-    ) ) );
-  }
-
-  if ( options.sketch.animation.showSpheres ?? true ) {
+  if ( render.showSpheres ?? true ) {
     targetVectors.forEach( ( vector ) => {
-      sketchState.shape.graphics.push();
-      sketchState.shape.graphics.translate(
+      g.push();
+      g.translate(
         vector.x,
         vector.y,
         50
       );
-      sketchState.shape.graphics.normalMaterial( vector );
-      sketchState.shape.graphics.sphere( options.sketch.animation.sphereSize ?? 30 );
-      sketchState.shape.graphics.pop();
+      g.normalMaterial( vector );
+      g.sphere( render.sphereSize ?? 30 );
+      g.pop();
     } );
   }
 
   grid.draw(
     gridOptions,
     ( position ) => {
-      sketchState.shape.graphics.push();
-      sketchState.shape.graphics.translate( position );
+      g.push();
+      g.translate( position );
 
       let minDistance = Infinity;
 
@@ -230,7 +164,7 @@ sketch.draw( () => {
           cellSize
         ],
         currentTime: switchIndex,
-        easingFn: easing?.[ options.sketch.animation.easing ] ?? easing.easeOutBack
+        easingFn: easing?.[ render.easing ] ?? easing.easeOutBack
       } );
 
       const fillAlpha = animation.ease( {
@@ -241,7 +175,7 @@ sketch.draw( () => {
         currentTime: switchIndex
       } );
 
-      const hue = sketchState.shape.graphics.noise(
+      const hue = g.noise(
         position.x / columns / 5,
         position.y / rows / 5
       // switchIndex
@@ -252,7 +186,7 @@ sketch.draw( () => {
       const tint = colors.rainbow( {
         hueOffset: switchIndex,
         hueIndex:
-        sketchState.shape.graphics.map(
+        g.map(
           hue,
           0,
           1,
@@ -270,56 +204,39 @@ sketch.draw( () => {
         ]
       } = tint;
 
-      sketchState.shape.graphics.fill(
+      g.fill(
         red,
         green,
         blue,
         fillAlpha
       );
-      sketchState.shape.graphics.stroke(
+      g.stroke(
         red,
         green,
         blue,
         strokeAlpha
       );
 
-      sketchState.shape.graphics.box(
+      g.box(
         w,
         h,
         -depth
       );
 
-      sketchState.shape.graphics.pop();
+      g.pop();
     }
   );
 
   // SHAPE
   p.image(
-    sketchState.shape.graphics,
+    g,
     0,
     0
   );
-  sketchState.shape.graphics.clear();
+  g.clear();
 
-  // WEBCAM - only render if enabled and capture element exists
-  if ( mediapipe.enabled && mediapipe.capture.element ) {
-    sketchState.webcam.graphics.clear();
-    sketchState.webcam.graphics.image(
-      mediapipe.capture.element,
-      0,
-      0,
-      mediapipe.capture.size.width * 2,
-      mediapipe.capture.size.height * 2
-    );
-    // sketchState.webcam.graphics.filter( POSTERIZE );
-    // sketchState.webcam.graphics.filter( INVERT );
-    // sketchState.webcam.graphics.filter( GRAY );
-    p.image(
-      sketchState.webcam.graphics,
-      0,
-      0,
-      p.width,
-      p.height
-    );
-  }
+  // Shared debug/demo overlay (crosshairs, markers, camera preview, legend),
+  // gated by `interaction.visualization` — off by default so the 3D scene
+  // stays clean, but available from the form.
+  drawInteractionOverlay( interaction );
 } );

--- a/src/templates/p5/sketches/kinetic/kinetic-grid-spheres/options.ts
+++ b/src/templates/p5/sketches/kinetic/kinetic-grid-spheres/options.ts
@@ -1,20 +1,50 @@
 import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
 import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+// Shared interaction defaults tuned for this sketch: six orbiting virtual
+// pointers drive the grid out of the box (matching the sketch's original
+// `spheresCount`), with hand tracking on by default. The on-canvas overlay is
+// muted since the sketch renders its own 3D spheres for each pointer.
+const interactionDefaults = {
+  ...interactionFormValues,
+  vision: {
+    ...interactionFormValues.vision,
+    enabled: true,
+    hands: {
+      ...interactionFormValues.vision.hands,
+      enabled: true
+    }
+  },
+  orbit: {
+    ...interactionFormValues.orbit,
+    enabled: true,
+    count: 6
+  },
+  visualization: {
+    ...interactionFormValues.visualization,
+    enabled: false
+  }
+};
+
 export const formValues = {
   grid: {
     gap: 3,
     depth: 10,
     columns: 36
   },
+  // How the grid reacts to interaction pointers, plus the 3D sphere markers
+  // rendered at each pointer.
   animation: {
-    useMouse: false,
-    useHands: true,
     showSpheres: true,
-    spheresCount: 6,
     sphereSize: 30,
     maxInfluenceDistance: 150,
     easing: "easeOutBack"
   },
+  interaction: interactionDefaults,
   title: titleDefaultValues,
   color: {
     opacityFactor: 1.5,
@@ -61,23 +91,9 @@ export const formConfiguration: Record<string, any> = {
     component: "nested-object",
     label: "Animation",
     fields: {
-      useMouse: {
-        label: "Use mouse",
-        component: "checkbox"
-      },
-      useHands: {
-        label: "Use hands",
-        component: "checkbox"
-      },
       showSpheres: {
         label: "Show spheres",
         component: "checkbox"
-      },
-      spheresCount: {
-        label: "Spheres count",
-        component: "slider",
-        min: 0,
-        max: 24
       },
       sphereSize: {
         label: "Sphere size",
@@ -98,6 +114,7 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interaction: interactionFormConfiguration,
   color: {
     component: "nested-object",
     label: "Color",

--- a/src/templates/p5/sketches/kinetic/kinetic-letters/index.js
+++ b/src/templates/p5/sketches/kinetic/kinetic-letters/index.js
@@ -1,41 +1,26 @@
 import options from "@/p5/utils/options.js";
 
 import cache from "@/p5/utils/cache.js";
-import shapes from "@/p5/utils/shapes.js";
-import events from "@/p5/utils/events.js";
 import string from "@/p5/utils/string.js";
-import sketch from "@/p5/utils/sketch.js";
-import easing from "@/p5/utils/easing.js";
-import graphics from "@/p5/utils/graphics.js";
-import * as common from "@/p5/utils/common.js";
-import animation from "@/p5/utils/animation.js";
-
-import drawHands from "@/p5/utils/mediapipe/drawHands.js";
-
-import mediapipe, {
-  init as mediapipeInit, setEnabled as setMediapipeEnabled
-} from "@/p5/utils/mediapipe/mediapipe.js";
-import {
+import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
+import easing from "@/p5/utils/easing.js";
+import graphics from "@/p5/utils/graphics.js";
+import animation from "@/p5/utils/animation.js";
 
-// Key landmarks for interaction (palm, fingertips)
-const interactionIndices = [
-  // 0,
-  4,
-  8,
-  12,
-  16
-  // 20,
-];
+import {
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
 
+// The letters live on their own buffer so their per-letter transforms stay
+// isolated from the main canvas; the interaction overlay (crosshairs, pointer
+// markers, camera preview…) then draws on top via drawInteractionOverlay.
 const layers = {
-  hands: {
-    graphics: undefined,
-    size: options.size,
-    background: undefined,
-    erase: 255
-  },
   visuals: {
     graphics: undefined,
     size: options.size,
@@ -43,45 +28,28 @@ const layers = {
       80
     ],
     erase: 255
-  },
-  pointers: {
-    graphics: undefined,
-    size: options.size,
-    background: undefined,
-    erase: 255
   }
 };
 
 const sketchState = {
-  letters: [],
-  handPointingImage: null
+  letters: []
 };
 
-events.register(
-  "engine-window-preload",
-  () => {
-    const p = getP5();
-
-    sketchState.handPointingImage = getP5().loadImage( "/assets/images/handpointing.png" );
-  }
-);
+const getBackgroundColor = () =>
+  options.sketch.backgroundColor ?? [
+    246,
+    235,
+    225
+  ];
 
 sketch.setup( async() => {
   const p = getP5();
 
-  p.background( ...( options.sketch.backgroundColor ?? [
-    246,
-    235,
-    225
-  ] ) );
+  p.background( ...getBackgroundColor() );
 
-  await mediapipeInit( {
-    enableCapture: false,
-    worker: false,
-    tasks: [
-      "hands"
-    ]
-  } );
+  // One call boots every enabled interaction source (mouse, touch, vision,
+  // orbit, audio, gyroscope…) declared in the shared `interaction` options.
+  await initInteraction( options.sketch?.interaction ?? {} );
 
   for ( const layerName in layers ) {
     const {
@@ -101,17 +69,10 @@ sketch.setup( async() => {
 
 sketch.draw( () => {
   const p = getP5();
+  const interaction = options.sketch?.interaction ?? {};
 
   p.clear();
-  p.background( ...( options.sketch.backgroundColor ?? [
-    246,
-    235,
-    225
-  ] ) );
-
-  const useHands = options.sketch.interactive.useHands ?? false;
-
-  setMediapipeEnabled( useHands );
+  p.background( ...getBackgroundColor() );
 
   sketchState.letters = cache.store(
     cache.key(
@@ -125,102 +86,9 @@ sketch.draw( () => {
       )
   );
 
-  drawHands(
-    mediapipe.tasks?.hands?.result,
-    layers.hands.graphics
-  );
-
-  const targetVectors = [];
-
-  if ( options.sketch.interactive.useMouse ) {
-    targetVectors.push( p.createVector(
-      p.mouseX,
-      p.mouseY
-    ) );
-  }
-
-  if ( useHands ) {
-    mediapipe.tasks?.hands?.result?.landmarks?.forEach( ( hand ) => {
-      const interactionPoints = interactionIndices
-        .map( ( i ) => hand[ i ] )
-        .filter( Boolean );
-
-      interactionPoints.forEach( ( point ) => {
-        if ( point ) {
-          const x = common.inverseX( point.x ) * p.width;
-          const y = point.y * p.height;
-
-          targetVectors.push( p.createVector(
-            x,
-            y
-          ) );
-        }
-      } );
-    } );
-  }
-
-  const margin = options.sketch.interactive.pointersMargin ?? 150;
-  const pointersCount = options.sketch.interactive.pointersCount ?? 5;
-  const W = p.width - margin;
-  const H = p.height - margin;
-
-  for ( let pointerIndex = 0; pointerIndex < pointersCount; pointerIndex++ ) {
-    const handProgression = pointerIndex / pointersCount;
-
-    const pointerPosition = p.createVector(
-      p.map(
-        Math.sin( animation.angle *
-            options.sketch.interactive.pointersSinAngleMultiplier +
-            handProgression *
-              options.sketch.interactive.pointersSinProgressionMultiplier ),
-        -1,
-        1,
-        margin,
-        W
-      ),
-      p.map(
-        Math.cos( animation.angle *
-            options.sketch.interactive.pointersCosAngleMultiplier +
-            handProgression *
-              options.sketch.interactive.pointersCosProgressionMultiplier ),
-        -1,
-        1,
-        margin,
-        H
-      )
-    );
-
-    targetVectors.push( pointerPosition );
-  }
-
-  if ( options.sketch.interactive.pointersLinesShow ) {
-    layers.pointers.graphics?.stroke( ...( options.sketch.interactive.pointersLinesStroke ?? [
-      0
-    ] ) );
-
-    layers.pointers.graphics?.strokeWeight( options.sketch.interactive.pointersLinesStrokeWeight );
-
-    targetVectors.forEach( ( vector ) => {
-      shapes.vl(
-        vector.x,
-        layers.pointers.graphics
-      );
-      shapes.hl(
-        vector.y,
-        layers.pointers.graphics
-      );
-
-      if (
-        layers.pointers.graphics && options.sketch.interactive.pointersImageShow
-      ) {
-        layers.pointers.graphics.image(
-          sketchState.handPointingImage,
-          vector.x,
-          vector.y
-        );
-      }
-    } );
-  }
+  // Every enabled source — pointer, hands, orbit, … — merged into one flat list
+  // of influence points, replacing the old hand-rolled mouse/hands/pointer loop.
+  const targetVectors = getPointers( interaction );
 
   if ( layers.visuals.graphics ) {
     drawLetterBodies(
@@ -256,6 +124,11 @@ sketch.draw( () => {
       layer.graphics.clear();
     }
   }
+
+  // Shared debug/demo overlay: crosshair lines, pointer markers, finger chains,
+  // camera preview and legend — all gated by the `interaction.visualization`
+  // options, so it's safe to call unconditionally.
+  drawInteractionOverlay( interaction );
 } );
 
 function addLetterBoxes(
@@ -289,6 +162,8 @@ function drawLetterBodies(
   graphics, bodies, targetVectors
 ) {
   const p = getP5();
+  const response = options.sketch.response ?? {};
+  const easingFn = easing?.[ response.easing ] ?? easing.easeOutSine;
   const sizeValues = [
     options.sketch.minLetterSize,
     options.sketch.maxLetterSize
@@ -305,7 +180,7 @@ function drawLetterBodies(
         y
       ),
       targetVectors,
-      options.sketch.interactive.maxInfluenceDistance ?? 250
+      response.maxInfluenceDistance ?? 250
     );
 
     graphics?.push();
@@ -314,15 +189,14 @@ function drawLetterBodies(
       y
     );
 
-    if ( options.sketch.interactive.varyAngle ) {
+    if ( response.varyAngle ) {
       const angle = animation.ease( {
         values: [
           0,
           p.PI
         ],
         currentTime: switchIndex,
-        easingFn:
-          easing?.[ options.sketch.interactive.easing ] ?? easing.easeOutSine
+        easingFn
       } );
 
       graphics.rotate( angle );
@@ -337,12 +211,11 @@ function drawLetterBodies(
     graphics.strokeWeight( options.sketch.strokeWeight );
     graphics.textFont( string.fonts?.[ options.sketch.font ] ?? string.fonts.waverseVariable );
 
-    if ( options.sketch.interactive.varySize ) {
+    if ( response.varySize ) {
       const size = animation.ease( {
         values: sizeValues,
         currentTime: switchIndex,
-        easingFn:
-          easing?.[ options.sketch.interactive.easing ] ?? easing.easeOutSine
+        easingFn
       } );
 
       graphics.textSize( size );

--- a/src/templates/p5/sketches/kinetic/kinetic-letters/options.ts
+++ b/src/templates/p5/sketches/kinetic/kinetic-letters/options.ts
@@ -1,6 +1,27 @@
 import {
   fontNames
 } from "@/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/constants/field-config";
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+// Shared interaction defaults, tuned for kinetic-letters: one orbiting virtual
+// pointer drives the letters out of the box (matching the sketch's original
+// behaviour), with a thin black crosshair through each pointer. Mouse and
+// vision stay opt-in; the user can flip on any source from the form.
+const interactionDefaults = {
+  ...interactionFormValues,
+  visualization: {
+    ...interactionFormValues.visualization,
+    showPointers: false,
+    showLegend: false,
+    linesStroke: [
+      0
+    ],
+    linesStrokeWeight: 2
+  }
+};
 
 export const formValues = {
   text: "abcdefghijklmnopqrstuvwxyz0123456789",
@@ -17,26 +38,14 @@ export const formValues = {
   minLetterSize: 24,
   maxLetterSize: 512,
   letterPositionMargin: 100,
-  interactive: {
+  // How each letter reacts to the nearest interaction pointer.
+  response: {
     varySize: true,
     varyAngle: true,
     maxInfluenceDistance: 250,
-    easing: "easeOutSine",
-    useMouse: false,
-    useHands: false,
-    pointersCount: 1,
-    pointersMargin: 150,
-    pointersSinAngleMultiplier: 2,
-    pointersCosAngleMultiplier: 1,
-    pointersSinProgressionMultiplier: 1,
-    pointersCosProgressionMultiplier: 4,
-    pointersImageShow: true,
-    pointersLinesShow: true,
-    pointersLinesStroke: [
-      0
-    ],
-    pointersLinesStrokeWeight: 2
+    easing: "easeOutSine"
   },
+  interaction: interactionDefaults,
   // title: titleDefaultValues,
   backgroundColor: [
     246,
@@ -95,9 +104,9 @@ export const formConfiguration: Record<string, any> = {
     max: 500,
     step: 1
   },
-  interactive: {
+  response: {
     component: "nested-object",
-    label: "Interactive",
+    label: "Letter response",
     fields: {
       varySize: {
         component: "checkbox",
@@ -117,78 +126,10 @@ export const formConfiguration: Record<string, any> = {
       easing: {
         component: "easing",
         label: "Easing function"
-      },
-      useMouse: {
-        component: "checkbox",
-        label: "Use mouse"
-      },
-      useHands: {
-        component: "checkbox",
-        label: "Use hands"
-      },
-      pointersCount: {
-        component: "slider",
-        label: "Pointers count",
-        min: 0,
-        max: 24,
-        step: 1
-      },
-      pointersMargin: {
-        component: "slider",
-        label: "Pointers margin",
-        min: 0,
-        max: 500,
-        step: 1
-      },
-      pointersSinAngleMultiplier: {
-        component: "slider",
-        label: "Sin angle multiplier",
-        min: 0.1,
-        max: 10,
-        step: 0.1
-      },
-      pointersCosAngleMultiplier: {
-        component: "slider",
-        label: "Cos angle multiplier",
-        min: 0.1,
-        max: 10,
-        step: 0.1
-      },
-      pointersSinProgressionMultiplier: {
-        component: "slider",
-        label: "Sin progression multiplier",
-        min: 0.1,
-        max: 10,
-        step: 0.1
-      },
-      pointersCosProgressionMultiplier: {
-        component: "slider",
-        label: "Cos progression multiplier",
-        min: 0.1,
-        max: 10,
-        step: 0.1
-      },
-      pointersImageShow: {
-        component: "checkbox",
-        label: "Show pointer images"
-      },
-      pointersLinesShow: {
-        component: "checkbox",
-        label: "Show pointer lines"
-      },
-      pointersLinesStroke: {
-        component: "color",
-        label: "Pointer lines stroke"
-      },
-      pointersLinesStrokeWeight: {
-        component: "slider",
-        label: "Pointer lines stroke weight",
-        min: 0.5,
-        max: 10,
-        step: 0.5
       }
     }
   },
+  interaction: interactionFormConfiguration,
   // title: titleFormConfiguration,
   backgroundColor: {
     component: "color",

--- a/src/templates/p5/sketches/kinetic/kinetic-plane/index.js
+++ b/src/templates/p5/sketches/kinetic/kinetic-plane/index.js
@@ -1,35 +1,24 @@
 import cache from "@/p5/utils/cache.js";
 import easing from "@/p5/utils/easing.js";
 import options from "@/p5/utils/options.js";
-import sketch from "@/p5/utils/sketch.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
 import graphics from "@/p5/utils/graphics.js";
 import * as common from "@/p5/utils/common.js";
 import animation from "@/p5/utils/animation.js";
 import renderTitle from "@/p5/utils/title/renderTitle.js";
 
-import addScreenPositionFunction from "@/utils/addScreenPositionFunction.js";
-
-import mediapipe, {
-  init as mediapipeInit,
-  setEnabled as setMediapipeEnabled
-} from "@/p5/utils/mediapipe/mediapipe.js";
+import mediapipe from "@/p5/utils/mediapipe/mediapipe.js";
 import {
-  getP5
-} from "@/p5/utils/sketch.js";
-
-// Key landmarks for interaction (fingertips)
-const interactionIndices = [
-  4,
-  8,
-  12,
-  16,
-  20
-];
+  initInteraction,
+  getPointers
+} from "@/p5/utils/interaction/index.js";
+import {
+  drawInteractionOverlay
+} from "@/p5/utils/interaction/overlay.js";
 
 const sketchState = {
-  interactive: {
-    image: null
-  },
   plane: {
     graphics: null,
     gridData: null
@@ -39,9 +28,7 @@ const sketchState = {
   }
 };
 
-sketch.setup( async( {
-  canvas
-} ) => {
+sketch.setup( async() => {
   const p = getP5();
 
   p.background( ...getBackgroundColor() );
@@ -54,20 +41,14 @@ sketch.setup( async( {
   );
   sketchState.plane.graphics.pixelDensity( 1 );
 
-  await addScreenPositionFunction( sketchState.plane.graphics );
-
   sketchState.webcam.graphics = p.createGraphics(
     p.width,
     p.height
   );
 
-  await mediapipeInit( {
-    enableCapture: false,
-    worker: false,
-    tasks: [
-      "hands"
-    ]
-  } );
+  // One call boots every enabled interaction source (mouse, vision, orbit…)
+  // declared in the shared `interaction` options.
+  await initInteraction( options.sketch?.interaction ?? {} );
 } );
 
 const getBackgroundColor = () =>
@@ -76,6 +57,20 @@ const getBackgroundColor = () =>
     235,
     225
   ];
+
+// Interaction pointers arrive in top-left canvas space; the plane lives in
+// centered WEBGL model space, so shift each pointer by half the canvas. This
+// replaces the old per-source screenPosition round-trip (≈ identity at the base
+// camera) with a deterministic, camera-independent conversion.
+const toModelSpace = ( pointers ) => {
+  const p = getP5();
+
+  return pointers.map( ( v ) =>
+    p.createVector(
+      v.x - p.width / 2,
+      v.y - p.height / 2
+    ) );
+};
 
 // Creates a grid of triangle vertices
 // Returns an immutable data structure containing all vertex information
@@ -187,18 +182,6 @@ function displayTriangleGrid(
     sketchState.plane.graphics.beginShape( p.TRIANGLES );
 
     triangle.forEach( ( _vertex ) => {
-      const wave = 0;
-
-      //   p.map(
-      //   Math.sin( animation.angle +
-      //     ( _vertex.x / p.width ) * 3 +
-      //     ( _vertex.y / p.height ) * 2 ),
-      //   -1,
-      //   1,
-      //   0,
-      //   900
-      // );
-
       // mouse displacement
       const switchIndex = computeDisplacement(
         p.createVector(
@@ -240,16 +223,11 @@ function displayTriangleGrid(
       sketchState.plane.graphics.vertex( ...vertices );
     } );
 
-    // p.strokeWeight(3)
-    // p.stroke("red")
-    // p.noFill();
-
     if ( options.sketch.grid.stroke.hide ) {
       sketchState.plane.graphics.noStroke();
     } else {
       sketchState.plane.graphics.stroke( ...options.sketch.grid.stroke.color );
     }
-    // sketchState.plane.graphics.noFill();
     sketchState.plane.graphics.endShape();
   } );
 
@@ -290,6 +268,7 @@ function computeDisplacement(
 
 sketch.draw( () => {
   const p = getP5();
+  const interaction = options.sketch?.interaction ?? {};
 
   p.clear();
   p.background( ...getBackgroundColor() );
@@ -310,59 +289,13 @@ sketch.draw( () => {
       )
   );
 
-  // Dynamically enable/disable mediapipe based on useHands option
-  const useHands = options.sketch.animation.useHands ?? true;
-
-  setMediapipeEnabled( useHands );
-
   const _image = options.sketch.texture.useWebcam
     ? mediapipe.capture.element
     : common.getAsset( options.sketch?.texture.image )?.img;
 
-  const targetVectors = [];
-
-  if ( options.sketch.animation.useMouse ?? true ) {
-    sketchState.plane.graphics.screenPosition( p.createVector(
-      p.mouseX - p.width / 2,
-      p.mouseY - p.height / 2
-    ) );
-  }
-
-  if ( options.sketch.animation.useHands ?? true ) {
-    mediapipe.tasks?.hands?.result?.landmarks?.forEach( ( hand ) => {
-      const interactionPoints = interactionIndices
-        .map( ( i ) => hand[ i ] )
-        .filter( Boolean );
-
-      interactionPoints.forEach( ( point ) => {
-        if ( point ) {
-          const x = common.inverseX( point.x ) * p.width;
-          const y = point.y * p.height;
-          const z = ( point.z * ( p.width + p.height ) ) / 2;
-
-          targetVectors.push( sketchState.plane.graphics.screenPosition( p.createVector(
-            x - p.width / 2,
-            y - p.height / 2,
-            z - p.width / 2 + p.height / 2
-          ) ) );
-        }
-      } );
-    } );
-  }
-
-  const margin = 150;
-  const W = p.width / 2 - margin;
-  const H = p.height / 2 - margin;
-  const targetsCount = options.sketch.animation.spheresCount ?? 3;
-
-  for ( let i = 0; i < targetsCount; i++ ) {
-    const targetProgression = i / targetsCount;
-
-    targetVectors.push( sketchState.plane.graphics.screenPosition( p.createVector(
-      Math.sin( animation.angle + i * 3 ) * W,
-      Math.cos( animation.angle + i * targetProgression ) * H
-    ) ) );
-  }
+  // Every enabled source — mouse, hands, orbit, … — merged into one flat list
+  // and mapped into the plane's centered coordinate space.
+  const targetVectors = toModelSpace( getPointers( interaction ) );
 
   displayTriangleGrid(
     sketchState.plane.gridData,
@@ -378,7 +311,6 @@ sketch.draw( () => {
         vector.y,
         50
       );
-      // sketchState.plane.graphics.normalMaterial( );
       sketchState.plane.graphics.sphere( options.sketch.animation.sphereSize ?? 30 );
       sketchState.plane.graphics.pop();
     } );
@@ -408,9 +340,6 @@ sketch.draw( () => {
       mediapipe.capture.size.width * 2,
       mediapipe.capture.size.height * 2
     );
-    // sketchState.webcam.graphics.filter( POSTERIZE );
-    // sketchState.webcam.graphics.filter( INVERT );
-    // sketchState.webcam.graphics.filter( GRAY );
     p.image(
       sketchState.webcam.graphics,
       0,
@@ -421,4 +350,9 @@ sketch.draw( () => {
   }
 
   renderTitle( options.sketch?.title );
+
+  // Shared debug/demo overlay (crosshairs, markers, camera preview, legend),
+  // gated by `interaction.visualization` — off by default so the 3D scene
+  // stays clean, but available from the form.
+  drawInteractionOverlay( interaction );
 } );

--- a/src/templates/p5/sketches/kinetic/kinetic-plane/options.ts
+++ b/src/templates/p5/sketches/kinetic/kinetic-plane/options.ts
@@ -1,5 +1,27 @@
 import titleDefaultValues from "@/p5/utils/title/titleDefaultValues";
 import titleFormConfiguration from "@/p5/utils/title/titleFormConfiguration";
+import {
+  interactionFormValues,
+  interactionFormConfiguration
+} from "@/p5/utils/interaction/defaults.js";
+
+// Shared interaction defaults tuned for this sketch: six orbiting virtual
+// pointers deform the plane out of the box (matching the sketch's original
+// `spheresCount`). Mouse and vision stay opt-in, and the on-canvas overlay is
+// muted since the sketch renders its own 3D spheres for each pointer.
+const interactionDefaults = {
+  ...interactionFormValues,
+  orbit: {
+    ...interactionFormValues.orbit,
+    enabled: true,
+    count: 6
+  },
+  visualization: {
+    ...interactionFormValues.visualization,
+    enabled: false
+  }
+};
+
 export const formValues = {
   texture: {
     image: null,
@@ -15,17 +37,17 @@ export const formValues = {
       hide: false
     }
   },
+  // How the plane reacts to interaction pointers, plus the 3D sphere markers
+  // rendered at each pointer and the optional webcam backdrop.
   animation: {
-    useMouse: false,
-    useHands: false,
     showWebcam: false,
     showSpheres: false,
-    spheresCount: 6,
     sphereSize: 30,
     depth: 100,
     maxInfluenceDistance: 150,
     easing: "easeOutBack"
   },
+  interaction: interactionDefaults,
   title: titleDefaultValues,
   backgroundColor: [
     246,
@@ -86,14 +108,6 @@ export const formConfiguration: Record<string, any> = {
     component: "nested-object",
     label: "Animation",
     fields: {
-      useMouse: {
-        label: "Use mouse",
-        component: "checkbox"
-      },
-      useHands: {
-        label: "Use hands",
-        component: "checkbox"
-      },
       showWebcam: {
         label: "Show webcam",
         component: "checkbox"
@@ -101,12 +115,6 @@ export const formConfiguration: Record<string, any> = {
       showSpheres: {
         label: "Show spheres",
         component: "checkbox"
-      },
-      spheresCount: {
-        label: "Spheres count",
-        component: "slider",
-        min: 0,
-        max: 24
       },
       sphereSize: {
         label: "Sphere size",
@@ -133,6 +141,7 @@ export const formConfiguration: Record<string, any> = {
       }
     }
   },
+  interaction: interactionFormConfiguration,
   title: titleFormConfiguration,
   backgroundColor: {
     component: "color",


### PR DESCRIPTION
## What & why

The `kinetic` sketches each carried their own hand-rolled interactive handlers — bespoke mouse/hands/orbit-pointer collection loops, direct MediaPipe wiring, and manual overlay drawing. This migrates **all three** onto the reusable, shared `@/p5/utils/interaction` system that metaballs / voronoi / interaction-test already use, so each sketch gains every input source (mouse, touch, vision, orbit, perlin, gyroscope, MIDI, audio, joypad) and the common debug overlay for free — and becomes far more flexible and configurable from the form.

Net: **~530 lines removed** across the three sketches, default look preserved.

## Sketches

### `kinetic-letters` (2D)
- `setup()` → `initInteraction(...)`; `draw()` → `getPointers(interaction)` replaces the hand-written mouse + MediaPipe-landmark + orbit-pointer loop.
- On-canvas visualization delegated to `drawInteractionOverlay(interaction)`.
- Removed the `hands`/`pointers` graphics layers and the `handpointing.png` preload; only the letter buffer remains. Letter-reaction knobs (`varySize`, `varyAngle`, `maxInfluenceDistance`, `easing`) moved to a `response` group.

### `kinetic-grid-spheres` & `kinetic-plane` (WEBGL)
- Same migration. Influence points come from `getPointers()`, mapped into each sketch's **centered WEBGL model space** with a plain `(canvas − center)` shift.
- This drops the per-source `screenPosition` round-trip (which was ≈ identity at the base camera and had already flattened `z` to 0) and `addScreenPositionFunction` entirely — the conversion is now camera-independent and robust.
- `drawInteractionOverlay(interaction)` wired in, gated by `interaction.visualization` (off by default so the 3D scene stays clean; on-demand from the form).
- `grid-spheres`: the ad-hoc full-canvas webcam blit (which drew over the art whenever hands were on) is replaced by the overlay's opt-in corner camera preview.
- `plane`: keeps its webcam-texture and `showWebcam` features (still reading `mediapipe.capture.element`, now driven by the interaction system's vision source).

## Options mapping

Every sketch now composes the shared `interactionFormValues` / `interactionFormConfiguration` from `@/p5/utils/interaction/defaults.js`:

| Old (per-sketch) | New (shared `interaction`) |
| --- | --- |
| `useMouse` | `mouse.enabled` |
| `useHands` | `vision.enabled` + `vision.hands.enabled` |
| `pointersCount` / `spheresCount` | `orbit.count` |
| `pointers*` motion multipliers | `orbit.*` (defaults already matched the sketches) |
| `pointersLines*` / `pointersImage*` | `visualization.*` |

Sketch-specific render/response knobs (`showSpheres`, `sphereSize`, `depth`, `maxInfluenceDistance`, `easing`, letter `response.*`) stay local.

## Behaviour parity

- Default output is preserved: letters/grid/plane are driven by the same orbiting pointers as before (the shared `_collectOrbit` reproduces the old pointer math, and `_normToCanvas` reproduces the old `inverseX` hand mapping).
- Mouse and camera/hands remain opt-in (grid-spheres keeps hands on by default), now alongside the full set of additional sources.

## Notes / minor behaviour changes

- The shared overlay does not implement the old kinetic-letters hand-pointing PNG (`showImages` is a no-op in `overlay.js`); it renders crosshairs + markers instead. If wanted, that belongs in the shared `overlay.js` so every sketch benefits.
- `grid-spheres` no longer blits the full webcam over the artwork; use the overlay's corner preview instead.
- `plane`'s webcam texture / `showWebcam` now require an enabled vision source (the camera starts lazily), rather than the camera always being on.

## Testing

- `npx eslint` on all changed files — clean.
- `npx tsc --noEmit` — no new type errors in the changed files (pre-existing unrelated errors only).
- `jest` interaction suites + sketch-metadata regression suite (1051 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvG1DZt9TEa5ndTfhatRkb