### PR TITLE
fix(capture): keep record button in view, merge dev preview options

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -66,16 +66,19 @@ const MODE_ORDER: ReadonlyArray<RecordingMode> = [
   "realtime"
 ];
 
-// Dev-only groups: a webm capture that, instead of downloading, is saved
-// back over the sketch's committed preview.
+// Dev-only group: a webm capture that, instead of downloading, is saved
+// back over the sketch's committed preview. Both flavours share one compact
+// group so the dropdown stays narrow and never pushes the record button off
+// screen.
+//   • async    — a deterministic frame-by-frame capture of the sketch's loop.
+//     No lead-in, no frame drops — the front-end stand-in for the headless
+//     generator, for when it isn't available.
 //   • realtime — after a 3-2-1 lead-in, a wall-clock capture. Lets
 //     interactive sketches (webcam / mic / hand tracking) get a real preview
 //     the headless generator can't produce.
-//   • async   — a deterministic frame-by-frame capture of the sketch's loop.
-//     No lead-in, no frame drops — the front-end stand-in for the headless
-//     generator, for when it isn't available.
-const PREVIEW_GROUP_LABEL = "Record preview (dev)";
-const PREVIEW_ASYNC_GROUP_LABEL = "Record preview (dev, async)";
+const PREVIEW_GROUP_LABEL = "DEV: previews recording";
+const PREVIEW_ASYNC_OPTION_LABEL = "Async";
+const PREVIEW_REALTIME_OPTION_LABEL = "Realtime";
 const IS_DEV = process.env.NODE_ENV === "development";
 
 // One <option> per group entry. The composite value carries everything
@@ -87,12 +90,18 @@ type Choice = {
   intent: RecordingIntent;
 };
 
