### PR TITLE
Make sketch sound settings panel viewport-aware

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/ControlledSliderInput.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/ControlledSliderInput.tsx
@@ -1,22 +1,10 @@
 "use client";
 
-import {
-  RotateCcw
-} from "lucide-react";
-import React, {
-  useState
-} from "react";
-import clsx from "clsx";
+import React from "react";
 import {
   useController
 } from "react-hook-form";
-import useDragSlider from "@/hooks/useDragSlider";
-import {
-  CONTROL_BAR_CLASS,
-  CONTROL_EDIT_INPUT_CLASS,
-  CONTROL_RESET_BUTTON_CLASS,
-  CONTROL_VALUE_BUTTON_CLASS
-} from "../../constants/control-bar";
+import SliderInput from "./SliderInput";
 
 type ControlledSliderInputProps = {
   name: string;
@@ -29,15 +17,9 @@ type ControlledSliderInputProps = {
 };
 
 /**
- * Touch-friendly replacement for the native range input, in the style of
- * Blender/Leva value sliders: the whole bar is the drag surface, the fill
- * shows the current value, and the label lives inside the bar so the control
- * doesn't need its own label row. Tapping the value switches the bar to a
- * number input for precise entry.
- *
- * The drag is handled by {@link useDragSlider} with `touch-action: pan-y`, so a
- * horizontal drag adjusts the value while a vertical drag scrolls the panel the
- * bar lives in.
+ * React-hook-form binding around the presentational {@link SliderInput}: reads
+ * and writes the field at `name`, delegating all rendering and drag behaviour to
+ * the shared slider so form fields and non-form controls look identical.
  */
 export default function ControlledSliderInput( {
   name,
@@ -54,147 +36,17 @@ export default function ControlledSliderInput( {
     name
   } );
 
-  const [
-    editing,
-    setEditing
-  ] = useState( false );
-
-  const decimals = step < 1 ? 2 : 0;
-  const numericValue = Number( field.value );
-  const value = Number.isFinite( numericValue ) ? numericValue : min;
-
-  const {
-    ref, handlers
-  } = useDragSlider( {
-    min,
-    max,
-    step,
-    value,
-    onChange: field.onChange
-  } );
-
-  const fraction =
-    max > min ? clampFraction( ( value - min ) / ( max - min ) ) : 0;
-
-  const commitEdit = ( raw: string ) => {
-    setEditing( false );
-
-    const parsed = decimals > 0
-      ? parseFloat( raw )
-      : parseInt(
-        raw,
-        10
-      );
-
-    if ( Number.isNaN( parsed ) ) {
-      return;
-    }
-
-    field.onChange( Math.min(
-      max,
-      Math.max(
-        min,
-        parsed
-      )
-    ) );
-  };
-
-  if ( editing ) {
-    return (
-      <input
-        type="number"
-        autoFocus
-        defaultValue={ value.toFixed( decimals ) }
-        step={ step }
-        min={ min }
-        max={ max }
-        inputMode={ decimals > 0 ? "decimal" : "numeric" }
-        aria-label={ `${ label ?? name } value` }
-        className={ CONTROL_EDIT_INPUT_CLASS }
-        onBlur={ ( e ) => commitEdit( e.target.value ) }
-        onKeyDown={ ( e ) => {
-          if ( e.key === "Enter" ) {
-            commitEdit( ( e.target as HTMLInputElement ).value );
-          } else if ( e.key === "Escape" ) {
-            setEditing( false );
-          }
-        } }
-      />
-    );
-  }
-
   return (
-    <div
-      ref={ ref }
-      role="slider"
-      tabIndex={ 0 }
-      aria-label={ label ?? name }
-      aria-valuemin={ min }
-      aria-valuemax={ max }
-      aria-valuenow={ value }
+    <SliderInput
+      value={ Number( field.value ) }
+      onChange={ field.onChange }
       onBlur={ field.onBlur }
-      { ...handlers }
-      className={ `group touch-pan-y select-none cursor-ew-resize outline-none focus-visible:ring-1 focus-visible:ring-focus ${ CONTROL_BAR_CLASS }` }
-    >
-      <div
-        className="pointer-events-none absolute inset-y-0 left-0 bg-foreground/10 transition-colors group-hover:bg-foreground/15"
-        style={ {
-          width: `${ fraction * 100 }%`
-        } }
-      />
-
-      <div
-        className="pointer-events-none absolute top-1/2 h-6 md:h-4 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/30"
-        style={ {
-          left: `${ fraction * 100 }%`
-        } }
-      />
-
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-2.5">
-        <span
-          className={ clsx(
-            "truncate",
-            isModified ? "font-medium text-foreground" : "text-label"
-          ) }
-        >
-          {label}
-        </span>
-
-        <span className="flex items-center gap-1 shrink-0">
-          {isModified && onReset && (
-            <button
-              type="button"
-              tabIndex={ -1 }
-              title="Reset to saved value"
-              onClick={ onReset }
-              onPointerDown={ ( e ) => e.stopPropagation() }
-              className={ CONTROL_RESET_BUTTON_CLASS }
-            >
-              <RotateCcw className="h-3.5 w-3.5 md:h-3 md:w-3" />
-            </button>
-          )}
-
-          <button
-            type="button"
-            title="Tap to type a value"
-            onClick={ () => setEditing( true ) }
-            onPointerDown={ ( e ) => e.stopPropagation() }
-            className={ CONTROL_VALUE_BUTTON_CLASS }
-          >
-            {value.toFixed( decimals )}
-          </button>
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function clampFraction( fraction: number ): number {
-  return Math.min(
-    1,
-    Math.max(
-      0,
-      fraction
-    )
+      label={ label ?? name }
+      min={ min }
+      max={ max }
+      step={ step }
+      isModified={ isModified }
+      onReset={ onReset }
+    />
   );
 }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/SliderInput.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ControlledSliderInput/SliderInput.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import {
+  RotateCcw
+} from "lucide-react";
+import React, {
+  useState
+} from "react";
+import clsx from "clsx";
+import useDragSlider from "@/hooks/useDragSlider";
+import {
+  CONTROL_BAR_CLASS,
+  CONTROL_EDIT_INPUT_CLASS,
+  CONTROL_RESET_BUTTON_CLASS,
+  CONTROL_VALUE_BUTTON_CLASS
+} from "../../constants/control-bar";
+
+type SliderInputProps = {
+  value: number;
+  onChange: ( next: number ) => void;
+  onBlur?: () => void;
+  label?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
+};
+
+/**
+ * Presentational, fully-controlled value slider in the style of Blender/Leva:
+ * the whole bar is the drag surface, the fill shows the current value, and the
+ * label lives inside the bar so the control needs no separate label row.
+ * Tapping the value switches the bar to a number input for precise entry.
+ *
+ * Form-agnostic — pass `value`/`onChange` directly. {@link ControlledSliderInput}
+ * wraps this with react-hook-form; anything outside a form (e.g. the UI-sound
+ * settings popover) can use it standalone so every slider looks identical.
+ *
+ * The drag is handled by {@link useDragSlider} with `touch-action: pan-y`, so a
+ * horizontal drag adjusts the value while a vertical drag scrolls the panel the
+ * bar lives in.
+ */
+export default function SliderInput( {
+  value: rawValue,
+  onChange,
+  onBlur,
+  label,
+  min = 0,
+  max = 100,
+  step = 1,
+  isModified = false,
+  onReset
+}: SliderInputProps ) {
+  const [
+    editing,
+    setEditing
+  ] = useState( false );
+
+  const decimals = step < 1 ? 2 : 0;
+  const numericValue = Number( rawValue );
+  const value = Number.isFinite( numericValue ) ? numericValue : min;
+
+  const {
+    ref, handlers
+  } = useDragSlider( {
+    min,
+    max,
+    step,
+    value,
+    onChange
+  } );
+
+  const fraction =
+    max > min ? clampFraction( ( value - min ) / ( max - min ) ) : 0;
+
+  const commitEdit = ( raw: string ) => {
+    setEditing( false );
+
+    const parsed = decimals > 0
+      ? parseFloat( raw )
+      : parseInt(
+        raw,
+        10
+      );
+
+    if ( Number.isNaN( parsed ) ) {
+      return;
+    }
+
+    onChange( Math.min(
+      max,
+      Math.max(
+        min,
+        parsed
+      )
+    ) );
+  };
+
+  if ( editing ) {
+    return (
+      <input
+        type="number"
+        autoFocus
+        defaultValue={ value.toFixed( decimals ) }
+        step={ step }
+        min={ min }
+        max={ max }
+        inputMode={ decimals > 0 ? "decimal" : "numeric" }
+        aria-label={ `${ label ?? "value" } value` }
+        className={ CONTROL_EDIT_INPUT_CLASS }
+        onBlur={ ( e ) => commitEdit( e.target.value ) }
+        onKeyDown={ ( e ) => {
+          if ( e.key === "Enter" ) {
+            commitEdit( ( e.target as HTMLInputElement ).value );
+          } else if ( e.key === "Escape" ) {
+            setEditing( false );
+          }
+        } }
+      />
+    );
+  }
+
+  return (
+    <div
+      ref={ ref }
+      role="slider"
+      tabIndex={ 0 }
+      aria-label={ label }
+      aria-valuemin={ min }
+      aria-valuemax={ max }
+      aria-valuenow={ value }
+      onBlur={ onBlur }
+      { ...handlers }
+      className={ `group touch-pan-y select-none cursor-ew-resize outline-none focus-visible:ring-1 focus-visible:ring-focus ${ CONTROL_BAR_CLASS }` }
+    >
+      <div
+        className="pointer-events-none absolute inset-y-0 left-0 bg-foreground/10 transition-colors group-hover:bg-foreground/15"
+        style={ {
+          width: `${ fraction * 100 }%`
+        } }
+      />
+
+      <div
+        className="pointer-events-none absolute top-1/2 h-6 md:h-4 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/30"
+        style={ {
+          left: `${ fraction * 100 }%`
+        } }
+      />
+
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-2.5">
+        <span
+          className={ clsx(
+            "truncate",
+            isModified ? "font-medium text-foreground" : "text-label"
+          ) }
+        >
+          {label}
+        </span>
+
+        <span className="flex items-center gap-1 shrink-0">
+          {isModified && onReset && (
+            <button
+              type="button"
+              tabIndex={ -1 }
+              title="Reset to saved value"
+              onClick={ onReset }
+              onPointerDown={ ( e ) => e.stopPropagation() }
+              className={ CONTROL_RESET_BUTTON_CLASS }
+            >
+              <RotateCcw className="h-3.5 w-3.5 md:h-3 md:w-3" />
+            </button>
+          )}
+
+          <button
+            type="button"
+            title="Tap to type a value"
+            onClick={ () => setEditing( true ) }
+            onPointerDown={ ( e ) => e.stopPropagation() }
+            className={ CONTROL_VALUE_BUTTON_CLASS }
+          >
+            {value.toFixed( decimals )}
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function clampFraction( fraction: number ): number {
+  return Math.min(
+    1,
+    Math.max(
+      0,
+      fraction
+    )
+  );
+}

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import React, {
-  useEffect, useRef, useState, useSyncExternalStore
+  useSyncExternalStore
 } from "react";
+import {
+  Popover, PopoverButton, PopoverPanel
+} from "@headlessui/react";
 import {
   Volume2, VolumeX
 } from "lucide-react";
@@ -30,39 +33,6 @@ export default function UiSoundSettingsButton( {
     subscribeUiSoundSettings,
     getUiSoundSettings,
     getUiSoundSettings
-  );
-  const [
-    open,
-    setOpen
-  ] = useState( false );
-  const containerRef = useRef<HTMLDivElement>( null );
-
-  // Close on outside pointerdown.
-  useEffect(
-    () => {
-      if ( !open ) {
-        return;
-      }
-
-      const onPointerDown = ( event: PointerEvent ) => {
-        if ( !containerRef.current?.contains( event.target as Node ) ) {
-          setOpen( false );
-        }
-      };
-
-      document.addEventListener(
-        "pointerdown",
-        onPointerDown
-      );
-
-      return () => document.removeEventListener(
-        "pointerdown",
-        onPointerDown
-      );
-    },
-    [
-      open
-    ]
   );
 
   const update = ( patch: Partial<UiSoundSettings> ) => {
@@ -109,13 +79,11 @@ export default function UiSoundSettingsButton( {
   );
 
   return (
-    <div
-      ref={ containerRef }
+    <Popover
       className="relative"
-      onClick={ ( e ) => e.stopPropagation() }
+      onClick={ ( e: React.MouseEvent ) => e.stopPropagation() }
     >
-      <button
-        type="button"
+      <PopoverButton
         className={ clsx(
           className,
           !settings.enabled && "opacity-50"
@@ -126,152 +94,152 @@ export default function UiSoundSettingsButton( {
             : "UI sound feedback (off) — click for options"
         }
         aria-label="UI sound feedback settings"
-        onClick={ () => setOpen( ( wasOpen ) => !wasOpen ) }
       >
         {settings.enabled ? (
           <Volume2 className="h-4 w-4" />
         ) : (
           <VolumeX className="h-4 w-4" />
         )}
-      </button>
+      </PopoverButton>
 
-      {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 flex w-64 flex-col gap-2 rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg">
-          {checkboxRow(
-            "Sound on value change",
-            settings.enabled,
-            ( enabled ) => update( {
-              enabled
-            } )
-          )}
+      <PopoverPanel
+        anchor="bottom end"
+        className="z-50 flex max-h-[calc(100vh-1rem)] w-64 max-w-[calc(100vw-1rem)] flex-col gap-2 overflow-y-auto rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg [--anchor-gap:0.25rem] [--anchor-padding:0.5rem]"
+      >
+        {checkboxRow(
+          "Sound on value change",
+          settings.enabled,
+          ( enabled ) => update( {
+            enabled
+          } )
+        )}
 
-          {checkboxRow(
-            "Sound on action buttons",
-            settings.actionSounds,
-            ( actionSounds ) => update( {
-              actionSounds
-            } )
-          )}
+        {checkboxRow(
+          "Sound on action buttons",
+          settings.actionSounds,
+          ( actionSounds ) => update( {
+            actionSounds
+          } )
+        )}
 
-          <label className="flex items-center justify-between gap-2">
-            <span>Click sound</span>
-            <select
-              className="rounded border border-theme bg-transparent px-1 py-0.5"
-              value={ settings.preset }
-              onChange={ ( e ) =>
-                update( {
-                  preset: e.target.value as UiSoundSettings[ "preset" ]
-                } ) }
-            >
-              {UI_SOUND_PRESETS.map( ( presetName ) => (
-                <option
-                  key={ presetName }
-                  value={ presetName }
-                >
-                  {presetName}
-                </option>
-              ) )}
-            </select>
-          </label>
-
-          {sliderRow(
-            "Volume",
-            settings.volume,
-            0,
-            1,
-            0.05,
-            ( volume ) => update( {
-              volume
-            } )
-          )}
-
-          {sliderRow(
-            "Pitch (×)",
-            settings.pitch,
-            0.5,
-            2,
-            0.05,
-            ( pitch ) => update( {
-              pitch
-            } )
-          )}
-
-          {sliderRow(
-            "Humanize",
-            settings.pitchVariation,
-            0,
-            1,
-            0.05,
-            ( pitchVariation ) => update( {
-              pitchVariation
-            } )
-          )}
-
-          {checkboxRow(
-            "Pitch varies by field",
-            settings.pitchByField,
-            ( pitchByField ) => update( {
-              pitchByField
-            } )
-          )}
-
-          {sliderRow(
-            "Min gap (ms)",
-            settings.minGapMs,
-            0,
-            300,
-            5,
-            ( minGapMs ) => update( {
-              minGapMs
-            } )
-          )}
-
-          {sliderRow(
-            "Clicks per change",
-            settings.repeatTimes,
-            1,
-            8,
-            1,
-            ( repeatTimes ) => update( {
-              repeatTimes
-            } )
-          )}
-
-          {settings.repeatTimes > 1 && (
-            <>
-              {sliderRow(
-                "Repeat interval (ms)",
-                settings.repeatIntervalMs,
-                20,
-                300,
-                5,
-                ( repeatIntervalMs ) => update( {
-                  repeatIntervalMs
-                } )
-              )}
-
-              {sliderRow(
-                "Pitch ramp (oct/click)",
-                settings.repeatPitchStep,
-                -0.5,
-                0.5,
-                0.01,
-                ( repeatPitchStep ) => update( {
-                  repeatPitchStep
-                } )
-              )}
-            </>
-          )}
-
-          <button
-            type="button"
-            className="mt-1 rounded-lg border border-theme px-2 py-1 hover:bg-hover"
-            onClick={ () => playPreview() }
+        <label className="flex items-center justify-between gap-2">
+          <span>Click sound</span>
+          <select
+            className="rounded border border-theme bg-transparent px-1 py-0.5"
+            value={ settings.preset }
+            onChange={ ( e ) =>
+              update( {
+                preset: e.target.value as UiSoundSettings[ "preset" ]
+              } ) }
           >
-            Test sound
-          </button>
-        </div>
-      )}
-    </div>
+            {UI_SOUND_PRESETS.map( ( presetName ) => (
+              <option
+                key={ presetName }
+                value={ presetName }
+              >
+                {presetName}
+              </option>
+            ) )}
+          </select>
+        </label>
+
+        {sliderRow(
+          "Volume",
+          settings.volume,
+          0,
+          1,
+          0.05,
+          ( volume ) => update( {
+            volume
+          } )
+        )}
+
+        {sliderRow(
+          "Pitch (×)",
+          settings.pitch,
+          0.5,
+          2,
+          0.05,
+          ( pitch ) => update( {
+            pitch
+          } )
+        )}
+
+        {sliderRow(
+          "Humanize",
+          settings.pitchVariation,
+          0,
+          1,
+          0.05,
+          ( pitchVariation ) => update( {
+            pitchVariation
+          } )
+        )}
+
+        {checkboxRow(
+          "Pitch varies by field",
+          settings.pitchByField,
+          ( pitchByField ) => update( {
+            pitchByField
+          } )
+        )}
+
+        {sliderRow(
+          "Min gap (ms)",
+          settings.minGapMs,
+          0,
+          300,
+          5,
+          ( minGapMs ) => update( {
+            minGapMs
+          } )
+        )}
+
+        {sliderRow(
+          "Clicks per change",
+          settings.repeatTimes,
+          1,
+          8,
+          1,
+          ( repeatTimes ) => update( {
+            repeatTimes
+          } )
+        )}
+
+        {settings.repeatTimes > 1 && (
+          <>
+            {sliderRow(
+              "Repeat interval (ms)",
+              settings.repeatIntervalMs,
+              20,
+              300,
+              5,
+              ( repeatIntervalMs ) => update( {
+                repeatIntervalMs
+              } )
+            )}
+
+            {sliderRow(
+              "Pitch ramp (oct/click)",
+              settings.repeatPitchStep,
+              -0.5,
+              0.5,
+              0.01,
+              ( repeatPitchStep ) => update( {
+                repeatPitchStep
+              } )
+            )}
+          </>
+        )}
+
+        <button
+          type="button"
+          className="mt-1 rounded-lg border border-theme px-2 py-1 hover:bg-hover"
+          onClick={ () => playPreview() }
+        >
+          Test sound
+        </button>
+      </PopoverPanel>
+    </Popover>
   );
 }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
@@ -7,7 +7,7 @@ import {
   Popover, PopoverButton, PopoverPanel
 } from "@headlessui/react";
 import {
-  Volume2, VolumeX
+  ChevronDown, Volume2, VolumeX
 } from "lucide-react";
 import clsx from "clsx";
 import {
@@ -18,11 +18,24 @@ import {
   setUiSoundSettings,
   subscribeUiSoundSettings
 } from "@/lib/uiSound";
+import SliderInput
+  from "../ContentItems/components/ControlledSliderInput/SliderInput";
+import {
+  BarLabelSegment, ToggleSwitch
+} from "../ContentItems/components/ControlChrome";
+import {
+  CONTROL_BAR_CLASS, CONTROL_CHEVRON_CLASS
+} from "../ContentItems/constants/control-bar";
 
 /**
  * Toggle + settings popover for the editor's value-change click feedback.
  * Lives in the sketch-settings actions row (desktop panel and mobile drawer),
  * next to reset / randomize — the actions it also gives a voice to.
+ *
+ * The controls reuse the shared form chrome — the Blender/Leva {@link SliderInput}
+ * bar, {@link ToggleSwitch} and the segmented select bar — so the panel looks and
+ * feels identical to every other control in the studio, even though it is driven
+ * by the UI-sound store rather than the sketch form.
  */
 export default function UiSoundSettingsButton( {
   className
@@ -47,33 +60,28 @@ export default function UiSoundSettingsButton( {
     step: number,
     onChange: ( next: number ) => void
   ) => (
-    <label className="flex flex-col gap-0.5">
-      <span className="flex justify-between">
-        <span>{label}</span>
-        <span className="opacity-60">{value}</span>
-      </span>
-      <input
-        type="range"
-        min={ min }
-        max={ max }
-        step={ step }
-        value={ value }
-        onChange={ ( e ) => onChange( Number( e.target.value ) ) }
-      />
-    </label>
+    <SliderInput
+      label={ label }
+      value={ value }
+      min={ min }
+      max={ max }
+      step={ step }
+      onChange={ onChange }
+    />
   );
 
-  const checkboxRow = (
+  const toggleRow = (
     label: string,
     checked: boolean,
     onChange: ( next: boolean ) => void
   ) => (
-    <label className="flex items-center justify-between gap-2">
+    <label className="flex cursor-pointer items-center justify-between gap-2 text-label">
       <span>{label}</span>
-      <input
-        type="checkbox"
-        checked={ checked }
-        onChange={ ( e ) => onChange( e.target.checked ) }
+      <ToggleSwitch
+        inputProps={ {
+          checked,
+          onChange: ( e ) => onChange( e.target.checked )
+        } }
       />
     </label>
   );
@@ -106,7 +114,7 @@ export default function UiSoundSettingsButton( {
         anchor="bottom end"
         className="z-[70] flex max-h-[calc(100vh-1rem)] w-64 max-w-[calc(100vw-1rem)] flex-col gap-2 overflow-y-auto rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg [--anchor-gap:0.25rem] [--anchor-padding:0.5rem]"
       >
-        {checkboxRow(
+        {toggleRow(
           "Sound on value change",
           settings.enabled,
           ( enabled ) => update( {
@@ -114,7 +122,7 @@ export default function UiSoundSettingsButton( {
           } )
         )}
 
-        {checkboxRow(
+        {toggleRow(
           "Sound on action buttons",
           settings.actionSounds,
           ( actionSounds ) => update( {
@@ -122,10 +130,17 @@ export default function UiSoundSettingsButton( {
           } )
         )}
 
-        <label className="flex items-center justify-between gap-2">
-          <span>Click sound</span>
+        <div className={ CONTROL_BAR_CLASS }>
+          <BarLabelSegment label="Click sound" />
+
+          <span className="pointer-events-none flex min-w-0 flex-1 items-center justify-between gap-1 px-2.5">
+            <span className="truncate">{settings.preset}</span>
+            <ChevronDown className={ CONTROL_CHEVRON_CLASS } />
+          </span>
+
           <select
-            className="rounded border border-theme bg-transparent px-1 py-0.5"
+            aria-label="Click sound"
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
             value={ settings.preset }
             onChange={ ( e ) =>
               update( {
@@ -141,7 +156,7 @@ export default function UiSoundSettingsButton( {
               </option>
             ) )}
           </select>
-        </label>
+        </div>
 
         {sliderRow(
           "Volume",
@@ -176,7 +191,7 @@ export default function UiSoundSettingsButton( {
           } )
         )}
 
-        {checkboxRow(
+        {toggleRow(
           "Pitch varies by field",
           settings.pitchByField,
           ( pitchByField ) => update( {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/SketchSettings/UiSoundSettingsButton.tsx
@@ -104,7 +104,7 @@ export default function UiSoundSettingsButton( {
 
       <PopoverPanel
         anchor="bottom end"
-        className="z-50 flex max-h-[calc(100vh-1rem)] w-64 max-w-[calc(100vw-1rem)] flex-col gap-2 overflow-y-auto rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg [--anchor-gap:0.25rem] [--anchor-padding:0.5rem]"
+        className="z-[70] flex max-h-[calc(100vh-1rem)] w-64 max-w-[calc(100vw-1rem)] flex-col gap-2 overflow-y-auto rounded-xl border border-theme glass p-3 text-xs text-foreground shadow-lg [--anchor-gap:0.25rem] [--anchor-padding:0.5rem]"
       >
         {checkboxRow(
           "Sound on value change",


### PR DESCRIPTION
## What & why

The sound-feedback settings popover in the sketch settings (the volume icon next to reset / randomize) opened in a fixed position — a hand-rolled `absolute right-0 top-full` panel with no viewport clamping. Near the edge of the window it spilled off-screen and was only partly visible.

Every other popover/overlay in this project is window-boundary aware via Headless UI's `Popover` + `PopoverPanel` with the `anchor` prop (Floating UI under the hood), e.g. `BindingAffordance`. This change brings the sound panel in line with that pattern.

## Changes

- `UiSoundSettingsButton.tsx`: replace the manual `absolute` panel with `Popover` / `PopoverButton` / `PopoverPanel` (`anchor="bottom end"`).
  - Panel now flips/shifts to stay on-screen and portals out of any clipping/scroll container.
  - Caps to the viewport: `max-h-[calc(100vh-1rem)] overflow-y-auto` and `max-w-[calc(100vw-1rem)]`, with anchor gap/padding vars.
  - Removes the now-redundant `open` state and the manual outside-pointerdown close handler — Headless UI owns open/close and dismissal.

## Testing

- `eslint --fix` clean on the changed file (also ran via the pre-commit hook).
- `tsc --noEmit`: no new type errors (the only errors reported are pre-existing, in unrelated `__tests__` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7TaedZT4zyBrmc6CpFNc6)_