### PR TITLE
feat(capture): dev-only async-loop "Record preview" flavour

### DIFF
--- a/src/app/api/dev/previews/save-from-blob/route.ts
+++ b/src/app/api/dev/previews/save-from-blob/route.ts
@@ -14,10 +14,11 @@ import {
 } from "@/lib/previewConfig";
 
 /**
- * Dev-only. Accepts a realtime "Record preview" capture (a WebM/MP4 blob),
- * re-encodes it into the sketch's committed preview variants on disk and
- * flags `hasPreview` in metadata. Nothing is returned to the browser — the
- * author reviews the written files and decides whether to commit them.
+ * Dev-only. Accepts a "Record preview" capture (a WebM/MP4 blob) from either
+ * the realtime or the async-loop flavour, re-encodes it into the sketch's
+ * committed preview variants on disk and flags `hasPreview` in metadata.
+ * Nothing is returned to the browser — the author reviews the written files
+ * and decides whether to commit them.
  */
 export async function POST( request: Request ) {
   if ( process.env.NODE_ENV === "production" ) {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -66,11 +66,16 @@ const MODE_ORDER: ReadonlyArray<RecordingMode> = [
   "realtime"
 ];
 
-// Dev-only group: a realtime webm capture that, instead of downloading,
-// is saved back over the sketch's committed preview after a 3-2-1 lead-in.
-// Lets interactive sketches (webcam / mic / hand tracking) get a real
-// preview the headless generator can't produce.
+// Dev-only groups: a webm capture that, instead of downloading, is saved
+// back over the sketch's committed preview.
+//   • realtime — after a 3-2-1 lead-in, a wall-clock capture. Lets
+//     interactive sketches (webcam / mic / hand tracking) get a real preview
+//     the headless generator can't produce.
+//   • async   — a deterministic frame-by-frame capture of the sketch's loop.
+//     No lead-in, no frame drops — the front-end stand-in for the headless
+//     generator, for when it isn't available.
 const PREVIEW_GROUP_LABEL = "Record preview (dev)";
+const PREVIEW_ASYNC_GROUP_LABEL = "Record preview (dev, async)";
 const IS_DEV = process.env.NODE_ENV === "development";
 
 // One <option> per group entry. The composite value carries everything
@@ -150,12 +155,27 @@ export default function BrowserRecordingButton( {
             "webm"
           ]
         } );
+
+        // The async flavour needs the engine to render arbitrary frames
+        // reproducibly — otherwise the deterministic loop can't be captured.
+        if ( capabilities.supportsDeterministicCapture ) {
+          modeGroups.push( {
+            key: "preview-async",
+            label: PREVIEW_ASYNC_GROUP_LABEL,
+            mode: "async-loop",
+            intent: "preview",
+            formats: [
+              "webm"
+            ]
+          } );
+        }
       }
 
       return modeGroups;
     },
     [
-      capabilities.supportedFormats
+      capabilities.supportedFormats,
+      capabilities.supportsDeterministicCapture
     ]
   );
 
