### PR TITLE
Add montage transition sound option

### DIFF
--- a/docs/SOUND_FEEDBACK.md
+++ b/docs/SOUND_FEEDBACK.md
@@ -84,6 +84,45 @@ also resets itself when the clock jumps backwards (capture restart).
 
 ---
 
+## Montage transition sound: `sound` option group
+
+New `sound` group on a slide's `transition` config
+(`SlideTransitionSchema.sound`), edited in the **Montage / transition** panel
+under **Transition sound**. Disabled by default; existing montage decks parse
+unchanged (the group is materialised on parse, its own `enabled` gates
+playback).
+
+A montage cycles its source variants deterministically off the loop
+progression, and the "arriving" variant flips at each segment midpoint — the
+same instant the dip fade peaks and the title label switches. This plays a hit
+right there, so the sound lands with the visual transition, "in between" the
+two slides.
+
+| Option             | Default  | What it does                                                                 |
+| ------------------ | -------- | ---------------------------------------------------------------------------- |
+| `enabled`          | `false`  | Master switch (independent of the montage master switch).                    |
+| `preset`           | `blip`   | Voice from the shared click synth.                                           |
+| `volume`           | `0.5`    | Hit gain (0–1).                                                              |
+| `pitch`            | `1`      | Global pitch multiplier (0.25–4).                                            |
+| `pitchVariation`   | `0`      | Random per-transition detune ("humanize", 1 ≈ ±half an octave).             |
+| `slidePitchSpread` | `0`      | Pitch offset by the arriving variant's index (octaves) — each slide its note.|
+| `repeat`           | `once`   | `once` = one hit; `count` = an N-hit burst with an optional `pitchStep` ramp.|
+
+### How it plays — and records
+
+Change detection is polled per drawn frame on the sketch clock
+(`time.seconds()`) by `createMontageSoundScheduler`
+(`src/templates/p5/utils/slides/morph/montageSound.js`), driven from
+`drawMontageSound.js` in `slides.updateMontageSound()` (post-draw). It watches
+the active-variant index and fires a hit through `audio.trigger("click", …)`
+whenever it advances — never on the montage slide's first frame (appearing is
+not a transition), and the scheduler resets its change baseline when the clock
+jumps backwards (capture restart). Because it routes through the sketch audio
+engine, the hits are baked into recordings (realtime and deterministic/server
+captures alike), exactly like the specs sound-on-change.
+
+---
+
 ## Editor UI sounds (`src/lib/uiSound.ts`)
 
 A separate, editor-only sound path: it owns its own `AudioContext` and is
@@ -125,3 +164,10 @@ in `localStorage` (`p5templates.uiSound.v1`):
   scheduler behaviour: staggering, per-line cooldown, burst cap, both repeat
   modes, line pitch spread, backwards-clock reset, and the
   `computeSpecsHeats` change callback.
+- `src/types/__tests__/slideTransition.test.ts` — `SlideTransitionSoundSchema`
+  defaults, count-mode burst defaults, enum/range validation, and the
+  pre-sound montage-deck heal.
+- `src/templates/p5/utils/slides/morph/__tests__/montageSound.test.ts` —
+  montage scheduler behaviour: fires only on variant advance (never on the
+  first frame), burst count + pitch ramp, per-variant pitch spread, and the
+  backwards-clock baseline reset.

--- a/docs/SOUND_FEEDBACK.md
+++ b/docs/SOUND_FEEDBACK.md
@@ -98,15 +98,15 @@ same instant the dip fade peaks and the title label switches. This plays a hit
 right there, so the sound lands with the visual transition, "in between" the
 two slides.
 
