### PR TITLE
Make QR code URL text white by default

### DIFF
--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -703,9 +703,9 @@ export const QrCodeItemSchema = z.object( {
   urlSize: z.number().positive()
     .default( 20 ),
   urlFill: RGBA.default( [
-    0,
-    0,
-    0
+    255,
+    255,
+    255
   ] )
 } );
 


### PR DESCRIPTION
## Summary

Changed the default color of QR code URL captions from black to white.

## Changes

- Modified `src/types/sketch.types.ts`: Updated `urlFill` default in `QrCodeItemSchema` from `[0, 0, 0]` (black) to `[255, 255, 255]` (white)

This affects the appearance of the URL text displayed below QR code content items, making them white by default instead of black.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEmmxL1o6XJi7AnGAJ6yAY)_