@@ -190,6 +210,8 @@ export default function BrowserRecordingButton( {
     return (
       <PreviewRecordingControls
         phase={ previewPhase }
+        mode={ choice.mode }
+        progress={ progress }
         countdown={ countdown }
         onStop={ onStop }
         onCancel={ onCancel }
@@ -308,18 +330,26 @@ function RealtimeRecordingControls( {
 }
 
 /**
- * Dev "Record preview" lifecycle. A lead-in countdown gives the author
- * time to get an interaction (webcam / mic / hand tracking) ready; the
- * capture then runs for a fixed length and auto-stops; finally the clip is
- * re-encoded server-side into the committed preview variants.
+ * Dev "Record preview" lifecycle, for both flavours. The clip is always
+ * re-encoded server-side into the committed preview variants once captured.
+ *
+ *   • realtime   – a lead-in countdown gives the author time to get an
+ *     interaction (webcam / mic / hand tracking) ready; the capture then runs
+ *     for a fixed length and auto-stops (the author may stop it early).
+ *   • async-loop – no countdown; a deterministic frame-by-frame pass of the
+ *     sketch's loop, surfaced as a progress bar with a cancel affordance.
  */
 function PreviewRecordingControls( {
   phase,
+  mode,
+  progress,
   countdown,
   onStop,
   onCancel
 }: {
   phase: PreviewPhase;
+  mode: RecordingMode;
+  progress: RecorderProgress | null;
   countdown: number;
   onStop: () => void;
   onCancel: () => void;
@@ -359,6 +389,19 @@ function PreviewRecordingControls( {
     );
   }
 
+  // Async-loop previews step through a known frame count — surface it as a
+  // progress bar + cancel (a mid-loop stop would commit a partial preview).
+  if ( mode === "async-loop" ) {
+    return (
+      <PreviewAsyncRecordingControls
+        progress={ progress }
+        onCancel={ onCancel }
+      />
+    );
+  }
+
+  // Realtime previews have no known length: the author stops the capture
+  // once the interaction they're demoing has played out.
   return (
     <div className="flex flex-col gap-1">
       <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
@@ -375,6 +418,79 @@ function PreviewRecordingControls( {
           className="block h-2.5 w-2.5 rounded-full bg-red-500 ring-1 ring-red-500/40 animate-pulse-soft"
         />
         <span className="truncate">Stop preview</span>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The `recording` phase of an async-loop dev preview. Mirrors the regular
+ * async-loop download button — a fill bar tracking the frame progress that
+ * parks at 100% during encode/finalise — but its stop control cancels the
+ * run and its wording reflects that this capture becomes the preview.
+ */
+function PreviewAsyncRecordingControls( {
+  progress,
+  onCancel
+}: {
+  progress: RecorderProgress | null;
+  onCancel: () => void;
+} ) {
+  const progressLabel = useMemo(
+    () => {
+      if ( !progress ) {
+        return "Recording preview…";
+      }
+
+      if ( progress.stage === "encoding" ) {
+        return "Encoding…";
+      }
+
+      if ( progress.stage === "finalizing" ) {
+        return "Finalising…";
+      }
+
+      const pct = progress.percentage.toFixed( 0 );
+
+      return `${ pct }% (${ progress.frame }/${ progress.totalFrames })`;
+    },
+    [
+      progress
+    ]
+  );
+
+  const targetFillPct = progress
+    ? progress.stage === "capturing"
+      ? progress.percentage
+      : 100
+    : 0;
+
+  const fillRef = useSmoothFill<HTMLSpanElement>(
+    true,
+    targetFillPct
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
+        {progressLabel}
+      </div>
+      <button
+        type="button"
+        onClick={ onCancel }
+        aria-label="Cancel preview recording"
+        className="relative overflow-hidden rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
+      >
+        <span
+          ref={ fillRef }
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 bg-red-500/20 pointer-events-none"
+          style={ {
+            width: "0%"
+          } }
+        />
+        <StopCircle className="relative h-4 w-4 flex-shrink-0" />
+        <span className="relative truncate">Cancel preview</span>
       </button>
     </div>
   );

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
@@ -26,16 +26,25 @@ import {
 /**
  * `download` – the default browser recording: capture, then hand the file
  *              to the user via a download.
- * `preview`  – dev-only. After a 3-2-1 countdown, capture a fixed-length
- *              realtime clip and POST it back to the dev server, which
- *              re-encodes it into the sketch's committed `preview.webm`
- *              variants instead of downloading anything. Lets interactive
- *              sketches (webcam / mic / hand tracking) get a real preview
- *              that the headless generator can't produce.
+ * `preview`  – dev-only. Capture a preview clip and POST it back to the dev
+ *              server, which re-encodes it into the sketch's committed
+ *              `preview.webm` variants instead of downloading anything. Two
+ *              flavours, chosen by the recording `mode`:
+ *                • realtime   – after a 3-2-1 countdown, a fixed-length
+ *                  wall-clock capture. Lets interactive sketches (webcam /
+ *                  mic / hand tracking) get a real preview the headless
+ *                  generator can't produce.
+ *                • async-loop – a deterministic frame-by-frame capture of the
+ *                  sketch's loop. No countdown (nothing to prepare) and no
+ *                  frame drops — the front-end equivalent of the headless
+ *                  generator, handy when it isn't available.
  */
 export type RecordingIntent = "download" | "preview";
 
-/** UI phase of a dev "Record preview" run. */
+/**
+ * UI phase of a dev "Record preview" run. `countdown` only applies to the
+ * realtime flavour; async-loop previews go straight to `recording`.
+ */
 export type PreviewPhase = "countdown" | "recording" | "saving";
 
 export type UseBrowserRecorderArgs = {
@@ -361,9 +370,14 @@ export function useBrowserRecorder( {
       }
 
       const isPreview = intent === "preview";
+      // Realtime previews lead in with a 3-2-1 countdown so the author can get
+      // an interaction (webcam / mic / hand tracking) ready. Async-loop
+      // previews are deterministic — nothing to prepare — so they skip the
+      // countdown and step straight into a frame-by-frame capture.
+      const isRealtimePreview = isPreview && mode === "realtime";
 
-      // Preview runs lock controls + count down *before* a recorder exists
-      // so the author can get an interaction ready and still cancel cleanly.
+      // Preview runs lock controls *before* a recorder exists so the author
+      // can (realtime) get an interaction ready and still cancel cleanly.
       // The download path keeps the original ordering (lock only once the
       // recorder is built) so a failed `createRecorder` can't leave the
       // controls stuck — there's nothing to clean up there yet.
@@ -379,17 +393,20 @@ export function useBrowserRecorder( {
           type: "SET_BROWSER_RECORDING",
           payload: true
         } );
-        setPreviewPhase( "countdown" );
 
-        try {
-          await runCountdown( PREVIEW_COUNTDOWN_SECS );
-        } catch {
-          // Cancelled during the countdown — `cancel()` already cleaned up.
-          return;
-        }
+        if ( isRealtimePreview ) {
+          setPreviewPhase( "countdown" );
 
-        if ( !previewActiveRef.current ) {
-          return;
+          try {
+            await runCountdown( PREVIEW_COUNTDOWN_SECS );
+          } catch {
+            // Cancelled during the countdown — `cancel()` already cleaned up.
+            return;
+          }
+
+          if ( !previewActiveRef.current ) {
+            return;
+          }
         }
       }
 
@@ -483,9 +500,11 @@ export function useBrowserRecorder( {
       } );
 
       try {
-        // Preview captures auto-stop after the canonical preview length so
-        // every committed loop is the same duration.
-        await recorder.start( isPreview
+        // Realtime previews auto-stop after the canonical preview length so
+        // every committed loop is the same duration. Async-loop previews run
+        // the sketch's deterministic loop to completion and rely on ffmpeg to
+        // trim to the canonical length when re-encoding.
+        await recorder.start( isRealtimePreview
           ? {
             maxDurationMs: PREVIEW_SECS * 1000
           }


### PR DESCRIPTION
## What

Adds a second dev-only **"Record preview"** option that captures the sketch preview from the front-end **asynchronously** (deterministic frame-by-frame), alongside the existing realtime one.

The realtime flavour records via `MediaRecorder` on a `captureStream()` after a 3-2-1 lead-in — ideal for interactive sketches (webcam / mic / hand tracking) where wall-clock capture is required. The new async flavour steps the sketch's loop frame-by-frame through the `AsyncLoopRecorder`: no lead-in (nothing to prepare) and no dropped frames, making it the front-end stand-in for the headless preview generator when that isn't available.

Both flavours POST the resulting clip to the existing `/api/dev/previews/save-from-blob` endpoint, which re-encodes it into the committed `preview.webm` / `preview-md.webm` variants and flags `hasPreview` — nothing is downloaded, and the author reviews the written files before committing.

## Changes

- **`BrowserRecordingButton.tsx`** — surface a `Record preview (dev, async)` group, gated on `capabilities.supportsDeterministicCapture` (the engine must render arbitrary frames reproducibly). Its `recording` phase renders as a frame-progress bar that parks at 100% during encode/finalise, with a **Cancel preview** affordance (a mid-loop stop would commit a partial loop).
- **`useBrowserRecorder.ts`** — scope the 3-2-1 countdown and the fixed `maxDurationMs` auto-stop to the realtime flavour only. Async-loop previews skip the countdown, run the deterministic loop to completion, and rely on ffmpeg (`-t PREVIEW_SECS`) to trim to the canonical length on re-encode. Both flavours still snapshot/restore engine playback and share the save → `previewSaved` path.
- **`save-from-blob/route.ts`** — no behavioural change; the endpoint already re-encodes any WebM/MP4 blob, so it serves both flavours. Doc comment updated.

Dev-only throughout: the async group only renders when `NODE_ENV === "development"`, and the endpoint 404s in production.

## Testing

- `npx tsc --noEmit` — no new errors in the changed files (pre-existing unrelated test-file errors remain).
- `npx eslint` on the three changed files — clean.
- `npx jest src/engines/recording` — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds77mvPLFaTQkMMRtz3FFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ds77mvPLFaTQkMMRtz3FFC)_