### PR TITLE
Add still-frame sequence export ("Frames" group) to capture actions

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/CaptureActions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/CaptureActions.tsx
@@ -30,6 +30,9 @@ import RecordingActions from "./components/RecordingActions";
 import {
   useBrowserRecorder
 } from "./hooks/useBrowserRecorder";
+import {
+  useFrameExporter
+} from "./hooks/useFrameExporter";
 import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
 import type {
   RecorderCapabilities
@@ -104,6 +107,12 @@ const CaptureActions = forwardRef<CaptureActionsRef, CaptureActionsProps>( (
     : null;
 
   const browserRecorder = useBrowserRecorder( {
+    engine,
+    options: options as never,
+    activeSlideIndex,
+    sketchName: name
+  } );
+  const frameExporter = useFrameExporter( {
     engine,
     options: options as never,
     activeSlideIndex,
@@ -728,6 +737,13 @@ const CaptureActions = forwardRef<CaptureActionsRef, CaptureActionsProps>( (
               onStart={ browserRecorder.start }
               onStop={ browserRecorder.stop }
               onCancel={ browserRecorder.cancel }
+              frameExport={ {
+                isExporting: frameExporter.isExporting,
+                progress: frameExporter.progress,
+                error: frameExporter.error,
+                onExport: frameExporter.exportFrames,
+                onCancel: frameExporter.cancel
+              } }
             />
           )}
 

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/components/BrowserRecordingButton.tsx
@@ -4,7 +4,7 @@ import React, {
   useMemo, useState
 } from "react";
 import {
-  Loader2, StopCircle
+  Download, Loader2, StopCircle
 } from "lucide-react";
 import type {
   RecorderCapabilities, RecorderProgress, RecordingFormat, RecordingMode
@@ -15,6 +15,9 @@ import {
 import type {
   PreviewPhase, RecordingIntent
 } from "../hooks/useBrowserRecorder";
+import type {
+  FrameCount, FrameExportProgress
+} from "../hooks/useFrameExporter";
 
 type BrowserRecordingButtonProps = {
   capabilities: RecorderCapabilities;
@@ -31,6 +34,16 @@ type BrowserRecordingButtonProps = {
   ) => void;
   onStop: () => void;
   onCancel: () => void;
+  // Still-frame sequence export ("Frames" group). Shares the sketch engine
+  // with recording, so the two can never run at once — the UI swaps between
+  // them.
+  frameExport: {
+    isExporting: boolean;
+    progress: FrameExportProgress | null;
+    error: Error | null;
+    onExport: ( count: FrameCount ) => void;
+    onCancel: () => void;
+  };
 };
 
 const FORMAT_LABEL: Record<RecordingFormat, string> = {
@@ -66,6 +79,34 @@ const MODE_ORDER: ReadonlyArray<RecordingMode> = [
   "realtime"
 ];
 
+// Still-frame export group. Each entry samples the loop evenly and bundles
+// the PNGs into a single `.zip` (see `useFrameExporter`). Gated on the engine
+// being able to render arbitrary frames reproducibly — a realtime-only sketch
+// can't be sampled deterministically.
+const FRAMES_GROUP_LABEL = "Frames (.zip)";
+
+const FRAMES_OPTIONS: ReadonlyArray<{
+  key: string;
+  label: string;
+  count: FrameCount;
+}> = [
+  {
+    key: "frames-10",
+    label: "10 × .png",
+    count: 10
+  },
+  {
+    key: "frames-20",
+    label: "20 × .png",
+    count: 20
+  },
+  {
+    key: "frames-all",
+    label: "All frames",
+    count: "all"
+  }
+];
+
 // Dev-only group: a webm capture that, instead of downloading, is saved
 // back over the sketch's committed preview. Both flavours share one compact
 // group so the dropdown stays narrow and never pushes the record button off
@@ -81,14 +122,25 @@ const PREVIEW_ASYNC_OPTION_LABEL = "Async";
 const PREVIEW_REALTIME_OPTION_LABEL = "Realtime";
 const IS_DEV = process.env.NODE_ENV === "development";
 
-// One <option> per group entry. The composite value carries everything
-// `start()` needs; including the group label in the visible text keeps the
+// One <option> per group entry. The composite value carries everything the
+// record button needs; including the group label in the visible text keeps the
 // active choice readable without re-opening the dropdown.
-type Choice = {
+//
+// A choice is either a video recording (`record`) or a still-frame sequence
+// export (`frames`) — the record button branches on `kind`.
+type RecordChoice = {
+  kind: "record";
   format: RecordingFormat;
   mode: RecordingMode;
   intent: RecordingIntent;
 };
+
+type FramesChoice = {
+  kind: "frames";
+  count: FrameCount;
+};
+
+type Choice = RecordChoice | FramesChoice;
 
 // One <option> in the dropdown. The label is what shows when collapsed, so
 // keep it short; the choice carries everything `start()` needs.
@@ -105,17 +157,32 @@ type RecordingGroup = {
 };
 
 function encodeChoice( c: Choice ): string {
-  return `${ c.format }|${ c.mode }|${ c.intent }`;
+  return c.kind === "frames"
+    ? `frames|${ c.count }`
+    : `record|${ c.format }|${ c.mode }|${ c.intent }`;
 }
 
 function decodeChoice( value: string ): Choice {
+  const parts = value.split( "|" );
+
+  if ( parts[ 0 ] === "frames" ) {
+    const raw = parts[ 1 ];
+
+    return {
+      kind: "frames",
+      count: raw === "all" ? "all" : Number( raw )
+    };
+  }
+
   const [
+    ,
     format,
     mode,
     intent
-  ] = value.split( "|" ) as [ RecordingFormat, RecordingMode, RecordingIntent ];
+  ] = parts as [ string, RecordingFormat, RecordingMode, RecordingIntent ];
 
   return {
+    kind: "record",
     format,
     mode,
     intent: intent ?? "download"
@@ -138,7 +205,8 @@ export default function BrowserRecordingButton( {
   previewSaved,
   onStart,
   onStop,
-  onCancel
+  onCancel,
+  frameExport
 }: BrowserRecordingButtonProps ) {
   const groups = useMemo<RecordingGroup[]>(
     () => {
@@ -157,6 +225,7 @@ export default function BrowserRecordingButton( {
                 f
               ),
               choice: {
+                kind: "record" as const,
                 format: f,
                 mode,
                 intent: "download" as RecordingIntent
@@ -175,6 +244,7 @@ export default function BrowserRecordingButton( {
             key: "preview-async",
             label: PREVIEW_ASYNC_OPTION_LABEL,
             choice: {
+              kind: "record",
               format: "webm",
               mode: "async-loop",
               intent: "preview"
@@ -186,6 +256,7 @@ export default function BrowserRecordingButton( {
           key: "preview-realtime",
           label: PREVIEW_REALTIME_OPTION_LABEL,
           choice: {
+            kind: "record",
             format: "webm",
             mode: "realtime",
             intent: "preview"
@@ -196,6 +267,24 @@ export default function BrowserRecordingButton( {
           key: "preview",
           label: PREVIEW_GROUP_LABEL,
           options: previewOptions
+        } );
+      }
+
+      // Deterministic engines can be frame-stepped, so offer the still-frame
+      // sequence export. Realtime-only sketches can't be sampled reproducibly,
+      // so the group is simply absent for them.
+      if ( capabilities.supportsDeterministicCapture ) {
+        modeGroups.push( {
+          key: "frames",
+          label: FRAMES_GROUP_LABEL,
+          options: FRAMES_OPTIONS.map( ( frameOption ) => ( {
+            key: frameOption.key,
+            label: frameOption.label,
+            choice: {
+              kind: "frames" as const,
+              count: frameOption.count
+            }
+          } ) )
         } );
       }
 
@@ -211,12 +300,17 @@ export default function BrowserRecordingButton( {
     () => {
       const preferredMode = capabilities.defaultMode;
       const options = groups.flatMap( ( g ) => g.options );
+      // Never default to a frames export — it's an explicit, opt-in action.
       const match =
-        options.find( ( o ) => o.choice.intent === "download" && o.choice.mode === preferredMode ) ??
-          options.find( ( o ) => o.choice.intent === "download" ) ??
+        options.find( ( o ) =>
+          o.choice.kind === "record" &&
+            o.choice.intent === "download" &&
+            o.choice.mode === preferredMode ) ??
+          options.find( ( o ) => o.choice.kind === "record" && o.choice.intent === "download" ) ??
           options[ 0 ];
 
       return match?.choice ?? {
+        kind: "record",
         mode: "async-loop",
         format: "webm",
         intent: "download"
@@ -233,13 +327,30 @@ export default function BrowserRecordingButton( {
     setChoice
   ] = useState<Choice>( defaultChoice );
 
+  // Recording controls only render off the back of a record choice, but the
+  // union forces a guard — fall back to the deterministic mode for the (never
+  // reached) frames case.
+  const recordMode: RecordingMode =
+    choice.kind === "record" ? choice.mode : "async-loop";
+
+  // A frames export owns the button for its duration — progress + cancel,
+  // no format dropdown.
+  if ( frameExport.isExporting ) {
+    return (
+      <FramesExportControls
+        progress={ frameExport.progress }
+        onCancel={ frameExport.onCancel }
+      />
+    );
+  }
+
   // A dev "Record preview" run drives its own countdown → recording →
   // saving controls, distinct from the regular realtime / async-loop UI.
   if ( previewPhase ) {
     return (
       <PreviewRecordingControls
         phase={ previewPhase }
-        mode={ choice.mode }
+        mode={ recordMode }
         progress={ progress }
         countdown={ countdown }
         onStop={ onStop }
@@ -249,7 +360,7 @@ export default function BrowserRecordingButton( {
   }
 
   if ( isRecording ) {
-    const isRealtime = choice.mode === "realtime";
+    const isRealtime = recordMode === "realtime";
 
     if ( isRealtime ) {
       return (
@@ -291,19 +402,33 @@ export default function BrowserRecordingButton( {
 
         <button
           type="button"
-          onClick={ () => onStart(
-            choice.format,
-            choice.mode,
-            choice.intent
-          ) }
-          aria-label="Start recording"
-          title="Start recording"
+          onClick={ () => {
+            if ( choice.kind === "frames" ) {
+              frameExport.onExport( choice.count );
+            } else {
+              onStart(
+                choice.format,
+                choice.mode,
+                choice.intent
+              );
+            }
+          } }
+          aria-label={
+            choice.kind === "frames" ? "Export frames" : "Start recording"
+          }
+          title={
+            choice.kind === "frames" ? "Export frames" : "Start recording"
+          }
           className="flex-shrink-0 border-l px-2 text-foreground hover:bg-hover transition-colors inline-flex items-center justify-center"
         >
-          <span
-            aria-hidden="true"
-            className="block h-3 w-3 rounded-full bg-red-500 ring-1 ring-red-500/40"
-          />
+          {choice.kind === "frames" ? (
+            <Download className="h-4 w-4" />
+          ) : (
+            <span
+              aria-hidden="true"
+              className="block h-3 w-3 rounded-full bg-red-500 ring-1 ring-red-500/40"
+            />
+          )}
         </button>
       </div>
 
@@ -313,9 +438,9 @@ export default function BrowserRecordingButton( {
         </div>
       )}
 
-      {error && (
+      {( error || frameExport.error ) && (
         <div className="text-[10px] text-red-500">
-          {error.message}
+          {( error ?? frameExport.error )?.message}
         </div>
       )}
     </div>
@@ -587,6 +712,74 @@ function AsyncLoopRecordingControls( {
         />
         <StopCircle className="relative h-4 w-4 flex-shrink-0" />
         <span className="relative truncate">Cancel recording</span>
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Progress + cancel affordance for a still-frame sequence export. Mirrors the
+ * async-loop recorder button — a fill bar tracking frame capture that parks at
+ * 100% while the PNGs are zipped — since both step the sketch frame-by-frame.
+ */
+function FramesExportControls( {
+  progress,
+  onCancel
+}: {
+  progress: FrameExportProgress | null;
+  onCancel: () => void;
+} ) {
+  const progressLabel = useMemo(
+    () => {
+      if ( !progress ) {
+        return "Preparing…";
+      }
+
+      if ( progress.stage === "zipping" ) {
+        return "Zipping…";
+      }
+
+      const pct = progress.percentage.toFixed( 0 );
+
+      return `${ pct }% (${ progress.frame }/${ progress.totalFrames })`;
+    },
+    [
+      progress
+    ]
+  );
+
+  const targetFillPct = progress
+    ? progress.stage === "capturing"
+      ? progress.percentage
+      : 100
+    : 0;
+
+  const fillRef = useSmoothFill<HTMLSpanElement>(
+    true,
+    targetFillPct
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="text-[10px] text-gray-400 text-center min-h-[1em]">
+        {progressLabel}
+      </div>
+      <button
+        type="button"
+        onClick={ onCancel }
+        aria-label="Cancel frame export"
+        className="relative overflow-hidden rounded-xl px-3 py-2.5 border border-red-500/40 text-red-600 text-xs font-medium transition-colors inline-flex items-center justify-center gap-1.5 bg-background hover:bg-red-500/5"
+      >
+        <span
+          ref={ fillRef }
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 bg-red-500/20 pointer-events-none"
+          style={ {
+            width: "0%"
+          } }
+        />
+        <StopCircle className="relative h-4 w-4 flex-shrink-0" />
+        <span className="relative truncate">Cancel export</span>
       </button>
     </div>
   );

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useFrameExporter.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/CaptureActions/hooks/useFrameExporter.ts
@@ -1,0 +1,386 @@
+"use client";
+
+import {
+  useCallback, useEffect, useRef, useState
+} from "react";
+import {
+  createEngineHost
+} from "@/engines/recording";
+import type {
+  SketchEngine
+} from "@/engines/types";
+import type {
+  SketchOption
+} from "@/types/sketch.types";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
+import {
+  createZip, type ZipEntry
+} from "@/utils/clientZip";
+
+/**
+ * A fixed number of evenly-sampled frames, or every frame of the loop.
+ */
+export type FrameCount = number | "all";
+
+export type FrameExportStage = "capturing" | "zipping";
+
+export type FrameExportProgress = {
+  /** 1-based index of the frame just captured. */
+  frame: number;
+  /** Total frames this export will grab. */
+  totalFrames: number;
+  percentage: number;
+  stage: FrameExportStage;
+};
+
+export type UseFrameExporterArgs = {
+  engine: SketchEngine | null;
+  options: SketchOption;
+  activeSlideIndex?: number;
+  sketchName: string;
+};
+
+export type UseFrameExporterReturn = {
+  isExporting: boolean;
+  progress: FrameExportProgress | null;
+  error: Error | null;
+  exportFrames: ( count: FrameCount ) => Promise<void>;
+  cancel: () => void;
+};
+
+function triggerDownload(
+  blob: Blob, filename: string
+) {
+  const url = URL.createObjectURL( blob );
+  const anchor = document.createElement( "a" );
+
+  anchor.style.display = "none";
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild( anchor );
+  anchor.click();
+  setTimeout(
+    () => {
+      anchor.remove();
+      URL.revokeObjectURL( url );
+    },
+    100
+  );
+}
+
+function canvasToPngBytes( canvas: HTMLCanvasElement ): Promise<Uint8Array> {
+  return new Promise( (
+    resolve, reject
+  ) => {
+    canvas.toBlob(
+      ( blob ) => {
+        if ( !blob ) {
+          reject( new Error( "Frame export: canvas.toBlob returned null." ) );
+
+          return;
+        }
+
+        blob
+          .arrayBuffer()
+          .then( ( buffer ) => resolve( new Uint8Array( buffer ) ) )
+          .catch( reject );
+      },
+      "image/png"
+    );
+  } );
+}
+
+/**
+ * Resolve the concrete, ordered frame indices to grab. A numeric `count`
+ * samples the loop evenly (start-aligned, no duplicated loop endpoint);
+ * `"all"` walks every frame. Numeric counts are clamped to the available
+ * frame span so short loops don't emit duplicate stills.
+ */
+function resolveFrameIndices(
+  count: FrameCount, totalFrames: number
+): number[] {
+  if ( count === "all" ) {
+    return Array.from(
+      {
+        length: totalFrames
+      },
+      (
+        _unused, index
+      ) => index
+    );
+  }
+
+  const sampleCount = Math.min(
+    count,
+    totalFrames
+  );
+
+  return Array.from(
+    {
+      length: sampleCount
+    },
+    (
+      _unused, index
+    ) => Math.floor( ( index * totalFrames ) / sampleCount )
+  );
+}
+
+/**
+ * Client-side "export a sequence of stills" companion to `useBrowserRecorder`.
+ *
+ * Reuses the engine's deterministic capture path — the same `seekAndDraw`
+ * machinery the async-loop video recorder uses — to render N evenly-spaced
+ * frames, snapshot each as a PNG, bundle them into a single `.zip`, and hand
+ * that to the user. Built for the Instagram "swipe-driven stop-motion"
+ * carousel: unzip → upload the ordered frames one by one.
+ *
+ * Only meaningful for engines that can render arbitrary frames reproducibly
+ * (`capabilities.supportsDeterministicCapture`); the UI gates on that.
+ */
+export function useFrameExporter( {
+  engine,
+  options,
+  activeSlideIndex,
+  sketchName
+}: UseFrameExporterArgs ): UseFrameExporterReturn {
+  const [
+    isExporting,
+    setIsExporting
+  ] = useState( false );
+  const [
+    progress,
+    setProgress
+  ] = useState<FrameExportProgress | null>( null );
+  const [
+    error,
+    setError
+  ] = useState<Error | null>( null );
+
+  const exportingRef = useRef( false );
+  const cancelledRef = useRef( false );
+
+  const [
+    {
+      looping
+    },
+    dispatch
+  ] = useSketch();
+  const loopingRef = useRef( looping );
+
+  loopingRef.current = looping;
+
+  const sketchNameRef = useRef( sketchName );
+
+  sketchNameRef.current = sketchName;
+
+  const exportFrames = useCallback(
+    async( count: FrameCount ) => {
+      // Re-entry while a capture (or a video recording that shares the engine)
+      // is in flight would corrupt both — bail out silently.
+      if ( exportingRef.current ) {
+        return;
+      }
+
+      if ( !engine ) {
+        setError( new Error( "Engine not ready." ) );
+
+        return;
+      }
+
+      const host = createEngineHost(
+        engine,
+        options,
+        activeSlideIndex
+      );
+      const totalFrames = Math.round( host.totalFrames );
+
+      if ( !Number.isFinite( totalFrames ) || totalFrames <= 0 ) {
+        setError( new Error( "This sketch has no frames to export." ) );
+
+        return;
+      }
+
+      const indices = resolveFrameIndices(
+        count,
+        totalFrames
+      );
+      const wasLooping = loopingRef.current;
+
+      exportingRef.current = true;
+      cancelledRef.current = false;
+      setError( null );
+      setProgress( null );
+      setIsExporting( true );
+      dispatch( {
+        type: "SET_BROWSER_RECORDING",
+        payload: true
+      } );
+
+      const source = host.getCaptureSource();
+
+      // Freeze the draw loop and drive time by frame index so every
+      // `seekAndDraw(i)` renders at exactly t = i / frameRate.
+      host.pause();
+      host.beginDeterministicCapture();
+
+      const finish = () => {
+        host.endDeterministicCapture();
+
+        // The recorder path always resumes; here we restore whatever the user
+        // had before so the Play/Pause button stays truthful.
+        try {
+          if ( wasLooping ) {
+            engine.play();
+          } else {
+            engine.pause();
+          }
+        } catch {
+          // Restoring playback must never mask the export outcome.
+        }
+
+        dispatch( {
+          type: "SET_LOOPING",
+          payload: wasLooping
+        } );
+        dispatch( {
+          type: "SET_BROWSER_RECORDING",
+          payload: false
+        } );
+        exportingRef.current = false;
+        setIsExporting( false );
+        setProgress( null );
+      };
+
+      try {
+        await host.resetToStart();
+
+        const {
+          width, height
+        } = source;
+
+        if ( !width || !height ) {
+          throw new Error( "Capture surface has no dimensions." );
+        }
+
+        const scratch = document.createElement( "canvas" );
+
+        scratch.width = width;
+        scratch.height = height;
+
+        const context = scratch.getContext( "2d" );
+
+        if ( !context ) {
+          throw new Error( "Could not acquire a 2D context for frame export." );
+        }
+
+        const padWidth = Math.max(
+          2,
+          String( indices.length ).length
+        );
+        const entries: ZipEntry[] = [];
+
+        for ( let position = 0; position < indices.length; position++ ) {
+          if ( cancelledRef.current ) {
+            finish();
+
+            return;
+          }
+
+          await host.seekAndDraw( indices[ position ] );
+
+          const image = await source.readFrame();
+
+          context.clearRect(
+            0,
+            0,
+            width,
+            height
+          );
+          context.drawImage(
+            image,
+            0,
+            0,
+            width,
+            height
+          );
+
+          const bytes = await canvasToPngBytes( scratch );
+          const label = String( position + 1 ).padStart(
+            padWidth,
+            "0"
+          );
+
+          entries.push( {
+            name: `frame-${ label }.png`,
+            data: bytes
+          } );
+
+          setProgress( {
+            frame: position + 1,
+            totalFrames: indices.length,
+            percentage: ( ( position + 1 ) / indices.length ) * 100,
+            stage: "capturing"
+          } );
+        }
+
+        if ( cancelledRef.current ) {
+          finish();
+
+          return;
+        }
+
+        setProgress( {
+          frame: indices.length,
+          totalFrames: indices.length,
+          percentage: 100,
+          stage: "zipping"
+        } );
+
+        const zip = createZip( entries );
+        const safeName = sketchNameRef.current || "sketch";
+        const suffix = count === "all" ? "all" : String( count );
+
+        triggerDownload(
+          zip,
+          `${ safeName }-frames-${ suffix }.zip`
+        );
+
+        finish();
+      } catch( caught ) {
+        setError( caught instanceof Error ? caught : new Error( String( caught ) ) );
+        finish();
+      }
+    },
+    [
+      engine,
+      options,
+      activeSlideIndex,
+      dispatch
+    ]
+  );
+
+  const cancel = useCallback(
+    () => {
+      // The capture loop checks this flag between frames and tears itself down.
+      cancelledRef.current = true;
+    },
+    []
+  );
+
+  // Abort an in-flight capture on unmount so the engine isn't left paused in
+  // deterministic mode with a half-built zip.
+  useEffect(
+    () => () => {
+      cancelledRef.current = true;
+    },
+    []
+  );
+
+  return {
+    isExporting,
+    progress,
+    error,
+    exportFrames,
+    cancel
+  };
+}

--- a/src/utils/__tests__/clientZip.test.ts
+++ b/src/utils/__tests__/clientZip.test.ts
@@ -1,0 +1,154 @@
+import {
+  execFileSync
+} from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  createZip, type ZipEntry
+} from "../clientZip";
+
+/**
+ * Validate the hand-rolled store-only ZIP writer against an independent
+ * oracle — Python's `zipfile`. `testzip()` recomputes every entry's CRC-32
+ * and returns the first corrupt name (or `None`), so a passing archive proves
+ * the headers, sizes, offsets and CRCs all line up.
+ */
+
+type OracleResult = {
+  bad: string | null;
+  names: string[];
+  contents: Record<string, string>; // name -> hex
+};
+
+async function zipToBuffer( entries: ZipEntry[] ): Promise<Buffer> {
+  const blob = createZip(
+    entries,
+    // Fixed date keeps the bytes deterministic across runs.
+    new Date( "2020-01-02T03:04:05Z" )
+  );
+
+  return Buffer.from( await blob.arrayBuffer() );
+}
+
+function inspectWithPython( zipBuffer: Buffer ): OracleResult {
+  const file = path.join(
+    fs.mkdtempSync( path.join(
+      os.tmpdir(),
+      "clientzip-"
+    ) ),
+    "archive.zip"
+  );
+
+  fs.writeFileSync(
+    file,
+    zipBuffer
+  );
+
+  const script = [
+    "import zipfile, json, sys",
+    "z = zipfile.ZipFile(sys.argv[1])",
+    "bad = z.testzip()",
+    "names = z.namelist()",
+    "contents = {n: z.read(n).hex() for n in names}",
+    "print(json.dumps({'bad': bad, 'names': names, 'contents': contents}))"
+  ].join( "\n" );
+
+  const stdout = execFileSync(
+    "python3",
+    [
+      "-c",
+      script,
+      file
+    ],
+    {
+      encoding: "utf8"
+    }
+  );
+
+  return JSON.parse( stdout ) as OracleResult;
+}
+
+function toHex( bytes: Uint8Array ): string {
+  return Buffer.from( bytes ).toString( "hex" );
+}
+
+describe(
+  "createZip",
+  () => {
+    it(
+      "produces an archive whose CRCs and contents a real unzip verifies",
+      async() => {
+        const encoder = new TextEncoder();
+        const entries: ZipEntry[] = [
+          {
+            name: "frame-01.png",
+            data: encoder.encode( "hello world" )
+          },
+          {
+            name: "frame-02.png",
+            // Full byte range, incl. 0x00, to exercise binary payloads.
+            data: new Uint8Array( Array.from(
+              {
+                length: 256
+              },
+              (
+                _unused, index
+              ) => index
+            ) )
+          }
+        ];
+
+        const result = inspectWithPython( await zipToBuffer( entries ) );
+
+        expect( result.bad ).toBeNull();
+        expect( result.names ).toEqual( [
+          "frame-01.png",
+          "frame-02.png"
+        ] );
+        expect( result.contents[ "frame-01.png" ] ).toBe( toHex( entries[ 0 ].data ) );
+        expect( result.contents[ "frame-02.png" ] ).toBe( toHex( entries[ 1 ].data ) );
+      }
+    );
+
+    it(
+      "preserves entry order for a many-frame export",
+      async() => {
+        const entries: ZipEntry[] = Array.from(
+          {
+            length: 20
+          },
+          (
+            _unused, index
+          ) => ( {
+            name: `frame-${ String( index + 1 ).padStart(
+              2,
+              "0"
+            ) }.png`,
+            data: new Uint8Array( [
+              index,
+              index + 1,
+              index + 2
+            ] )
+          } )
+        );
+
+        const result = inspectWithPython( await zipToBuffer( entries ) );
+
+        expect( result.bad ).toBeNull();
+        expect( result.names ).toEqual( entries.map( ( entry ) => entry.name ) );
+      }
+    );
+
+    it(
+      "emits a valid empty archive",
+      async() => {
+        const result = inspectWithPython( await zipToBuffer( [] ) );
+
+        expect( result.bad ).toBeNull();
+        expect( result.names ).toEqual( [] );
+      }
+    );
+  }
+);

--- a/src/utils/clientZip.ts
+++ b/src/utils/clientZip.ts
@@ -1,0 +1,344 @@
+/**
+ * Minimal store-only (no compression) ZIP writer for the browser.
+ *
+ * PNG frames are already compressed, so running them through DEFLATE would
+ * burn CPU for no size win — every entry is stored (method 0). The output is
+ * a standard `.zip` that Finder, Explorer and the Instagram uploader read
+ * once unzipped. Deliberately dependency-free: `archiver`/`tar` are Node-only
+ * and can't run client-side.
+ *
+ * Scope: single-disk archives with < 65 535 entries and each file/offset
+ * under 4 GiB. That is far beyond a frame export, so ZIP64 is not needed.
+ */
+
+export type ZipEntry = {
+  name: string;
+  data: Uint8Array;
+};
+
+const LOCAL_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_HEADER_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_SIGNATURE = 0x06054b50;
+// General-purpose bit 11: filenames + comments are UTF-8.
+const UTF8_FLAG = 0x0800;
+
+let crcTable: Uint32Array | null = null;
+
+function getCrcTable(): Uint32Array {
+  if ( crcTable ) {
+    return crcTable;
+  }
+
+  const table = new Uint32Array( 256 );
+
+  for ( let n = 0; n < 256; n++ ) {
+    let c = n;
+
+    for ( let k = 0; k < 8; k++ ) {
+      c = c & 1 ? 0xedb88320 ^ ( c >>> 1 ) : c >>> 1;
+    }
+
+    table[ n ] = c >>> 0;
+  }
+
+  crcTable = table;
+
+  return table;
+}
+
+function crc32( bytes: Uint8Array ): number {
+  const table = getCrcTable();
+  let crc = 0xffffffff;
+
+  for ( let i = 0; i < bytes.length; i++ ) {
+    crc = ( crc >>> 8 ) ^ table[ ( crc ^ bytes[ i ] ) & 0xff ];
+  }
+
+  return ( crc ^ 0xffffffff ) >>> 0;
+}
+
+/**
+ * Encode a JS `Date` into the packed DOS date/time fields ZIP uses. Seconds
+ * have 2-second resolution in this format — expected, not a bug.
+ */
+function toDosDateTime( date: Date ): {
+  time: number;
+  date: number;
+} {
+  const time =
+    ( ( date.getHours() & 0x1f ) << 11 ) |
+    ( ( date.getMinutes() & 0x3f ) << 5 ) |
+    ( ( date.getSeconds() >> 1 ) & 0x1f );
+
+  const year = Math.max(
+    0,
+    date.getFullYear() - 1980
+  );
+
+  const dosDate =
+    ( ( year & 0x7f ) << 9 ) |
+    ( ( ( date.getMonth() + 1 ) & 0x0f ) << 5 ) |
+    ( date.getDate() & 0x1f );
+
+  return {
+    time,
+    date: dosDate
+  };
+}
+
+/**
+ * Assemble `entries` into a stored (uncompressed) ZIP `Blob`. `date` stamps
+ * every entry's modified time; it defaults to now but is injectable so callers
+ * can produce deterministic archives in tests.
+ */
+export function createZip(
+  entries: ZipEntry[], date: Date = new Date()
+): Blob {
+  const encoder = new TextEncoder();
+  const {
+    time: dosTime, date: dosDate
+  } = toDosDateTime( date );
+
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  let offset = 0;
+
+  for ( const entry of entries ) {
+    const nameBytes = encoder.encode( entry.name );
+    const crc = crc32( entry.data );
+    const size = entry.data.length;
+
+    const local = new Uint8Array( 30 + nameBytes.length );
+    const localView = new DataView( local.buffer );
+
+    localView.setUint32(
+      0,
+      LOCAL_HEADER_SIGNATURE,
+      true
+    );
+    localView.setUint16(
+      4,
+      20,
+      true
+    ); // version needed to extract
+    localView.setUint16(
+      6,
+      UTF8_FLAG,
+      true
+    );
+    localView.setUint16(
+      8,
+      0,
+      true
+    ); // method: stored
+    localView.setUint16(
+      10,
+      dosTime,
+      true
+    );
+    localView.setUint16(
+      12,
+      dosDate,
+      true
+    );
+    localView.setUint32(
+      14,
+      crc,
+      true
+    );
+    localView.setUint32(
+      18,
+      size,
+      true
+    ); // compressed size
+    localView.setUint32(
+      22,
+      size,
+      true
+    ); // uncompressed size
+    localView.setUint16(
+      26,
+      nameBytes.length,
+      true
+    );
+    localView.setUint16(
+      28,
+      0,
+      true
+    ); // extra field length
+    local.set(
+      nameBytes,
+      30
+    );
+
+    localParts.push(
+      local,
+      entry.data
+    );
+
+    const central = new Uint8Array( 46 + nameBytes.length );
+    const centralView = new DataView( central.buffer );
+
+    centralView.setUint32(
+      0,
+      CENTRAL_HEADER_SIGNATURE,
+      true
+    );
+    centralView.setUint16(
+      4,
+      20,
+      true
+    ); // version made by
+    centralView.setUint16(
+      6,
+      20,
+      true
+    ); // version needed to extract
+    centralView.setUint16(
+      8,
+      UTF8_FLAG,
+      true
+    );
+    centralView.setUint16(
+      10,
+      0,
+      true
+    ); // method: stored
+    centralView.setUint16(
+      12,
+      dosTime,
+      true
+    );
+    centralView.setUint16(
+      14,
+      dosDate,
+      true
+    );
+    centralView.setUint32(
+      16,
+      crc,
+      true
+    );
+    centralView.setUint32(
+      20,
+      size,
+      true
+    );
+    centralView.setUint32(
+      24,
+      size,
+      true
+    );
+    centralView.setUint16(
+      28,
+      nameBytes.length,
+      true
+    );
+    centralView.setUint16(
+      30,
+      0,
+      true
+    ); // extra field length
+    centralView.setUint16(
+      32,
+      0,
+      true
+    ); // comment length
+    centralView.setUint16(
+      34,
+      0,
+      true
+    ); // disk number start
+    centralView.setUint16(
+      36,
+      0,
+      true
+    ); // internal attributes
+    centralView.setUint32(
+      38,
+      0,
+      true
+    ); // external attributes
+    centralView.setUint32(
+      42,
+      offset,
+      true
+    ); // local header offset
+    central.set(
+      nameBytes,
+      46
+    );
+
+    centralParts.push( central );
+
+    offset += local.length + entry.data.length;
+  }
+
+  const centralSize = centralParts.reduce(
+    (
+      sum, part
+    ) => sum + part.length,
+    0
+  );
+  const centralOffset = offset;
+
+  const end = new Uint8Array( 22 );
+  const endView = new DataView( end.buffer );
+
+  endView.setUint32(
+    0,
+    END_OF_CENTRAL_SIGNATURE,
+    true
+  );
+  endView.setUint16(
+    4,
+    0,
+    true
+  ); // this disk number
+  endView.setUint16(
+    6,
+    0,
+    true
+  ); // disk with central directory
+  endView.setUint16(
+    8,
+    entries.length,
+    true
+  ); // entries on this disk
+  endView.setUint16(
+    10,
+    entries.length,
+    true
+  ); // total entries
+  endView.setUint32(
+    12,
+    centralSize,
+    true
+  );
+  endView.setUint32(
+    16,
+    centralOffset,
+    true
+  );
+  endView.setUint16(
+    20,
+    0,
+    true
+  ); // comment length
+
+  // `Uint8Array` is generic over its backing buffer in current lib.dom types,
+  // and `BlobPart` only admits `ArrayBuffer`-backed views. Every array here is
+  // `ArrayBuffer`-backed at runtime, so narrow the union at this boundary.
+  const blobParts = [
+    ...localParts,
+    ...centralParts,
+    end
+  ] as BlobPart[];
+
+  return new Blob(
+    blobParts,
+    {
+      type: "application/zip"
+    }
+  );
+}


### PR DESCRIPTION
## What

Adds a **front-end** still-frame sequence export alongside the existing browser video recorder. From the capture actions dropdown, a new **`Frames (.zip)`** option group offers:

- **10 × .png**
- **20 × .png**
- **All frames**

Selecting one and hitting the button samples the sketch's loop evenly, snapshots each frame as a PNG, bundles them into a single `.zip`, and downloads it.

### Why

Built for the Instagram "swipe-driven stop-motion" carousel: publish a carousel of N frames and let viewers scrub the animation by long-pressing the dots and scrolling horizontally. Unzip the export → upload the ordered frames one by one. Previously this was done by hand (pause the sketch, screenshot repeatedly); this makes it a first-class action. Also handy for pulling a clean still out of a sketch.

## How

- **`src/utils/clientZip.ts`** — a dependency-free, store-only (no compression) ZIP writer for the browser. `archiver`/`tar` are Node-only, so this is hand-rolled: local headers + central directory + EOCD, with CRC-32. PNGs are already compressed, so *stored* is the right mode. Validated against Python's `zipfile` oracle (see tests).
- **`useFrameExporter.ts`** — reuses the engine's deterministic capture path (the same `seekAndDraw` machinery the async-loop video recorder uses) to render N evenly-spaced frames, draw each onto a scratch canvas, `toBlob` → PNG, then `createZip` + download. Snapshots/restores play-pause and `browserRecording` state exactly like `useBrowserRecorder`, so playback controls stay truthful.
- **`BrowserRecordingButton.tsx`** — the format `<select>` gains the `Frames (.zip)` optgroup. The choice model became a `record | frames` discriminated union; the button branches on `kind` (record → `onStart`, frames → `onExport`) and renders a dedicated capture/zip progress + cancel control while exporting. The group is gated on `supportsDeterministicCapture`, so realtime-only sketches (which can't be sampled reproducibly) simply don't show it.
- **`CaptureActions.tsx`** — wires `useFrameExporter` and passes it through.

## Notes / decisions

- All three options deliver a single `.zip` (not individual downloads) — browsers throttle/block multi-file downloads, and one archive keeps the frames ordered (`frame-01.png`, `frame-02.png`, …). Easy to flip to individual files if preferred.
- Frames are sampled evenly and start-aligned (`floor(i * total / n)`), so no duplicated loop endpoint — clean for a looping stop-motion.
- Lives inside the existing browser-recording UI, so it inherits the `browserRecordingSupported` gate.

## Testing

- `src/utils/__tests__/clientZip.test.ts` — validates the archive against Python's `zipfile` (`testzip()` recomputes every CRC-32): binary payloads, 20-frame ordering, and the empty archive all pass.
- `tsc --noEmit` clean for the changed files; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxCrXmtUpwDE63AywuxEjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxCrXmtUpwDE63AywuxEjj)_