+// One <option> in the dropdown. The label is what shows when collapsed, so
+// keep it short; the choice carries everything `start()` needs.
+type RecordingOption = {
+  key: string;
+  label: string;
+  choice: Choice;
+};
+
 type RecordingGroup = {
   key: string;
   label: string;
-  mode: RecordingMode;
-  intent: RecordingIntent;
-  formats: RecordingFormat[];
+  options: RecordingOption[];
 };
 
 function encodeChoice( c: Choice ): string {
@@ -139,36 +148,55 @@ export default function BrowserRecordingButton( {
         .map( ( mode ) => ( {
           key: mode,
           label: MODE_LABEL[ mode ],
-          mode,
-          intent: "download" as RecordingIntent,
-          formats: MODE_FORMATS[ mode ].filter( ( f ) => supported.has( f ) )
+          options: MODE_FORMATS[ mode ]
+            .filter( ( f ) => supported.has( f ) )
+            .map( ( f ) => ( {
+              key: `${ mode }-${ f }`,
+              label: formatChoiceLabel(
+                MODE_LABEL[ mode ],
+                f
+              ),
+              choice: {
+                format: f,
+                mode,
+                intent: "download" as RecordingIntent
+              }
+            } ) )
         } ) )
-        .filter( ( g ) => g.formats.length > 0 );
+        .filter( ( g ) => g.options.length > 0 );
 
       if ( IS_DEV && supported.has( "webm" ) ) {
-        modeGroups.push( {
-          key: "preview",
-          label: PREVIEW_GROUP_LABEL,
-          mode: "realtime",
-          intent: "preview",
-          formats: [
-            "webm"
-          ]
-        } );
+        const previewOptions: RecordingOption[] = [];
 
         // The async flavour needs the engine to render arbitrary frames
         // reproducibly — otherwise the deterministic loop can't be captured.
         if ( capabilities.supportsDeterministicCapture ) {
-          modeGroups.push( {
+          previewOptions.push( {
             key: "preview-async",
-            label: PREVIEW_ASYNC_GROUP_LABEL,
-            mode: "async-loop",
-            intent: "preview",
-            formats: [
-              "webm"
-            ]
+            label: PREVIEW_ASYNC_OPTION_LABEL,
+            choice: {
+              format: "webm",
+              mode: "async-loop",
+              intent: "preview"
+            }
           } );
         }
+
+        previewOptions.push( {
+          key: "preview-realtime",
+          label: PREVIEW_REALTIME_OPTION_LABEL,
+          choice: {
+            format: "webm",
+            mode: "realtime",
+            intent: "preview"
+          }
+        } );
+
+        modeGroups.push( {
+          key: "preview",
+          label: PREVIEW_GROUP_LABEL,
+          options: previewOptions
+        } );
       }
 
       return modeGroups;
@@ -182,15 +210,16 @@ export default function BrowserRecordingButton( {
   const defaultChoice: Choice = useMemo(
     () => {
       const preferredMode = capabilities.defaultMode;
-      const group =
-        groups.find( ( g ) => g.intent === "download" && g.mode === preferredMode ) ??
-          groups.find( ( g ) => g.intent === "download" ) ??
-          groups[ 0 ];
+      const options = groups.flatMap( ( g ) => g.options );
+      const match =
+        options.find( ( o ) => o.choice.intent === "download" && o.choice.mode === preferredMode ) ??
+          options.find( ( o ) => o.choice.intent === "download" ) ??
+          options[ 0 ];
 
-      return {
-        mode: group?.mode ?? "async-loop",
-        format: group?.formats[ 0 ] ?? "webm",
-        intent: group?.intent ?? "download"
+      return match?.choice ?? {
+        mode: "async-loop",
+        format: "webm",
+        intent: "download"
       };
     },
     [
@@ -243,24 +272,17 @@ export default function BrowserRecordingButton( {
           id="recording-format"
           value={ encodeChoice( choice ) }
           onChange={ ( e ) => setChoice( decodeChoice( e.target.value ) ) }
-          className="flex-1 px-2 py-2 bg-background text-foreground text-xs focus:outline-none"
+          className="flex-1 min-w-0 px-2 py-2 bg-background text-foreground text-xs focus:outline-none"
           aria-label="Recording format"
         >
           {groups.map( ( group ) => (
             <optgroup key={ group.key } label={ group.label }>
-              {group.formats.map( ( f ) => (
+              {group.options.map( ( option ) => (
                 <option
-                  key={ `${ group.key }-${ f }` }
-                  value={ encodeChoice( {
-                    format: f,
-                    mode: group.mode,
-                    intent: group.intent
-                  } ) }
+                  key={ option.key }
+                  value={ encodeChoice( option.choice ) }
                 >
-                  {formatChoiceLabel(
-                    group.label,
-                    f
-                  )}
+                  {option.label}
                 </option>
               ) )}
             </optgroup>
@@ -276,7 +298,7 @@ export default function BrowserRecordingButton( {
           ) }
           aria-label="Start recording"
           title="Start recording"
-          className="border-l px-2 text-foreground hover:bg-hover transition-colors inline-flex items-center justify-center"
+          className="flex-shrink-0 border-l px-2 text-foreground hover:bg-hover transition-colors inline-flex items-center justify-center"
         >
           <span
             aria-hidden="true"


### PR DESCRIPTION
## Problem

In the capture actions, the dev preview options in the recording format dropdown were too wide. Each dev option carried a long label (e.g. `Record preview (dev, async): .webm`), and the `<select>` was `flex-1` with no `min-w-0`, so its intrinsic content width (driven by the longest option) forced the whole row wider than its container. This pushed the red **record** button out of the visible zone, so the button could no longer be seen or clicked.

## Changes

`src/components/.../CaptureActions/components/BrowserRecordingButton.tsx`:

- **Keep the record button on the right.** Added `min-w-0` to the `<select>` so flex can actually shrink it, and `flex-shrink-0` to the record button so it is never squeezed. Long options now fit the available space — the select truncates its collapsed text instead of growing the row.
- **Merge the dev options into one compact group.** The two separate dev optgroups (`Record preview (dev)` and `Record preview (dev, async)`) are now a single group **`DEV: previews recording`** with two short options: **Async** and **Realtime**. Async is only offered when the engine supports deterministic capture (unchanged behavior).
- Generalized the internal group model so each `<option>` carries its own short label, decoupling the dev options' labels from the download options' `mode: format` labels.

No behavioral change to what each option records — only the labels/layout and grouping changed.

## Testing

- `eslint` — clean (also auto-run via lint-staged on commit)
- `tsc --noEmit` — no new type errors
- No existing unit tests cover these components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPTVZh4kP2NnsG5mugMugH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPTVZh4kP2NnsG5mugMugH)_