### PR TITLE
feat(breakdown): diff-style sketch breakdown — one step at a time

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds.ts
@@ -8,7 +8,8 @@ import {
   Sparkles as VisualIcon,
   Terminal as SpecsIcon,
   QrCode as QrCodeIcon,
-  Gauge as HudIcon
+  Gauge as HudIcon,
+  ListOrdered as BreakdownIcon
 } from "lucide-react";
 import {
   ItemKind,
@@ -23,6 +24,7 @@ export const ITEM_ORDER: ItemKind[] = [
   "images-stack",
   "meta",
   "specs",
+  "breakdown",
   "hud",
   "background",
   "qrcode"
@@ -48,6 +50,11 @@ export const ITEM_META: Record<ItemKind, ItemKindMeta> = {
     label: "Specs",
     Icon: SpecsIcon,
     description: "Technical overlay of the sketch settings"
+  },
+  breakdown: {
+    label: "Breakdown",
+    Icon: BreakdownIcon,
+    description: "Step-by-step diff: the sketch stabilizes while each changed parameter is narrated"
   },
   hud: {
     label: "HUD",

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/types/item-kinds.ts
@@ -4,6 +4,7 @@ export type ItemKind =
   | "title"
   | "meta"
   | "specs"
+  | "breakdown"
   | "hud"
   | "image"
   | "images-stack"

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem.ts
@@ -1,5 +1,6 @@
 import {
   BackgroundItemSchema,
+  BreakdownItemSchema,
   HudItemSchema,
   ImageItemSchema,
   ImagesStackItemSchema,
@@ -41,6 +42,10 @@ export default function makeDefaultItem( type: ItemKind ): ContentItem {
       } );
     case "specs":
       return SpecsItemSchema.parse( {
+        type
+      } );
+    case "breakdown":
+      return BreakdownItemSchema.parse( {
         type
       } );
     case "hud":

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -591,6 +591,171 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       }
     }
   },
+  breakdown: {
+    placement: {
+      label: "Placement",
+      component: "select",
+      options: [
+        {
+          value: "fixed",
+          label: "Fixed position"
+        },
+        {
+          value: "roaming",
+          label: "Roaming (moves each step)"
+        }
+      ]
+    },
+    position: {
+      label: "Position (fixed placement only)",
+      component: "vector2d",
+      allowNegative: false,
+      min: 0,
+      max: 1,
+      step: 0.01,
+      yDown: true
+    },
+    showHeader: {
+      label: "Show header row",
+      component: "checkbox"
+    },
+    showCounter: {
+      label: "Show step counter",
+      component: "checkbox"
+    },
+    showTitle: {
+      label: "Show step title",
+      component: "checkbox"
+    },
+    counterMode: {
+      label: "Counter style",
+      component: "select",
+      options: [
+        {
+          value: "numeric",
+          label: "Numeric (1/3)"
+        },
+        {
+          value: "letters",
+          label: "Letters (A, B, C…)"
+        }
+      ]
+    },
+    fill: {
+      label: "Fill",
+      component: "color"
+    },
+    backgroundColor: {
+      label: "Background",
+      component: "color"
+    },
+    backgroundStroke: {
+      label: "Background stroke",
+      component: "color"
+    },
+    backgroundRadius: {
+      label: "Background radius",
+      component: "slider",
+      min: 0,
+      max: 200,
+      step: 1
+    },
+    font: {
+      label: "Font",
+      component: "select",
+      options: fontSelectOptions
+    },
+    size: {
+      label: "Size",
+      component: "slider",
+      min: 8,
+      max: 96,
+      step: 1
+    },
+    lineHeight: {
+      label: "Line height",
+      component: "slider",
+      min: 1,
+      max: 3,
+      step: 0.05
+    },
+    blend: {
+      label: "Blend",
+      component: "select",
+      options: blendSelectOptions
+    },
+    build: {
+      label: "Breakdown engine",
+      component: "nested-object",
+      initialExpanded: true,
+      fields: {
+        selection: {
+          label: "Steps",
+          component: "select",
+          options: [
+            {
+              value: "changed",
+              label: "Changed parameters only (diff vs defaults)"
+            },
+            {
+              value: "all",
+              label: "All parameters"
+            }
+          ]
+        },
+        departure: {
+          label: "Departure (how far values start)",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.05
+        },
+        introRatio: {
+          label: "Intro span (loop fraction)",
+          component: "slider",
+          min: 0,
+          max: 0.3,
+          step: 0.01
+        },
+        outroRatio: {
+          label: "Outro span (loop fraction)",
+          component: "slider",
+          min: 0,
+          max: 0.4,
+          step: 0.01
+        },
+        holdRatio: {
+          label: "Hold after lock (per step)",
+          component: "slider",
+          min: 0,
+          max: 0.9,
+          step: 0.01
+        },
+        easing: {
+          label: "Step easing",
+          component: "easing"
+        },
+        snapKeys: {
+          label: "Snap keys (no lerp)",
+          component: "item-list",
+          itemConfig: {
+            label: "Key",
+            component: "text",
+            placeholder: "e.g. seed or sites.seed"
+          }
+        },
+        excludeKeys: {
+          label: "Excluded keys (never animated)",
+          component: "item-list",
+          itemConfig: {
+            label: "Key",
+            component: "text",
+            placeholder: "e.g. backgroundColor"
+          }
+        }
+      }
+    }
+  },
   specs: {
     style: {
       label: "Style",

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -641,6 +641,36 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
         }
       ]
     },
