### PR TITLE
Add 4K resolution presets (portrait and landscape)

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
@@ -93,10 +93,24 @@ export const sizePresetOptions: SelectOption[] = [
     "Landscape"
   ),
   createSizePresetOption(
+    3840,
+    2160,
+    "4K",
+    "Landscape"
+  ),
+  createSizePresetOption(
     1920 * 4,
     1080 * 4,
     "Ultra HD",
     "Landscape"
+  ),
+
+  // portrait
+  createSizePresetOption(
+    2160,
+    3840,
+    "4K",
+    "Portrait"
   )
 ];
 


### PR DESCRIPTION
## Summary

Added 4K resolution presets to the template canvas size options, supporting both landscape and portrait orientations.

## Changes

- **4K Landscape**: 3840 × 2160 (standard UHD 4K)
- **4K Portrait**: 2160 × 3840 (portrait orientation 4K)

These presets are now available in the canvas size dropdown alongside existing presets like Full HD and Ultra HD.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCFLYdWHSKfu2ucsPxqVWS)_