### PR TITLE
Canvas ⇄ panel: drag HUD/montage sub-items, and reveal an item's options on select

### DIFF
--- a/src/templates/p5/utils/hud/widgets/badge.js
+++ b/src/templates/p5/utils/hud/widgets/badge.js
@@ -3,7 +3,9 @@ import {
   resolveValue
 } from "../sources.js";
 import {
+  anchoredRect,
   getFont,
+  reportWidgetBounds,
   resolveAnchor,
   toColor,
   withHudTransform
@@ -42,7 +44,7 @@ function segmentText( token ) {
  * "·" separator; `override` replaces the whole text when set.
  */
 export default function badge(
-  cfg, style
+  cfg, style, part
 ) {
   withHudTransform( ( p ) => {
     const {
@@ -77,6 +79,31 @@ export default function badge(
       cfg.fill ?? style.fill
     );
     const font = getFont( cfg.font ?? style.font );
+
+    p.push();
+    p.textFont( font );
+    p.textSize( size );
+    const width = p.textWidth( text );
+
+    p.pop();
+
+    // Report the visible rectangle so the on-canvas drag can grab this badge.
+    const rect = anchoredRect(
+      p,
+      x,
+      y,
+      align,
+      width,
+      size
+    );
+
+    reportWidgetBounds(
+      part,
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h
+    );
 
     string.write(
       text,

--- a/src/templates/p5/utils/hud/widgets/common.js
+++ b/src/templates/p5/utils/hud/widgets/common.js
@@ -3,6 +3,9 @@ import animation from "../../animation.js";
 import sketch, {
   getP5
 } from "../../sketch.js";
+import {
+  reportItemPartBounds
+} from "../../slides/common/itemBoundsRegistry.js";
 
 export const FALLBACK_FILL = [
   0,
@@ -121,6 +124,58 @@ export function resolveBlock(
     anchorX,
     anchorY
   };
+}
+
+/**
+ * Top-left rectangle of an align-anchored block of size w×h whose align corner
+ * sits at (x, y) — the same corner→top-left conversion resolveBlock does, but
+ * from an already-resolved anchor point + alignment (used by the text widgets
+ * that lay out with resolveAnchor rather than resolveBlock).
+ */
+export function anchoredRect(
+  p, x, y, align, w, h
+) {
+  const [
+    anchorX,
+    anchorY
+  ] = align;
+  const rectX =
+    anchorX === p.RIGHT
+      ? x - w
+      : anchorX === p.CENTER
+        ? x - w / 2
+        : x;
+  const rectY =
+    anchorY === p.BOTTOM
+      ? y - h
+      : anchorY === p.CENTER
+        ? y - h / 2
+        : y;
+
+  return {
+    x: rectX,
+    y: rectY,
+    w,
+    h
+  };
+}
+
+/**
+ * Report a widget's drawn rectangle (canvas pixels) under its HUD sub-key, so
+ * the on-canvas content drag can grab and move that one widget by its visible
+ * body. `part` is the widget key (badge, gauge, sparkline, counter, swatch);
+ * a no-op outside a content-item bounds bracket (see itemBoundsRegistry).
+ */
+export function reportWidgetBounds(
+  part, x, y, w, h
+) {
+  reportItemPartBounds(
+    part,
+    x,
+    y,
+    w,
+    h
+  );
 }
 
 /**

--- a/src/templates/p5/utils/hud/widgets/counter.js
+++ b/src/templates/p5/utils/hud/widgets/counter.js
@@ -4,8 +4,10 @@ import {
   resolveValue
 } from "../sources.js";
 import {
+  anchoredRect,
   formatValue,
   getFont,
+  reportWidgetBounds,
   resolveAnchor,
   toColor,
   withHudTransform
@@ -16,7 +18,7 @@ import {
  * its source live each frame (deterministic — no wall-clock lerp).
  */
 export default function counter(
-  cfg, style
+  cfg, style, part
 ) {
   withHudTransform( ( p ) => {
     const raw = resolveValue( cfg.source );
@@ -50,6 +52,39 @@ export default function counter(
           unit
         )
         : `${ raw ?? "—" }`;
+
+    // Report the visible rectangle (label above value) so the on-canvas drag
+    // can grab this counter. The two lines stack from the anchor: label at the
+    // top, value half a line below it.
+    p.push();
+    p.textFont( font );
+    p.textSize( s * 0.42 );
+    const labelWidth = p.textWidth( label );
+
+    p.textSize( s );
+    const valueWidth = p.textWidth( valueText );
+
+    p.pop();
+
+    const rect = anchoredRect(
+      p,
+      x,
+      y,
+      align,
+      Math.max(
+        labelWidth,
+        valueWidth
+      ),
+      s * 1.5
+    );
+
+    reportWidgetBounds(
+      part,
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h
+    );
 
     string.write(
       label,

--- a/src/templates/p5/utils/hud/widgets/gauge.js
+++ b/src/templates/p5/utils/hud/widgets/gauge.js
@@ -7,6 +7,7 @@ import {
 import {
   formatValue,
   getFont,
+  reportWidgetBounds,
   resolveBlock,
   toColor,
   withHudTransform
@@ -18,7 +19,7 @@ import {
  * (linear) by default; an optional easingFn restyles it.
  */
 export default function gauge(
-  cfg, style
+  cfg, style, part
 ) {
   withHudTransform( ( p ) => {
     const raw = resolveValue( cfg.source );
@@ -41,6 +42,15 @@ export default function gauge(
       p,
       cfg.anchor ?? "bottom-left",
       cfg.offset,
+      barW,
+      blockH
+    );
+
+    // Report the visible rectangle so the on-canvas drag can grab this gauge.
+    reportWidgetBounds(
+      part,
+      blockX,
+      blockY,
       barW,
       blockH
     );

--- a/src/templates/p5/utils/hud/widgets/sparkline.js
+++ b/src/templates/p5/utils/hud/widgets/sparkline.js
@@ -10,6 +10,7 @@ import {
 import {
   formatValue,
   getFont,
+  reportWidgetBounds,
   resolveBlock,
   toColor,
   withHudTransform
@@ -20,7 +21,7 @@ import {
  * buffer it feeds itself) as a polyline, with the label + current value above.
  */
 export default function sparkline(
-  cfg, style
+  cfg, style, part
 ) {
   withHudTransform( ( p ) => {
     const meta = resolveMeta( cfg.source );
@@ -45,6 +46,15 @@ export default function sparkline(
       p,
       cfg.anchor ?? "bottom-right",
       cfg.offset,
+      boxW,
+      blockH
+    );
+
+    // Report the visible rectangle so the on-canvas drag can grab this sparkline.
+    reportWidgetBounds(
+      part,
+      blockX,
+      blockY,
       boxW,
       blockH
     );

--- a/src/templates/p5/utils/hud/widgets/swatch.js
+++ b/src/templates/p5/utils/hud/widgets/swatch.js
@@ -5,6 +5,7 @@ import {
 } from "../sources.js";
 import {
   getFont,
+  reportWidgetBounds,
   resolveBlock,
   toColor,
   toHex,
@@ -36,7 +37,7 @@ function toRgbArray( value ) {
  * probe pushed with a colour value (e.g. a dominant colour).
  */
 export default function swatch(
-  cfg, style
+  cfg, style, part
 ) {
   withHudTransform( ( p ) => {
     const arr = toRgbArray( resolveValue( cfg.source ) );
@@ -59,6 +60,15 @@ export default function swatch(
       p,
       cfg.anchor ?? "top-right",
       cfg.offset,
+      blockW,
+      chip
+    );
+
+    // Report the visible rectangle so the on-canvas drag can grab this swatch.
+    reportWidgetBounds(
+      part,
+      blockX,
+      blockY,
       blockW,
       chip
     );

--- a/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
+++ b/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
@@ -626,6 +626,130 @@ describe(
 );
 
 describe(
+  "content drag — montage title overlay",
+  () => {
+    // The montage variant-title is a slide-level label at
+    // slide.transition.title.position — not a content-list item.
+    beforeEach( () => {
+      store = {
+        slides: [
+          {
+            content: [],
+            transition: {
+              enabled: true,
+              title: {
+                enabled: true,
+                align: "right",
+                position: {
+                  x: 0.9,
+                  y: 0.1
+                }
+              }
+            }
+          }
+        ]
+      };
+      setSketchOptions.mockClear();
+      registerContentDrag();
+    } );
+
+    // The montage title keys its bounds by the sentinel "index" within its
+    // slide scope (slide:0 → montage-title), and reports the whole-label rect.
+    function reportTitleBounds() {
+      beginItemBounds(
+        "slide:0",
+        "montage-title"
+      );
+      // A right-aligned label whose anchor (0.9,0.1)*1000 = (900,100) sits at
+      // its right edge; the drawn rect spans to the left of it.
+      reportItemBounds(
+        720,
+        100,
+        180,
+        30
+      );
+      endItemBounds();
+    }
+
+    it(
+      "grabs the montage title by its rectangle and persists its position",
+      () => {
+        reportTitleBounds();
+
+        const down = pressAt(
+          "pointerdown",
+          800,
+          115
+        );
+
+        expect( down.defaultPrevented ).toBe( true );
+
+        // Drag +50/+40, release.
+        pressAt(
+          "pointermove",
+          850,
+          155
+        );
+        pressAt(
+          "pointerup",
+          850,
+          155
+        );
+
+        expect( setSketchOptions ).toHaveBeenCalledTimes( 1 );
+
+        const [
+          update,
+          origin
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { slides: Array<{ transition: { title: { position: { x: number;
+            y: number } } } }> },
+          string
+        ];
+
+        expect( origin ).toBe( "p5" );
+        // Anchor moved by the pointer delta (+0.05, +0.04) from (0.9, 0.1).
+        expect( update.slides[ 0 ].transition.title.position.x ).toBeCloseTo( 0.95 );
+        expect( update.slides[ 0 ].transition.title.position.y ).toBeCloseTo( 0.14 );
+      }
+    );
+
+    it(
+      "is not draggable when the montage transition is disabled",
+      () => {
+        store = {
+          slides: [
+            {
+              content: [],
+              transition: {
+                enabled: false,
+                title: {
+                  enabled: true,
+                  align: "right",
+                  position: {
+                    x: 0.9,
+                    y: 0.1
+                  }
+                }
+              }
+            }
+          ]
+        };
+        registerContentDrag();
+
+        const down = pressAt(
+          "pointerdown",
+          800,
+          115
+        );
+
+        expect( down.defaultPrevented ).toBe( false );
+      }
+    );
+  }
+);
+
+describe(
   "content drag — hover redraw respects pause",
   () => {
     afterEach( () => {

--- a/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
+++ b/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
@@ -91,6 +91,7 @@ import {
 import {
   beginItemBounds,
   reportItemBounds,
+  reportItemPartBounds,
   endItemBounds
 } from "../common/itemBoundsRegistry.js";
 import {
@@ -440,6 +441,182 @@ describe(
           "pointerdown",
           500,
           500
+        );
+
+        expect( down.defaultPrevented ).toBe( false );
+      }
+    );
+  }
+);
+
+describe(
+  "content drag — HUD sub-item widgets",
+  () => {
+    // A HUD item has no position of its own; each widget carries its own
+    // `offset`. Dragging one widget must move ONLY that widget's offset.
+    beforeEach( () => {
+      store = {
+        content: [
+          {
+            type: "hud",
+            badge: {
+              enabled: true,
+              offset: {
+                x: 0.9,
+                y: 0.1
+              }
+            },
+            gauge: {
+              enabled: true,
+              offset: {
+                x: 0.1,
+                y: 0.9
+              }
+            }
+          }
+        ]
+      };
+      setSketchOptions.mockClear();
+      registerContentDrag();
+    } );
+
+    // Report each enabled widget's drawn rectangle for this frame, the way the
+    // real widget renderers do inside freeLayout's bounds bracket.
+    function reportHudBounds() {
+      beginItemBounds(
+        "global",
+        0
+      );
+      // badge drawn top-right, gauge drawn bottom-left — well separated.
+      reportItemPartBounds(
+        "badge",
+        800,
+        80,
+        150,
+        30
+      );
+      reportItemPartBounds(
+        "gauge",
+        60,
+        820,
+        200,
+        60
+      );
+      endItemBounds();
+    }
+
+    it(
+      "grabs a HUD widget by its drawn rectangle and persists its offset",
+      () => {
+        reportHudBounds();
+
+        // Press inside the badge rect, drag +100/+50, release.
+        const down = pressAt(
+          "pointerdown",
+          850,
+          95
+        );
+
+        expect( down.defaultPrevented ).toBe( true );
+
+        pressAt(
+          "pointermove",
+          950,
+          145
+        );
+        pressAt(
+          "pointerup",
+          950,
+          145
+        );
+
+        expect( setSketchOptions ).toHaveBeenCalledTimes( 1 );
+
+        const [
+          update
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { content: Array<{
+            badge: { offset: { x: number;
+              y: number } };
+            gauge: { offset: { x: number;
+              y: number } };
+          }> }
+        ];
+
+        // Badge moved by the pointer delta (+0.1, +0.05) from (0.9, 0.1).
+        expect( update.content[ 0 ].badge.offset.x ).toBeCloseTo( 1 );
+        expect( update.content[ 0 ].badge.offset.y ).toBeCloseTo( 0.15 );
+        // The gauge (a sibling widget) is untouched.
+        expect( update.content[ 0 ].gauge.offset.x ).toBeCloseTo( 0.1 );
+        expect( update.content[ 0 ].gauge.offset.y ).toBeCloseTo( 0.9 );
+      }
+    );
+
+    it(
+      "moves only the pressed widget when two widgets are enabled",
+      () => {
+        reportHudBounds();
+
+        // Press inside the gauge rect this time.
+        pressAt(
+          "pointerdown",
+          120,
+          850
+        );
+        pressAt(
+          "pointermove",
+          220,
+          850
+        );
+        pressAt(
+          "pointerup",
+          220,
+          850
+        );
+
+        const [
+          update
+        ] = setSketchOptions.mock.calls[ 0 ] as [
+          { content: Array<{
+            badge: { offset: { x: number;
+              y: number } };
+            gauge: { offset: { x: number;
+              y: number } };
+          }> }
+        ];
+
+        // Gauge moved +0.1 on x; badge stayed put.
+        expect( update.content[ 0 ].gauge.offset.x ).toBeCloseTo( 0.2 );
+        expect( update.content[ 0 ].badge.offset.x ).toBeCloseTo( 0.9 );
+        expect( update.content[ 0 ].badge.offset.y ).toBeCloseTo( 0.1 );
+      }
+    );
+
+    it(
+      "does not target a disabled widget",
+      () => {
+        store = {
+          content: [
+            {
+              type: "hud",
+              badge: {
+                enabled: false,
+                offset: {
+                  x: 0.9,
+                  y: 0.1
+                }
+              }
+            }
+          ]
+        };
+        registerContentDrag();
+
+        // No bounds reported (disabled widget isn't drawn); a press on empty
+        // canvas must fall through so the viewport can still pan.
+        const down = pressAt(
+          "pointerdown",
+          850,
+          95
         );
 
         expect( down.defaultPrevented ).toBe( false );

--- a/src/templates/p5/utils/slides/common/drawSlideHud.js
+++ b/src/templates/p5/utils/slides/common/drawSlideHud.js
@@ -56,7 +56,8 @@ export default function drawSlideHud( item ) {
     try {
       render(
         cfg,
-        style
+        style,
+        key
       );
     } catch( error ) {
       // An overlay widget must never break the sketch's render loop.

--- a/src/templates/p5/utils/slides/common/itemBoundsRegistry.js
+++ b/src/templates/p5/utils/slides/common/itemBoundsRegistry.js
@@ -18,15 +18,20 @@ import {
 // were reported on so a consumer can ignore stale rects (item removed,
 // renderer bailed early).
 
-const registry = new Map(); // "scope:index" → { x, y, w, h, frame, order }
+const registry = new Map(); // "scope:index[:part]" → { x, y, w, h, frame, order }
 
 let currentKey = null;
 let drawOrder = 0;
 
+// A `part` addresses a positioned sub-item WITHIN a content item — a HUD widget
+// (badge, gauge, …) whose own `offset` places it independently of the item.
+// Whole-item bounds omit it; sub-item bounds append it as a third segment.
 export function itemBoundsKey(
-  scope, index
+  scope, index, part
 ) {
-  return `${ scope }:${ index }`;
+  const base = `${ scope }:${ index }`;
+
+  return part == null ? base : `${ base }:${ part }`;
 }
 
 /** Called by freeLayout before dispatching one item's renderer. */
@@ -75,17 +80,49 @@ export function reportItemBounds(
 }
 
 /**
+ * Called by a sub-item renderer (a HUD widget) with the rectangle it just drew,
+ * in canvas pixels, tagged with its `part` key. Registers under the current
+ * item's `scope:index:part`, so the drag layer can hit-test and move that one
+ * widget independently. No-op outside a begin/endItemBounds bracket.
+ */
+export function reportItemPartBounds(
+  part, x, y, w, h
+) {
+  if ( !currentKey || part == null || ![
+    x,
+    y,
+    w,
+    h
+  ].every( Number.isFinite ) ) {
+    return;
+  }
+
+  registry.set(
+    `${ currentKey }:${ part }`,
+    {
+      x,
+      y,
+      w,
+      h,
+      frame: getP5()?.frameCount ?? 0,
+      order: drawOrder++
+    }
+  );
+}
+
+/**
  * The rectangle an item was last drawn at, or null when none was reported
  * recently (renderer bailed, item removed, sketch not yet drawn). `maxAge`
  * is in frames; a noLoop sketch doesn't advance frameCount, so its last
  * report stays valid.
  */
 export function getItemBounds(
-  scope, index, maxAge = 3
+  scope, index, part, maxAge = 3
 ) {
   const entry = registry.get( itemBoundsKey(
     scope,
-    index
+    index,
+    part
   ) );
 
   if ( !entry ) {

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -67,6 +67,49 @@ const DRAGGABLE_TYPES = new Set( [
   "specs"
 ] );
 
+// A "hud" content item has no single position of its own — instead it holds
+// several telemetry widgets, each of which carries its own normalized `offset`
+// anchor and draws independently. Those widgets are draggable SUB-ITEMS: each
+// becomes its own grab target (identified by a `part` key on top of the item's
+// scope + index) and a drag writes back item[part].offset rather than
+// item.position. Only the offset-anchored widgets are listed here — crosshairs
+// (positioned by a data source) and boundingBox (a region rect) place
+// themselves differently and aren't offset-draggable. Ordered to match their
+// draw order in drawSlideHud (later = on top) so hit-testing picks the widget
+// drawn on top when two overlap.
+const HUD_DRAGGABLE_WIDGETS = [
+  "sparkline",
+  "gauge",
+  "swatch",
+  "counter",
+  "badge"
+];
+
+// Per-widget offset defaults (mirroring the Hud*Schema defaults) so a widget
+// with no persisted offset still resolves the anchor point it actually draws at.
+const HUD_OFFSET_DEFAULTS = {
+  badge: {
+    x: 0.95,
+    y: 0.06
+  },
+  gauge: {
+    x: 0.05,
+    y: 0.9
+  },
+  sparkline: {
+    x: 0.95,
+    y: 0.9
+  },
+  counter: {
+    x: 0.05,
+    y: 0.85
+  },
+  swatch: {
+    x: 0.95,
+    y: 0.2
+  }
+};
+
 // Pick-up radius around an item's anchor point, in ON-SCREEN (CSS) pixels.
 // Converted to canvas-pixel space per use (see grabRadius) so the touch target
 // stays the same physical size on every device — a fixed canvas-pixel radius
@@ -147,10 +190,14 @@ function textMargin( item ) {
   };
 }
 
+// `part` scopes the key to a draggable sub-item (a HUD widget) within the item;
+// omit it for a whole-item (position) drag.
 function overrideKey(
-  scope, index
+  scope, index, part
 ) {
-  return `${ scope }:${ index }`;
+  const base = `${ scope }:${ index }`;
+
+  return part == null ? base : `${ base }:${ part }`;
 }
 
 /**
@@ -165,23 +212,51 @@ export function resolveDraggedItem(
     return item;
   }
 
-  const override = overrides.get( overrideKey(
+  // Whole-item position override (text, specs, qrcode, …).
+  const positionOverride = overrides.get( overrideKey(
     scope,
     index
   ) );
 
-  if ( !override ) {
-    return item;
+  let next = positionOverride
+    ? {
+      ...item,
+      position: {
+        ...( item.position ?? {} ),
+        x: positionOverride.x,
+        y: positionOverride.y
+      }
+    }
+    : item;
+
+  // Per-widget offset overrides (HUD sub-items).
+  if ( item.type === "hud" ) {
+    for ( const key of HUD_DRAGGABLE_WIDGETS ) {
+      const widgetOverride = overrides.get( overrideKey(
+        scope,
+        index,
+        key
+      ) );
+
+      if ( !widgetOverride ) {
+        continue;
+      }
+
+      next = {
+        ...next,
+        [ key ]: {
+          ...( next[ key ] ?? {} ),
+          offset: {
+            ...( next[ key ]?.offset ?? {} ),
+            x: widgetOverride.x,
+            y: widgetOverride.y
+          }
+        }
+      };
+    }
   }
 
-  return {
-    ...item,
-    position: {
-      ...( item.position ?? {} ),
-      x: override.x,
-      y: override.y
-    }
-  };
+  return next;
 }
 
 // Same wrap as slides/index.js uses to resolve the rendered slide, so the scope
@@ -213,7 +288,48 @@ function collectTargets( p ) {
     content.forEach( (
       item, index
     ) => {
-      if ( !item || !DRAGGABLE_TYPES.has( item.type ) ) {
+      if ( !item ) {
+        return;
+      }
+
+      // A HUD item contributes one grab target PER enabled offset-anchored
+      // widget instead of a single item-level target.
+      if ( item.type === "hud" ) {
+        HUD_DRAGGABLE_WIDGETS.forEach( ( key ) => {
+          const widget = item[ key ];
+
+          if ( !widget?.enabled ) {
+            return;
+          }
+
+          const defaults = HUD_OFFSET_DEFAULTS[ key ];
+          const override = overrides.get( overrideKey(
+            scope,
+            index,
+            key
+          ) );
+          const offset = override ?? widget.offset ?? {};
+
+          targets.push( {
+            x: ( offset.x ?? defaults.x ) * p.width,
+            y: ( offset.y ?? defaults.y ) * p.height,
+            bounds: getItemBounds(
+              scope,
+              index,
+              key
+            ),
+            scope,
+            index,
+            part: key,
+            marginX: 0,
+            marginY: 0
+          } );
+        } );
+
+        return;
+      }
+
+      if ( !DRAGGABLE_TYPES.has( item.type ) ) {
         return;
       }
 
@@ -239,6 +355,7 @@ function collectTargets( p ) {
         ),
         scope,
         index,
+        part: null,
         marginX: margin.h,
         marginY: margin.v
       } );
@@ -331,7 +448,8 @@ function applyMove(
   overrides.set(
     overrideKey(
       activeDrag.scope,
-      activeDrag.index
+      activeDrag.index,
+      activeDrag.part
     ),
     {
       x: clamp01( point.x / p.width + activeDrag.offsetX - activeDrag.marginX ),
@@ -354,25 +472,58 @@ function applyToContent(
   const next = content.map( (
     item, index
   ) => {
-    const override = overrides.get( overrideKey(
+    if ( !item ) {
+      return item;
+    }
+
+    let updated = item;
+
+    const positionOverride = overrides.get( overrideKey(
       scope,
       index
     ) );
 
-    if ( !override || !item ) {
-      return item;
+    if ( positionOverride ) {
+      changed = true;
+      updated = {
+        ...updated,
+        position: {
+          ...( updated.position ?? {} ),
+          x: positionOverride.x,
+          y: positionOverride.y
+        }
+      };
     }
 
-    changed = true;
+    // HUD sub-items persist into item[widget].offset, not item.position.
+    if ( item.type === "hud" ) {
+      for ( const key of HUD_DRAGGABLE_WIDGETS ) {
+        const widgetOverride = overrides.get( overrideKey(
+          scope,
+          index,
+          key
+        ) );
 
-    return {
-      ...item,
-      position: {
-        ...( item.position ?? {} ),
-        x: override.x,
-        y: override.y
+        if ( !widgetOverride ) {
+          continue;
+        }
+
+        changed = true;
+        updated = {
+          ...updated,
+          [ key ]: {
+            ...( updated[ key ] ?? {} ),
+            offset: {
+              ...( updated[ key ]?.offset ?? {} ),
+              x: widgetOverride.x,
+              y: widgetOverride.y
+            }
+          }
+        };
       }
-    };
+    }
+
+    return updated;
   } );
 
   return changed ? next : null;
@@ -521,6 +672,7 @@ function onPointerDown( event ) {
     pointerId: event.pointerId,
     scope: target.scope,
     index: target.index,
+    part: target.part,
     marginX: target.marginX,
     marginY: target.marginY,
     // Anchor − pointer at grab time (normalized), so the item follows from
@@ -607,7 +759,8 @@ function onPointerMove( event ) {
   );
   const key = hit === -1 ? null : overrideKey(
     targets[ hit ].scope,
-    targets[ hit ].index
+    targets[ hit ].index,
+    targets[ hit ].part
   );
 
   setCursor( hit === -1 ? "" : "move" );
@@ -672,7 +825,8 @@ function drawAffordance() {
     if (
       activeDrag &&
       target.scope === activeDrag.scope &&
-      target.index === activeDrag.index
+      target.index === activeDrag.index &&
+      target.part === activeDrag.part
     ) {
       grabbed.add( index );
     }

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -119,6 +119,19 @@ const GRAB_RADIUS_SCREEN_PX = 44;
 
 export const GLOBAL_CONTENT_SCOPE = "global";
 
+// The montage variant-title overlay (slide.transition.title) is a slide-level
+// positioned label, NOT a content-list item — so it can't be addressed by an
+// array index. It gets this sentinel "index" within its slide scope instead,
+// giving it a bounds/override key of `slide:<n>:montage-title` alongside the
+// numeric content-item keys it can never collide with.
+export const MONTAGE_TITLE_INDEX = "montage-title";
+
+// Renderer defaults for the montage title anchor (mirrors drawMontageTitle).
+const MONTAGE_TITLE_DEFAULTS = {
+  x: 0.95,
+  y: 0.08
+};
+
 export function slideContentScope( index ) {
   return `slide:${ index }`;
 }
@@ -259,6 +272,27 @@ export function resolveDraggedItem(
   return next;
 }
 
+/**
+ * The montage title's live position for the given slide while it is being
+ * dragged, or its stored position otherwise. drawMontageTitle calls this so the
+ * label follows the pointer before the move is persisted (the overlay renders
+ * outside freeLayout, so it can't go through resolveDraggedItem).
+ */
+export function resolveMontageTitlePosition(
+  slideIndex, position
+) {
+  if ( overrides.size === 0 ) {
+    return position;
+  }
+
+  const override = overrides.get( overrideKey(
+    slideContentScope( slideIndex ),
+    MONTAGE_TITLE_INDEX
+  ) );
+
+  return override ?? position;
+}
+
 // Same wrap as slides/index.js uses to resolve the rendered slide, so the scope
 // written here always matches the scope freeLayout renders with.
 function currentSlideIndex( count ) {
@@ -366,11 +400,37 @@ function collectTargets( p ) {
 
   if ( slidesArray.length > 0 ) {
     const slideIndex = currentSlideIndex( slidesArray.length );
+    const slide = slidesArray[ slideIndex ];
 
     add(
       slideContentScope( slideIndex ),
-      slidesArray[ slideIndex ]?.content
+      slide?.content
     );
+
+    // Montage variant-title overlay: a slide-level positioned label, draggable
+    // when the current slide's montage transition and its title are both on.
+    if ( slide?.transition?.enabled && slide.transition.title?.enabled ) {
+      const scope = slideContentScope( slideIndex );
+      const override = overrides.get( overrideKey(
+        scope,
+        MONTAGE_TITLE_INDEX
+      ) );
+      const position = override ?? slide.transition.title.position ?? {};
+
+      targets.push( {
+        x: ( position.x ?? MONTAGE_TITLE_DEFAULTS.x ) * p.width,
+        y: ( position.y ?? MONTAGE_TITLE_DEFAULTS.y ) * p.height,
+        bounds: getItemBounds(
+          scope,
+          MONTAGE_TITLE_INDEX
+        ),
+        scope,
+        index: MONTAGE_TITLE_INDEX,
+        part: null,
+        marginX: 0,
+        marginY: 0
+      } );
+    }
   }
 
   add(
@@ -554,21 +614,50 @@ function persistOverrides() {
   const nextSlides = slidesArray.map( (
     slide, slideIndex
   ) => {
-    const next = applyToContent(
-      slideContentScope( slideIndex ),
+    const scope = slideContentScope( slideIndex );
+    let nextSlide = slide;
+
+    const nextContentList = applyToContent(
+      scope,
       slide?.content
     );
 
-    if ( !next ) {
-      return slide;
+    if ( nextContentList ) {
+      nextSlide = {
+        ...nextSlide,
+        content: nextContentList
+      };
     }
 
-    slidesChanged = true;
+    // Montage title position lives at slide.transition.title.position — not in
+    // the content list, so it persists here rather than through applyToContent.
+    const titleOverride = overrides.get( overrideKey(
+      scope,
+      MONTAGE_TITLE_INDEX
+    ) );
 
-    return {
-      ...slide,
-      content: next
-    };
+    if ( titleOverride && slide?.transition?.title ) {
+      nextSlide = {
+        ...nextSlide,
+        transition: {
+          ...nextSlide.transition,
+          title: {
+            ...nextSlide.transition.title,
+            position: {
+              ...( nextSlide.transition.title.position ?? {} ),
+              x: titleOverride.x,
+              y: titleOverride.y
+            }
+          }
+        }
+      };
+    }
+
+    if ( nextSlide !== slide ) {
+      slidesChanged = true;
+    }
+
+    return nextSlide;
   } );
 
   if ( slidesChanged ) {

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -18,8 +18,14 @@ import drawMontageTitle from "./montageTitle/index.js";
 import {
   registerContentDrag,
   slideContentScope,
-  GLOBAL_CONTENT_SCOPE
+  GLOBAL_CONTENT_SCOPE,
+  MONTAGE_TITLE_INDEX
 } from "./contentDrag.js";
+
+import {
+  beginItemBounds,
+  endItemBounds
+} from "./common/itemBoundsRegistry.js";
 
 import {
   coerceFramerate
@@ -268,10 +274,23 @@ const slides = {
     const slide = this.current;
 
     if ( slide?.transition?.enabled && slide.transition.title?.enabled ) {
+      const slideIndex = wrap(
+        Number( this.index ) || 0,
+        this.count
+      );
+
+      // Bracket the overlay so its reported rectangle keys to this slide's
+      // montage-title target — the surface the on-canvas drag hit-tests.
+      beginItemBounds(
+        slideContentScope( slideIndex ),
+        MONTAGE_TITLE_INDEX
+      );
       drawMontageTitle(
         slide,
-        options?.slides || []
+        options?.slides || [],
+        slideIndex
       );
+      endItemBounds();
     }
   },
 

--- a/src/templates/p5/utils/slides/montageTitle/index.js
+++ b/src/templates/p5/utils/slides/montageTitle/index.js
@@ -11,6 +11,12 @@ import {
 import {
   formatSlideTitle
 } from "./formatTitle.js";
+import {
+  reportItemBounds
+} from "../common/itemBoundsRegistry.js";
+import {
+  resolveMontageTitlePosition
+} from "../contentDrag.js";
 
 /**
  * Overlay that names the variant a montage slide is currently showing. It rides
@@ -376,7 +382,7 @@ function paintRoll(
 }
 
 export default function drawMontageTitle(
-  slide, allSlides
+  slide, allSlides, slideIndex = 0
 ) {
   const transition = slide?.transition;
   const title = transition?.title;
@@ -472,8 +478,39 @@ export default function drawMontageTitle(
     );
   }
 
-  const anchorX = p.width * ( title.position?.x ?? 0.95 );
-  const anchorY = p.height * ( title.position?.y ?? 0.08 );
+  // While the label is being dragged on canvas, follow the live position; the
+  // stored one applies otherwise (the overlay renders outside freeLayout, so it
+  // resolves its own drag override rather than going through resolveDraggedItem).
+  const position = resolveMontageTitlePosition(
+    slideIndex,
+    title.position
+  );
+  const anchorX = p.width * ( position?.x ?? 0.95 );
+  const anchorY = p.height * ( position?.y ?? 0.08 );
+
+  // Report the shown label's rectangle so the drag layer can grab it by its
+  // visible body (the anchor sits at the aligned edge, often off the glyphs).
+  const shownText = switchT < 0.5 ? fromLabel : toLabel;
+
+  if ( shownText ) {
+    p.push();
+    p.textFont( font );
+    p.textSize( size );
+    const shownWidth = p.textWidth( shownText );
+
+    p.pop();
+
+    reportItemBounds(
+      alignLeft(
+        anchorX,
+        shownWidth,
+        title.align
+      ),
+      anchorY,
+      shownWidth,
+      size
+    );
+  }
 
   if ( !changing ) {
     paintLabel(


### PR DESCRIPTION
Three related improvements to the on-canvas content-item editing flow.

## 1. HUD widget sub-items are draggable

A `hud` item has no position of its own — it holds telemetry widgets (`badge`, `gauge`, `sparkline`, `counter`, `swatch`), each with its own normalized `offset`. Each is now an individual grab target: the drag model gained an optional `part` segment on top of `scope` + `index`, widgets report their drawn rectangles (`reportItemPartBounds` + `reportWidgetBounds`/`anchoredRect`), and a drag resolves/persists into `item[widget].offset`. `crosshairs` (source-bound) and `boundingBox` (region rect) position differently and are left out.

## 2. The montage variant-title label is draggable

`slide.transition.title` is a slide-level label rendered outside the content list. It gets a slide-scoped target via a sentinel index (`montage-title`): `slides/index` brackets the overlay so its rectangle is hit-testable, `drawMontageTitle` follows the live position (`resolveMontageTitlePosition`) and reports its rect, and a release persists into `slide.transition.title.position`.

## 3. Selecting an item on canvas reveals its panel section

Pressing or dragging any content item now surfaces its form section in the options panel — it opens the enclosing zone (global content, or switches to and opens the owning slide), opens the item (and any HUD sub-widget's nested section), scrolls it into view, and gives it a brief macOS-menu-bar-style border pulse.

- On grab, `contentDrag` dispatches a `studio:content-item-select` window event carrying `{ scope, index, part }` (same channel style as the existing `studio:*` command events).
- `useContentItemSelection` (new provider + listener) maps the event to the two collapsible systems (`setSection` for zones, `setExpanded` for the `item-…`/`nested-…` keys) and to slide selection, then publishes the selected path.
- `ItemFormWrapper` scrolls its row into view once the expand animation settles and pulses it; the row is exposed via `CollapsibleItem`'s `rootRef`.
- `tailwind` gains a `select-pulse` inset-ring keyframe (clip-safe, layout-inert).

The montage title (a non-content-item target) reveals its zone/slide as far as it can be addressed.

## Behaviour

- Hover any draggable item/sub-item → "move" cursor + outline ring around its visible rectangle.
- Drag → follows the pointer by offset, siblings untouched; release persists (origin `"p5"`), surviving reload/export and reflected in the form.
- Click or drag-start → the item's panel section opens, scrolls into view, and pulses.

## Tests

`contentDrag.test.ts` drives the real capture-phase pointer flow: HUD widget grab-by-rect + `offset` persist, move-only-the-pressed-widget, disabled-widget fall-through; montage-title grab-by-rect + `position` persist and transition-disabled fall-through; and the `studio:content-item-select` event firing on grab / staying silent on a miss. Full suite green: `npm run check` (lint + 1452 tests) + `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxd8o4G7w54iNJpw1UDXP