### PR TITLE
Fix play/pause state desync after in-browser recording

### DIFF
--- a/src/engines/recording/__tests__/AsyncLoopRecorder.test.ts
+++ b/src/engines/recording/__tests__/AsyncLoopRecorder.test.ts
@@ -146,6 +146,58 @@ describe(
     );
 
     test(
+      "resumes the host before emitting \"stop\", so a listener's own play/pause call has the last word",
+      async() => {
+        const totalFrames = 2;
+        const calls: string[] = [];
+        const host = makeHost(
+          totalFrames,
+          30,
+          calls
+        );
+        const addFrameCounter = {
+          count: 0
+        };
+        const receivedParams = {
+          value: null as Parameters<FrameEncoderFactory>[ 0 ] | null
+        };
+        const recorder = new AsyncLoopRecorder(
+          host,
+          "webm",
+          makeEncoderFactory(
+            addFrameCounter,
+            receivedParams
+          )
+        );
+
+        recorder.on(
+          "stop",
+          () => {
+            // Simulates the browser-recorder hook's cleanup(), which decides
+            // the final playback state from its own snapshot and must not be
+            // clobbered by a resume() firing after this listener returns.
+            calls.push( "listener-pause-decision" );
+            host.pause();
+          }
+        );
+
+        await recorder.start();
+        await recorder.stop();
+
+        const resumeIdx = calls.indexOf( "resume" );
+        const stopListenerIdx = calls.indexOf( "listener-pause-decision" );
+
+        expect( resumeIdx ).toBeGreaterThanOrEqual( 0 );
+        expect( stopListenerIdx ).toBeGreaterThanOrEqual( 0 );
+        expect( resumeIdx ).toBeLessThan( stopListenerIdx );
+
+        // The listener's decision, made after resume(), must be the final
+        // call — not overwritten by a later resume().
+        expect( calls[ calls.length - 1 ] ).toBe( "pause" );
+      }
+    );
+
+    test(
       "leaves deterministic mode + resumes the host when setup fails",
       async() => {
         const calls: string[] = [];

--- a/src/engines/recording/strategies/AsyncLoopRecorder.ts
+++ b/src/engines/recording/strategies/AsyncLoopRecorder.ts
@@ -213,6 +213,13 @@ export class AsyncLoopRecorder extends BaseRecorder {
           stage: "finalizing"
         }
       );
+
+      // Tear down (and resume the host) BEFORE emitting "stop" — listeners
+      // (e.g. the recording hook's cleanup) decide the final play/pause
+      // state synchronously on this event, and that decision must be the
+      // last word. Emitting first would let `resumeHost()` below run after
+      // the listener's decision and silently override it back to playing.
+      this.teardown();
       this.emit(
         "stop",
         result
@@ -221,6 +228,8 @@ export class AsyncLoopRecorder extends BaseRecorder {
       return result;
     } catch( error ) {
       const err = error instanceof Error ? error : new Error( String( error ) );
+
+      this.teardown();
 
       if ( this.cancelled ) {
         this.emit(
@@ -236,20 +245,27 @@ export class AsyncLoopRecorder extends BaseRecorder {
 
       throw err;
     } finally {
-      // Always exit capture mode — leaving it on would silence the next
-      // interactive session as `trigger()` would keep logging instead of
-      // playing.
-      if ( this.audioCaptureActive ) {
-        getAudioBridge()?.endCapture();
-        this.audioCaptureActive = false;
-      }
-
-      this._isRecording = false;
-      this.encoder?.dispose();
-      this.encoder = null;
-      this.exitDeterministic();
-      this.resumeHost();
+      // Safety net for any path that throws before reaching the explicit
+      // `teardown()` calls above — every step inside is idempotent, so a
+      // second invocation here is a no-op in the normal case.
+      this.teardown();
     }
+  }
+
+  private teardown(): void {
+    // Always exit capture mode — leaving it on would silence the next
+    // interactive session as `trigger()` would keep logging instead of
+    // playing.
+    if ( this.audioCaptureActive ) {
+      getAudioBridge()?.endCapture();
+      this.audioCaptureActive = false;
+    }
+
+    this._isRecording = false;
+    this.encoder?.dispose();
+    this.encoder = null;
+    this.exitDeterministic();
+    this.resumeHost();
   }
 
   stop(): Promise<RecorderResult> {


### PR DESCRIPTION
## Summary

- After an in-browser recording finished, the sketch kept playing even though the Play/Pause button showed "paused" — the engine and the UI disagreed on playback state.
- Root cause: `AsyncLoopRecorder` (the default recording strategy for mp4/webm/gif downloads and previews) emitted the `"stop"` event *before* running its own teardown. The `"stop"` listener in `useBrowserRecorder` synchronously restores the pre-recording play/pause state (`cleanup()`), but control then returned into `AsyncLoopRecorder`'s `finally` block, which unconditionally called `host.resume()` — silently overriding the listener's decision back to "playing" a moment after the UI had already rendered "paused".
- Fix: extracted the teardown logic (exit deterministic mode, resume host, dispose encoder, etc.) into a `teardown()` method and call it *before* emitting `"stop"`/`"cancel"`/`"error"`, so the recording hook's play/pause restoration is genuinely the last word. This mirrors the ordering `RealtimeRecorder` already used (it wasn't affected by this bug).

## Test plan

- [x] `npm run lint`
- [x] `npm test` (1433 tests, including a new regression test in `AsyncLoopRecorder.test.ts` asserting `resume()` fires before the `"stop"` listener runs, and that the listener's own play/pause call is the final state change)
- [x] `npm run check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01S73AJ2NrbGfM8edufg1jvh)_