-| Option             | Default  | What it does                                                                 |
-| ------------------ | -------- | ---------------------------------------------------------------------------- |
-| `enabled`          | `false`  | Master switch (independent of the montage master switch).                    |
-| `preset`           | `blip`   | Voice from the shared click synth.                                           |
-| `volume`           | `0.5`    | Hit gain (0–1).                                                              |
-| `pitch`            | `1`      | Global pitch multiplier (0.25–4).                                            |
-| `pitchVariation`   | `0`      | Random per-transition detune ("humanize", 1 ≈ ±half an octave).             |
-| `slidePitchSpread` | `0`      | Pitch offset by the arriving variant's index (octaves) — each slide its note.|
-| `repeat`           | `once`   | `once` = one hit; `count` = an N-hit burst with an optional `pitchStep` ramp.|
+| Option             | Default   | What it does                                                                 |
+| ------------------ | --------- | ---------------------------------------------------------------------------- |
+| `enabled`          | `false`   | Master switch (independent of the montage master switch).                    |
+| `preset`           | `pop`     | Voice from the shared click synth.                                          |
+| `volume`           | `0.5`     | Hit gain (0–1).                                                             |
+| `pitch`            | `1`       | Base pitch multiplier (0.25–4); 1 = neutral.                               |
+| `pitchVariation`   | `0`       | Random per-transition detune ("humanize", 1 ≈ ±half an octave).            |
+| `slidePitchSpread` | `1.05`    | Pitch offset by the arriving variant's index (octaves) — each slide its note.|
+| `repeat`           | `count`   | `once` = one hit; `count` = an N-hit burst with an optional `pitchStep` ramp. Defaults to a 3-hit rising burst (`pitchStep` 0.35). |
 
 ### How it plays — and records
 

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SlideTransitionSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SlideTransitionSettings.tsx
@@ -14,6 +14,9 @@ import {
   SketchOptionInput,
   SlideTitleSchema,
   SlideTransitionSchema,
+  SlideTransitionSoundRepeatSchema,
+  SlideTransitionSoundSchema,
+  SPECS_SOUND_PRESETS,
   TITLE_ALIGNMENTS,
   TITLE_CHANGE_ANIMATIONS,
   TITLE_DISPLAY_STYLES,
@@ -81,6 +84,21 @@ const TITLE_ALIGN_LABELS: Record<( typeof TITLE_ALIGNMENTS )[ number ], string> 
   left: "Left",
   center: "Center",
   right: "Right"
+};
+
+const SOUND_PRESET_LABELS: Record<( typeof SPECS_SOUND_PRESETS )[ number ], string> = {
+  click: "Click",
+  tick: "Tick",
+  blip: "Blip",
+  pop: "Pop",
+  beep: "Beep",
+  wood: "Woodblock",
+  typewriter: "Typewriter"
+};
+
+const SOUND_REPEAT_LABELS: Record<"once" | "count", string> = {
+  once: "Once per change",
+  count: "Burst (N hits)"
 };
 
 /**
@@ -590,6 +608,198 @@ function SlideTitleControls( {
   );
 }
 
+/**
+ * "Transition sound" sub-panel of the montage controls: a hit played through
+ * the sketch audio engine each time the montage advances to the next variant
+ * (the audible counterpart of the dip / title switch). Because it routes
+ * through the audio engine, it is baked into recordings too. The repeat "count"
+ * mode reveals its burst controls, mirroring the mode-specific reveals above.
+ */
+function SlideTransitionSoundControls( {
+  base
+}: {
+  base: string;
+} ) {
+  // Untyped like SlideTitleControls: the sound field paths are built from a
+  // runtime string the strict SketchOptionInput field-path type can't narrow.
+  const {
+    control, setValue
+  } = useFormContext();
+  const soundBase = `${ base }.sound`;
+
+  const sound = useWatch( {
+    control,
+    name: soundBase
+  } ) as Record<string, unknown> | undefined;
+
+  const enabled = Boolean( sound?.enabled );
+  const repeat = sound?.repeat as Record<string, unknown> | undefined;
+  const repeatMode = ( repeat?.mode as string ) ?? "once";
+
+  const handleToggle = ( on: boolean ) => {
+    if ( on ) {
+      setValue(
+        soundBase,
+        SlideTransitionSoundSchema.parse( {
+          ...( sound ?? {} ),
+          enabled: true
+        } ),
+        {
+          shouldDirty: true
+        }
+      );
+    } else {
+      setValue(
+        `${ soundBase }.enabled`,
+        false,
+        {
+          shouldDirty: true
+        }
+      );
+    }
+  };
+
+  const handleRepeatMode = ( mode: string ) => {
+    // Reparse the whole repeat group so switching modes fills that mode's
+    // defaults (the discriminated union has different fields per mode).
+    setValue(
+      `${ soundBase }.repeat`,
+      SlideTransitionSoundRepeatSchema.parse( {
+        mode
+      } ),
+      {
+        shouldDirty: true
+      }
+    );
+  };
+
+  return (
+    <div className="mt-1 rounded-lg border border-theme bg-foreground/[0.03] p-1">
+      <label className="flex cursor-pointer items-center justify-between gap-2 px-1 py-1.5 md:py-1 select-none text-foreground">
+        <span className="truncate">Transition sound</span>
+        <span className="relative inline-flex shrink-0 items-center">
+          <input
+            type="checkbox"
+            checked={ enabled }
+            onChange={ ( e ) => handleToggle( e.target.checked ) }
+            className="peer sr-only"
+          />
+          <span className="h-6 w-10 md:h-5 md:w-9 rounded-full border border-theme bg-foreground/10 transition-colors peer-checked:bg-foreground peer-focus-visible:ring-2 peer-focus-visible:ring-focus/50" />
+          <span className="pointer-events-none absolute left-0.5 top-1/2 h-5 w-5 md:h-4 md:w-4 -translate-y-1/2 rounded-full border border-theme bg-background shadow transition-transform peer-checked:translate-x-4" />
+        </span>
+      </label>
+
+      {enabled && (
+        <div className="flex flex-col gap-1 pt-1">
+          <BarSelect
+            name={ `${ soundBase }.preset` }
+            label="Sound"
+            options={ SPECS_SOUND_PRESETS.map( ( value ) => ( {
+              value,
+              label: SOUND_PRESET_LABELS[ value ]
+            } ) ) }
+          />
+
+          <ResettableSlider
+            name={ `${ soundBase }.volume` }
+            label="Volume"
+            min={ 0 }
+            max={ 1 }
+            step={ 0.05 }
+          />
+
+          <ResettableSlider
+            name={ `${ soundBase }.pitch` }
+            label="Pitch (×)"
+            min={ 0.25 }
+            max={ 4 }
+            step={ 0.05 }
+          />
+
+          <ResettableSlider
+            name={ `${ soundBase }.pitchVariation` }
+            label="Humanize"
+            min={ 0 }
+            max={ 1 }
+            step={ 0.05 }
+          />
+
+          <ResettableSlider
+            name={ `${ soundBase }.slidePitchSpread` }
+            label="Pitch by slide (oct)"
+            min={ -2 }
+            max={ 2 }
+            step={ 0.05 }
+          />
+
+          {/* Reparses the whole repeat group on change so "count" fills its
+              own defaults (times / interval / pitchStep) — BarSelect would set
+              only the mode string and leave the burst sliders unbound. */}
+          <div className={ CONTROL_BAR_CLASS }>
+            <span className="flex shrink-0 items-center px-2.5 text-label">
+              Repeat
+            </span>
+            <span className="pointer-events-none flex min-w-0 flex-1 items-center justify-between gap-1 px-2.5">
+              <span className="truncate">{SOUND_REPEAT_LABELS[ repeatMode as "once" | "count" ] ?? repeatMode}</span>
+              <ChevronDown className={ CONTROL_CHEVRON_CLASS } />
+            </span>
+            <select
+              aria-label="Repeat"
+              className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+              value={ repeatMode }
+              onChange={ ( e ) => handleRepeatMode( e.target.value ) }
+            >
+              {(
+                [
+                  "once",
+                  "count"
+                ] as const
+              ).map( ( value ) => (
+                <option key={ value } value={ value }>
+                  {SOUND_REPEAT_LABELS[ value ]}
+                </option>
+              ) )}
+            </select>
+          </div>
+
+          {repeatMode === "count" && (
+            <Fragment>
+              <ResettableSlider
+                name={ `${ soundBase }.repeat.times` }
+                label="Hits"
+                min={ 2 }
+                max={ 16 }
+                step={ 1 }
+              />
+              <ResettableSlider
+                name={ `${ soundBase }.repeat.interval` }
+                label="Interval (s)"
+                min={ 0.02 }
+                max={ 2 }
+                step={ 0.01 }
+              />
+              <ResettableSlider
+                name={ `${ soundBase }.repeat.pitchStep` }
+                label="Pitch ramp (oct/hit)"
+                min={ -0.5 }
+                max={ 0.5 }
+                step={ 0.01 }
+              />
+            </Fragment>
+          )}
+
+          <p className="px-1 pt-0.5 text-[0.65rem] leading-snug text-label">
+            Plays a hit at each variant change — the audible counterpart of the
+            dip / title switch. Routes through the sketch audio engine, so it is
+            baked into recordings. &ldquo;Pitch by slide&rdquo; gives each
+            variant its own note.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 type Props = {
   activeIndex: number;
 };
@@ -740,6 +950,8 @@ export default function SlideTransitionSettings( {
           )}
 
           <SlideTitleControls base={ base } />
+
+          <SlideTransitionSoundControls base={ base } />
         </div>
       )}
     </div>

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -12,6 +12,7 @@ import {
 
 import getMontageSketch from "./morph/index.js";
 import drawMontageDip from "./morph/drawMontageDip.js";
+import drawMontageSound from "./morph/drawMontageSound.js";
 import drawMontageTitle from "./montageTitle/index.js";
 
 import {
@@ -53,6 +54,7 @@ const slides = {
         slides.render( options );
         slides.renderMontageOverlay();
         slides.renderMontageTitle();
+        slides.updateMontageSound();
       }
     );
 
@@ -239,6 +241,21 @@ const slides = {
 
     if ( slide?.transition?.enabled && slide.transition.style === "dip" ) {
       drawMontageDip(
+        slide,
+        options?.slides || []
+      );
+    }
+  },
+
+  // Play the montage transition sound: schedules a hit through the sketch
+  // audio engine each time the current montage slide advances to a new variant.
+  // Paints nothing — polled once per frame so it stays deterministic in
+  // captures, like the specs sound-on-change.
+  updateMontageSound() {
+    const slide = this.current;
+
+    if ( slide?.transition?.enabled && slide.transition.sound?.enabled ) {
+      drawMontageSound(
         slide,
         options?.slides || []
       );

--- a/src/templates/p5/utils/slides/morph/__tests__/montageSound.test.ts
+++ b/src/templates/p5/utils/slides/morph/__tests__/montageSound.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Behavioural tests for the montage transition sound scheduler: it fires a hit
+ * only when the arriving variant advances (never on first appearance), supports
+ * an N-hit burst, spreads pitch by variant index, and resets its change
+ * baseline when the sketch clock jumps backwards (capture restart / deck reset)
+ * so a rewind never mis-fires.
+ *
+ * The scheduler polls a caller-provided clock and takes an injected trigger,
+ * so no Web Audio (or audio engine import) is needed here.
+ */
+
+// The module under test imports the audio engine only for its default
+// instance; stub it so the sketch/p5 import chain never loads in node.
+jest.mock(
+  "../../../audio.js",
+  () => ( {
+    __esModule: true,
+    default: {
+      trigger: jest.fn()
+    }
+  } )
+);
+
+import {
+  createMontageSoundScheduler
+} from "../montageSound.js";
+
+const baseOption = {
+  enabled: true,
+  preset: "blip",
+  volume: 0.5,
+  pitch: 1,
+  pitchVariation: 0,
+  slidePitchSpread: 0,
+  repeat: {
+    mode: "once"
+  }
+};
+
+function makeScheduler() {
+  const fired: any[] = [];
+  const scheduler = createMontageSoundScheduler(
+    ( params: any ) => fired.push( params ),
+    () => 0.5 // deterministic "random"
+  );
+
+  return {
+    fired,
+    scheduler
+  };
+}
+
+describe(
+  "createMontageSoundScheduler",
+  () => {
+    it(
+      "does not fire on the first observed frame (appearing is not a transition)",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.update(
+          1,
+          baseOption,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+
+        expect( fired ).toHaveLength( 0 );
+      }
+    );
+
+    it(
+      "fires one hit when the active variant advances",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.update(
+          1,
+          baseOption,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.5,
+          baseOption,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+
+        expect( fired ).toHaveLength( 1 );
+        expect( fired[ 0 ] ).toMatchObject( {
+          preset: "blip",
+          gain: 0.5,
+          rate: 1
+        } );
+      }
+    );
+
+    it(
+      "does not re-fire while the active variant is unchanged",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.update(
+          1,
+          baseOption,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.1,
+          baseOption,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.2,
+          baseOption,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+
+        expect( fired ).toHaveLength( 1 );
+      }
+    );
+
+    it(
+      "plays a burst of `times` hits spaced by `interval` in count mode",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        const option = {
+          ...baseOption,
+          repeat: {
+            mode: "count",
+            times: 3,
+            interval: 0.06,
+            pitchStep: 0
+          }
+        };
+
+        scheduler.update(
+          1,
+          option,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        // Advance -> enqueue burst; only the first hit is due at t=1.5.
+        scheduler.update(
+          1.5,
+          option,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        scheduler.update(
+          1.56,
+          option,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 2 );
+
+        scheduler.update(
+          1.62,
+          option,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 3 );
+      }
+    );
+
+    it(
+      "ramps burst pitch by pitchStep octaves per hit",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        const option = {
+          ...baseOption,
+          repeat: {
+            mode: "count",
+            times: 2,
+            interval: 0.05,
+            pitchStep: 0.5
+          }
+        };
+
+        scheduler.update(
+          1,
+          option,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.5,
+          option,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.55,
+          option,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+
+        expect( fired ).toHaveLength( 2 );
+        // Second hit is a half-octave up: 2^0.5 ≈ 1.4142.
+        expect( fired[ 1 ].rate / fired[ 0 ].rate ).toBeCloseTo(
+          Math.SQRT2,
+          5
+        );
+      }
+    );
+
+    it(
+      "gives each arriving variant its own note via slidePitchSpread",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        const option = {
+          ...baseOption,
+          slidePitchSpread: 1 // one octave across the whole montage
+        };
+
+        scheduler.update(
+          1,
+          option,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        scheduler.update(
+          1.5,
+          option,
+          {
+            activeIndex: 2,
+            count: 3
+          }
+        );
+
+        // Arriving at the last of 3 variants -> full octave up: rate ≈ 2.
+        expect( fired ).toHaveLength( 1 );
+        expect( fired[ 0 ].rate ).toBeCloseTo(
+          2,
+          5
+        );
+      }
+    );
+
+    it(
+      "resets its change baseline when the clock jumps backwards",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+
+        scheduler.update(
+          5,
+          baseOption,
+          {
+            activeIndex: 0,
+            count: 3
+          }
+        );
+        scheduler.update(
+          5.5,
+          baseOption,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        // Capture restart: clock rewinds to 0. The first frame after the reset
+        // re-establishes the baseline and must NOT fire.
+        scheduler.update(
+          0,
+          baseOption,
+          {
+            activeIndex: 1,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        // Subsequent advances fire normally again.
+        scheduler.update(
+          0.5,
+          baseOption,
+          {
+            activeIndex: 2,
+            count: 3
+          }
+        );
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+  }
+);

--- a/src/templates/p5/utils/slides/morph/drawMontageSound.js
+++ b/src/templates/p5/utils/slides/morph/drawMontageSound.js
@@ -1,0 +1,63 @@
+import animation from "../../animation.js";
+import time from "../../time.js";
+import resolveMontageSources from "./resolveMontageSources.js";
+import {
+  mapProgressionToSegment
+} from "./segmentMapper.js";
+import montageSound from "./montageSound.js";
+
+/**
+ * Drive the montage transition sound for the current slide. Runs once per frame
+ * (post-draw) while a montage slide is active: it maps the loop progression to
+ * the current segment, derives which variant is "arrived" (the one shown after
+ * the segment midpoint — the same flip the dip and title ride), and hands it to
+ * the polled scheduler, which fires a hit whenever that variant advances.
+ *
+ * No-op unless the slide is a montage with `sound.enabled` and at least two
+ * resolved sources (fewer than two means nothing ever transitions).
+ *
+ * Named "draw*" to match its sibling overlays (drawMontageDip / drawMontage
+ * Title), though it paints nothing — it schedules audio.
+ */
+export default function drawMontageSound(
+  montageSlide, allSlides
+) {
+  const transition = montageSlide?.transition;
+  const sound = transition?.sound;
+
+  if ( !transition?.enabled || !sound?.enabled ) {
+    return;
+  }
+
+  const sources = resolveMontageSources(
+    montageSlide,
+    allSlides
+  );
+
+  if ( sources.length < 2 ) {
+    return;
+  }
+
+  const {
+    fromIndex,
+    toIndex,
+    localT
+  } = mapProgressionToSegment(
+    animation.progression,
+    sources.length,
+    transition
+  );
+
+  // The arriving variant flips at the segment midpoint — matching the dip's
+  // param snap and the title's label switch, so the hit lands with the visual.
+  const activeIndex = localT < 0.5 ? fromIndex : toIndex;
+
+  montageSound.update(
+    time.seconds(),
+    sound,
+    {
+      activeIndex,
+      count: sources.length
+    }
+  );
+}

--- a/src/templates/p5/utils/slides/morph/montageSound.js
+++ b/src/templates/p5/utils/slides/morph/montageSound.js
@@ -25,11 +25,11 @@ import audio from "../../audio.js";
  */
 
 const DEFAULTS = {
-  preset: "blip",
+  preset: "pop",
   volume: 0.5,
   pitch: 1,
   pitchVariation: 0,
-  slidePitchSpread: 0
+  slidePitchSpread: 1.05
 };
 
 export function createMontageSoundScheduler(

--- a/src/templates/p5/utils/slides/morph/montageSound.js
+++ b/src/templates/p5/utils/slides/morph/montageSound.js
@@ -1,0 +1,204 @@
+import audio from "../../audio.js";
+
+/**
+ * Turns montage variant changes into sound through the sketch audio engine.
+ * A montage cycles deterministically off the loop progression; the arriving
+ * variant flips at each segment midpoint (where the dip peaks and the title
+ * switches). This scheduler watches that "active variant" index and fires a
+ * hit — the audible counterpart of the visual switch — every time it advances.
+ *
+ * Because everything routes through `audio.trigger("click", …)`, a hit that
+ * plays live while editing is also logged during deterministic capture and
+ * baked into the exported video's soundtrack.
+ *
+ * Scheduling is polled, not timer-based: `drawMontageSound` calls
+ * `update(now, option, meta)` once per frame with the sketch clock
+ * (`time.seconds()`), so a due hit fires on a real frame — which is exactly
+ * what keeps it deterministic when the recorder steps frames faster or slower
+ * than the wall clock.
+ *
+ * Behaviour knobs come from the transition's `sound` options
+ * (SlideTransitionSoundSchema):
+ *   - `slidePitchSpread` gives each arriving variant its own note;
+ *   - `pitchVariation` humanises the pitch per transition;
+ *   - `repeat` turns one change into an N-hit burst with an optional pitch ramp.
+ */
+
+const DEFAULTS = {
+  preset: "blip",
+  volume: 0.5,
+  pitch: 1,
+  pitchVariation: 0,
+  slidePitchSpread: 0
+};
+
+export function createMontageSoundScheduler(
+  trigger = ( params ) => audio.trigger(
+    "click",
+    params
+  ),
+  random = Math.random
+) {
+  // Pending hits: { at, preset, gain, rate }.
+  let queue = [];
+  // Active variant index observed on the previous frame. null until the first
+  // frame is seen so the montage never "clicks" the instant it appears.
+  let lastActiveIndex = null;
+  // Backwards-clock detection (capture restart, deck reset, loop wrap handled
+  // separately since a wrap is a legitimate transition).
+  let lastNow = -Infinity;
+
+  const reset = () => {
+    queue = [];
+    lastActiveIndex = null;
+    lastNow = -Infinity;
+  };
+
+  // 2^x pitch algebra keeps every knob musical (octaves, not raw Hz).
+  const computeRate = (
+    option, activeIndex, count, repeatIndex, pitchStep
+  ) => {
+    const spread = option.slidePitchSpread ?? DEFAULTS.slidePitchSpread;
+    const variation = option.pitchVariation ?? DEFAULTS.pitchVariation;
+    const slideOffset =
+      count > 1 ? spread * ( activeIndex / ( count - 1 ) ) : 0;
+    const humanize = ( random() * 2 - 1 ) * variation * 0.5;
+    const ramp = pitchStep * repeatIndex;
+
+    return (
+      ( option.pitch ?? DEFAULTS.pitch ) *
+      Math.pow(
+        2,
+        slideOffset + humanize + ramp
+      )
+    );
+  };
+
+  const enqueueTransition = (
+    option, activeIndex, count, now
+  ) => {
+    const repeat = option.repeat ?? {
+      mode: "once"
+    };
+    // [offset seconds, repeat index] pairs for this transition's hit series.
+    let series = [
+      [
+        0,
+        0
+      ]
+    ];
+    let pitchStep = 0;
+
+    if ( repeat.mode === "count" ) {
+      const times = repeat.times ?? 3;
+      const interval = repeat.interval ?? 0.06;
+
+      pitchStep = repeat.pitchStep ?? 0;
+      series = Array.from(
+        {
+          length: times
+        },
+        (
+          _, i
+        ) => [
+          i * interval,
+          i
+        ]
+      );
+    }
+
+    for ( const [
+      offset,
+      repeatIndex
+    ] of series ) {
+      queue.push( {
+        at: now + offset,
+        preset: option.preset ?? DEFAULTS.preset,
+        gain: option.volume ?? DEFAULTS.volume,
+        rate: computeRate(
+          option,
+          activeIndex,
+          count,
+          repeatIndex,
+          pitchStep
+        )
+      } );
+    }
+  };
+
+  const fireDue = ( now ) => {
+    if ( !queue.length ) {
+      return;
+    }
+
+    // Hits that went stale while the montage wasn't drawn (hidden tab, fade
+    // window) are dropped, not fired: releasing them all in one frame would
+    // stack into a single loud transient.
+    const staleBefore = now - 0.25;
+    const due = queue.filter( ( hit ) => hit.at <= now && hit.at >= staleBefore );
+
+    queue = queue.filter( ( hit ) => hit.at > now );
+
+    for ( const hit of due ) {
+      trigger( {
+        preset: hit.preset,
+        gain: hit.gain,
+        rate: hit.rate
+      } );
+    }
+  };
+
+  return {
+    reset,
+
+    /**
+     * Poll one frame. `now` is the sketch clock in seconds; `activeIndex` is
+     * the variant currently arrived (segment flip), `count` the number of
+     * montage sources. Fires a transition hit whenever `activeIndex` advances.
+     */
+    update(
+      now, option, {
+        activeIndex, count
+      } = {}
+    ) {
+      // The sketch clock resets on capture start / deck reset. Any state keyed
+      // to the old timeline would mis-fire (or silence) every future hit; drop
+      // the change baseline so the restart doesn't read as a transition.
+      if ( now + 0.5 < lastNow ) {
+        reset();
+      }
+
+      lastNow = now;
+
+      if (
+        Number.isInteger( activeIndex ) &&
+        activeIndex !== lastActiveIndex
+      ) {
+        // Skip the very first observation: appearing on a montage slide is not
+        // itself a transition.
+        if ( lastActiveIndex !== null ) {
+          enqueueTransition(
+            option,
+            activeIndex,
+            count ?? 1,
+            now
+          );
+        }
+
+        lastActiveIndex = activeIndex;
+      }
+
+      fireDue( now );
+    },
+
+    /** Number of queued hits (test / debug seam). */
+    pending() {
+      return queue.length;
+    }
+  };
+}
+
+// Shared instance for the montage overlay renderer. Module scope is fine: only
+// the current slide is ever a montage at a time, so a single active-variant
+// tracker is correct.
+export default createMontageSoundScheduler();

--- a/src/types/__tests__/slideTransition.test.ts
+++ b/src/types/__tests__/slideTransition.test.ts
@@ -61,8 +61,8 @@ describe(
         expect( t.title.prefix ).toBe( "VARIANT" );
         // The transition sound is always materialised too, disabled by default.
         expect( t.sound.enabled ).toBe( false );
-        expect( t.sound.preset ).toBe( "blip" );
-        expect( t.sound.repeat.mode ).toBe( "once" );
+        expect( t.sound.preset ).toBe( "pop" );
+        expect( t.sound.repeat.mode ).toBe( "count" );
       }
     );
 
@@ -79,7 +79,10 @@ describe(
 
         expect( t.sound.enabled ).toBe( false );
         expect( t.sound.volume ).toBeGreaterThanOrEqual( 0 );
-        expect( t.sound.slidePitchSpread ).toBe( 0 );
+        expect( t.sound.slidePitchSpread ).toBeCloseTo(
+          1.05,
+          5
+        );
       }
     );
 
@@ -115,12 +118,26 @@ describe(
         const sound = SlideTransitionSoundSchema.parse( {} );
 
         expect( sound.enabled ).toBe( false );
-        expect( sound.preset ).toBe( "blip" );
+        expect( sound.preset ).toBe( "pop" );
         expect( sound.volume ).toBe( 0.5 );
+        // Base pitch is neutral (multiplier 1); transposition comes from the
+        // per-slide spread and the burst ramp instead.
         expect( sound.pitch ).toBe( 1 );
         expect( sound.pitchVariation ).toBe( 0 );
-        expect( sound.slidePitchSpread ).toBe( 0 );
-        expect( sound.repeat.mode ).toBe( "once" );
+        expect( sound.slidePitchSpread ).toBeCloseTo(
+          1.05,
+          5
+        );
+        // Defaults to a 3-hit rising burst.
+        expect( sound.repeat.mode ).toBe( "count" );
+
+        if ( sound.repeat.mode === "count" ) {
+          expect( sound.repeat.times ).toBe( 3 );
+          expect( sound.repeat.pitchStep ).toBeCloseTo(
+            0.35,
+            5
+          );
+        }
       }
     );
 
@@ -140,7 +157,7 @@ describe(
           expect( sound.repeat.times ).toBe( 3 );
           expect( sound.repeat.interval ).toBeGreaterThan( 0 );
           expect( sound.repeat.pitchStep ).toBeCloseTo(
-            0.08,
+            0.35,
             5
           );
         }

--- a/src/types/__tests__/slideTransition.test.ts
+++ b/src/types/__tests__/slideTransition.test.ts
@@ -1,5 +1,8 @@
 import {
-  SlideSchema, SlideTitleSchema, SlideTransitionSchema
+  SlideSchema,
+  SlideTitleSchema,
+  SlideTransitionSchema,
+  SlideTransitionSoundSchema
 } from "@/types/sketch.types";
 
 describe(
@@ -56,6 +59,27 @@ describe(
         expect( t.title.enabled ).toBe( false );
         expect( t.title.mode ).toBe( "alphabet" );
         expect( t.title.prefix ).toBe( "VARIANT" );
+        // The transition sound is always materialised too, disabled by default.
+        expect( t.sound.enabled ).toBe( false );
+        expect( t.sound.preset ).toBe( "blip" );
+        expect( t.sound.repeat.mode ).toBe( "once" );
+      }
+    );
+
+    test(
+      "heals a pre-sound montage deck by materialising a disabled sound",
+      () => {
+        // A montage saved before the sound option existed has no `sound` key;
+        // parsing must add it (disabled) rather than drop it, so old decks stay
+        // silent and new sub-controls have defined values to bind to.
+        const t = SlideTransitionSchema.parse( {
+          enabled: true,
+          style: "morph"
+        } );
+
+        expect( t.sound.enabled ).toBe( false );
+        expect( t.sound.volume ).toBeGreaterThanOrEqual( 0 );
+        expect( t.sound.slidePitchSpread ).toBe( 0 );
       }
     );
 
@@ -76,6 +100,61 @@ describe(
         } ).success ).toBe( false );
         expect( SlideTransitionSchema.safeParse( {
           sources: "everything"
+        } ).success ).toBe( false );
+      }
+    );
+  }
+);
+
+describe(
+  "SlideTransitionSoundSchema",
+  () => {
+    test(
+      "applies sensible defaults, disabled by default",
+      () => {
+        const sound = SlideTransitionSoundSchema.parse( {} );
+
+        expect( sound.enabled ).toBe( false );
+        expect( sound.preset ).toBe( "blip" );
+        expect( sound.volume ).toBe( 0.5 );
+        expect( sound.pitch ).toBe( 1 );
+        expect( sound.pitchVariation ).toBe( 0 );
+        expect( sound.slidePitchSpread ).toBe( 0 );
+        expect( sound.repeat.mode ).toBe( "once" );
+      }
+    );
+
+    test(
+      "fills count-mode burst defaults",
+      () => {
+        const sound = SlideTransitionSoundSchema.parse( {
+          enabled: true,
+          repeat: {
+            mode: "count"
+          }
+        } );
+
+        expect( sound.repeat.mode ).toBe( "count" );
+
+        if ( sound.repeat.mode === "count" ) {
+          expect( sound.repeat.times ).toBe( 3 );
+          expect( sound.repeat.interval ).toBeGreaterThan( 0 );
+          expect( sound.repeat.pitchStep ).toBeCloseTo(
+            0.08,
+            5
+          );
+        }
+      }
+    );
+
+    test(
+      "rejects an unknown preset and out-of-range volume",
+      () => {
+        expect( SlideTransitionSoundSchema.safeParse( {
+          preset: "foghorn"
+        } ).success ).toBe( false );
+        expect( SlideTransitionSoundSchema.safeParse( {
+          volume: 4
         } ).success ).toBe( false );
       }
     );

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -1062,6 +1062,72 @@ export const SlideTitleSchema = z.object( {
   changeEasing: z.string().default( "easeOutCubic" )
 } );
 
+/* ---------------- montage transition sound ---------------------- */
+
+// How a single transition sounds: one hit, or an N-hit burst with an optional
+// pitch ramp (a "spin-up" whoosh as the variant snaps in). Discriminated union
+// so the panel shows only the controls the picked mode uses, matching the
+// specs sound-on-change pattern.
+export const SlideTransitionSoundRepeatSchema = z
+  .discriminatedUnion(
+    "mode",
+    [
+      z.object( {
+        mode: z.literal( "once" )
+      } ),
+      z.object( {
+        mode: z.literal( "count" ),
+        // total hits per transition (first one included)
+        times: z.number().int()
+          .min( 2 )
+          .max( 16 )
+          .default( 3 ),
+        // seconds between hits of the burst
+        interval: soundRepeatInterval.default( 0.06 ),
+        // pitch ramp per hit, in octaves ( + rises, - falls, 0 = flat )
+        pitchStep: z.number().min( -0.5 )
+          .max( 0.5 )
+          .default( 0.08 )
+      } )
+    ]
+  )
+  .default( {
+    mode: "once"
+  } );
+
+// Sound played when a montage advances from one variant to the next — the
+// audible counterpart of the visual dip / title switch, heard "in between" the
+// two slides at each transition. Off by default so existing decks stay silent;
+// routes through the sketch audio engine (audio.trigger("click", …)) so it is
+// heard live AND baked into recordings, sample-accurate in deterministic
+// captures.
+export const SlideTransitionSoundSchema = z
+  .object( {
+    // Master switch (independent from the montage master switch).
+    enabled: z.boolean().default( false ),
+    // Voice from the shared click synth.
+    preset: z.enum( SPECS_SOUND_PRESETS ).default( "blip" ),
+    volume: z.number().min( 0 )
+      .max( 1 )
+      .default( 0.5 ),
+    // Global pitch multiplier (1 = as designed, 2 = octave up).
+    pitch: z.number().min( 0.25 )
+      .max( 4 )
+      .default( 1 ),
+    // Random per-transition detune, 0..1 (1 ≈ ±half an octave) — "humanize".
+    pitchVariation: z.number().min( 0 )
+      .max( 1 )
+      .default( 0 ),
+    // Pitch offset by the arriving variant's index, in octaves across the
+    // montage, so each slide lands on its own note (a small arpeggio as the
+    // montage cycles). 0 = every transition sounds at the same pitch.
+    slidePitchSpread: z.number().min( -2 )
+      .max( 2 )
+      .default( 0 ),
+    repeat: SlideTransitionSoundRepeatSchema
+  } )
+  .default( {} );
+
 // A "montage" slide morphs the sketch parameters of several OTHER slides into
 // one another over its own duration, in a loop. Only the sources' `sketch`
 // params are interpolated — the montage keeps its own size/animation, so source
@@ -1119,7 +1185,11 @@ export const SlideTransitionSchema = z.object( {
 
   // Overlay naming the variant currently on screen. Always present after parse
   // (its own `enabled` gates rendering) so existing montage decks heal in.
-  title: SlideTitleSchema.default( {} )
+  title: SlideTitleSchema.default( {} ),
+
+  // Sound played at each variant change. Always present after parse (its own
+  // `enabled` gates playback) so existing montage decks heal in silently.
+  sound: SlideTransitionSoundSchema.default( {} )
 } );
 
 /* ---------------- slide schema (with name) ---------------------- */
@@ -1162,6 +1232,7 @@ export type ContentItem = z.infer<typeof ContentItemSchema>;
 export type SlideOption = z.infer<typeof SlideSchema>;
 export type SlideTransitionOption = z.infer<typeof SlideTransitionSchema>;
 export type SlideTitleOption = z.infer<typeof SlideTitleSchema>;
+export type SlideTransitionSoundOption = z.infer<typeof SlideTransitionSoundSchema>;
 export type AssetsOption = z.infer<typeof Assets>;
 
 export type SketchOption = z.infer<typeof OptionsSchema>;

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -1087,12 +1087,18 @@ export const SlideTransitionSoundRepeatSchema = z
         // pitch ramp per hit, in octaves ( + rises, - falls, 0 = flat )
         pitchStep: z.number().min( -0.5 )
           .max( 0.5 )
-          .default( 0.08 )
+          .default( 0.35 )
       } )
     ]
   )