+    typewriter: {
+      label: "Typewriter on labels",
+      component: "checkbox"
+    },
+    valueStyle: {
+      label: "Value animation",
+      component: "select",
+      options: [
+        {
+          value: "bar",
+          label: "Progress bar (gauge)"
+        },
+        {
+          value: "ticker",
+          label: "Ticker (live value)"
+        },
+        {
+          value: "roll",
+          label: "Roll (odometer)"
+        },
+        {
+          value: "fade",
+          label: "Fade"
+        },
+        {
+          value: "rise",
+          label: "Rise"
+        }
+      ]
+    },
     fill: {
       label: "Fill",
       component: "color"
@@ -734,6 +764,13 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
         easing: {
           label: "Step easing",
           component: "easing"
+        },
+        lineStagger: {
+          label: "Line stagger (0 = together)",
+          component: "slider",
+          min: 0,
+          max: 1,
+          step: 0.05
         },
         snapKeys: {
           label: "Snap keys (no lerp)",

--- a/src/components/ClientProcessingSketch/components/SketchProvider/SketchContextProvider.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchProvider/SketchContextProvider.tsx
@@ -142,6 +142,42 @@ export default function SketchContextProvider( {
     ]
   );
 
+  /* ---- Sketch form metadata → runtime ---------------------------- */
+  // Publish the sketch's stock defaults + per-field form config (ranges,
+  // components) so the breakdown overlay can diff the tuned values against
+  // the stock ones and bound its start values by each parameter's real
+  // slider range. The returned object is memoized on the two state refs —
+  // the breakdown orchestrator ref-keys its derived cache on
+  // formValues/formConfiguration identity, so a fresh wrapper per call must
+  // not translate into a fresh payload per call.
+  const formMeta = useMemo(
+    () => ( {
+      formValues: state.sketchFormValues,
+      formConfiguration: state.sketchFormConfiguration
+    } ),
+    [
+      state.sketchFormValues,
+      state.sketchFormConfiguration
+    ]
+  );
+
+  useEffect(
+    () => {
+      if ( typeof window === "undefined" ) {
+        return;
+      }
+
+      window.getSketchFormMeta = () => formMeta;
+
+      return () => {
+        delete window.getSketchFormMeta;
+      };
+    },
+    [
+      formMeta
+    ]
+  );
+
   /* ---- p5 → React sync ------------------------------------------ */
   useEffect(
     () =>

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/deriveSteps.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/deriveSteps.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Covers the diff-style step derivation:
+ *   - selection "changed": only leaves differing from the stock defaults
+ *     (relative epsilon on numbers, per-component on arrays, missing stock
+ *     counts as changed); no reachable formValues → behaves as "all"
+ *   - grouping: nested objects = one step each; isolated top-level leaves =
+ *     their OWN step (no shared PARAMETERS gathering)
+ *   - exclude-key matching, reserved-key skipping, overflow flagging
+ */
+
+import deriveBreakdownSteps, {
+  MAX_ANIM_STEPS,
+  classifyLeaf,
+  differs,
+  formConfigAt,
+  matchesKeyList
+} from "../deriveSteps.js";
+
+const sketch = {
+  seed: 42,
+  animated: true,
+  strokeColor: [
+    255,
+    0,
+    0
+  ],
+  grid: {
+    columns: 8,
+    offset: [
+      0.5,
+      0.25
+    ]
+  },
+  noise: {
+    scale: 0.25,
+    octaves: 3
+  }
+};
+
+describe(
+  "matchesKeyList",
+  () => {
+    it(
+      "matches full dotted paths and bare leaf names",
+      () => {
+        expect( matchesKeyList(
+          "sites.seed",
+          [
+            "seed"
+          ]
+        ) ).toBe( true );
+        expect( matchesKeyList(
+          "sites.seed",
+          [
+            "sites.seed"
+          ]
+        ) ).toBe( true );
+        expect( matchesKeyList(
+          "sites.reseed",
+          [
+            "seed"
+          ]
+        ) ).toBe( false );
+      }
+    );
+  }
+);
+
+describe(
+  "formConfigAt / classifyLeaf",
+  () => {
+    const formConfiguration = {
+      grid: {
+        component: "nested-object",
+        fields: {
+          columns: {
+            component: "slider",
+            min: 1,
+            max: 20
+          }
+        }
+      },
+      tint: {
+        component: "color"
+      }
+    };
+
+    it(
+      "walks nested-object fields for dotted paths",
+      () => {
+        expect( formConfigAt(
+          formConfiguration,
+          "grid.columns"
+        ) ).toMatchObject( {
+          component: "slider"
+        } );
+        expect( formConfigAt(
+          formConfiguration,
+          "grid.rows"
+        ) ).toBeUndefined();
+      }
+    );
+
+    it(
+      "classifies by shape, upgraded by the form config",
+      () => {
+        expect( classifyLeaf( 3 ) ).toBe( "numbers" );
+        expect( classifyLeaf( true ) ).toBe( "booleans" );
+        expect( classifyLeaf( "morph" ) ).toBe( "strings" );
+        expect( classifyLeaf( [
+          1,
+          2
+        ] ) ).toBe( "vectors" );
+        expect( classifyLeaf( [
+          255,
+          0,
+          0
+        ] ) ).toBe( "colors" );
+        expect( classifyLeaf(
+          [
+            0,
+            0,
+            0
+          ],
+          {
+            component: "color"
+          }
+        ) ).toBe( "colors" );
+      }
+    );
+  }
+);
+
+describe(
+  "differs",
+  () => {
+    it(
+      "compares numbers with a relative epsilon",
+      () => {
+        expect( differs(
+          1,
+          1 + 1e-9
+        ) ).toBe( false );
+        expect( differs(
+          1,
+          2
+        ) ).toBe( true );
+      }
+    );
+
+    it(
+      "compares arrays per component and flags length mismatches",
+      () => {
+        expect( differs(
+          [
+            255,
+            0,
+            0
+          ],
+          [
+            255,
+            0,
+            0
+          ]
+        ) ).toBe( false );
+        expect( differs(
+          [
+            255,
+            0,
+            0
+          ],
+          [
+            255,
+            0,
+            1
+          ]
+        ) ).toBe( true );
+        expect( differs(
+          [
+            255,
+            0,
+            0
+          ],
+          [
+            255,
+            0
+          ]
+        ) ).toBe( true );
+      }
+    );
+
+    it(
+      "treats a missing stock value as changed",
+      () => {
+        expect( differs(
+          5,
+          undefined
+        ) ).toBe( true );
+      }
+    );
+  }
+);
+
+describe(
+  "deriveBreakdownSteps — grouping",
+  () => {
+    it(
+      "isolated top-level leaves each become their OWN step; nested objects one step each",
+      () => {
+        const steps = deriveBreakdownSteps(
+          sketch,
+          {
+            selection: "all"
+          }
+        );
+
+        expect( steps.map( ( s: any ) => s.label ) ).toEqual( [
+          "SEED",
+          "ANIMATED",
+          "STROKE COLOR",
+          "GRID",
+          "NOISE"
+        ] );
+        expect( steps[ 3 ].paths ).toEqual( [
+          "grid.columns",
+          "grid.offset"
+        ] );
+        expect( steps[ 3 ].leaves[ 0 ] ).toMatchObject( {
+          path: "grid.columns",
+          cls: "numbers"
+        } );
+      }
+    );
+
+    it(
+      "skips reserved runtime keys and non-animatable leaves",
+      () => {
+        const steps = deriveBreakdownSteps(
+          {
+            bindings: {
+              magnitude: "mic"
+            },
+            interaction: {
+              mode: "orbit"
+            },
+            callback: () => 1,
+            empty: null,
+            mixed: [
+              1,
+              "two"
+            ],
+            scale: 2
+          },
+          {
+            selection: "all"
+          }
+        );
+
+        expect( steps.map( ( s: any ) => s.id ) ).toEqual( [
+          "scale"
+        ] );
+      }
+    );
+
+    it(
+      "excludeKeys removes leaves (dotted or bare) from every step",
+      () => {
+        const steps = deriveBreakdownSteps(
+          sketch,
+          {
+            selection: "all",
+            excludeKeys: [
+              "seed",
+              "grid.offset"
+            ]
+          }
+        );
+
+        const allPaths = steps.flatMap( ( s: any ) => s.paths );
+
+        expect( allPaths ).not.toContain( "seed" );
+        expect( allPaths ).not.toContain( "grid.offset" );
+        expect( allPaths ).toContain( "grid.columns" );
+      }
+    );
+  }
+);
+
+describe(
+  "deriveBreakdownSteps — diff selection",
+  () => {
+    const formMeta = {
+      formValues: {
+        seed: 42, // unchanged
+        animated: false, // changed
+        strokeColor: [
+          255,
+          0,
+          0
+        ], // unchanged
+        grid: {
+          columns: 8, // unchanged
+          offset: [
+            0.5,
+            0.5
+          ] // changed (second component)
+        },
+        noise: {
+          scale: 0.25,
+          octaves: 3
+        } // unchanged group
+      }
+    };
+
+    it(
+      "keeps only changed leaves; a partially-changed group narrates only those",
+      () => {
+        const steps = deriveBreakdownSteps(
+          sketch,
+          {
+            selection: "changed"
+          },
+          formMeta
+        );
+
+        expect( steps.map( ( s: any ) => s.id ) ).toEqual( [
+          "animated",
+          "grid"
+        ] );
+        expect( steps[ 1 ].paths ).toEqual( [
+          "grid.offset"
+        ] );
+      }
+    );
+
+    it(
+      "a leaf missing from the stock defaults counts as changed",
+      () => {
+        const steps = deriveBreakdownSteps(
+          {
+            extra: 10
+          },
+          {
+            selection: "changed"
+          },
+          {
+            formValues: {
+              other: 1
+            }
+          }
+        );
+
+        expect( steps.map( ( s: any ) => s.id ) ).toEqual( [
+          "extra"
+        ] );
+      }
+    );
+
+    it(
+      "without reachable formValues, 'changed' behaves as 'all'",
+      () => {
+        const all = deriveBreakdownSteps(
+          sketch,
+          {
+            selection: "all"
+          }
+        );
+        const noMeta = deriveBreakdownSteps(
+          sketch,
+          {
+            selection: "changed"
+          },
+          {}
+        );
+
+        expect( noMeta.map( ( s: any ) => s.id ) ).toEqual( all.map( ( s: any ) => s.id ) );
+      }
+    );
+
+    it(
+      "returns [] when nothing changed",
+      () => {
+        const steps = deriveBreakdownSteps(
+          {
+            seed: 42
+          },
+          {
+            selection: "changed"
+          },
+          {
+            formValues: {
+              seed: 42
+            }
+          }
+        );
+
+        expect( steps ).toEqual( [] );
+      }
+    );
+  }
+);
+
+describe(
+  "deriveBreakdownSteps — overflow",
+  () => {
+    it(
+      "flags steps past MAX_ANIM_STEPS as overflow",
+      () => {
+        const wide: Record<string, number> = {};
+
+        for ( let i = 0; i < MAX_ANIM_STEPS + 5; i++ ) {
+          wide[ `p${ String( i ).padStart(
+            2,
+            "0"
+          ) }` ] = i;
+        }
+
+        const steps = deriveBreakdownSteps(
+          wide,
+          {
+            selection: "all"
+          }
+        );
+
+        expect( steps ).toHaveLength( MAX_ANIM_STEPS + 5 );
+        expect( steps.filter( ( s: any ) => s.overflow ) ).toHaveLength( 5 );
+        expect( steps[ MAX_ANIM_STEPS - 1 ].overflow ).toBe( false );
+        expect( steps[ MAX_ANIM_STEPS ].overflow ).toBe( true );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/format.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/format.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Covers the breakdown's text formatting helpers.
+ */
+
+import {
+  formatCounter,
+  formatValue,
+  humanizeKey,
+  looksLikeColor,
+  looksLikeVector,
+  nearlyEqual
+} from "../format.js";
+
+describe(
+  "humanizeKey",
+  () => {
+    it(
+      "splits camelCase and separators into upper-case words",
+      () => {
+        expect( humanizeKey( "strokeWeight" ) ).toBe( "STROKE WEIGHT" );
+        expect( humanizeKey( "noise_detail-x" ) ).toBe( "NOISE DETAIL X" );
+        expect( humanizeKey( "grid.columns" ) ).toBe( "GRID COLUMNS" );
+      }
+    );
+  }
+);
+
+describe(
+  "formatValue",
+  () => {
+    it(
+      "formats scalars",
+      () => {
+        expect( formatValue( 3 ) ).toBe( "3" );
+        expect( formatValue( 0.256 ) ).toBe( "0.26" );
+        expect( formatValue( true ) ).toBe( "on" );
+        expect( formatValue( false ) ).toBe( "off" );
+        expect( formatValue( "smooth" ) ).toBe( "smooth" );
+      }
+    );
+
+    it(
+      "formats colors, vectors and opaque arrays",
+      () => {
+        expect( formatValue( [
+          255,
+          0,
+          0
+        ] ) ).toBe( "rgba(255, 0, 0)" );
+        expect( formatValue( [
+          0.5,
+          0.25
+        ] ) ).toBe( "(0.5, 0.25)" );
+        expect( formatValue( [
+          1,
+          "a",
+          true
+        ] ) ).toBe( "[3]" );
+      }
+    );
+
+    it(
+      "returns null for values the overlay never narrates",
+      () => {
+        expect( formatValue( null ) ).toBeNull();
+        expect( formatValue( undefined ) ).toBeNull();
+        expect( formatValue( () => 1 ) ).toBeNull();
+        expect( formatValue( {
+          nested: true
+        } ) ).toBeNull();
+      }
+    );
+  }
+);
+
+describe(
+  "formatCounter",
+  () => {
+    it(
+      "renders numeric counters as index/total",
+      () => {
+        expect( formatCounter(
+          0,
+          3,
+          "numeric"
+        ) ).toBe( "1/3" );
+        expect( formatCounter(
+          2,
+          3
+        ) ).toBe( "3/3" );
+      }
+    );
+
+    it(
+      "renders spreadsheet-style letters",
+      () => {
+        expect( formatCounter(
+          0,
+          3,
+          "letters"
+        ) ).toBe( "A" );
+        expect( formatCounter(
+          25,
+          99,
+          "letters"
+        ) ).toBe( "Z" );
+        expect( formatCounter(
+          26,
+          99,
+          "letters"
+        ) ).toBe( "AA" );
+        expect( formatCounter(
+          27,
+          99,
+          "letters"
+        ) ).toBe( "AB" );
+      }
+    );
+  }
+);
+
+describe(
+  "nearlyEqual",
+  () => {
+    it(
+      "compares with a relative epsilon",
+      () => {
+        expect( nearlyEqual(
+          1,
+          1 + 1e-9
+        ) ).toBe( true );
+        expect( nearlyEqual(
+          1000000,
+          1000000.5
+        ) ).toBe( true );
+        expect( nearlyEqual(
+          0.1,
+          0.2
+        ) ).toBe( false );
+        expect( nearlyEqual(
+          0,
+          0
+        ) ).toBe( true );
+      }
+    );
+  }
+);
+
+describe(
+  "shape guards",
+  () => {
+    it(
+      "detects color- and vector-shaped arrays",
+      () => {
+        expect( looksLikeColor( [
+          0,
+          0,
+          0,
+          255
+        ] ) ).toBe( true );
+        expect( looksLikeColor( [
+          0,
+          0
+        ] ) ).toBe( false );
+        expect( looksLikeVector( [
+          0,
+          0
+        ] ) ).toBe( true );
+        expect( looksLikeVector( [
+          0,
+          0,
+          0
+        ] ) ).toBe( false );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/format.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/format.test.ts
@@ -8,7 +8,8 @@ import {
   humanizeKey,
   looksLikeColor,
   looksLikeVector,
-  nearlyEqual
+  nearlyEqual,
+  sampleValueTexts
 } from "../format.js";
 
 describe(
@@ -114,6 +115,76 @@ describe(
           99,
           "letters"
         ) ).toBe( "AB" );
+      }
+    );
+  }
+);
+
+describe(
+  "sampleValueTexts",
+  () => {
+    it(
+      "captures mid-lerp texts wider than both endpoints",
+      () => {
+        const texts = sampleValueTexts(
+          2,
+          8
+        );
+
+        // endpoints are single chars; intermediates carry decimals
+        expect( texts ).toContain( "2" );
+        expect( texts ).toContain( "8" );
+        expect( texts.some( ( t ) => t.length > 1 ) ).toBe( true );
+      }
+    );
+
+    it(
+      "samples colors with whole channels",
+      () => {
+        const texts = sampleValueTexts(
+          [
+            0,
+            0,
+            0
+          ],
+          [
+            255,
+            255,
+            255
+          ]
+        );
+
+        expect( texts[ 0 ] ).toBe( "rgba(0, 0, 0)" );
+        expect( texts[ texts.length - 1 ] ).toBe( "rgba(255, 255, 255)" );
+        expect( texts ).toContain( "rgba(128, 128, 128)" );
+      }
+    );
+
+    it(
+      "snapping and non-lerpable values only show their endpoints",
+      () => {
+        expect( sampleValueTexts(
+          2,
+          8,
+          true
+        ) ).toEqual( [
+          "2",
+          "8"
+        ] );
+        expect( sampleValueTexts(
+          "linear",
+          "smooth"
+        ) ).toEqual( [
+          "linear",
+          "smooth"
+        ] );
+        expect( sampleValueTexts(
+          true,
+          false
+        ) ).toEqual( [
+          "on",
+          "off"
+        ] );
       }
     );
   }

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/index.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/index.test.ts
@@ -27,6 +27,7 @@ const makeItem = ( buildOverrides = {} ) => ( {
     outroRatio: 0.1,
     holdRatio: 0,
     easing: "linear",
+    lineStagger: 0,
     snapKeys: [
       "seed"
     ],
@@ -322,7 +323,88 @@ describe(
         expect( state.progress.phase ).toBe( "build" );
         expect( state.progress.currentStep ).toBe( 0 );
         expect( state.currentFlat.get( "amplitude" ) ).toBeGreaterThan( 0 );
+        expect( state.leafT.get( "amplitude" ) ).toBeGreaterThan( 0 );
+        expect( state.leafT.get( "amplitude" ) ).toBeLessThan( 1 );
         expect( state.schedule.windows ).toHaveLength( 3 );
+      }
+    );
+  }
+);
+
+describe(
+  "lineStagger",
+  () => {
+    const twoLeafSketch = {
+      grid: {
+        columns: 8,
+        rows: 4
+      }
+    };
+
+    it(
+      "0 = every leaf of a step shares the same progress",
+      () => {
+        const state = getBreakdownState(
+          twoLeafSketch,
+          undefined,
+          makeItem(),
+          0.5
+        );
+
+        expect( state.leafT.get( "grid.columns" ) ).toBeCloseTo( state.leafT.get( "grid.rows" ) );
+      }
+    );
+
+    it(
+      "> 0 offsets the leaves of a step (also shifting the injected values)",
+      () => {
+        const item = makeItem( {
+          lineStagger: 0.8
+        } );
+        const state = getBreakdownState(
+          twoLeafSketch,
+          undefined,
+          item,
+          0.5
+        );
+
+        const first = state.leafT.get( "grid.columns" );
+        const second = state.leafT.get( "grid.rows" );
+
+        expect( first ).toBeGreaterThan( second );
+
+        // The injected values reflect the offset too — first leaf further
+        // along its 0 → final travel than the second.
+        const out = getBreakdownSketch(
+          twoLeafSketch,
+          undefined,
+          item,
+          0.5
+        );
+
+        expect( out.grid.columns / 8 ).toBeGreaterThan( out.grid.rows / 4 );
+      }
+    );
+
+    it(
+      "changing lineStagger (new build ref) invalidates the caches",
+      () => {
+        const a = getBreakdownSketch(
+          twoLeafSketch,
+          undefined,
+          makeItem(),
+          0.5
+        );
+        const b = getBreakdownSketch(
+          twoLeafSketch,
+          undefined,
+          makeItem( {
+            lineStagger: 1
+          } ),
+          0.5
+        );
+
+        expect( b ).not.toBe( a );
       }
     );
   }

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/index.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/index.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Integration of the breakdown orchestrator:
+ *   - intro → start values; past outroStart → the final object BY REFERENCE
+ *   - mid-window numbers lerp between start and final; snap keys stay final
+ *   - memoization: same refs + same progression → same object identity;
+ *     changed store refs OR changed form-meta refs → recompute; the drag
+ *     layer's { ...item, position } wrapper does NOT invalidate
+ *   - no-op contract (null) for missing items / nothing changed
+ *   - findActiveBreakdownItem scoping (slide wins over global, index wraps)
+ */
+
+import getBreakdownSketch, {
+  __resetBreakdownCaches,
+  findActiveBreakdownItem,
+  getBreakdownState
+} from "../index.js";
+
+const makeItem = ( buildOverrides = {} ) => ( {
+  type: "breakdown",
+  placement: "fixed",
+  build: {
+    selection: "all",
+    departure: 1,
+    introRatio: 0.1,
+    outroRatio: 0.1,
+    holdRatio: 0,
+    easing: "linear",
+    snapKeys: [
+      "seed"
+    ],
+    excludeKeys: [],
+    ...buildOverrides
+  }
+} );
+
+const globalSketch = {
+  amplitude: 100,
+  seed: 42,
+  grid: {
+    columns: 8
+  }
+};
+
+beforeEach( () => {
+  __resetBreakdownCaches();
+  delete ( window as any ).getSketchFormMeta;
+} );
+
+describe(
+  "getBreakdownSketch",
+  () => {
+    it(
+      "returns start values during the intro",
+      () => {
+        const out = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          makeItem(),
+          0.05
+        );
+
+        // no form ranges: numbers head to 0; snap key keeps final
+        expect( out.amplitude ).toBe( 0 );
+        expect( out.grid.columns ).toBe( 0 );
+        expect( out.seed ).toBe( 42 );
+      }
+    );
+
+    it(
+      "returns the final object by reference once everything is locked",
+      () => {
+        const item = makeItem();
+        const state = getBreakdownState(
+          globalSketch,
+          undefined,
+          item,
+          0
+        );
+        const out = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.95
+        );
+
+        expect( out ).toBe( state.finalSketch );
+        expect( out.amplitude ).toBe( 100 );
+      }
+    );
+
+    it(
+      "lerps numbers inside their window",
+      () => {
+        // Three steps (AMPLITUDE, SEED-snap… actually SEED is its own step
+        // but stays final via snapKeys; steps: amplitude, seed, grid) over
+        // [0.1, 0.9]. Probe inside the FIRST window.
+        const out = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          makeItem(),
+          0.2
+        );
+
+        expect( out.amplitude ).toBeGreaterThan( 0 );
+        expect( out.amplitude ).toBeLessThan( 100 );
+
+        // later steps untouched yet; snap key always final
+        expect( out.grid.columns ).toBe( 0 );
+        expect( out.seed ).toBe( 42 );
+      }
+    );
+
+    it(
+      "applies per-slide overrides on top of the global sketch",
+      () => {
+        const slideSketch = {
+          amplitude: 50
+        };
+        const out = getBreakdownSketch(
+          globalSketch,
+          slideSketch,
+          makeItem(),
+          0.95
+        );
+
+        expect( out.amplitude ).toBe( 50 );
+      }
+    );
+
+    it(
+      "memoizes per progression and invalidates on store ref changes",
+      () => {
+        const item = makeItem();
+        const a = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.2
+        );
+        const b = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.2
+        );
+
+        expect( b ).toBe( a );
+
+        const c = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.21
+        );
+
+        expect( c ).not.toBe( a );
+
+        const editedSketch = {
+          ...globalSketch
+        };
+        const d = getBreakdownSketch(
+          editedSketch,
+          undefined,
+          item,
+          0.21
+        );
+
+        expect( d ).not.toBe( c );
+      }
+    );
+
+    it(
+      "the drag layer's { ...item, position } wrapper does NOT invalidate",
+      () => {
+        const item = makeItem();
+        const a = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.2
+        );
+        const wrapped = {
+          ...item,
+          position: {
+            x: 0.4,
+            y: 0.4
+          }
+        };
+        const b = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          wrapped,
+          0.2
+        );
+
+        expect( b ).toBe( a );
+      }
+    );
+
+    it(
+      "invalidates when the form-meta bridge's refs change",
+      () => {
+        const item = makeItem( {
+          selection: "changed"
+        } );
+        const metaA = {
+          formValues: {
+            amplitude: 100,
+            seed: 42,
+            grid: {
+              columns: 8
+            }
+          }
+        };
+
+        ( window as any ).getSketchFormMeta = () => metaA;
+
+        // Everything matches stock → nothing changed → no-op
+        expect( getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.2
+        ) ).toBeNull();
+
+        // Stock changes (user edits) → amplitude now differs → steps appear
+        const metaB = {
+          formValues: {
+            amplitude: 1,
+            seed: 42,
+            grid: {
+              columns: 8
+            }
+          }
+        };
+
+        ( window as any ).getSketchFormMeta = () => metaB;
+
+        const out = getBreakdownSketch(
+          globalSketch,
+          undefined,
+          item,
+          0.5
+        );
+
+        expect( out ).not.toBeNull();
+      }
+    );
+
+    it(
+      "reuses untouched subtrees of the final object",
+      () => {
+        const withStatic = {
+          ...globalSketch,
+          untouched: {
+            deep: true
+          }
+        };
+        const item = makeItem( {
+          excludeKeys: [
+            "untouched.deep"
+          ]
+        } );
+        const state = getBreakdownState(
+          withStatic,
+          undefined,
+          item,
+          0.2
+        );
+        const out = getBreakdownSketch(
+          withStatic,
+          undefined,
+          item,
+          0.2
+        );
+
+        expect( out.untouched ).toBe( state.finalSketch.untouched );
+      }
+    );
+
+    it(
+      "is a no-op for missing items or empty step lists",
+      () => {
+        expect( getBreakdownSketch(
+          globalSketch,
+          undefined,
+          undefined,
+          0.2
+        ) ).toBeNull();
+
+        expect( getBreakdownSketch(
+          {},
+          undefined,
+          makeItem(),
+          0.2
+        ) ).toBeNull();
+      }
+    );
+  }
+);
+
+describe(
+  "getBreakdownState",
+  () => {
+    it(
+      "exposes the narration state for the same frame",
+      () => {
+        const state = getBreakdownState(
+          globalSketch,
+          undefined,
+          makeItem(),
+          0.2
+        );
+
+        expect( state.steps.map( ( s: any ) => s.label ) ).toEqual( [
+          "AMPLITUDE",
+          "SEED",
+          "GRID"
+        ] );
+        expect( state.progress.phase ).toBe( "build" );
+        expect( state.progress.currentStep ).toBe( 0 );
+        expect( state.currentFlat.get( "amplitude" ) ).toBeGreaterThan( 0 );
+        expect( state.schedule.windows ).toHaveLength( 3 );
+      }
+    );
+  }
+);
+
+describe(
+  "findActiveBreakdownItem",
+  () => {
+    const breakdownA = {
+      type: "breakdown",
+      id: "global"
+    };
+    const breakdownB = {
+      type: "breakdown",
+      id: "slide"
+    };
+
+    it(
+      "prefers the current slide's item over the global one",
+      () => {
+        const store = {
+          content: [
+            breakdownA
+          ],
+          slides: [
+            {
+              content: []
+            },
+            {
+              content: [
+                {
+                  type: "text"
+                },
+                breakdownB
+              ]
+            }
+          ]
+        };
+
+        expect( findActiveBreakdownItem(
+          store,
+          1,
+          2
+        ) ).toBe( breakdownB );
+        expect( findActiveBreakdownItem(
+          store,
+          0,
+          2
+        ) ).toBe( breakdownA );
+      }
+    );
+
+    it(
+      "wraps the slide index like getSlide does",
+      () => {
+        const store = {
+          slides: [
+            {
+              content: [
+                breakdownB
+              ]
+            }
+          ]
+        };
+
+        expect( findActiveBreakdownItem(
+          store,
+          -1,
+          1
+        ) ).toBe( breakdownB );
+      }
+    );
+
+    it(
+      "falls back to global content with no slides",
+      () => {
+        expect( findActiveBreakdownItem(
+          {
+            content: [
+              breakdownA
+            ]
+          },
+          null,
+          0
+        ) ).toBe( breakdownA );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/schedule.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/schedule.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Covers the breakdown timeline model:
+ *   - intro | build | outro phase boundaries and clamping
+ *   - strictly sequential windows tiling the build span exactly
+ *   - holdRatio front-loading (lockAt before window end)
+ *   - currentStep / stepLocalT resolution (narration cursor)
+ *   - progression wrapping (recording clock climbs past 1)
+ *   - easing applied to step progress
+ */
+
+import {
+  buildBreakdownSchedule,
+  resolveBreakdownProgress,
+  wrapProgression
+} from "../schedule.js";
+
+const build = ( overrides = {} ) => ( {
+  introRatio: 0.1,
+  outroRatio: 0.1,
+  holdRatio: 0,
+  ...overrides
+} );
+
+describe(
+  "wrapProgression",
+  () => {
+    it(
+      "folds the monotonic recording clock back into [0,1)",
+      () => {
+        expect( wrapProgression( 0.25 ) ).toBeCloseTo( 0.25 );
+        expect( wrapProgression( 1.25 ) ).toBeCloseTo( 0.25 );
+        expect( wrapProgression( -0.25 ) ).toBeCloseTo( 0.75 );
+        expect( wrapProgression( 2 ) ).toBe( 0 );
+      }
+    );
+  }
+);
+
+describe(
+  "buildBreakdownSchedule",
+  () => {
+    it(
+      "reserves intro and outro spans (defaults: intro 0, outro 0.1)",
+      () => {
+        const schedule = buildBreakdownSchedule(
+          3,
+          {}
+        );
+
+        expect( schedule.introEnd ).toBe( 0 );
+        expect( schedule.outroStart ).toBeCloseTo( 0.9 );
+        expect( schedule.windows ).toHaveLength( 3 );
+      }
+    );
+
+    it(
+      "windows tile the build span exactly, strictly sequential",
+      () => {
+        const schedule = buildBreakdownSchedule(
+          4,
+          build()
+        );
+        const {
+          windows
+        } = schedule;
+
+        expect( windows[ 0 ].start ).toBeCloseTo( schedule.introEnd );
+        expect( windows[ 3 ].end ).toBeCloseTo( schedule.outroStart );
+
+        for ( let i = 1; i < windows.length; i++ ) {
+          expect( windows[ i ].start ).toBeCloseTo( windows[ i - 1 ].end );
+        }
+      }
+    );
+
+    it(
+      "holdRatio locks each step before its window ends",
+      () => {
+        const schedule = buildBreakdownSchedule(
+          2,
+          build( {
+            holdRatio: 0.5
+          } )
+        );
+
+        for ( const window of schedule.windows ) {
+          expect( window.lockAt ).toBeCloseTo( window.start + ( window.end - window.start ) * 0.5 );
+        }
+      }
+    );
+
+    it(
+      "keeps a minimum build span when intro + outro over-reserve",
+      () => {
+        const squeezed = buildBreakdownSchedule(
+          2,
+          build( {
+            introRatio: 0.3,
+            outroRatio: 0.6
+          } )
+        );
+
+        expect( squeezed.outroStart - squeezed.introEnd ).toBeCloseTo( 0.2 );
+      }
+    );
+
+    it(
+      "0 steps yields no windows; a single step spans the whole build",
+      () => {
+        expect( buildBreakdownSchedule(
+          0,
+          build()
+        ).windows ).toHaveLength( 0 );
+
+        const single = buildBreakdownSchedule(
+          1,
+          build()
+        );
+
+        expect( single.windows[ 0 ].start ).toBeCloseTo( single.introEnd );
+        expect( single.windows[ 0 ].end ).toBeCloseTo( single.outroStart );
+      }
+    );
+  }
+);
+
+describe(
+  "resolveBreakdownProgress",
+  () => {
+    const schedule = buildBreakdownSchedule(
+      2,
+      build()
+    );
+
+    it(
+      "reports the intro phase, previewing step 0",
+      () => {
+        const state = resolveBreakdownProgress(
+          schedule,
+          0.05
+        );
+
+        expect( state.phase ).toBe( "intro" );
+        expect( state.phaseT ).toBeCloseTo( 0.5 );
+        expect( state.stepT ).toEqual( [
+          0,
+          0
+        ] );
+        expect( state.currentStep ).toBe( 0 );
+        expect( state.stepLocalT ).toBe( 0 );
+      }
+    );
+
+    it(
+      "reports the outro with every step locked, pinned to the last step",
+      () => {
+        const state = resolveBreakdownProgress(
+          schedule,
+          0.95
+        );
+
+        expect( state.phase ).toBe( "outro" );
+        expect( state.stepT ).toEqual( [
+          1,
+          1
+        ] );
+        expect( state.lockedCount ).toBe( 2 );
+        expect( state.currentStep ).toBe( 1 );
+        expect( state.stepLocalT ).toBe( 1 );
+      }
+    );
+
+    it(
+      "tracks the current step and its local position mid-build",
+      () => {
+        // Two windows over [0.1, 0.9]: first is [0.1, 0.5].
+        const state = resolveBreakdownProgress(
+          schedule,
+          0.3
+        );
+
+        expect( state.phase ).toBe( "build" );
+        expect( state.currentStep ).toBe( 0 );
+        expect( state.stepLocalT ).toBeCloseTo( 0.5 );
+        expect( state.activeIndices ).toEqual( [
+          0
+        ] );
+        expect( state.stepT[ 1 ] ).toBe( 0 );
+
+        const later = resolveBreakdownProgress(
+          schedule,
+          0.7
+        );
+
+        expect( later.currentStep ).toBe( 1 );
+        expect( later.stepLocalT ).toBeCloseTo( 0.5 );
+        expect( later.lockedCount ).toBe( 1 );
+      }
+    );
+
+    it(
+      "stepLocalT keeps advancing past lockAt while stepT holds at 1",
+      () => {
+        const held = buildBreakdownSchedule(
+          1,
+          build( {
+            introRatio: 0,
+            outroRatio: 0,
+            holdRatio: 0.5
+          } )
+        );
+        const state = resolveBreakdownProgress(
+          held,
+          0.75
+        );
+
+        expect( state.stepT[ 0 ] ).toBe( 1 ); // locked at 0.5
+        expect( state.stepLocalT ).toBeCloseTo( 0.75 ); // narration continues
+      }
+    );
+
+    it(
+      "applies easing to the eased track but not the raw one",
+      () => {
+        const square = ( x: number ) => x * x;
+        const state = resolveBreakdownProgress(
+          schedule,
+          0.3,
+          square
+        );
+
+        expect( state.stepT[ 0 ] ).toBeCloseTo( state.rawStepT[ 0 ] ** 2 );
+      }
+    );
+
+    it(
+      "wraps a monotonic recording progression",
+      () => {
+        const wrapped = resolveBreakdownProgress(
+          schedule,
+          1.3
+        );
+        const direct = resolveBreakdownProgress(
+          schedule,
+          0.3
+        );
+
+        expect( wrapped ).toEqual( direct );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/breakdown/__tests__/startValues.test.ts
+++ b/src/sketches/p5/utils/slides/breakdown/__tests__/startValues.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Covers the deterministic min/opposite/departure start-value rules:
+ *   - number with form range: start at min; min ≈ final → start at max
+ *   - departure scales the travel (1 = full, 0.5 = half, 0 = identity)
+ *   - integer steps snap (no float-dust narration)
+ *   - colors invert per RGB channel (alpha kept), scaled by departure
+ *   - booleans flip at departure ≥ 0.5; strings keep final
+ *   - vector2d leaves resolve per-axis ranges from the parent pad
+ *   - no form range → heuristic toward 0 (or 1 when final is 0)
+ *   - snap/exclude keys keep their final values
+ */
+
+import buildStartValues from "../startValues.js";
+
+const sketch = {
+  seed: 42,
+  animated: true,
+  mode: "smooth",
+  strokeColor: [
+    200,
+    50,
+    50,
+    255
+  ],
+  grid: {
+    columns: 8,
+    position: {
+      x: 0.5,
+      y: 0.25
+    }
+  }
+};
+
+const formMeta = {
+  formConfiguration: {
+    strokeColor: {
+      component: "color"
+    },
+    grid: {
+      component: "nested-object",
+      fields: {
+        columns: {
+          component: "slider",
+          min: 2,
+          max: 20,
+          step: 1
+        },
+        position: {
+          component: "vector2d",
+          allowNegative: false,
+          min: 0,
+          max: 1,
+          step: 0.01
+        }
+      }
+    }
+  }
+};
+
+const build = ( overrides = {} ) => ( {
+  departure: 1,
+  snapKeys: [
+    "seed"
+  ],
+  excludeKeys: [
+    "animated"
+  ],
+  ...overrides
+} );
+
+describe(
+  "buildStartValues — numbers",
+  () => {
+    it(
+      "starts at the form minimum at full departure",
+      () => {
+        const start = buildStartValues(
+          sketch,
+          build(),
+          formMeta
+        );
+
+        expect( start.grid.columns ).toBe( 2 );
+      }
+    );
+
+    it(
+      "flips to the maximum when the minimum IS the final value",
+      () => {
+        const atMin = buildStartValues(
+          {
+            grid: {
+              columns: 2
+            }
+          },
+          build( {
+            excludeKeys: []
+          } ),
+          formMeta
+        );
+
+        expect( atMin.grid.columns ).toBe( 20 );
+      }
+    );
+
+    it(
+      "departure scales the travel and snaps integer steps",
+      () => {
+        // final 8, candidate min 2 → travel −6; departure 0.5 → 8 − 3 = 5
+        const half = buildStartValues(
+          sketch,
+          build( {
+            departure: 0.5
+          } ),
+          formMeta
+        );
+
+        expect( half.grid.columns ).toBe( 5 );
+
+        // departure 0.1 → 8 − 0.6 = 7.4 → snapped to 7
+        const close = buildStartValues(
+          sketch,
+          build( {
+            departure: 0.1
+          } ),
+          formMeta
+        );
+
+        expect( close.grid.columns ).toBe( 7 );
+      }
+    );
+
+    it(
+      "departure 0 is the identity — nothing moves",
+      () => {
+        const start = buildStartValues(
+          sketch,
+          build( {
+            departure: 0
+          } ),
+          formMeta
+        );
+
+        expect( start.grid.columns ).toBe( 8 );
+        expect( start.strokeColor ).toEqual( sketch.strokeColor );
+      }
+    );
+
+    it(
+      "without a form range, heads toward 0 (or 1 when the final is 0)",
+      () => {
+        const start = buildStartValues(
+          {
+            amplitude: 100,
+            silent: 0
+          },
+          build( {
+            excludeKeys: []
+          } ),
+          {}
+        );
+
+        expect( start.amplitude ).toBe( 0 );
+        expect( start.silent ).toBe( 1 );
+      }
+    );
+  }
+);
+
+describe(
+  "buildStartValues — colors, booleans, strings, vectors",
+  () => {
+    it(
+      "inverts RGB channels and keeps alpha",
+      () => {
+        const start = buildStartValues(
+          sketch,
+          build(),
+          formMeta
+        );
+
+        expect( start.strokeColor ).toEqual( [
+          55,
+          205,
+          205,
+          255
+        ] );
+      }
+    );
+
+    it(
+      "scales the color inversion by departure",
+      () => {
+        const half = buildStartValues(
+          sketch,
+          build( {
+            departure: 0.5
+          } ),
+          formMeta
+        );
+
+        // 200 → lerp(200, 55, 0.5) ≈ 128; 50 → lerp(50, 205, 0.5) ≈ 128
+        expect( half.strokeColor[ 0 ] ).toBe( 128 );
+        expect( half.strokeColor[ 1 ] ).toBe( 128 );
+        expect( half.strokeColor[ 3 ] ).toBe( 255 );
+      }
+    );
+
+    it(
+      "flips booleans at departure ≥ 0.5 and keeps strings",
+      () => {
+        const noExcludes = build( {
+          excludeKeys: []
+        } );
+        const far = buildStartValues(
+          sketch,
+          noExcludes,
+          formMeta
+        );
+
+        expect( far.animated ).toBe( false );
+        expect( far.mode ).toBe( "smooth" );
+
+        const near = buildStartValues(
+          sketch,
+          {
+            ...noExcludes,
+            departure: 0.4
+          },
+          formMeta
+        );
+
+        expect( near.animated ).toBe( true );
+      }
+    );
+
+    it(
+      "resolves vector2d leaves against the pad's axis ranges",
+      () => {
+        const start = buildStartValues(
+          sketch,
+          build(),
+          formMeta
+        );
+
+        // x final 0.5, min 0 → start 0; y final 0.25, min 0 → start 0
+        expect( start.grid.position.x ).toBe( 0 );
+        expect( start.grid.position.y ).toBe( 0 );
+
+        // a final AT the min flips to the max
+        const atMin = buildStartValues(
+          {
+            grid: {
+              position: {
+                x: 0,
+                y: 0.25
+              }
+            }
+          },
+          build(),
+          formMeta
+        );
+
+        expect( atMin.grid.position.x ).toBe( 1 );
+      }
+    );
+  }
+);
+
+describe(
+  "buildStartValues — key lists",
+  () => {
+    it(
+      "snap and exclude keys keep their final values",
+      () => {
+        const start = buildStartValues(
+          sketch,
+          build(),
+          formMeta
+        );
+
+        expect( start.seed ).toBe( 42 ); // snapKeys
+        expect( start.animated ).toBe( true ); // excludeKeys
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/breakdown/deriveSteps.js
+++ b/src/sketches/p5/utils/slides/breakdown/deriveSteps.js
@@ -1,0 +1,370 @@
+// Derive the breakdown's step list: the DIFF of the sketch's parameters.
+// Pure: no p5 / DOM / store access — the orchestrator feeds it the merged
+// final params and the sketch's form metadata (stock defaults + field
+// config).
+//
+// Grouping: a nested object is one step; an isolated top-level field is its
+// OWN step (no shared "PARAMETERS" gathering). Order = config walk order.
+
+import {
+  humanizeKey,
+  looksLikeColor,
+  looksLikeVector,
+  nearlyEqual
+} from "./format.js";
+
+// Hard cap so a 100-param sketch stays a watchable narration: overflow steps
+// are flagged — they get no schedule window, stay at their final values from
+// frame 0 and never reach the counter.
+export const MAX_ANIM_STEPS = 24;
+
+// Runtime-only keys that are never part of the visual recipe.
+const RESERVED_KEYS = new Set( [
+  "bindings",
+  "interaction"
+] );
+
+function isPlainObject( value ) {
+  return value != null && typeof value === "object" && !Array.isArray( value );
+}
+
+// Same matching rule as lerpParams' shouldSnap: a key list entry matches the
+// full dotted path OR the bare leaf name ("seed" matches "sites.seed").
+export function matchesKeyList(
+  path, keys
+) {
+  if ( !Array.isArray( keys ) || !keys.length ) {
+    return false;
+  }
+
+  const leaf = path.includes( "." ) ? path.slice( path.lastIndexOf( "." ) + 1 ) : path;
+
+  return keys.includes( path ) || keys.includes( leaf );
+}
+
+export function getByPath(
+  obj, path
+) {
+  let level = obj;
+
+  for ( const segment of String( path ).split( "." ) ) {
+    if ( !isPlainObject( level ) ) {
+      return undefined;
+    }
+
+    level = level[ segment ];
+  }
+
+  return level;
+}
+
+/**
+ * Resolve a dotted path inside a form configuration, walking nested-object
+ * `fields` maps. Returns the FieldConfig or undefined.
+ */
+export function formConfigAt(
+  formConfiguration, path
+) {
+  if ( !isPlainObject( formConfiguration ) ) {
+    return undefined;
+  }
+
+  const segments = String( path ).split( "." );
+
+  let level = formConfiguration;
+
+  for ( let i = 0; i < segments.length; i++ ) {
+    const entry = level?.[ segments[ i ] ];
+
+    if ( !entry ) {
+      return undefined;
+    }
+
+    if ( i === segments.length - 1 ) {
+      return entry;
+    }
+
+    level = entry.fields;
+  }
+
+  return undefined;
+}
+
+// Classify one leaf value. The form config upgrades ambiguous shapes
+// ([r,g,b] vs 3-vector) to certainty; the renderer keys the color chip off
+// this.
+export function classifyLeaf(
+  value, fieldConfig
+) {
+  if ( fieldConfig?.component === "color" ) {
+    return "colors";
+  }
+
+  if ( fieldConfig?.component === "vector2d" ) {
+    return "vectors";
+  }
+
+  if ( typeof value === "number" ) {
+    return "numbers";
+  }
+
+  if ( typeof value === "boolean" ) {
+    return "booleans";
+  }
+
+  if ( typeof value === "string" ) {
+    return "strings";
+  }
+
+  if ( looksLikeVector( value ) ) {
+    return "vectors";
+  }
+
+  if ( looksLikeColor( value ) ) {
+    return "colors";
+  }
+
+  return "numbers";
+}
+
+/**
+ * Does a final value differ from its stock default? Numbers compare with a
+ * relative epsilon; a stock value that's missing entirely counts as changed
+ * (the param exists only in the tuned version).
+ */
+export function differs(
+  finalValue, stockValue
+) {
+  if ( stockValue === undefined ) {
+    return true;
+  }
+
+  if ( typeof finalValue === "number" && typeof stockValue === "number" ) {
+    return !nearlyEqual(
+      finalValue,
+      stockValue
+    );
+  }
+
+  if ( Array.isArray( finalValue ) ) {
+    if ( !Array.isArray( stockValue ) || stockValue.length !== finalValue.length ) {
+      return true;
+    }
+
+    return finalValue.some( (
+      component, i
+    ) => (
+      typeof component === "number" && typeof stockValue[ i ] === "number"
+        ? !nearlyEqual(
+          component,
+          stockValue[ i ]
+        )
+        : component !== stockValue[ i ]
+    ) );
+  }
+
+  return finalValue !== stockValue;
+}
+
+// A leaf the animation can meaningfully vary. Arrays are kept only when
+// fully numeric (colors / vectors / numeric tuples).
+function isAnimatableLeaf( value ) {
+  if ( value === null || value === undefined ) {
+    return false;
+  }
+
+  switch ( typeof value ) {
+    case "number":
+    case "boolean":
+    case "string":
+      return true;
+    default:
+      break;
+  }
+
+  return Array.isArray( value ) && value.every( ( v ) => typeof v === "number" );
+}
+
+// Depth-first walk collecting animatable leaves as { path, value, cls }.
+function collectLeaves(
+  node, prefix, excludeKeys, formConfiguration, out
+) {
+  if ( !isPlainObject( node ) ) {
+    return;
+  }
+
+  for ( const key of Object.keys( node ) ) {
+    if ( !prefix && RESERVED_KEYS.has( key ) ) {
+      continue;
+    }
+
+    const path = prefix ? `${ prefix }.${ key }` : key;
+
+    if ( matchesKeyList(
+      path,
+      excludeKeys
+    ) ) {
+      continue;
+    }
+
+    const value = node[ key ];
+
+    if ( isPlainObject( value ) ) {
+      collectLeaves(
+        value,
+        path,
+        excludeKeys,
+        formConfiguration,
+        out
+      );
+      continue;
+    }
+
+    if ( !isAnimatableLeaf( value ) ) {
+      continue;
+    }
+
+    out.push( {
+      path,
+      value,
+      cls: classifyLeaf(
+        value,
+        formConfigAt(
+          formConfiguration,
+          path
+        )
+      )
+    } );
+  }
+}
+
+// The class a group of leaves reads as: its majority class (first wins ties).
+function majorityClass( leaves ) {
+  const counts = new Map();
+
+  let best = "numbers";
+  let bestCount = 0;
+
+  for ( const leaf of leaves ) {
+    const count = ( counts.get( leaf.cls ) ?? 0 ) + 1;
+
+    counts.set(
+      leaf.cls,
+      count
+    );
+
+    if ( count > bestCount ) {
+      best = leaf.cls;
+      bestCount = count;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Build the ordered step list.
+ *
+ * Returns [ { id, label, cls, leaves, paths, finalSlice, overflow } ] where
+ * `leaves` = [ { path, value, cls } ] (the renderer needs per-leaf classes
+ * for the color chip), `paths`/`finalSlice` are derived conveniences for the
+ * interpolator, and `overflow` marks steps past MAX_ANIM_STEPS.
+ */
+export default function deriveBreakdownSteps(
+  finalSketch, build = {}, formMeta = {}
+) {
+  const excludeKeys = build.excludeKeys ?? [];
+  const leaves = [];
+
+  collectLeaves(
+    finalSketch,
+    "",
+    excludeKeys,
+    formMeta.formConfiguration,
+    leaves
+  );
+
+  // Diff selection: keep only leaves whose final value differs from the
+  // stock default at the same path. Without reachable stock values the diff
+  // is undefined — degrade to "all" (documented fallback).
+  const stock = formMeta.formValues;
+  const useDiff =
+    ( build.selection ?? "changed" ) === "changed" &&
+    isPlainObject( stock ) &&
+    Object.keys( stock ).length > 0;
+
+  const selected = useDiff
+    ? leaves.filter( ( leaf ) => differs(
+      leaf.value,
+      getByPath(
+        stock,
+        leaf.path
+      )
+    ) )
+    : leaves;
+
+  if ( !selected.length ) {
+    return [];
+  }
+
+  // Group by top-level key: one step per nested object, and each isolated
+  // top-level leaf becomes its own step.
+  const steps = [];
+  const groupIndex = new Map();
+
+  for ( const leaf of selected ) {
+    const dot = leaf.path.indexOf( "." );
+
+    if ( dot === -1 ) {
+      steps.push( {
+        id: leaf.path,
+        label: humanizeKey( leaf.path ),
+        leaves: [
+          leaf
+        ]
+      } );
+      continue;
+    }
+
+    const groupKey = leaf.path.slice(
+      0,
+      dot
+    );
+
+    if ( !groupIndex.has( groupKey ) ) {
+      const step = {
+        id: groupKey,
+        label: humanizeKey( groupKey ),
+        leaves: []
+      };
+
+      groupIndex.set(
+        groupKey,
+        step
+      );
+      steps.push( step );
+    }
+
+    groupIndex.get( groupKey ).leaves.push( leaf );
+  }
+
+  return steps.map( (
+    step, index
+  ) => {
+    const finalSlice = {};
+
+    for ( const leaf of step.leaves ) {
+      finalSlice[ leaf.path ] = leaf.value;
+    }
+
+    return {
+      id: step.id,
+      label: step.label,
+      cls: majorityClass( step.leaves ),
+      leaves: step.leaves,
+      paths: step.leaves.map( ( leaf ) => leaf.path ),
+      finalSlice,
+      overflow: index >= MAX_ANIM_STEPS
+    };
+  } );
+}

--- a/src/sketches/p5/utils/slides/breakdown/formMeta.js
+++ b/src/sketches/p5/utils/slides/breakdown/formMeta.js
@@ -1,0 +1,20 @@
+// Guarded reader for the sketch's form metadata (stock defaults + per-field
+// config), published by the React SketchContext provider as
+// window.getSketchFormMeta. Returns {} in a bare runtime harness so the diff
+// selection and start-value ranges degrade to their heuristics instead of
+// throwing — same pattern as the HUD's sketchInfo() reader.
+
+export default function getFormMeta() {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.getSketchFormMeta === "function"
+  ) {
+    try {
+      return window.getSketchFormMeta() ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+}

--- a/src/sketches/p5/utils/slides/breakdown/format.js
+++ b/src/sketches/p5/utils/slides/breakdown/format.js
@@ -105,6 +105,80 @@ export function formatCounter(
   return `${ index + 1 }/${ total }`;
 }
 
+/**
+ * Every text a lerping value can render as, sampled at t = 0, 0.1 … 1.
+ * The overlay reserves its value column at the WIDEST of these — measuring
+ * only the endpoints under-reserves ("5.13" between "2" and "8") and the
+ * panel overflows mid-lerp. Lerps are monotone per component, so a 0.1 grid
+ * bounds the real maximum. Snapping values only ever show their endpoints.
+ */
+export function sampleValueTexts(
+  start, final, snap = false
+) {
+  const endpoints = () =>
+    [
+      formatValue( start ),
+      formatValue( final )
+    ].filter( ( text ) => text !== null );
+
+  if (
+    snap ||
+    start === null ||
+    final === null ||
+    typeof start === "boolean" ||
+    typeof start === "string" ||
+    typeof start !== typeof final
+  ) {
+    return endpoints();
+  }
+
+  const lerpNumber = (
+    a, b, t
+  ) => a + ( b - a ) * t;
+
+  const texts = [];
+
+  for ( let i = 0; i <= 10; i++ ) {
+    const t = i / 10;
+
+    let value;
+
+    if ( typeof start === "number" ) {
+      value = lerpNumber(
+        start,
+        final,
+        t
+      );
+    } else if (
+      Array.isArray( start ) &&
+      Array.isArray( final ) &&
+      start.length === final.length
+    ) {
+      value = start.map( (
+        component, k
+      ) => (
+        typeof component === "number" && typeof final[ k ] === "number"
+          ? lerpNumber(
+            component,
+            final[ k ],
+            t
+          )
+          : t < 0.5 ? component : final[ k ]
+      ) );
+    } else {
+      return endpoints();
+    }
+
+    const text = formatValue( value );
+
+    if ( text !== null ) {
+      texts.push( text );
+    }
+  }
+
+  return texts;
+}
+
 // Relative-epsilon numeric equality shared by the diff selection (deriveSteps)
 // and the min≈final opposite-end rule (startValues).
 export function nearlyEqual(

--- a/src/sketches/p5/utils/slides/breakdown/format.js
+++ b/src/sketches/p5/utils/slides/breakdown/format.js
@@ -1,0 +1,118 @@
+// Text formatting shared by the breakdown overlay and its step derivation.
+// Pure — no p5 / DOM dependency, so it is unit-testable in node.
+
+export function formatNumber( value ) {
+  if ( Number.isInteger( value ) ) {
+    return String( value );
+  }
+
+  return String( Math.round( value * 100 ) / 100 );
+}
+
+export function looksLikeColor( value ) {
+  return (
+    Array.isArray( value ) &&
+    ( value.length === 3 || value.length === 4 ) &&
+    value.every( ( v ) => typeof v === "number" )
+  );
+}
+
+export function looksLikeVector( value ) {
+  return (
+    Array.isArray( value ) &&
+    value.length === 2 &&
+    value.every( ( v ) => typeof v === "number" )
+  );
+}
+
+/**
+ * Human-readable one-line rendering of a leaf value, or null for values the
+ * breakdown never narrates (functions, exotic objects).
+ */
+export function formatValue( value ) {
+  if ( value === null || value === undefined ) {
+    return null;
+  }
+
+  switch ( typeof value ) {
+    case "number":
+      return formatNumber( value );
+    case "boolean":
+      return value ? "on" : "off";
+    case "string":
+      return value;
+    case "function":
+      return null;
+    default:
+      break;
+  }
+
+  if ( Array.isArray( value ) ) {
+    if ( looksLikeColor( value ) ) {
+      // Whole channels: mid-lerp colours narrate as "rgba(180, 21, 45)"
+      // instead of float dust.
+      return `rgba(${ value.map( ( channel ) => Math.round( channel ) ).join( ", " ) })`;
+    }
+
+    if ( looksLikeVector( value ) ) {
+      return `(${ formatNumber( value[ 0 ] ) }, ${ formatNumber( value[ 1 ] ) })`;
+    }
+
+    return `[${ value.length }]`;
+  }
+
+  return null;
+}
+
+// "strokeWeight" / "noise_detail-x" -> "STROKE WEIGHT" / "NOISE DETAIL X"
+export function humanizeKey( key ) {
+  return String( key )
+    .replace(
+      /([a-z0-9])([A-Z])/g,
+      "$1 $2"
+    )
+    .replace(
+      /[-_.]+/g,
+      " "
+    )
+    .trim()
+    .toUpperCase();
+}
+
+/**
+ * Header counter for the current step:
+ *   - "numeric": "2/5"
+ *   - "letters": spreadsheet-style A, B, … Z, AA, AB (total not shown)
+ */
+export function formatCounter(
+  index, total, mode = "numeric"
+) {
+  if ( mode === "letters" ) {
+    let n = Math.max(
+      0,
+      Math.trunc( index )
+    );
+    let out = "";
+
+    do {
+      out = String.fromCharCode( 65 + ( n % 26 ) ) + out;
+      n = Math.floor( n / 26 ) - 1;
+    } while ( n >= 0 );
+
+    return out;
+  }
+
+  return `${ index + 1 }/${ total }`;
+}
+
+// Relative-epsilon numeric equality shared by the diff selection (deriveSteps)
+// and the min≈final opposite-end rule (startValues).
+export function nearlyEqual(
+  a, b
+) {
+  return Math.abs( a - b ) <= 1e-6 * Math.max(
+    1,
+    Math.abs( a ),
+    Math.abs( b )
+  );
+}

--- a/src/sketches/p5/utils/slides/breakdown/index.js
+++ b/src/sketches/p5/utils/slides/breakdown/index.js
@@ -1,0 +1,377 @@
+// Breakdown orchestrator: turns a "breakdown" content item into per-frame
+// interpolated sketch parameters (the sketch visibly stabilizes group by
+// group) and into the narration state the overlay renders. Injected in
+// slides.getSketchSettings — the same seam the montage uses — so the running
+// sketch and every overlay reading options.sketch see the in-progress values
+// with zero per-sketch code.
+//
+// PERFORMANCE CONTRACT: getSketchSettings fires on EVERY options.sketch
+// property access (dozens+ per frame), so everything here is memoized:
+//   - derived cache: steps + start values + schedule, keyed on the STORE
+//     object identities (global sketch / slide sketch / item.build) plus the
+//     form-meta bridge's formValues/formConfiguration refs (the diff
+//     selection depends on them). The option store and the React provider
+//     replace objects on edit, so ref-equality is a correct invalidation
+//     key. NOTE: the caller's merged { ...global, ...slide } object is
+//     rebuilt per access — never key on it.
+//   - frame cache: the interpolated values, keyed on (derived, progression).
+//     Deterministic capture pins the frame → same progression → cache hit;
+//     live playback recomputes once per frame.
+
+import lerpParams from "../morph/lerpParams.js";
+import easing from "../../easing.js";
+import animation from "../../animation.js";
+import {
+  getSketchOptions
+} from "../../../shared/syncSketchOptions.js";
+import deriveBreakdownSteps, {
+  getByPath
+} from "./deriveSteps.js";
+import buildStartValues from "./startValues.js";
+import getFormMeta from "./formMeta.js";
+import {
+  buildBreakdownSchedule,
+  resolveBreakdownProgress
+} from "./schedule.js";
+
+function isPlainObject( value ) {
+  return value != null && typeof value === "object" && !Array.isArray( value );
+}
+
+/**
+ * Find the breakdown item governing the current frame, reading RAW store
+ * arrays only (never the options proxy — its get trap would recurse back
+ * into getSketchSettings). Slide content wins over global content; the first
+ * breakdown item per list wins.
+ */
+export function findActiveBreakdownItem(
+  optionsTarget, slideIndex, slideCount
+) {
+  const pick = ( list ) =>
+    ( Array.isArray( list )
+      ? list.find( ( item ) => item?.type === "breakdown" )
+      : undefined );
+
+  if ( slideCount > 0 && slideIndex != null ) {
+    const n = slideCount;
+    const idx = ( ( ( Math.trunc( Number( slideIndex ) || 0 ) ) % n ) + n ) % n;
+    const slideItem = pick( optionsTarget?.slides?.[ idx ]?.content );
+
+    if ( slideItem ) {
+      return slideItem;
+    }
+  }
+
+  return pick( optionsTarget?.content );
+}
+
+/* ---- derived cache (steps / start values / schedule) -------------- */
+
+let derivedCache = null;
+
+function getDerived(
+  globalSketch, slideSketch, item
+) {
+  // Key on the item's `build` object, not the item itself: only `build`
+  // affects derivation, and the drag layer wraps the item in a fresh
+  // { ...item, position } object every frame mid-drag — keying on the item
+  // would make the overlay (dragged wrapper) and the injection (raw store
+  // item) thrash this single-slot cache against each other.
+  const buildRef = item?.build ?? item;
+  const formMeta = getFormMeta();
+
+  if (
+    derivedCache &&
+    derivedCache.globalRef === globalSketch &&
+    derivedCache.slideRef === slideSketch &&
+    derivedCache.buildRef === buildRef &&
+    derivedCache.formValuesRef === formMeta.formValues &&
+    derivedCache.formConfigRef === formMeta.formConfiguration
+  ) {
+    return derivedCache;
+  }
+
+  const finalSketch = {
+    ...( globalSketch || {} ),
+    ...( slideSketch || {} )
+  };
+  const build = item?.build ?? {};
+  const steps = deriveBreakdownSteps(
+    finalSketch,
+    build,
+    formMeta
+  );
+  const animSteps = steps.filter( ( step ) => !step.overflow );
+  const startValues = buildStartValues(
+    finalSketch,
+    build,
+    formMeta
+  );
+
+  // Flat start slice per animated step (mirrors each step's finalSlice), so
+  // the per-frame work is a handful of leaf lerps — no deep walks.
+  const startSlices = animSteps.map( ( step ) => {
+    const slice = {};
+
+    for ( const path of step.paths ) {
+      slice[ path ] = getByPath(
+        startValues,
+        path
+      );
+    }
+
+    return slice;
+  } );
+
+  // Every ancestor prefix of an animated path: the reifier rebuilds only
+  // these subtrees and reuses the final object's references elsewhere.
+  const animatedPrefixes = new Set();
+
+  for ( const step of animSteps ) {
+    for ( const path of step.paths ) {
+      const segments = path.split( "." );
+
+      let prefix = "";
+
+      for ( let i = 0; i < segments.length - 1; i++ ) {
+        prefix = prefix ? `${ prefix }.${ segments[ i ] }` : segments[ i ];
+        animatedPrefixes.add( prefix );
+      }
+    }
+  }
+
+  derivedCache = {
+    globalRef: globalSketch,
+    slideRef: slideSketch,
+    buildRef,
+    formValuesRef: formMeta.formValues,
+    formConfigRef: formMeta.formConfiguration,
+    finalSketch,
+    build,
+    steps,
+    animSteps,
+    startValues,
+    startSlices,
+    animatedPrefixes,
+    schedule: buildBreakdownSchedule(
+      animSteps.length,
+      build
+    ),
+    easingFn: easing[ build.easing ] ?? easing.linear
+  };
+
+  return derivedCache;
+}
+
+/* ---- frame cache (per-progression interpolation) ------------------ */
+
+let frameCache = null;
+
+function getFrame(
+  derived, progression
+) {
+  if (
+    frameCache &&
+    frameCache.derived === derived &&
+    frameCache.progression === progression
+  ) {
+    return frameCache;
+  }
+
+  const progress = resolveBreakdownProgress(
+    derived.schedule,
+    progression,
+    derived.easingFn
+  );
+
+  // Flat path → in-progress value for every animated leaf. Fully locked
+  // steps contribute nothing (their leaves read final via the reify reuse).
+  const currentFlat = new Map();
+
+  let allLocked = true;
+
+  derived.animSteps.forEach( (
+    step, index
+  ) => {
+    const t = progress.stepT[ index ];
+
+    if ( t >= 1 ) {
+      return;
+    }
+
+    allLocked = false;
+
+    const slice = lerpParams(
+      derived.startSlices[ index ],
+      step.finalSlice,
+      t,
+      derived.build.snapKeys ?? []
+    );
+
+    for ( const path of step.paths ) {
+      currentFlat.set(
+        path,
+        slice[ path ]
+      );
+    }
+  } );
+
+  frameCache = {
+    derived,
+    progression,
+    progress,
+    currentFlat,
+    allLocked,
+    nested: null
+  };
+
+  return frameCache;
+}
+
+// Rebuild the sketch object with in-progress leaves substituted, reusing the
+// final object's references for every untouched subtree.
+function reify(
+  node, prefix, currentFlat, animatedPrefixes
+) {
+  if ( !isPlainObject( node ) ) {
+    return node;
+  }
+
+  if ( prefix && !animatedPrefixes.has( prefix ) ) {
+    return node;
+  }
+
+  const out = {};
+
+  for ( const key of Object.keys( node ) ) {
+    const path = prefix ? `${ prefix }.${ key }` : key;
+
+    if ( currentFlat.has( path ) ) {
+      out[ key ] = currentFlat.get( path );
+      continue;
+    }
+
+    const value = node[ key ];
+
+    out[ key ] = isPlainObject( value )
+      ? reify(
+        value,
+        path,
+        currentFlat,
+        animatedPrefixes
+      )
+      : value;
+  }
+
+  return out;
+}
+
+/**
+ * The injection entry: the sketch parameters the running sketch should see
+ * at `progression`, or null when the breakdown is a no-op (missing item,
+ * nothing changed / nothing animatable) — the caller then falls back to the
+ * normal effective settings.
+ */
+export default function getBreakdownSketch(
+  globalSketch, slideSketch, item, progression
+) {
+  if ( !item ) {
+    return null;
+  }
+
+  const derived = getDerived(
+    globalSketch,
+    slideSketch,
+    item
+  );
+
+  if ( !derived.animSteps.length ) {
+    return null;
+  }
+
+  const frame = getFrame(
+    derived,
+    progression
+  );
+
+  // Everything settled (outro, or all windows locked) → the final object.
+  if ( frame.allLocked ) {
+    return derived.finalSketch;
+  }
+
+  if ( !frame.nested ) {
+    frame.nested = reify(
+      derived.finalSketch,
+      "",
+      frame.currentFlat,
+      derived.animatedPrefixes
+    );
+  }
+
+  return frame.nested;
+}
+
+/**
+ * The overlay entry: narration state for the same frame, served from the
+ * same caches so the overlay can never drift from what the sketch renders.
+ */
+export function getBreakdownState(
+  globalSketch, slideSketch, item, progression
+) {
+  const derived = getDerived(
+    globalSketch,
+    slideSketch,
+    item
+  );
+  const frame = getFrame(
+    derived,
+    progression
+  );
+
+  return {
+    steps: derived.steps,
+    animSteps: derived.animSteps,
+    schedule: derived.schedule,
+    startValues: derived.startValues,
+    finalSketch: derived.finalSketch,
+    progress: frame.progress,
+    currentFlat: frame.currentFlat
+  };
+}
+
+/**
+ * Convenience for the overlay renderer: resolve the narration state against
+ * the RAW option store (options.sketch reads back the interpolated values —
+ * the final values must come from the store), mirroring exactly what the
+ * injection in slides.getSketchSettings resolves, so both hit the same
+ * caches for the same frame. The slide index comes from the slides module's
+ * window bridge to avoid a circular import (slides/index.js imports us).
+ */
+export function getBreakdownRuntimeState( item ) {
+  const store = getSketchOptions() ?? {};
+  const slideCount = Array.isArray( store.slides ) ? store.slides.length : 0;
+  const slideIndex =
+    typeof window !== "undefined" ? window.slides?.index : null;
+
+  let slideSketch;
+
+  if ( slideCount > 0 && slideIndex != null ) {
+    const n = slideCount;
+    const idx = ( ( Math.trunc( Number( slideIndex ) || 0 ) % n ) + n ) % n;
+
+    slideSketch = store.slides[ idx ]?.sketch;
+  }
+
+  return getBreakdownState(
+    store.sketch || {},
+    slideSketch,
+    item,
+    animation.progression
+  );
+}
+
+// Test hook: caches are module state; tests reset them between cases.
+export function __resetBreakdownCaches() {
+  derivedCache = null;
+  frameCache = null;
+}

--- a/src/sketches/p5/utils/slides/breakdown/index.js
+++ b/src/sketches/p5/utils/slides/breakdown/index.js
@@ -19,6 +19,7 @@
 //     live playback recomputes once per frame.
 
 import lerpParams from "../morph/lerpParams.js";
+import staggeredProgress from "../morph/staggeredProgress.js";
 import easing from "../../easing.js";
 import animation from "../../animation.js";
 import {
@@ -184,36 +185,63 @@ function getFrame(
     derived.easingFn
   );
 
-  // Flat path → in-progress value for every animated leaf. Fully locked
-  // steps contribute nothing (their leaves read final via the reify reuse).
+  // Flat path → in-progress value for every animated leaf, plus the eased
+  // per-leaf progress the overlay renders (bars, crossfades). With
+  // build.lineStagger > 0 the leaves of one step animate offset from each
+  // other (staggeredProgress within the step's raw window) — one line after
+  // another at 1. Fully locked leaves contribute no currentFlat entry (they
+  // read final via the reify reuse).
   const currentFlat = new Map();
+  const leafT = new Map();
+  const spread = derived.build.lineStagger ?? 0;
+  const snapKeys = derived.build.snapKeys ?? [];
 
   let allLocked = true;
 
   derived.animSteps.forEach( (
     step, index
   ) => {
-    const t = progress.stepT[ index ];
+    const raw = progress.rawStepT[ index ];
+    const denom = step.paths.length - 1;
 
-    if ( t >= 1 ) {
-      return;
-    }
+    step.paths.forEach( (
+      path, leafIndex
+    ) => {
+      const leafRaw = staggeredProgress(
+        raw,
+        denom > 0 ? leafIndex / denom : 0,
+        spread
+      );
+      const eased =
+        leafRaw <= 0 ? 0 : leafRaw >= 1 ? 1 : derived.easingFn( leafRaw );
 
-    allLocked = false;
+      leafT.set(
+        path,
+        eased
+      );
 
-    const slice = lerpParams(
-      derived.startSlices[ index ],
-      step.finalSlice,
-      t,
-      derived.build.snapKeys ?? []
-    );
+      if ( leafRaw >= 1 ) {
+        return;
+      }
 
-    for ( const path of step.paths ) {
+      allLocked = false;
+
+      const slice = lerpParams(
+        {
+          [ path ]: derived.startSlices[ index ][ path ]
+        },
+        {
+          [ path ]: step.finalSlice[ path ]
+        },
+        eased,
+        snapKeys
+      );
+
       currentFlat.set(
         path,
         slice[ path ]
       );
-    }
+    } );
   } );
 
   frameCache = {
@@ -221,6 +249,7 @@ function getFrame(
     progression,
     progress,
     currentFlat,
+    leafT,
     allLocked,
     nested: null
   };
@@ -335,7 +364,8 @@ export function getBreakdownState(
     startValues: derived.startValues,
     finalSketch: derived.finalSketch,
     progress: frame.progress,
-    currentFlat: frame.currentFlat
+    currentFlat: frame.currentFlat,
+    leafT: frame.leafT
   };
 }
 

--- a/src/sketches/p5/utils/slides/breakdown/schedule.js
+++ b/src/sketches/p5/utils/slides/breakdown/schedule.js
@@ -1,0 +1,197 @@
+// The breakdown's timeline model: maps the loop clock [0,1) onto
+// intro | build | outro phases and gives every step its own strictly
+// SEQUENTIAL window inside the build span — one parameter group settles at a
+// time, which is the whole point of the diff narration. Pure: both the
+// parameter interpolator and the overlay read this one model, so they can
+// never drift apart.
+
+function clamp01( value ) {
+  if ( !Number.isFinite( value ) ) {
+    return 0;
+  }
+
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
+// Recording's clock climbs monotonically past 1 (see time.phase) — fold it
+// back so one recorded pass equals one breakdown cycle, negatives included.
+export function wrapProgression( progression ) {
+  const p = Number( progression ) || 0;
+
+  return ( ( p % 1 ) + 1 ) % 1;
+}
+
+/**
+ * Build the per-step windows, in LOOP coordinates. Windows tile the build
+ * span exactly: step i spans [introEnd + i·width, introEnd + (i+1)·width]
+ * with width = buildSpan / stepCount.
+ *
+ * `holdRatio` front-loads each window: the morph happens in the first
+ * (1−holdRatio) of the window (up to `lockAt`), then the value holds locked
+ * while the narration finishes its lines.
+ */
+export function buildBreakdownSchedule(
+  stepCount, build = {}
+) {
+  const introRatio = clamp01( build.introRatio ?? 0 );
+  const outroRatio = clamp01( build.outroRatio ?? 0.1 );
+
+  // Keep a usable build span even when intro + outro over-reserve the loop.
+  const MIN_BUILD_SPAN = 0.2;
+
+  let introEnd = introRatio;
+  let outroStart = 1 - outroRatio;
+
+  if ( outroStart - introEnd < MIN_BUILD_SPAN ) {
+    const overflow = MIN_BUILD_SPAN - ( outroStart - introEnd );
+    const total = introRatio + outroRatio;
+    const introShare = total > 0 ? introRatio / total : 0.5;
+
+    introEnd -= overflow * introShare;
+    outroStart += overflow * ( 1 - introShare );
+
+    introEnd = clamp01( introEnd );
+    outroStart = clamp01( outroStart );
+  }
+
+  const buildSpan = outroStart - introEnd;
+  const windows = [];
+
+  if ( stepCount > 0 ) {
+    const width = buildSpan / stepCount;
+    const holdRatio = clamp01( build.holdRatio ?? 0.15 );
+
+    for ( let i = 0; i < stepCount; i++ ) {
+      const start = introEnd + i * width;
+      const end = introEnd + ( i + 1 ) * width;
+
+      // The morph finishes holdRatio early; from lockAt on, the value holds.
+      const lockAt = start + ( end - start ) * ( 1 - holdRatio );
+
+      windows.push( {
+        start,
+        end,
+        lockAt
+      } );
+    }
+  }
+
+  return {
+    introEnd,
+    outroStart,
+    windows
+  };
+}
+
+/**
+ * Resolve the timeline at a given loop progression.
+ *
+ * Returns:
+ *   phase          "intro" | "build" | "outro"
+ *   phaseT         0..1 within the current phase (outro drives the fade-out)
+ *   stepT          eased 0..1 per step (0 pending, 1 locked)
+ *   rawStepT       un-eased 0..1 per step
+ *   activeIndices  steps currently mid-morph (0 < raw < 1)
+ *   lockedCount    steps fully settled
+ *   currentStep    index of the step ON SCREEN (intro → 0, outro → last)
+ *   stepLocalT     0..1 position inside the current step's FULL window —
+ *                  drives the narration typewriter (distinct from stepT,
+ *                  which stops moving at lockAt)
+ */
+export function resolveBreakdownProgress(
+  schedule, progression, easingFn
+) {
+  const p = wrapProgression( progression );
+  const {
+    introEnd,
+    outroStart,
+    windows
+  } = schedule;
+
+  const ease = typeof easingFn === "function" ? easingFn : ( x ) => x;
+
+  let phase = "build";
+  let phaseT = 0;
+
+  if ( p < introEnd ) {
+    phase = "intro";
+    phaseT = introEnd > 0 ? p / introEnd : 1;
+  } else if ( p >= outroStart ) {
+    phase = "outro";
+    phaseT = outroStart < 1 ? ( p - outroStart ) / ( 1 - outroStart ) : 1;
+  } else {
+    const span = outroStart - introEnd;
+
+    phaseT = span > 0 ? ( p - introEnd ) / span : 1;
+  }
+
+  const stepT = [];
+  const rawStepT = [];
+  const activeIndices = [];
+
+  let lockedCount = 0;
+
+  windows.forEach( (
+    window, index
+  ) => {
+    let raw;
+
+    if ( phase === "intro" ) {
+      raw = 0;
+    } else if ( phase === "outro" ) {
+      raw = 1;
+    } else {
+      const moveSpan = window.lockAt - window.start;
+
+      raw = moveSpan > 0
+        ? clamp01( ( p - window.start ) / moveSpan )
+        : ( p >= window.start ? 1 : 0 );
+    }
+
+    if ( raw >= 1 ) {
+      lockedCount += 1;
+    } else if ( raw > 0 ) {
+      activeIndices.push( index );
+    }
+
+    rawStepT.push( raw );
+    stepT.push( raw <= 0 ? 0 : raw >= 1 ? 1 : clamp01( ease( raw ) ) );
+  } );
+
+  // Which step the overlay narrates right now. Windows tile the build span,
+  // so during build it's a plain floor over the build-local position; the
+  // intro previews step 0 and the outro pins the last step (fading out).
+  let currentStep = 0;
+  let stepLocalT = 0;
+
+  if ( windows.length ) {
+    if ( phase === "intro" ) {
+      currentStep = 0;
+      stepLocalT = 0;
+    } else if ( phase === "outro" ) {
+      currentStep = windows.length - 1;
+      stepLocalT = 1;
+    } else {
+      currentStep = Math.min(
+        windows.length - 1,
+        Math.floor( phaseT * windows.length )
+      );
+
+      const window = windows[ currentStep ];
+      const span = window.end - window.start;
+
+      stepLocalT = span > 0 ? clamp01( ( p - window.start ) / span ) : 1;
+    }
+  }
+
+  return {
+    phase,
+    phaseT: clamp01( phaseT ),
+    stepT,
+    rawStepT,
+    activeIndices,
+    lockedCount,
+    currentStep,
+    stepLocalT
+  };
+}

--- a/src/sketches/p5/utils/slides/breakdown/startValues.js
+++ b/src/sketches/p5/utils/slides/breakdown/startValues.js
@@ -1,0 +1,290 @@
+// Build the parameter object the breakdown animates FROM. No randomness:
+// each value departs deterministically toward the "opposite" end of its own
+// range and travels back to the final value.
+//
+// Per-leaf rule:
+//   candidate = the field's form MIN; if min ≈ final (relative epsilon) the
+//   candidate flips to MAX — the opposite end. Then `departure` (0..1)
+//   scales how far the start actually sits:
+//     start = final + ( candidate − final ) × departure
+//   1 = full opposite/min, 0.1 = already close (the breakdown just
+//   "stabilizes" the sketch), 0 = identity (nothing moves).
+//
+// Colors invert per RGB channel (alpha kept); booleans flip when departure
+// ≥ 0.5 (they snap mid-window anyway); strings/enums keep their final value
+// (narrating a fake enum reads wrong). Pure and rng-free → identical between
+// live preview and deterministic capture by construction.
+
+import {
+  looksLikeColor,
+  nearlyEqual
+} from "./format.js";
+import {
+  matchesKeyList,
+  formConfigAt
+} from "./deriveSteps.js";
+
+const RESERVED_KEYS = new Set( [
+  "bindings",
+  "interaction"
+] );
+
+function isPlainObject( value ) {
+  return value != null && typeof value === "object" && !Array.isArray( value );
+}
+
+// Numeric range of a form field, when it exposes one. For a leaf nested
+// under a vector2d pad ("position.x"), the range comes from the pad's shared
+// + per-axis config.
+function numericRange(
+  fieldConfig, axis
+) {
+  if ( !fieldConfig ) {
+    return null;
+  }
+
+  if (
+    fieldConfig.component === "slider" ||
+    fieldConfig.component === "number"
+  ) {
+    if (
+      typeof fieldConfig.min === "number" &&
+      typeof fieldConfig.max === "number"
+    ) {
+      return {
+        min: fieldConfig.min,
+        max: fieldConfig.max,
+        step: fieldConfig.step
+      };
+    }
+
+    return null;
+  }
+
+  if ( fieldConfig.component === "vector2d" && axis ) {
+    const allowNegative = fieldConfig.allowNegative ?? true;
+    const min = fieldConfig.min ?? ( allowNegative ? -1 : 0 );
+    const max = fieldConfig.max ?? 1;
+    const perAxis = axis === "x" ? fieldConfig.xAxis : fieldConfig.yAxis;
+
+    return {
+      min: perAxis?.min ?? min,
+      max: perAxis?.max ?? max,
+      step: perAxis?.step ?? fieldConfig.step
+    };
+  }
+
+  return null;
+}
+
+function snapToStep(
+  value, range
+) {
+  if ( typeof range?.step !== "number" || range.step <= 0 ) {
+    return value;
+  }
+
+  const snapped = range.min + Math.round( ( value - range.min ) / range.step ) * range.step;
+
+  // Avoid float dust on integer steps (a start of 4.000000000000001 narrates
+  // badly in the overlay).
+  return Number.isInteger( range.step ) ? Math.round( snapped ) : snapped;
+}
+
+// Departure-scaled travel from the final value toward a candidate.
+function departFrom(
+  finalValue, candidate, departure
+) {
+  return finalValue + ( candidate - finalValue ) * departure;
+}
+
+function startNumber(
+  finalValue, departure, range
+) {
+  if ( range ) {
+    const candidate = nearlyEqual(
+      range.min,
+      finalValue
+    )
+      ? range.max
+      : range.min;
+
+    return snapToStep(
+      departFrom(
+        finalValue,
+        candidate,
+        departure
+      ),
+      range
+    );
+  }
+
+  // No form range: head toward 0, or toward 1 when the final IS 0.
+  const candidate = nearlyEqual(
+    finalValue,
+    0
+  ) ? 1 : 0;
+  const start = departFrom(
+    finalValue,
+    candidate,
+    departure
+  );
+
+  return Number.isInteger( finalValue ) ? Math.round( start ) : start;
+}
+
+/**
+ * One leaf's start value.
+ */
+function startLeaf(
+  finalValue, departure, fieldConfig, axis
+) {
+  if ( typeof finalValue === "number" ) {
+    return startNumber(
+      finalValue,
+      departure,
+      numericRange(
+        fieldConfig,
+        axis
+      )
+    );
+  }
+
+  if ( typeof finalValue === "boolean" ) {
+    return departure >= 0.5 ? !finalValue : finalValue;
+  }
+
+  if ( typeof finalValue === "string" ) {
+    return finalValue;
+  }
+
+  if ( Array.isArray( finalValue ) ) {
+    const isColor =
+      fieldConfig?.component === "color" || looksLikeColor( finalValue );
+
+    if ( isColor ) {
+      // Opposite = inverted RGB; alpha (index 3) kept — a transparent start
+      // would hide the whole travel.
+      return finalValue.map( (
+        channel, i
+      ) => (
+        i === 3
+          ? channel
+          : Math.round( departFrom(
+            channel,
+            255 - channel,
+            departure
+          ) )
+      ) );
+    }
+
+    return finalValue.map( ( component ) => (
+      typeof component === "number"
+        ? startNumber(
+          component,
+          departure,
+          null
+        )
+        : component
+    ) );
+  }
+
+  return finalValue;
+}
+
+function buildLevel(
+  node, prefix, context
+) {
+  const out = {};
+
+  for ( const key of Object.keys( node ) ) {
+    if ( !prefix && RESERVED_KEYS.has( key ) ) {
+      out[ key ] = node[ key ];
+      continue;
+    }
+
+    const path = prefix ? `${ prefix }.${ key }` : key;
+    const value = node[ key ];
+
+    if ( isPlainObject( value ) ) {
+      out[ key ] = buildLevel(
+        value,
+        path,
+        context
+      );
+      continue;
+    }
+
+    // Excluded / snap keys keep their final value (excluded also gets no
+    // step; snap keys flip mid-window via lerpParams' snap rule anyway).
+    if (
+      matchesKeyList(
+        path,
+        context.excludeKeys
+      ) ||
+      matchesKeyList(
+        path,
+        context.snapKeys
+      )
+    ) {
+      out[ key ] = value;
+      continue;
+    }
+
+    let fieldConfig = formConfigAt(
+      context.formConfiguration,
+      path
+    );
+    let axis;
+
+    // A number under a vector2d pad has its config on the PARENT path.
+    if ( !fieldConfig && prefix && ( key === "x" || key === "y" ) ) {
+      const parent = formConfigAt(
+        context.formConfiguration,
+        prefix
+      );
+
+      if ( parent?.component === "vector2d" ) {
+        fieldConfig = parent;
+        axis = key;
+      }
+    }
+
+    out[ key ] = startLeaf(
+      value,
+      context.departure,
+      fieldConfig,
+      axis
+    );
+  }
+
+  return out;
+}
+
+/**
+ * Build the start-parameter object, same shape as `finalSketch`.
+ *
+ * `formMeta` is `{ formValues, formConfiguration }` from the sketch's
+ * options.ts (via the window.getSketchFormMeta bridge) — optional; without
+ * it the numeric heuristics take over (bare capture harness).
+ */
+export default function buildStartValues(
+  finalSketch, build = {}, formMeta = {}
+) {
+  if ( !isPlainObject( finalSketch ) ) {
+    return {};
+  }
+
+  return buildLevel(
+    finalSketch,
+    "",
+    {
+      departure: build.departure ?? 1,
+      snapKeys: build.snapKeys ?? [
+        "seed"
+      ],
+      excludeKeys: build.excludeKeys ?? [],
+      formConfiguration: formMeta.formConfiguration
+    }
+  );
+}

--- a/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
@@ -1,0 +1,441 @@
+import string from "../../string.js";
+import sketch, {
+  getP5
+} from "../../sketch.js";
+import {
+  getBreakdownRuntimeState
+} from "../breakdown/index.js";
+import {
+  getByPath
+} from "../breakdown/deriveSteps.js";
+import {
+  formatCounter,
+  formatValue,
+  humanizeKey
+} from "../breakdown/format.js";
+import drawItemBackground, {
+  measureVerticalTextBox
+} from "./drawItemBackground.js";
+import {
+  reportItemBounds
+} from "./itemBoundsRegistry.js";
+
+/**
+ * Diff-narration overlay for the breakdown item. The parameter interpolation
+ * itself is injected in slides.getSketchSettings (see ../breakdown/); this
+ * overlay tells the story of the CURRENT step only, in the specs visual
+ * language (same text colour for text + panel outline, black panel):
+ *
+ *   1/3  DOTS                ← header: counter + step title (hideable)
+ *   COUNT: 42                ← the group's changing leaves, typed in
+ *   FILL: rgba(255, 0, 0) ▪  ← colours carry a live-animating chip
+ *
+ * During the outro the whole block fades out, leaving the settled sketch.
+ * Everything derives from the shared schedule (animation.progression) — no
+ * wall clock, so frame-by-frame capture reproduces the narration exactly.
+ *
+ * Placement: "fixed" uses the draggable position; "roaming" walks a
+ * deterministic corner tour (one anchor per step, `currentStep % 5`) so the
+ * block never hides the same region of the sketch twice.
+ */
+
+// Corner tour for roaming placement: top-left → top-right → bottom-right →
+// bottom-left → center. (x, y) is the anchor point in canvas fractions;
+// (ax, ay) is which corner of the BLOCK sits on that point, so the block
+// hugs each edge without overflowing.
+const ROAM_ANCHORS = [
+  {
+    x: 0.06,
+    y: 0.08,
+    ax: 0,
+    ay: 0
+  },
+  {
+    x: 0.94,
+    y: 0.08,
+    ax: 1,
+    ay: 0
+  },
+  {
+    x: 0.94,
+    y: 0.92,
+    ax: 1,
+    ay: 1
+  },
+  {
+    x: 0.06,
+    y: 0.92,
+    ax: 0,
+    ay: 1
+  },
+  {
+    x: 0.5,
+    y: 0.5,
+    ax: 0.5,
+    ay: 0.5
+  }
+];
+
+// Fraction of each step window the body lines take to type in.
+const TYPE_IN_SPAN = 0.4;
+
+function clamp01( value ) {
+  return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
+export default function drawSlideBreakdown( breakdownOption ) {
+  const p = getP5();
+
+  // A montage slide's params morph between OTHER slides — the breakdown
+  // injection is inert there (montage wins in getSketchSettings), so the
+  // narration would lie. Stay silent on montage slides.
+  const currentSlide =
+    typeof window !== "undefined" ? window.slides?.current : undefined;
+
+  if ( currentSlide?.transition?.enabled ) {
+    return;
+  }
+
+  const state = getBreakdownRuntimeState( breakdownOption );
+  const {
+    animSteps,
+    progress,
+    currentFlat,
+    startValues
+  } = state;
+
+  // Nothing changed (diff mode) or nothing animatable: the injection no-ops
+  // and the overlay hides — an honest diff shows nothing when nothing
+  // differs.
+  if ( !animSteps.length ) {
+    return;
+  }
+
+  const {
+    phase,
+    phaseT,
+    currentStep,
+    stepLocalT
+  } = progress;
+
+  // Outro: fade the whole block out, panel included.
+  const alpha = phase === "outro" ? Math.round( 255 * ( 1 - phaseT ) ) : 255;
+
+  if ( alpha <= 0 ) {
+    return;
+  }
+
+  const step = animSteps[ currentStep ];
+
+  if ( !step ) {
+    return;
+  }
+
+  const size = breakdownOption.size ?? 22;
+  const lineStep = size * ( breakdownOption.lineHeight ?? 1.4 );
+  const font =
+    string.fonts?.[ breakdownOption.font ] ?? string.fonts.spaceMonoRegular;
+
+  const measureWidth = ( text ) => {
+    p.push();
+    p.textFont( font );
+    p.textSize( size );
+    const w = p.textWidth( text );
+
+    p.pop();
+
+    return w;
+  };
+
+  /* ---- row model (measured at FINAL values: stable within a step) --- */
+
+  const showHeader = breakdownOption.showHeader ?? true;
+  const showCounter = breakdownOption.showCounter ?? true;
+  const showTitle = breakdownOption.showTitle ?? true;
+
+  let headerText = "";
+
+  if ( showHeader && ( showCounter || showTitle ) ) {
+    const parts = [];
+
+    if ( showCounter ) {
+      parts.push( formatCounter(
+        currentStep,
+        animSteps.length,
+        breakdownOption.counterMode
+      ) );
+    }
+
+    if ( showTitle ) {
+      parts.push( step.label );
+    }
+
+    headerText = parts.join( "  " );
+  }
+
+  // One body line per leaf: "SUB LABEL: value". Nested leaves label with the
+  // path past the group prefix; an isolated leaf repeats its own name (needed
+  // when the header is hidden).
+  const chipSide = size * 0.9;
+  const chipGap = size * 0.4;
+
+  const bodyLines = step.leaves.map( ( leaf ) => {
+    const subPath = leaf.path.startsWith( `${ step.id }.` )
+      ? leaf.path.slice( step.id.length + 1 )
+      : leaf.path;
+    const label = humanizeKey( subPath );
+    const finalText = `${ label }: ${ formatValue( leaf.value ) ?? "" }`;
+
+    // In-flight values sit BETWEEN start and final, so their rendered text
+    // never outgrows the wider of the two extremes (plus a small margin for
+    // the fractional digits a lerp introduces between integer endpoints).
+    // Measuring only the final would under-reserve — mid-lerp a right-
+    // anchored roaming block would overflow the canvas edge.
+    const startValue = getByPath(
+      startValues,
+      leaf.path
+    );
+    const startText = `${ label }: ${ formatValue( startValue ) ?? "" }`;
+
+    return {
+      leaf,
+      label,
+      width:
+        Math.max(
+          measureWidth( finalText ),
+          measureWidth( startText )
+        ) +
+        size * 0.8 +
+        ( leaf.cls === "colors" ? chipGap + chipSide : 0 )
+    };
+  } );
+
+  const rows = ( headerText ? 1 : 0 ) + bodyLines.length;
+
+  if ( !rows ) {
+    return;
+  }
+
+  const blockW = Math.max(
+    headerText ? measureWidth( headerText ) : 0,
+    ...bodyLines.map( ( line ) => line.width ),
+    size * 4
+  );
+  const blockH = ( rows - 1 ) * lineStep + size;
+
+  /* ---- placement ----------------------------------------------------- */
+
+  p.push();
+  if ( sketch.sketchOptions?.type === "webgl" ) {
+    p.translate(
+      -p.width / 2,
+      -p.height / 2
+    );
+  }
+
+  let originX;
+  let originY;
+
+  if ( ( breakdownOption.placement ?? "fixed" ) === "roaming" ) {
+    // Deterministic corner tour — a different anchor per step, keyed on the
+    // step index only (loop-clock world, capture-safe).
+    const anchor = ROAM_ANCHORS[ currentStep % ROAM_ANCHORS.length ];
+
+    originX = p.width * anchor.x - blockW * anchor.ax;
+    originY = p.height * anchor.y - blockH * anchor.ay;
+    // Roaming blocks are not draggable — no reported bounds (and contentDrag
+    // additionally skips them, see its collectTargets guard).
+  } else {
+    originX = p.width * ( breakdownOption.position?.x ?? 0.06 );
+    originY = p.height * ( breakdownOption.position?.y ?? 0.08 );
+
+    // Generous, stable grab zone for the on-canvas drag (specs pattern).
+    reportItemBounds(
+      originX,
+      originY - size,
+      blockW,
+      blockH + size * 2
+    );
+  }
+
+  /* ---- panel (specs invocation, drawn first) -------------------------- */
+
+  const texts = [];
+
+  if ( headerText ) {
+    texts.push( headerText );
+  }
+
+  bodyLines.forEach( ( line ) => texts.push( `${ line.label }: ${ formatValue( line.leaf.value ) ?? "" }` ) );
+
+  const firstBox = measureVerticalTextBox(
+    font,
+    texts[ 0 ],
+    originX,
+    originY,
+    size
+  );
+  const lastBox = measureVerticalTextBox(
+    font,
+    texts[ texts.length - 1 ],
+    originX,
+    originY + ( rows - 1 ) * lineStep,
+    size
+  );
+  const bgPad = size * 0.35;
+
+  drawItemBackground( {
+    x: originX - bgPad,
+    y: firstBox.top - bgPad,
+    w: blockW + bgPad * 2,
+    h: lastBox.bottom - firstBox.top + bgPad * 2,
+    color: breakdownOption.backgroundColor,
+    radius: breakdownOption.backgroundRadius ?? 0,
+    alpha: alpha / 255,
+    stroke: breakdownOption.backgroundStroke,
+    strokeWeight: Math.min(
+      Math.max(
+        1,
+        size * 0.06
+      ),
+      4
+    )
+  } );
+
+  /* ---- text ------------------------------------------------------------ */
+
+  const textFill = p.color( ...( breakdownOption.fill ?? [
+    0,
+    255,
+    120
+  ] ) );
+
+  textFill.setAlpha( alpha );
+
+  const writeLine = (
+    text, x, y
+  ) => {
+    string.write(
+      text,
+      x,
+      y,
+      {
+        size,
+        font,
+        fill: textFill,
+        stroke: false,
+        strokeWeight: 0,
+        blendMode: breakdownOption.blend,
+        textWidth: -1,
+        textAlign: [
+          p.LEFT,
+          p.TOP
+        ]
+      }
+    );
+  };
+
+  let y = originY;
+
+  if ( headerText ) {
+    writeLine(
+      headerText,
+      originX,
+      y
+    );
+    y += lineStep;
+  }
+
+  // Body lines type in over the first part of the step window: earlier lines
+  // full, the appearing line per-character (specs boot-log pattern).
+  const exactLines =
+    clamp01( stepLocalT / TYPE_IN_SPAN ) * bodyLines.length;
+  const fullyVisible = Math.floor( exactLines );
+  const typingFraction = exactLines - fullyVisible;
+
+  bodyLines.forEach( (
+    line, index
+  ) => {
+    if ( index > fullyVisible ) {
+      return;
+    }
+
+    const liveValue = currentFlat.has( line.leaf.path )
+      ? currentFlat.get( line.leaf.path )
+      : line.leaf.value;
+    const full = `${ line.label }: ${ formatValue( liveValue ) ?? "" }`;
+
+    if ( index < fullyVisible ) {
+      writeLine(
+        full,
+        originX,
+        y
+      );
+
+      // Live colour chip after the text (HUD swatch look: filled square +
+      // 1px border in the text colour).
+      if ( line.leaf.cls === "colors" && Array.isArray( liveValue ) ) {
+        const chipX = originX + measureWidth( full ) + chipGap;
+        const chipY = y + ( size - chipSide ) / 2;
+        const chipColor = p.color(
+          liveValue[ 0 ] ?? 0,
+          liveValue[ 1 ] ?? 0,
+          liveValue[ 2 ] ?? 0
+        );
+
+        chipColor.setAlpha( Math.min(
+          liveValue[ 3 ] ?? 255,
+          alpha
+        ) );
+
+        const border = p.color( ...( breakdownOption.fill ?? [
+          0,
+          255,
+          120
+        ] ) );
+
+        border.setAlpha( Math.min(
+          120,
+          alpha
+        ) );
+
+        p.push();
+        p.blendMode( p.BLEND );
+        p.noStroke();
+        p.fill( chipColor );
+        p.rect(
+          chipX,
+          chipY,
+          chipSide,
+          chipSide
+        );
+        p.noFill();
+        p.stroke( border );
+        p.strokeWeight( 1 );
+        p.rect(
+          chipX,
+          chipY,
+          chipSide,
+          chipSide
+        );
+        p.pop();
+      }
+    } else {
+      // Line currently being typed: reveal character by character.
+      const visibleCount = Math.ceil( full.length * typingFraction );
+
+      writeLine(
+        full.slice(
+          0,
+          visibleCount
+        ),
+        originX,
+        y
+      );
+    }
+
+    y += lineStep;
+  } );
+
+  p.pop();
+}

--- a/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
@@ -6,13 +6,16 @@ import {
   getBreakdownRuntimeState
 } from "../breakdown/index.js";
 import {
-  getByPath
+  getByPath,
+  matchesKeyList
 } from "../breakdown/deriveSteps.js";
 import {
   formatCounter,
   formatValue,
-  humanizeKey
+  humanizeKey,
+  sampleValueTexts
 } from "../breakdown/format.js";
+import staggeredProgress from "../morph/staggeredProgress.js";
 import drawItemBackground, {
   measureVerticalTextBox
 } from "./drawItemBackground.js";
@@ -26,23 +29,29 @@ import {
  * overlay tells the story of the CURRENT step only, in the specs visual
  * language (same text colour for text + panel outline, black panel):
  *
- *   1/3  DOTS                ← header: counter + step title (hideable)
- *   COUNT: 42                ← the group's changing leaves, typed in
- *   FILL: rgba(255, 0, 0) ▪  ← colours carry a live-animating chip
+ *   1/3  DOTS                ← header: counter + step title (hideable; the
+ *                              title hides itself on isolated single params
+ *                              whose body line repeats the same name)
+ *   COUNT: ▓▓▓░░░ 42         ← changing leaves; the value renders per
+ *   FILL:  ▓▓░░░░ ▪            `valueStyle`: gauge-style bar (default),
+ *                              live ticker, roll / fade / rise transitions
  *
- * During the outro the whole block fades out, leaving the settled sketch.
- * Everything derives from the shared schedule (animation.progression) — no
- * wall clock, so frame-by-frame capture reproduces the narration exactly.
+ * Labels appear whole by default — only the value animates; `typewriter`
+ * re-enables per-character typing, and `build.lineStagger` offsets the lines
+ * of a group (0 = all together, 1 ≈ one after another; it also staggers the
+ * injected values, so overlay and sketch stay in lock-step via the shared
+ * per-leaf progress). Layout reserves each value column at the widest text
+ * the lerp can produce (sampleValueTexts), so nothing overflows the panel
+ * mid-animation. During the outro the whole block fades out.
  *
  * Placement: "fixed" uses the draggable position; "roaming" walks a
- * deterministic corner tour (one anchor per step, `currentStep % 5`) so the
- * block never hides the same region of the sketch twice.
+ * deterministic corner tour (one anchor per step, `currentStep % 5`). All
+ * timing derives from animation.progression — capture-deterministic.
  */
 
 // Corner tour for roaming placement: top-left → top-right → bottom-right →
 // bottom-left → center. (x, y) is the anchor point in canvas fractions;
-// (ax, ay) is which corner of the BLOCK sits on that point, so the block
-// hugs each edge without overflowing.
+// (ax, ay) is which corner of the BLOCK sits on that point.
 const ROAM_ANCHORS = [
   {
     x: 0.06,
@@ -76,8 +85,8 @@ const ROAM_ANCHORS = [
   }
 ];
 
-// Fraction of each step window the body lines take to type in.
-const TYPE_IN_SPAN = 0.4;
+// Fraction of each step window over which lines reveal (stagger/typewriter).
+const REVEAL_SPAN = 0.4;
 
 function clamp01( value ) {
   return value < 0 ? 0 : value > 1 ? 1 : value;
@@ -101,6 +110,7 @@ export default function drawSlideBreakdown( breakdownOption ) {
     animSteps,
     progress,
     currentFlat,
+    leafT,
     startValues
   } = state;
 
@@ -131,10 +141,16 @@ export default function drawSlideBreakdown( breakdownOption ) {
     return;
   }
 
-  const size = breakdownOption.size ?? 22;
+  const size = breakdownOption.size ?? 16;
   const lineStep = size * ( breakdownOption.lineHeight ?? 1.4 );
   const font =
     string.fonts?.[ breakdownOption.font ] ?? string.fonts.spaceMonoRegular;
+  const valueStyle = breakdownOption.valueStyle ?? "bar";
+  const typewriter = breakdownOption.typewriter ?? false;
+  const lineStagger = breakdownOption.build?.lineStagger ?? 0;
+  const snapKeys = breakdownOption.build?.snapKeys ?? [
+    "seed"
+  ];
 
   const measureWidth = ( text ) => {
     p.push();
@@ -147,15 +163,33 @@ export default function drawSlideBreakdown( breakdownOption ) {
     return w;
   };
 
-  /* ---- row model (measured at FINAL values: stable within a step) --- */
+  const baseFill = () => {
+    const c = p.color( ...( breakdownOption.fill ?? [
+      0,
+      255,
+      120
+    ] ) );
+
+    c.setAlpha( alpha );
+
+    return c;
+  };
+
+  /* ---- header --------------------------------------------------------- */
 
   const showHeader = breakdownOption.showHeader ?? true;
   const showCounter = breakdownOption.showCounter ?? true;
   const showTitle = breakdownOption.showTitle ?? true;
 
+  // An isolated single param's body line repeats the full parameter name —
+  // a header title would be a word-for-word duplicate. Groups reduced to one
+  // changed sub-property keep theirs (GRID / COLUMNS: 8 is informative).
+  const titleRedundant =
+    step.leaves.length === 1 && !step.leaves[ 0 ].path.includes( "." );
+
   let headerText = "";
 
-  if ( showHeader && ( showCounter || showTitle ) ) {
+  if ( showHeader && ( showCounter || ( showTitle && !titleRedundant ) ) ) {
     const parts = [];
 
     if ( showCounter ) {
@@ -166,47 +200,69 @@ export default function drawSlideBreakdown( breakdownOption ) {
       ) );
     }
 
-    if ( showTitle ) {
+    if ( showTitle && !titleRedundant ) {
       parts.push( step.label );
     }
 
     headerText = parts.join( "  " );
   }
 
-  // One body line per leaf: "SUB LABEL: value". Nested leaves label with the
-  // path past the group prefix; an isolated leaf repeats its own name (needed
-  // when the header is hidden).
+  /* ---- row model -------------------------------------------------------
+   * Column layout, reserved up front so nothing can overflow mid-lerp:
+   *   LABEL:  [ value zone ]
+   * The value zone is sized at the WIDEST text the lerp can render
+   * (sampleValueTexts) plus the bar / colour chip the style adds.
+   */
+
   const chipSide = size * 0.9;
-  const chipGap = size * 0.4;
+  const gap = size * 0.4;
+  const barW = size * 6;
+  const barH = size * 0.45;
 
   const bodyLines = step.leaves.map( ( leaf ) => {
     const subPath = leaf.path.startsWith( `${ step.id }.` )
       ? leaf.path.slice( step.id.length + 1 )
       : leaf.path;
-    const label = humanizeKey( subPath );
-    const finalText = `${ label }: ${ formatValue( leaf.value ) ?? "" }`;
-
-    // In-flight values sit BETWEEN start and final, so their rendered text
-    // never outgrows the wider of the two extremes (plus a small margin for
-    // the fractional digits a lerp introduces between integer endpoints).
-    // Measuring only the final would under-reserve — mid-lerp a right-
-    // anchored roaming block would overflow the canvas edge.
+    const labelText = `${ humanizeKey( subPath ) }: `;
     const startValue = getByPath(
       startValues,
       leaf.path
     );
-    const startText = `${ label }: ${ formatValue( startValue ) ?? "" }`;
+    const isColor = leaf.cls === "colors";
+    const snap = matchesKeyList(
+      leaf.path,
+      snapKeys
+    );
+
+    const maxTextW = Math.max(
+      0,
+      ...sampleValueTexts(
+        startValue,
+        leaf.value,
+        snap
+      ).map( measureWidth )
+    );
+
+    // What the style renders inside the value zone:
+    //   bar    → bar [+ live text | chip]
+    //   ticker → live text [+ chip]
+    //   roll/fade/rise → start/final texts crossfading [+ chip]
+    let valueZoneW;
+
+    if ( valueStyle === "bar" ) {
+      valueZoneW = barW + gap + ( isColor ? chipSide : maxTextW );
+    } else {
+      valueZoneW = maxTextW + ( isColor ? gap + chipSide : 0 );
+    }
 
     return {
       leaf,
-      label,
-      width:
-        Math.max(
-          measureWidth( finalText ),
-          measureWidth( startText )
-        ) +
-        size * 0.8 +
-        ( leaf.cls === "colors" ? chipGap + chipSide : 0 )
+      labelText,
+      startValue,
+      isColor,
+      labelW: measureWidth( labelText ),
+      valueZoneW,
+      width: measureWidth( labelText ) + valueZoneW
     };
   } );
 
@@ -223,7 +279,7 @@ export default function drawSlideBreakdown( breakdownOption ) {
   );
   const blockH = ( rows - 1 ) * lineStep + size;
 
-  /* ---- placement ----------------------------------------------------- */
+  /* ---- placement ------------------------------------------------------- */
 
   p.push();
   if ( sketch.sketchOptions?.type === "webgl" ) {
@@ -258,26 +314,20 @@ export default function drawSlideBreakdown( breakdownOption ) {
     );
   }
 
-  /* ---- panel (specs invocation, drawn first) -------------------------- */
+  /* ---- panel (specs invocation, drawn first) ---------------------------- */
 
-  const texts = [];
-
-  if ( headerText ) {
-    texts.push( headerText );
-  }
-
-  bodyLines.forEach( ( line ) => texts.push( `${ line.label }: ${ formatValue( line.leaf.value ) ?? "" }` ) );
-
+  const firstText = headerText || bodyLines[ 0 ].labelText;
+  const lastLine = bodyLines[ bodyLines.length - 1 ];
   const firstBox = measureVerticalTextBox(
     font,
-    texts[ 0 ],
+    firstText,
     originX,
     originY,
     size
   );
   const lastBox = measureVerticalTextBox(
     font,
-    texts[ texts.length - 1 ],
+    lastLine ? lastLine.labelText : firstText,
     originX,
     originY + ( rows - 1 ) * lineStep,
     size
@@ -302,19 +352,19 @@ export default function drawSlideBreakdown( breakdownOption ) {
     )
   } );
 
-  /* ---- text ------------------------------------------------------------ */
+  /* ---- drawing helpers --------------------------------------------------- */
 
-  const textFill = p.color( ...( breakdownOption.fill ?? [
-    0,
-    255,
-    120
-  ] ) );
-
-  textFill.setAlpha( alpha );
-
-  const writeLine = (
-    text, x, y
+  const writeText = (
+    text, x, y, alphaFactor = 1
   ) => {
+    if ( !text ) {
+      return;
+    }
+
+    const fill = baseFill();
+
+    fill.setAlpha( Math.round( alpha * clamp01( alphaFactor ) ) );
+
     string.write(
       text,
       x,
@@ -322,7 +372,7 @@ export default function drawSlideBreakdown( breakdownOption ) {
       {
         size,
         font,
-        fill: textFill,
+        fill,
         stroke: false,
         strokeWeight: 0,
         blendMode: breakdownOption.blend,
@@ -335,10 +385,111 @@ export default function drawSlideBreakdown( breakdownOption ) {
     );
   };
 
+  const drawChip = (
+    x, y, liveValue
+  ) => {
+    if ( !Array.isArray( liveValue ) ) {
+      return;
+    }
+
+    const chipY = y + ( size - chipSide ) / 2;
+    const chipColor = p.color(
+      liveValue[ 0 ] ?? 0,
+      liveValue[ 1 ] ?? 0,
+      liveValue[ 2 ] ?? 0
+    );
+
+    chipColor.setAlpha( Math.min(
+      liveValue[ 3 ] ?? 255,
+      alpha
+    ) );
+
+    const border = baseFill();
+
+    border.setAlpha( Math.min(
+      120,
+      alpha
+    ) );
+
+    p.push();
+    p.blendMode( p.BLEND );
+    p.noStroke();
+    p.fill( chipColor );
+    p.rect(
+      x,
+      chipY,
+      chipSide,
+      chipSide
+    );
+    p.noFill();
+    p.stroke( border );
+    p.strokeWeight( 1 );
+    p.rect(
+      x,
+      chipY,
+      chipSide,
+      chipSide
+    );
+    p.pop();
+  };
+
+  const drawBar = (
+    x, y, t
+  ) => {
+    const barY = y + ( size - barH ) / 2;
+    const track = baseFill();
+
+    track.setAlpha( Math.min(
+      60,
+      alpha
+    ) );
+
+    p.push();
+    p.blendMode( p.BLEND );
+    p.noStroke();
+    p.fill( track );
+    p.rect(
+      x,
+      barY,
+      barW,
+      barH
+    );
+    p.fill( baseFill() );
+    p.rect(
+      x,
+      barY,
+      barW * clamp01( t ),
+      barH
+    );
+    p.pop();
+  };
+
+  // Clip to one line's value zone so rise/roll glyphs sliding vertically
+  // never bleed into the neighbouring lines.
+  const withLineClip = (
+    x, y, w, draw
+  ) => {
+    const ctx = p.drawingContext;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(
+      x,
+      y - size * 0.2,
+      w,
+      size * 1.4
+    );
+    ctx.clip();
+    draw();
+    ctx.restore();
+  };
+
+  /* ---- text -------------------------------------------------------------- */
+
   let y = originY;
 
   if ( headerText ) {
-    writeLine(
+    writeText(
       headerText,
       originX,
       y
@@ -346,92 +497,216 @@ export default function drawSlideBreakdown( breakdownOption ) {
     y += lineStep;
   }
 
-  // Body lines type in over the first part of the step window: earlier lines
-  // full, the appearing line per-character (specs boot-log pattern).
-  const exactLines =
-    clamp01( stepLocalT / TYPE_IN_SPAN ) * bodyLines.length;
-  const fullyVisible = Math.floor( exactLines );
-  const typingFraction = exactLines - fullyVisible;
+  const leafCount = bodyLines.length;
 
   bodyLines.forEach( (
     line, index
   ) => {
-    if ( index > fullyVisible ) {
+    // Per-line reveal: with lineStagger 0 every line is on from the step's
+    // first frame; higher values wash the lines in one after another over
+    // the first REVEAL_SPAN of the window.
+    const reveal = staggeredProgress(
+      clamp01( stepLocalT / REVEAL_SPAN ),
+      leafCount > 1 ? index / ( leafCount - 1 ) : 0,
+      lineStagger
+    );
+
+    if ( reveal <= 0 ) {
+      y += lineStep;
+
       return;
     }
 
-    const liveValue = currentFlat.has( line.leaf.path )
-      ? currentFlat.get( line.leaf.path )
+    const path = line.leaf.path;
+    const t = leafT.get( path ) ?? 1;
+    const liveValue = currentFlat.has( path )
+      ? currentFlat.get( path )
       : line.leaf.value;
-    const full = `${ line.label }: ${ formatValue( liveValue ) ?? "" }`;
+    const startText = formatValue( line.startValue ) ?? "";
+    const finalText = formatValue( line.leaf.value ) ?? "";
+    const liveText = formatValue( liveValue ) ?? "";
 
-    if ( index < fullyVisible ) {
-      writeLine(
-        full,
-        originX,
-        y
-      );
+    // Label: whole by default; per-character only when typewriter is on.
+    const labelText = typewriter
+      ? line.labelText.slice(
+        0,
+        Math.ceil( line.labelText.length * reveal )
+      )
+      : line.labelText;
 
-      // Live colour chip after the text (HUD swatch look: filled square +
-      // 1px border in the text colour).
-      if ( line.leaf.cls === "colors" && Array.isArray( liveValue ) ) {
-        const chipX = originX + measureWidth( full ) + chipGap;
-        const chipY = y + ( size - chipSide ) / 2;
-        const chipColor = p.color(
-          liveValue[ 0 ] ?? 0,
-          liveValue[ 1 ] ?? 0,
-          liveValue[ 2 ] ?? 0
-        );
+    writeText(
+      labelText,
+      originX,
+      y
+    );
 
-        chipColor.setAlpha( Math.min(
-          liveValue[ 3 ] ?? 255,
-          alpha
-        ) );
+    // The value zone renders once the label is fully in.
+    const valueReady = !typewriter || reveal >= 1;
+    const valueX = originX + line.labelW;
 
-        const border = p.color( ...( breakdownOption.fill ?? [
-          0,
-          255,
-          120
-        ] ) );
+    if ( valueReady ) {
+      switch ( valueStyle ) {
+        case "ticker":
+          writeText(
+            liveText,
+            valueX,
+            y
+          );
 
-        border.setAlpha( Math.min(
-          120,
-          alpha
-        ) );
+          if ( line.isColor ) {
+            drawChip(
+              valueX + measureWidth( liveText ) + gap,
+              y,
+              liveValue
+            );
+          }
 
-        p.push();
-        p.blendMode( p.BLEND );
-        p.noStroke();
-        p.fill( chipColor );
-        p.rect(
-          chipX,
-          chipY,
-          chipSide,
-          chipSide
-        );
-        p.noFill();
-        p.stroke( border );
-        p.strokeWeight( 1 );
-        p.rect(
-          chipX,
-          chipY,
-          chipSide,
-          chipSide
-        );
-        p.pop();
+          break;
+
+        case "fade":
+          writeText(
+            startText,
+            valueX,
+            y,
+            1 - t
+          );
+          writeText(
+            finalText,
+            valueX,
+            y,
+            t
+          );
+
+          if ( line.isColor ) {
+            drawChip(
+              valueX + line.valueZoneW - chipSide,
+              y,
+              liveValue
+            );
+          }
+
+          break;
+
+        case "rise": {
+          const amp = size * 0.55;
+          const textZoneW = line.valueZoneW - ( line.isColor ? gap + chipSide : 0 );
+
+          withLineClip(
+            valueX,
+            y,
+            textZoneW,
+            () => {
+              writeText(
+                startText,
+                valueX,
+                y - t * amp,
+                1 - t
+              );
+              writeText(
+                finalText,
+                valueX,
+                y + ( 1 - t ) * amp,
+                t
+              );
+            }
+          );
+
+          if ( line.isColor ) {
+            drawChip(
+              valueX + line.valueZoneW - chipSide,
+              y,
+              liveValue
+            );
+          }
+
+          break;
+        }
+
+        case "roll": {
+          // Per-character odometer: each column rolls from the start glyph
+          // to the final glyph, later columns trailing slightly.
+          const textZoneW = line.valueZoneW - ( line.isColor ? gap + chipSide : 0 );
+          const charW = measureWidth( "0" ) || size * 0.6;
+          const maxLen = Math.max(
+            startText.length,
+            finalText.length
+          );
+
+          withLineClip(
+            valueX,
+            y,
+            textZoneW,
+            () => {
+              for ( let k = 0; k < maxLen; k++ ) {
+                const fromChar = startText[ k ] ?? "";
+                const toChar = finalText[ k ] ?? "";
+                const charT = staggeredProgress(
+                  t,
+                  maxLen > 1 ? k / ( maxLen - 1 ) : 0,
+                  0.35
+                );
+                const x = valueX + k * charW;
+
+                if ( fromChar === toChar ) {
+                  writeText(
+                    toChar,
+                    x,
+                    y
+                  );
+                  continue;
+                }
+
+                writeText(
+                  fromChar,
+                  x,
+                  y - charT * size * 1.1,
+                  1 - charT
+                );
+                writeText(
+                  toChar,
+                  x,
+                  y + ( 1 - charT ) * size * 1.1,
+                  charT
+                );
+              }
+            }
+          );
+
+          if ( line.isColor ) {
+            drawChip(
+              valueX + line.valueZoneW - chipSide,
+              y,
+              liveValue
+            );
+          }
+
+          break;
+        }
+
+        case "bar":
+        default:
+          drawBar(
+            valueX,
+            y,
+            t
+          );
+
+          if ( line.isColor ) {
+            drawChip(
+              valueX + barW + gap,
+              y,
+              liveValue
+            );
+          } else {
+            writeText(
+              liveText,
+              valueX + barW + gap,
+              y
+            );
+          }
+
+          break;
       }
-    } else {
-      // Line currently being typed: reveal character by character.
-      const visibleCount = Math.ceil( full.length * typingFraction );
-
-      writeLine(
-        full.slice(
-          0,
-          visibleCount
-        ),
-        originX,
-        y
-      );
     }
 
     y += lineStep;

--- a/src/sketches/p5/utils/slides/contentDrag.js
+++ b/src/sketches/p5/utils/slides/contentDrag.js
@@ -64,7 +64,8 @@ const DRAGGABLE_TYPES = new Set( [
   "images-stack",
   "visual",
   "qrcode",
-  "specs"
+  "specs",
+  "breakdown"
 ] );
 
 // A "hud" content item has no single position of its own — instead it holds
@@ -182,6 +183,11 @@ function positionDefaults( type ) {
       return {
         x: 0.05,
         y: 0.06
+      };
+    case "breakdown":
+      return {
+        x: 0.06,
+        y: 0.08
       };
     default:
       return {
@@ -364,6 +370,14 @@ function collectTargets( p ) {
       }
 
       if ( !DRAGGABLE_TYPES.has( item.type ) ) {
+        return;
+      }
+
+      // A roaming breakdown places itself (corner tour, one anchor per step)
+      // and ignores item.position entirely. It must be excluded HERE — the
+      // hit-test's anchor-disc fallback would otherwise still grab it at its
+      // unused stored position even though it reports no bounds.
+      if ( item.type === "breakdown" && item.placement === "roaming" ) {
         return;
       }
 

--- a/src/sketches/p5/utils/slides/index.js
+++ b/src/sketches/p5/utils/slides/index.js
@@ -11,6 +11,10 @@ import {
 } from "./layouts";
 
 import getMontageSketch from "./morph/index.js";
+import getBreakdownSketch, {
+  findActiveBreakdownItem
+} from "./breakdown/index.js";
+import animation from "../animation.js";
 import drawMontageDip from "./morph/drawMontageDip.js";
 import drawMontageSound from "./morph/drawMontageSound.js";
 import drawMontageTitle from "./montageTitle/index.js";
@@ -320,6 +324,30 @@ const slides = {
 
       if ( montage ) {
         return montage;
+      }
+    }
+
+    // Breakdown diff narration: when a "breakdown" content item governs this
+    // frame (current slide's content wins over global), return the
+    // interpolated in-progress parameters instead of the settled merge —
+    // same injection seam as the montage above (which wins on its own
+    // slides). Reads raw store arrays only; the orchestrator memoizes.
+    const breakdownItem = findActiveBreakdownItem(
+      optionsTarget,
+      this.index,
+      Array.isArray( optionsTarget?.slides ) ? optionsTarget.slides.length : 0
+    );
+
+    if ( breakdownItem ) {
+      const built = getBreakdownSketch(
+        globalSketch,
+        currentSlide?.sketch,
+        breakdownItem,
+        animation.progression
+      );
+
+      if ( built ) {
+        return built;
       }
     }
 

--- a/src/sketches/p5/utils/slides/layouts/freeLayout.js
+++ b/src/sketches/p5/utils/slides/layouts/freeLayout.js
@@ -9,6 +9,7 @@ import drawSlideImages from "../common/drawSlideImages.js";
 import drawSlideBackground from "../common/drawSlideBackground.js";
 import drawSlideImagesStack from "../common/drawSlideImagesStack.js";
 import drawSlideQrCode from "../common/drawSlideQrCode.js";
+import drawSlideBreakdown from "../common/drawSlideBreakdown.js";
 import {
   resolveDraggedItem
 } from "../contentDrag.js";
@@ -49,6 +50,9 @@ export default function freeLayout(
         break;
       case "specs":
         drawSlideSpecs( item );
+        break;
+      case "breakdown":
+        drawSlideBreakdown( item );
         break;
       case "hud":
         drawSlideHud( item );

--- a/src/types/__tests__/breakdownItem.test.ts
+++ b/src/types/__tests__/breakdownItem.test.ts
@@ -42,8 +42,10 @@ describe(
           showCounter: true,
           showTitle: true,
           counterMode: "numeric",
+          typewriter: false,
+          valueStyle: "bar",
           font: "spaceMonoRegular",
-          size: 22,
+          size: 16,
           lineHeight: 1.4,
           backgroundRadius: 0
         } );
@@ -75,6 +77,7 @@ describe(
           outroRatio: 0.1,
           holdRatio: 0.15,
           easing: "easeInOutCubic",
+          lineStagger: 0,
           snapKeys: [
             "seed"
           ],
@@ -249,6 +252,12 @@ describe(
           BreakdownItemSchema.parse( {
             type: "breakdown",
             counterMode: "roman"
+          } ) ).toThrow();
+
+        expect( () =>
+          BreakdownItemSchema.parse( {
+            type: "breakdown",
+            valueStyle: "confetti"
           } ) ).toThrow();
       }
     );

--- a/src/types/__tests__/breakdownItem.test.ts
+++ b/src/types/__tests__/breakdownItem.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Guards the "breakdown" content item wiring.
+ *
+ * Like every other content item, the breakdown is spread across four places
+ * that must stay in agreement: the Zod schema (source of truth), the
+ * discriminated union, the makeDefaultItem factory, and the form
+ * field-config. If any of them drifts the item either fails to parse, can't
+ * be added from the palette, or renders a form with missing/orphan fields.
+ * Also locks in the strip-healing of persisted v2 items (the discarded
+ * construction-animation iteration that shipped to dev decks).
+ */
+
+import {
+  BreakdownBuildSchema,
+  BreakdownItemSchema,
+  ContentItemSchema
+} from "@/types/sketch.types";
+import makeDefaultItem
+  from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/utils/makeDefaultItem";
+import {
+  formConfig
+} from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config";
+import {
+  ITEM_META,
+  ITEM_ORDER
+} from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/AddItemControls/components/ItemPalette/constants/item-kinds";
+
+describe(
+  "breakdown content item",
+  () => {
+    it(
+      "applies the v3 defaults (specs look, visible panel)",
+      () => {
+        const item = BreakdownItemSchema.parse( {
+          type: "breakdown"
+        } );
+
+        expect( item ).toMatchObject( {
+          type: "breakdown",
+          placement: "fixed",
+          showHeader: true,
+          showCounter: true,
+          showTitle: true,
+          counterMode: "numeric",
+          font: "spaceMonoRegular",
+          size: 22,
+          lineHeight: 1.4,
+          backgroundRadius: 0
+        } );
+        expect( item.fill ).toEqual( [
+          0,
+          255,
+          120
+        ] );
+        expect( item.backgroundColor ).toEqual( [
+          0,
+          0,
+          0,
+          128
+        ] );
+        expect( item.backgroundStroke ).toEqual( [
+          0,
+          255,
+          120,
+          255
+        ] );
+        expect( item.position ).toEqual( {
+          x: 0.06,
+          y: 0.08
+        } );
+        expect( item.build ).toMatchObject( {
+          selection: "changed",
+          departure: 1,
+          introRatio: 0,
+          outroRatio: 0.1,
+          holdRatio: 0.15,
+          easing: "easeInOutCubic",
+          snapKeys: [
+            "seed"
+          ],
+          excludeKeys: []
+        } );
+      }
+    );
+
+    it(
+      "is accepted by the ContentItem discriminated union",
+      () => {
+        const parsed = ContentItemSchema.parse( {
+          type: "breakdown",
+          placement: "roaming",
+          build: {
+            departure: 0.5
+          }
+        } );
+
+        expect( parsed.type ).toBe( "breakdown" );
+
+        if ( parsed.type === "breakdown" ) {
+          expect( parsed.placement ).toBe( "roaming" );
+          expect( parsed.build.departure ).toBe( 0.5 );
+          expect( parsed.build.selection ).toBe( "changed" );
+        }
+      }
+    );
+
+    it(
+      "makeDefaultItem('breakdown') round-trips through the schema",
+      () => {
+        const item = makeDefaultItem( "breakdown" );
+
+        expect( item.type ).toBe( "breakdown" );
+        expect( () => ContentItemSchema.parse( item ) ).not.toThrow();
+      }
+    );
+
+    it(
+      "is wired into the palette",
+      () => {
+        expect( ITEM_ORDER ).toContain( "breakdown" );
+        expect( ITEM_META.breakdown ).toMatchObject( {
+          label: "Breakdown"
+        } );
+      }
+    );
+
+    it(
+      "has a form-config entry for every schema field (no orphan fields)",
+      () => {
+        const schemaFields = Object.keys( BreakdownItemSchema.shape ).filter( ( field ) => field !== "type" );
+        const configFields = Object.keys( formConfig.breakdown );
+
+        for ( const field of schemaFields ) {
+          expect( configFields ).toContain( field );
+        }
+
+        const buildConfig = formConfig.breakdown.build as {
+          fields: Record<string, unknown>;
+        };
+        const buildFields = Object.keys( buildConfig.fields );
+
+        for ( const field of Object.keys( BreakdownBuildSchema.removeDefault().shape ) ) {
+          expect( buildFields ).toContain( field );
+        }
+      }
+    );
+
+    it(
+      "strip-heals a persisted v2 (construction animation) item",
+      () => {
+        const v2Item = {
+          type: "breakdown",
+          intro: "how it's made",
+          title: "",
+          cta: "follow for more",
+          build: {
+            animate: true,
+            startMode: "random",
+            seed: 3,
+            randomSpread: 1,
+            concurrency: 2,
+            grouped: true,
+            ordering: "type",
+            typeOrder: [
+              "colors",
+              "numbers"
+            ],
+            reverse: false,
+            introRatio: 0.08,
+            outroRatio: 0.12,
+            holdRatio: 0.15,
+            easing: "easeInOutCubic",
+            snapKeys: [
+              "seed"
+            ],
+            excludeKeys: []
+          },
+          font: "spaceMonoRegular",
+          size: 22,
+          lineHeight: 1.5,
+          fill: [
+            235,
+            235,
+            235
+          ],
+          accent: [
+            0,
+            255,
+            120
+          ],
+          blend: "source-over",
+          position: {
+            x: 0.06,
+            y: 0.08
+          },
+          panel: {
+            enabled: true,
+            background: [
+              10,
+              10,
+              10,
+              190
+            ],
+            padding: 1,
+            radius: 12
+          }
+        };
+
+        const healed = ContentItemSchema.parse( v2Item );
+
+        expect( healed.type ).toBe( "breakdown" );
+
+        if ( healed.type === "breakdown" ) {
+          // v2-only keys stripped, v3 defaults filled in
+          expect( healed ).not.toHaveProperty( "intro" );
+          expect( healed ).not.toHaveProperty( "cta" );
+          expect( healed ).not.toHaveProperty( "accent" );
+          expect( healed ).not.toHaveProperty( "panel" );
+          expect( healed.build ).not.toHaveProperty( "startMode" );
+          expect( healed.build ).not.toHaveProperty( "concurrency" );
+          expect( healed.build.selection ).toBe( "changed" );
+          expect( healed.build.departure ).toBe( 1 );
+
+          // shared, shape-compatible fields survive
+          expect( healed.build.holdRatio ).toBe( 0.15 );
+          expect( healed.size ).toBe( 22 );
+        }
+      }
+    );
+
+    it(
+      "rejects unknown placement / selection / counter modes",
+      () => {
+        expect( () =>
+          BreakdownItemSchema.parse( {
+            type: "breakdown",
+            placement: "orbiting"
+          } ) ).toThrow();
+
+        expect( () =>
+          BreakdownItemSchema.parse( {
+            type: "breakdown",
+            build: {
+              selection: "everything"
+            }
+          } ) ).toThrow();
+
+        expect( () =>
+          BreakdownItemSchema.parse( {
+            type: "breakdown",
+            counterMode: "roman"
+          } ) ).toThrow();
+      }
+    );
+  }
+);

--- a/src/types/recording.types.ts
+++ b/src/types/recording.types.ts
@@ -134,6 +134,14 @@ declare global {
       engine: string;
       category: string;
     };
+    // Sketch form metadata (stock defaults + per-field config), published by
+    // the SketchContext provider so the breakdown overlay can diff the tuned
+    // values against stock and bound its start values by each parameter's
+    // real form range.
+    getSketchFormMeta?: () => {
+      formValues?: Record<string, any>;
+      formConfiguration?: Record<string, any>;
+    };
     // Script loader
     removeLoadedScripts: () => void;
 

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -471,6 +471,20 @@ export const BREAKDOWN_PLACEMENTS = [
   "roaming"
 ] as const;
 
+// How a line's changing value is rendered:
+//   - "bar": gauge-style progress bar filling start → final (the default)
+//   - "ticker": the live interpolated value printed as text
+//   - "roll": per-character odometer from the start text to the final text
+//   - "fade": alpha crossfade start text → final text
+//   - "rise": start text slides up and out, final text rises in from below
+export const BREAKDOWN_VALUE_STYLES = [
+  "bar",
+  "ticker",
+  "roll",
+  "fade",
+  "rise"
+] as const;
+
 // Engine/derivation settings, grouped under `build` on purpose: this object's
 // identity is the derived-cache key in the breakdown orchestrator, and it
 // survives the drag layer's per-frame { ...item, position } wrapper — keying
@@ -500,6 +514,13 @@ export const BreakdownBuildSchema = z
       .default( 0.15 ),
     // Easing key from easing.js applied to each step's local progress.
     easing: z.string().default( "easeInOutCubic" ),
+    // Per-line offset WITHIN a step (0..1): 0 = every leaf of the group
+    // animates together (default), 1 ≈ strictly one line after another.
+    // Lives in `build` because it shifts the INJECTED values, not just the
+    // overlay — the orchestrator's derived cache keys on this object.
+    lineStagger: z.number().min( 0 )
+      .max( 1 )
+      .default( 0 ),
     // Params that snap at their window midpoint instead of lerping —
     // discrete or cache-invalidating values (montage precedent).
     snapKeys: z.array( z.string() ).default( [
@@ -532,9 +553,13 @@ export const BreakdownItemSchema = z.object( {
   showCounter: z.boolean().default( true ),
   showTitle: z.boolean().default( true ),
   counterMode: z.enum( BREAKDOWN_COUNTER_MODES ).default( "numeric" ),
+  // Typewriter effect on the line text. Off by default: labels show up
+  // whole immediately — only the value in front of them animates.
+  typewriter: z.boolean().default( false ),
+  valueStyle: z.enum( BREAKDOWN_VALUE_STYLES ).default( "bar" ),
   font: z.string().default( "spaceMonoRegular" ),
   size: z.number().positive()
-    .default( 22 ),
+    .default( 16 ),
   lineHeight: z.number().positive()
     .default( 1.4 ),
   fill: RGBA.default( [

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -445,6 +445,123 @@ export const SpecsItemSchema = z.object( {
   sound: SpecsSoundSchema
 } );
 
+/* ---------------- sketch breakdown (diff overlay) ------------------ */
+
+// Which parameters become breakdown steps:
+//   - "changed": only params whose final value differs from the sketch's
+//     stock defaults (formValues, via window.getSketchFormMeta) — the diff.
+//     Degrades to "all" when the bridge is unreachable (bare harness).
+//   - "all": every animatable parameter group.
+export const BREAKDOWN_SELECTION_MODES = [
+  "changed",
+  "all"
+] as const;
+
+// Header counter style: "1/3" vs spreadsheet letters "A", "B", …
+export const BREAKDOWN_COUNTER_MODES = [
+  "numeric",
+  "letters"
+] as const;
+
+// Where the block sits: a fixed draggable anchor, or roaming — a
+// deterministic corner-tour that moves to a different anchor each step so
+// the block never hides the same region of the sketch twice.
+export const BREAKDOWN_PLACEMENTS = [
+  "fixed",
+  "roaming"
+] as const;
+
+// Engine/derivation settings, grouped under `build` on purpose: this object's
+// identity is the derived-cache key in the breakdown orchestrator, and it
+// survives the drag layer's per-frame { ...item, position } wrapper — keying
+// on the item itself would make the HUD (dragged wrapper) and the injection
+// (raw store item) thrash the single-slot cache against each other.
+export const BreakdownBuildSchema = z
+  .object( {
+    selection: z.enum( BREAKDOWN_SELECTION_MODES ).default( "changed" ),
+    // How far start values depart from the final value (1 = the full
+    // opposite end of the field's range, 0.1 = already close — the
+    // breakdown just "stabilizes" the sketch).
+    departure: z.number().min( 0 )
+      .max( 1 )
+      .default( 1 ),
+    // Loop fractions reserved before step 1 and after the last step (the
+    // block fades out during the outro, leaving the settled sketch alone).
+    introRatio: z.number().min( 0 )
+      .max( 0.3 )
+      .default( 0 ),
+    outroRatio: z.number().min( 0 )
+      .max( 0.4 )
+      .default( 0.1 ),
+    // Fraction of each step window held ON the final value before the next
+    // step starts (front-loaded morph, then lock).
+    holdRatio: z.number().min( 0 )
+      .max( 0.9 )
+      .default( 0.15 ),
+    // Easing key from easing.js applied to each step's local progress.
+    easing: z.string().default( "easeInOutCubic" ),
+    // Params that snap at their window midpoint instead of lerping —
+    // discrete or cache-invalidating values (montage precedent).
+    snapKeys: z.array( z.string() ).default( [
+      "seed"
+    ] ),
+    // Params that never animate (always final) and get no breakdown step.
+    excludeKeys: z.array( z.string() ).default( [] )
+  } )
+  .default( {} );
+
+// Diff-style narration overlay: only the parameters that change become
+// steps, shown ONE AT A TIME in the specs visual language (same text/stroke
+// colour, black panel) while the injected interpolation makes the running
+// sketch visibly stabilize group by group. Parameter interpolation is
+// injected in slides.getSketchSettings (see sketches/p5/utils/slides/
+// breakdown/) — montage slides win; the first breakdown item per list wins
+// (slide content over global).
+export const BreakdownItemSchema = z.object( {
+  type: z.literal( "breakdown" ),
+  build: BreakdownBuildSchema,
+  placement: z.enum( BREAKDOWN_PLACEMENTS ).default( "fixed" ),
+  // Fixed placement only — roaming ignores it (and disables dragging).
+  position: Vec2.default( {
+    x: 0.06,
+    y: 0.08
+  } ),
+  // Header row: "1/3 DOTS". Three independent switches — header kills the
+  // whole row; counter and title hide their own half.
+  showHeader: z.boolean().default( true ),
+  showCounter: z.boolean().default( true ),
+  showTitle: z.boolean().default( true ),
+  counterMode: z.enum( BREAKDOWN_COUNTER_MODES ).default( "numeric" ),
+  font: z.string().default( "spaceMonoRegular" ),
+  size: z.number().positive()
+    .default( 22 ),
+  lineHeight: z.number().positive()
+    .default( 1.4 ),
+  fill: RGBA.default( [
+    0,
+    255,
+    120
+  ] ),
+  // Unlike specs, the panel is VISIBLE by default: black at 50%, outlined in
+  // the text colour ("text and contour share the same colour").
+  backgroundColor: RGBA.default( [
+    0,
+    0,
+    0,
+    128
+  ] ),
+  backgroundStroke: RGBA.default( [
+    0,
+    255,
+    120,
+    255
+  ] ),
+  backgroundRadius: z.number().min( 0 )
+    .max( 200 )
+    .default( 0 ),
+  blend: Blend.default( "source-over" )
+} );
+
 export const TextItemSchema = z.object( {
   type: z.literal( "text" ),
   content: z.string().default( "" ),
@@ -1008,6 +1125,7 @@ export const ContentItemSchema = z.discriminatedUnion(
     BackgroundItemSchema,
     MetaItemSchema,
     SpecsItemSchema,
+    BreakdownItemSchema,
     TextItemSchema,
     TitleItemSchema,
     ImagesStackItemSchema,
@@ -1362,6 +1480,8 @@ export const OptionsSchema = z.object( {
 } );
 
 export type ContentItem = z.infer<typeof ContentItemSchema>;
+export type BreakdownItemOption = z.infer<typeof BreakdownItemSchema>;
+export type BreakdownBuildOption = z.infer<typeof BreakdownBuildSchema>;
 export type SlideOption = z.infer<typeof SlideSchema>;
 export type SlideTransitionOption = z.infer<typeof SlideTransitionSchema>;
 export type SlideTitleOption = z.infer<typeof SlideTitleSchema>;


### PR DESCRIPTION
## What

A **breakdown** content item (global or per-slide) that narrates the **diff** of the sketch's parameters in the specs visual language, one step at a time, while the injected interpolation makes the running sketch visibly stabilize group by group.

> Third iteration. The previous construction-animation approach on this branch was discarded; the branch was restarted from `main` after the templates→sketches rename, and this lands the diff-style redesign.

## The overlay

```
┌──────────────────────────────┐
│ 1/2  RENDER                  │  ← header: counter (1/3 or A/B/C) + step title
│ EDGE STRENGTH: 0.09          │  ← changing leaves, typed in, LIVE values
│ EDGE COLOR: rgba(151, 68, 0)▪│  ← colours carry an animating swatch chip
└──────────────────────────────┘
```

- **Specs look**: shared `drawItemBackground` panel — black 50% by default, **outlined in the text colour** ("text and contour share the same colour"), corner radius, metric-based padding. Boot-log typewriter, `string.write`, spaceMono, specs green.
- **Diff selection** (`build.selection`): `changed` (default) keeps only parameters whose final value differs from the sketch's stock `formValues` — your recipe — via a new memoized `window.getSketchFormMeta` bridge; degrades to `all` without the bridge. Nothing changed → the block hides and the injection no-ops (an honest diff).
- **Grouping**: nested objects = one step each; isolated top-level fields = their **own** step. Strictly sequential windows, `holdRatio` + easing.
- **Header switches**: `showHeader` / `showCounter` / `showTitle` independently; counter numeric `1/3` or spreadsheet letters `A, B…`.
- **Deterministic starts — no randomness**: each value departs from its field's form **min** (flipping to **max** when min ≈ final — the "opposite"), scaled by **`departure`** (0..1): 1 = full travel, 0.1 = the sketch starts almost right and the breakdown just stabilizes it. Colours invert per RGB channel (alpha kept); booleans flip at ≥ 0.5; strings snap.
- **Roaming placement**: optional mode where the block moves to a different corner (then centre) on every step — deterministic `currentStep % 5` tour, edge-aware anchoring, capture-safe. Fixed placement stays draggable on canvas; roaming is excluded from the drag layer at the target-builder level (its hit-test has an anchor-disc fallback).

## Mechanics

- Injection between the montage branch (montage **wins**) and `resolveEffectiveSketch` in `slides.getSketchSettings` — the seam every `options.sketch` read flows through, so the sketch and all overlays see the in-progress values with zero per-sketch code.
- Two-level memoization (the seam fires on every property access): derived cache keyed on store / `item.build` / form-meta object identities, plus a per-progression frame cache. The drag layer's per-frame `{ ...item, position }` wrapper does not invalidate.
- Line widths are reserved at `max(startText, finalText)` so a right-anchored roaming block never overflows mid-lerp.
- All timing from `animation.progression` (frame-pinned during capture) — fully deterministic recordings.
- Persisted items from the discarded previous iteration strip-heal through Zod (covered by a test).

## Verification

- **Playwright smoke** on `voronoi-v1-cells`: tuned 3 params vs stock → exactly 2 steps narrated (`1/2 RENDER`, `2/2 BACKGROUND COLOR`) with live lerping values and the colour chip; letters mode shows `B`; roaming places step 1 top-left and step 2 top-right inside the canvas; outro fades the block onto the settled sketch. No console/page errors.
- `npm run check` — lint clean, **1666 tests** (64 new: format incl. letter counters, schedule `currentStep`/`stepLocalT`, diff derivation incl. partially-changed groups, min/opposite/departure start rules, orchestrator caches incl. form-meta invalidation, schema wiring + healing).
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DGwogTYQzXxjs6v3ht9m1