### PR TITLE
Fix all p5 utils to use getP5() for p5 instance access

### DIFF
--- a/src/templates/p5/utils/matter/matter.js
+++ b/src/templates/p5/utils/matter/matter.js
@@ -97,6 +97,7 @@ sketch.draw( (
   time, center, favouriteColour
 ) => {
   const p = getP5();
+
   p.background( ...options.colors.background );
 
   if ( !mediapipe.idle ) {

--- a/src/templates/p5/utils/matter/matter.js
+++ b/src/templates/p5/utils/matter/matter.js
@@ -1,7 +1,9 @@
 import options from "@/p5/utils/options.js";
 
 import string from "@/p5/utils/string.js";
-import sketch from "@/p5/utils/sketch.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
 import events from "@/p5/utils/events.js";
 import * as common from "@/p5/utils/common.js";
 
@@ -35,52 +37,53 @@ const matter = {
 events.register(
   "pre-setup",
   () => {
+    const p = getP5();
     const margin = BOUNDARY_MARGIN;
     const thickness = BOUNDARY_THICKNESS;
 
     addBoundary(
       p.width / 2,
-      height + thickness / 2 - margin,
-      width,
+      p.height + thickness / 2 - margin,
+      p.width,
       thickness
     );
     addBoundary(
       p.width / 2,
       -thickness / 2 + margin,
-      width,
+      p.width,
       thickness
     );
     addBoundary(
       -thickness / 2 + margin,
-      height / 2,
+      p.height / 2,
       thickness,
-      height
+      p.height
     );
     addBoundary(
-      width + thickness / 2 - margin,
-      height / 2,
+      p.width + thickness / 2 - margin,
+      p.height / 2,
       thickness,
-      height
+      p.height
     );
 
     for ( let i = 0; i < BALLS_COUNT; i++ ) {
       addBall(
-        random(
+        p.random(
           thickness,
-          width - thickness
+          p.width - thickness
         ),
-        random(
+        p.random(
           thickness,
-          height - thickness
+          p.height - thickness
         ),
-        random( ...BALLS_SIZE )
+        p.random( ...BALLS_SIZE )
       );
     }
 
     matter.letterBodies = addLetterBoxes(
       "soup tracking",
       p.width / 2 - 300,
-      height / 2
+      p.height / 2
     );
   }
 );
@@ -93,6 +96,7 @@ matter.engine.gravity = {
 sketch.draw( (
   time, center, favouriteColour
 ) => {
+  const p = getP5();
   p.background( ...options.colors.background );
 
   if ( !mediapipe.idle ) {
@@ -155,7 +159,7 @@ sketch.draw( (
       graphics, background, erase, size
     } = layer;
 
-    image(
+    p.image(
       graphics,
       0,
       0,

--- a/src/templates/p5/utils/slides/common/drawSlideImage.js
+++ b/src/templates/p5/utils/slides/common/drawSlideImage.js
@@ -7,29 +7,33 @@ import animation from "../../animation.js";
 import {
   reportItemBounds
 } from "./itemBoundsRegistry.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function drawSlideImage(
   imageOption, slideOptions
 ) {
+  const p = getP5();
   const image = getAsset( imageOption.source );
 
   if ( !image ) {
     return;
   }
 
-  const imagePosition = createVector(
-    width * imageOption.position.x,
-    height * imageOption.position.y
+  const imagePosition = p.createVector(
+    p.width * imageOption.position.x,
+    p.height * imageOption.position.y
   );
 
   if ( imageOption.animation ) {
     if ( imageOption.animation.name === "noise-floating" ) {
-      noiseDetail( ...( imageOption?.animation?.noiseDetail ?? [
+      p.noiseDetail( ...( imageOption?.animation?.noiseDetail ?? [
         2,
         0.7
       ] ) );
 
-      const imageAngle = noise( animation.angle ) * TAU;
+      const imageAngle = p.noise( animation.angle ) * p.TAU;
 
       imagePosition.add(
         mappers.fn(

--- a/src/templates/p5/utils/slides/common/drawSlideImagesStack.js
+++ b/src/templates/p5/utils/slides/common/drawSlideImagesStack.js
@@ -5,10 +5,14 @@ import * as common from "../../common.js";
 import {
   reportItemBounds
 } from "./itemBoundsRegistry.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function drawSlideImagesStack(
   imagesStackOption, slideOptions
 ) {
+  const p = getP5();
   const {
     sources,
     position,
@@ -31,7 +35,7 @@ export default function drawSlideImagesStack(
     return;
   }
 
-  const imageIndexDisplay = map(
+  const imageIndexDisplay = p.map(
     animation.triangleProgression( 2 ),
     0,
     1,
@@ -47,8 +51,8 @@ export default function drawSlideImagesStack(
   {
     const stackScale = scaleValue ?? 1;
     const stackMargin = imagesStackOption.margin ?? 80;
-    const availableW = width * stackScale - 2 * stackMargin;
-    const availableH = height * stackScale - 2 * stackMargin;
+    const availableW = p.width * stackScale - 2 * stackMargin;
+    const availableH = p.height * stackScale - 2 * stackMargin;
     const img0 = images[ 0 ].img;
 
     if ( img0?.width && availableW > 0 && availableH > 0 ) {
@@ -60,21 +64,21 @@ export default function drawSlideImagesStack(
       const h = img0.height * fit * stackScale;
 
       reportItemBounds(
-        position.x * width - w / 2,
-        position.y * height - h / 2,
+        position.x * p.width - w / 2,
+        position.y * p.height - h / 2,
         w,
         h
       );
     }
   }
 
-  push();
+  p.push();
 
-  translate(
-    position.x * width,
-    position.y * height
+  p.translate(
+    position.x * p.width,
+    position.y * p.height
   );
-  rotate( rotationValue );
+  p.rotate( rotationValue );
 
   for ( let i = 0; i < images.length; i++ ) {
     if ( imageIndexDisplay < i ) {
@@ -82,7 +86,7 @@ export default function drawSlideImagesStack(
     }
 
     if ( progressiveRotation !== 0 ) {
-      rotate( map(
+      p.rotate( p.map(
         i,
         0,
         images.length - 1,
@@ -91,22 +95,22 @@ export default function drawSlideImagesStack(
       ) );
     }
 
-    const imagePosition = createVector();
+    const imagePosition = p.createVector();
 
     if ( imagesStackOption.animation ) {
       if ( imagesStackOption.animation.name === "random" ) {
         const randomShiftMargin = imagesStackOption.animation.shift || 80;
 
         imagePosition.add(
-          map(
-            noise( i ),
+          p.map(
+            p.noise( i ),
             0,
             1,
             -randomShiftMargin,
             randomShiftMargin
           ),
-          map(
-            noise( i ),
+          p.map(
+            p.noise( i ),
             0,
             1,
             -randomShiftMargin,
@@ -125,5 +129,5 @@ export default function drawSlideImagesStack(
     } );
   }
 
-  pop();
+  p.pop();
 }

--- a/src/templates/p5/utils/slides/common/drawSlideVisual.js
+++ b/src/templates/p5/utils/slides/common/drawSlideVisual.js
@@ -1,8 +1,12 @@
 import visualMaps from "../../visuals";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function drawSlideVisual(
   visualItemOptions, _slideOptions
 ) {
+  const p = getP5();
   const {
     visual,
     position,
@@ -14,16 +18,16 @@ export default function drawSlideVisual(
     return;
   }
 
-  push();
+  p.push();
 
-  translate(
-    position.x * width,
-    position.y * height
+  p.translate(
+    position.x * p.width,
+    position.y * p.height
   );
-  scale( scaleValue );
-  rotate( rotationValue );
+  p.scale( scaleValue );
+  p.rotate( rotationValue );
 
   visualMaps?.[ visual.name ]?.( visual );
 
-  pop();
+  p.pop();
 }

--- a/src/templates/p5/utils/slides/layouts/imageFullLayout.js
+++ b/src/templates/p5/utils/slides/layouts/imageFullLayout.js
@@ -1,17 +1,21 @@
 import {
   getAssets
 } from "../../common.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function imageFullLayout( opts ) {
+  const p = getP5();
   const img = getAssets( opts )[ 0 ];
 
   if ( img ) {
-    image(
+    p.image(
       img.img,
       0,
       0,
-      width,
-      height
+      p.width,
+      p.height
     );
   }
 }

--- a/src/templates/p5/utils/slides/layouts/imageGridLayout.js
+++ b/src/templates/p5/utils/slides/layouts/imageGridLayout.js
@@ -1,8 +1,12 @@
 import {
   getAssets
 } from "../../common.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function imageGridLayout( opts ) {
+  const p = getP5();
   const imgs = getAssets( opts ).slice(
     0,
     4
@@ -11,15 +15,15 @@ export default function imageGridLayout( opts ) {
   imgs.forEach( (
     o, i
   ) => {
-    const x = ( ( i % 2 ) * width ) / 2;
-    const y = ( Math.floor( i / 2 ) * height ) / 2;
+    const x = ( ( i % 2 ) * p.width ) / 2;
+    const y = ( Math.floor( i / 2 ) * p.height ) / 2;
 
-    image(
+    p.image(
       o.img,
       x,
       y,
       p.width / 2,
-      height / 2
+      p.height / 2
     );
   } );
 }

--- a/src/templates/p5/utils/slides/layouts/imagePolaroidLayout.js
+++ b/src/templates/p5/utils/slides/layouts/imagePolaroidLayout.js
@@ -1,8 +1,12 @@
 import {
   getAssets
 } from "../../common.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function imagePolaroidLayout( opts ) {
+  const p = getP5();
   const imgs = getAssets( opts );
   const w = p.width / 2;
   const h = ( w * 4 ) / 3;
@@ -11,34 +15,34 @@ export default function imagePolaroidLayout( opts ) {
     o, i
   ) => {
     const x = 40 + i * ( w + 40 );
-    const y = height / 2 - h / 2;
+    const y = p.height / 2 - h / 2;
 
-    push();
-    translate(
+    p.push();
+    p.translate(
       x + w / 2,
       y + h / 2
     );
-    rotate( radians( -5 + 10 * i ) );
-    translate(
+    p.rotate( p.radians( -5 + 10 * i ) );
+    p.translate(
       -w / 2,
       -h / 2
     );
-    fill( 255 );
-    noStroke();
-    rect(
+    p.fill( 255 );
+    p.noStroke();
+    p.rect(
       0,
       0,
       w,
       h + 20,
       10
     );
-    image(
+    p.image(
       o.img,
       10,
       10,
       w - 20,
       h - 30
     );
-    pop();
+    p.pop();
   } );
 }

--- a/src/templates/p5/utils/slides/layouts/imageSplitLayout.js
+++ b/src/templates/p5/utils/slides/layouts/imageSplitLayout.js
@@ -1,29 +1,33 @@
 import {
   getAssets
 } from "../../common.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function imageSplitLayout( opts ) {
+  const p = getP5();
   const [
     a,
     b
   ] = getAssets( opts );
 
   if ( a ) {
-    image(
+    p.image(
       a.img,
       0,
       0,
       p.width / 2,
-      height
+      p.height
     );
   }
   if ( b ) {
-    image(
+    p.image(
       b.img,
       p.width / 2,
       0,
       p.width / 2,
-      height
+      p.height
     );
   }
 }

--- a/src/templates/p5/utils/slides/layouts/imageStripLayout.js
+++ b/src/templates/p5/utils/slides/layouts/imageStripLayout.js
@@ -1,18 +1,22 @@
 import {
   getAssets
 } from "../../common.js";
+import {
+  getP5
+} from "../../sketch.js";
 
 export default function imageStripLayout( opts ) {
+  const p = getP5();
   const imgs = getAssets( opts );
-  const h = height / imgs.length;
+  const h = p.height / imgs.length;
 
   imgs.forEach( (
     o, i
-  ) => image(
+  ) => p.image(
     o.img,
     0,
     i * h,
-    width,
+    p.width,
     h
   ) );
 }


### PR DESCRIPTION
## Summary

Fixed all p5 utility functions to properly access the p5 instance via `getP5()` instead of using direct p5 global calls, ensuring consistent usage of the modern sketch API pattern documented in CLAUDE.md.

## Files Fixed

### Slides utilities
- **drawSlideVisual.js** — push, translate, scale, rotate, pop, width, height
- **drawSlideImagesStack.js** — map, width, height, push, translate, rotate, createVector, noise, pop

### Image layout functions
- **imagePolaroidLayout.js** — width, height, push, translate, rotate, fill, noStroke, rect, image, pop, radians
- **imageGridLayout.js** — width, height, image
- **imageFullLayout.js** — image, width, height
- **imageSplitLayout.js** — image, width, height
- **imageStripLayout.js** — height, image, width

### Matter physics utility
- **matter.js** — random, width, height, image

## Changes

All p5 functions and variables are now accessed through the p5 instance obtained via `getP5()`:
- `push()` → `p.push()`
- `pop()` → `p.pop()`
- `translate()` → `p.translate()`
- `rotate()` → `p.rotate()`
- `scale()` → `p.scale()`
- `image()` → `p.image()`
- `fill()` / `stroke()` / `rect()` / `ellipse()` / `line()` → `p.fill()` / `p.stroke()` / etc.
- `createVector()` / `random()` / `noise()` / `map()` → `p.createVector()` / `p.random()` / `p.noise()` / `p.map()`
- `width` / `height` → `p.width` / `p.height`

This ensures all utilities consistently use the active p5 instance, fixing potential issues where sketches might use multiple p5 instances or where globals might be undefined.