+  // Default to a short 3-hit rising burst: the "spin-up" reads more clearly as
+  // a transition than a single tick. Fully specified so the parsed default is
+  // complete (a bare { mode } would leave the burst fields unbound in the UI).
   .default( {
-    mode: "once"
+    mode: "count",
+    times: 3,
+    interval: 0.06,
+    pitchStep: 0.35
   } );
 
 // Sound played when a montage advances from one variant to the next — the
@@ -1106,7 +1112,7 @@ export const SlideTransitionSoundSchema = z
     // Master switch (independent from the montage master switch).
     enabled: z.boolean().default( false ),
     // Voice from the shared click synth.
-    preset: z.enum( SPECS_SOUND_PRESETS ).default( "blip" ),
+    preset: z.enum( SPECS_SOUND_PRESETS ).default( "pop" ),
     volume: z.number().min( 0 )
       .max( 1 )
       .default( 0.5 ),
@@ -1123,7 +1129,7 @@ export const SlideTransitionSoundSchema = z
     // montage cycles). 0 = every transition sounds at the same pitch.
     slidePitchSpread: z.number().min( -2 )
       .max( 2 )
-      .default( 0 ),
+      .default( 1.05 ),
     repeat: SlideTransitionSoundRepeatSchema
   } )
   .default( {} );


