### PR TITLE
Fix UI sound feedback playing on sketch open

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -8,6 +8,9 @@ import {
   FormProvider, useFieldArray, useWatch
 } from "react-hook-form";
 import initOptions from "@/utils/initOptions";
+import {
+  withSilentFormWrite
+} from "@/lib/uiSound";
 import useRecordingStatusStream from "@/hooks/useRecordingStatusStream";
 import type {
   JobModel
@@ -188,11 +191,13 @@ export default function TemplateOptions( {
         if ( origin === "react" ) {
           return;
         }
-        syncLeafValues(
-          opts,
-          getValues(),
-          ""
-        );
+        withSilentFormWrite( () => {
+          syncLeafValues(
+            opts,
+            getValues(),
+            ""
+          );
+        } );
       } );
     },
     [

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ItemListRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ItemListRenderer.tsx
@@ -30,6 +30,9 @@ import {
   ChevronDown, GripVertical, Plus, Trash2
 } from "lucide-react";
 import clsx from "clsx";
+import {
+  withSilentFormWrite
+} from "@/lib/uiSound";
 import FieldRenderer from "./FieldRenderer";
 import CollapsibleItem from "@/components/CollapsibleItem";
 import type {
@@ -201,31 +204,33 @@ export default function ItemListRenderer( {
         Array.isArray( currentValue ) && currentValue.length > 0;
 
       if ( !hasExistingValues ) {
-        if ( config.defaultItems && config.defaultItems.length > 0 ) {
-          setValue(
-            name,
-            config.defaultItems,
-            {
-              shouldDirty: false,
-              shouldTouch: false
-            }
-          );
-        } else if ( config.minItems && config.minItems > 0 ) {
-          setValue(
-            name,
-            Array.from(
+        withSilentFormWrite( () => {
+          if ( config.defaultItems && config.defaultItems.length > 0 ) {
+            setValue(
+              name,
+              config.defaultItems,
               {
-                length: config.minItems
-              },
-              () =>
-                getDefaultValueForConfig( config.itemConfig )
-            ),
-            {
-              shouldDirty: false,
-              shouldTouch: false
-            }
-          );
-        }
+                shouldDirty: false,
+                shouldTouch: false
+              }
+            );
+          } else if ( config.minItems && config.minItems > 0 ) {
+            setValue(
+              name,
+              Array.from(
+                {
+                  length: config.minItems
+                },
+                () =>
+                  getDefaultValueForConfig( config.itemConfig )
+              ),
+              {
+                shouldDirty: false,
+                shouldTouch: false
+              }
+            );
+          }
+        } );
       }
 
       didInitRef.current = true;

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useFormState.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useFormState.ts
@@ -9,7 +9,7 @@ import {
 } from "react-hook-form";
 import initOptions from "@/utils/initOptions";
 import {
-  playValueChange
+  isSilentFormWrite, playValueChange
 } from "@/lib/uiSound";
 import {
   useInterval
@@ -63,9 +63,12 @@ export function useFormState( {
         value, info
       ) => {
         // Audible tick on real value edits (sliders, inputs, action buttons).
-        // Form-level events (reset, initial populate) carry no field name and
-        // stay silent. Muting/throttling lives inside the sound module.
-        if ( info?.name ) {
+        // Form-level events (reset) carry no field name and stay silent.
+        // Programmatic syncs (sketch-driven option sync, list-default
+        // population on mount) carry a field name but are wrapped in
+        // withSilentFormWrite() by their callers, so they stay silent too.
+        // Muting/throttling lives inside the sound module.
+        if ( info?.name && !isSilentFormWrite() ) {
           playValueChange( info.name );
         }
 

--- a/src/lib/uiSound.ts
+++ b/src/lib/uiSound.ts
@@ -48,6 +48,34 @@ export interface UiSoundSettings {
 
 export const UI_SOUND_PRESETS = CLICK_PRESET_NAMES;
 
+/* ------------------------------------------------------------------ */
+/*  Silent writes                                                      */
+/* ------------------------------------------------------------------ */
+
+// react-hook-form's watch() fires with a field name for ANY setValue(),
+// whether it came from a user dragging a slider or from code silently
+// syncing the form (sketch-driven option sync, list-default population on
+// mount, …). Callers doing the latter wrap their setValue() calls in
+// withSilentFormWrite() so the value-change click in useFormState doesn't
+// fire for writes the user never made.
+let silentWrite = false;
+
+export function withSilentFormWrite<T>( fn: () => T ): T {
+  const previous = silentWrite;
+
+  silentWrite = true;
+
+  try {
+    return fn();
+  } finally {
+    silentWrite = previous;
+  }
+}
+
+export function isSilentFormWrite(): boolean {
+  return silentWrite;
+}
+
 export const UI_SOUND_DEFAULTS: UiSoundSettings = {
   enabled: false,
   actionSounds: true,


### PR DESCRIPTION
## Summary

- The editor's "value change" click sound (`playValueChange`, wired up in `useFormState`'s `watch()` subscription) fired for **any** `setValue()` call that carried a field name — including programmatic writes that aren't user edits.
- Two such non-user writes exist in the codebase, both already marked `shouldDirty: false` to flag themselves as synthetic:
  - `TemplateOptions.tsx`'s sketch-driven option sync effect, which fires as soon as a sketch reports its initial/computed options back to the form (this is what produced the spurious click right when opening a sketch).
  - `ItemListRenderer.tsx`'s one-time population of `defaultItems`/`minItems` for empty list fields on mount.
- Added a `withSilentFormWrite()` helper in `src/lib/uiSound.ts` (a synchronous flag, since react-hook-form's `watch()` subject fires synchronously within the `setValue()` call) and wrapped both call sites in it. `useFormState`'s watch callback now skips playing the click while the flag is set.
- Genuine user-driven edits (sliders, selects, buttons that use `shouldDirty: true`) are unaffected and still click as before.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (1432 tests passing)
- [x] `npm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGEgpdf8XuhBSk7vZ3t7gJ)_