### PR DESCRIPTION
## What

Montage slides ease sketch values across their source variants. We already have sound-on-value-change for the specs overlay; this adds a configurable **sound played at each montage variant change** — the audible counterpart of the visual dip fade / title switch, heard "in between" the two slides.

## How it works

A montage cycles its sources deterministically off the loop progression, and the "arriving" variant flips at each segment midpoint — the same instant the dip fade peaks and the title label switches. The new scheduler watches that active-variant index and fires a hit right there, so the sound lands with the visual transition.

- **Schema** (`SlideTransitionSoundSchema`, added to `SlideTransitionSchema.sound`): `enabled` (off by default), `preset`, `volume`, `pitch`, `pitchVariation` (humanize), `slidePitchSpread` (each variant its own note), and a `repeat` union (`once` / `count` burst with a pitch ramp). Materialised on parse, so pre-sound montage decks heal in silently.
- **Runtime** (`morph/montageSound.js` + `morph/drawMontageSound.js`, wired via `slides.updateMontageSound()` in post-draw): polled per drawn frame on the sketch clock, fires through `audio.trigger("click", …)`. It never fires on the montage slide's first frame (appearing isn't a transition) and resets its change baseline on a backwards clock jump (capture restart). Because it routes through the sketch audio engine, hits are baked into recordings and stay sample-accurate in deterministic/server captures — same path as the specs sound-on-change.
- **UI**: a **Transition sound** sub-panel in the Montage / transition settings, mirroring the existing Slide title sub-panel.

## Tests

- `src/types/__tests__/slideTransition.test.ts` — `SlideTransitionSoundSchema` defaults, count-mode burst defaults, enum/range validation, pre-sound deck heal.
- `src/templates/p5/utils/slides/morph/__tests__/montageSound.test.ts` — scheduler: fires only on variant advance (never first frame), burst count + pitch ramp, per-variant pitch spread, backwards-clock baseline reset.

`npm run check` (lint + 1404 tests) and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UidUtLvoD3JR3cJ4tQGper

---
_Generated by [Claude Code](https://claude.ai/code/session_01UidUtLvoD3JR3cJ4tQGper)_