### PR TITLE
Scope UI sound feedback to sketch-settings fields only

### DIFF
--- a/src/lib/__tests__/uiSound.test.ts
+++ b/src/lib/__tests__/uiSound.test.ts
@@ -129,5 +129,69 @@ describe(
         expect( scheduleClick ).not.toHaveBeenCalled();
       }
     );
+
+    it(
+      "stays silent for non-sketch fields even during a real gesture",
+      async() => {
+        const mod = await loadModule();
+
+        mod.setUiSoundSettings( {
+          enabled: true
+        } );
+        window.dispatchEvent( new Event( "pointerdown" ) );
+
+        // Content items, slide-level content and general settings never click.
+        mod.playValueChange( "content.0.text" );
+        mod.playValueChange( "slides.1.content.2.hud.badge.enabled" );
+        mod.playValueChange( "slides.0.transition.enabled" );
+        mod.playValueChange( "size.width" );
+        mod.playValueChange( "animation.duration" );
+
+        expect( scheduleClick ).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      "clicks for global and per-slide sketch parameters",
+      async() => {
+        const mod = await loadModule();
+
+        mod.setUiSoundSettings( {
+          enabled: true,
+          minGapMs: 0
+        } );
+        window.dispatchEvent( new Event( "pointerdown" ) );
+
+        mod.playValueChange( "sketch.magnitude" );
+        mod.playValueChange( "slides.2.sketch.colors.0" );
+
+        expect( scheduleClick ).toHaveBeenCalledTimes( 2 );
+      }
+    );
+  }
+);
+
+describe(
+  "isSoundFeedbackField",
+  () => {
+    it(
+      "matches only sketch-settings paths",
+      async() => {
+        const mod = await loadModule();
+
+        expect( mod.isSoundFeedbackField( "sketch" ) ).toBe( true );
+        expect( mod.isSoundFeedbackField( "sketch.magnitude" ) ).toBe( true );
+        expect( mod.isSoundFeedbackField( "slides.0.sketch" ) ).toBe( true );
+        expect( mod.isSoundFeedbackField( "slides.12.sketch.colors.0" ) ).toBe( true );
+
+        expect( mod.isSoundFeedbackField( "content.0.text" ) ).toBe( false );
+        expect( mod.isSoundFeedbackField( "slides.0.content.1.type" ) ).toBe( false );
+        expect( mod.isSoundFeedbackField( "slides.0.transition.enabled" ) ).toBe( false );
+        expect( mod.isSoundFeedbackField( "size.width" ) ).toBe( false );
+        expect( mod.isSoundFeedbackField( "animation.duration" ) ).toBe( false );
+        // A field that merely contains "sketch" further down must not match.
+        expect( mod.isSoundFeedbackField( "content.0.sketch" ) ).toBe( false );
+      }
+    );
   }
 );

--- a/src/lib/uiSound.ts
+++ b/src/lib/uiSound.ts
@@ -404,11 +404,33 @@ function playClicks(
 }
 
 /**
+ * The one rule that decides which field edits are audible. Feedback is scoped
+ * to the sketch's own parameters — the controls under the Sketch Settings
+ * panel, whether the global set (`sketch.*`) or a slide override
+ * (`slides.<n>.sketch.*`). Everything else in the options form stays silent:
+ * content items (text / specs / hud / …), adding / removing / reordering
+ * slides and content items, montage transitions, and the general
+ * size / animation settings. So composing a deck is quiet and only tweaking the
+ * sketch's parameters ticks.
+ */
+const SKETCH_SETTING_FIELD = /^(?:slides\.\d+\.)?sketch(?:\.|$)/;
+
+export function isSoundFeedbackField( fieldPath: string ): boolean {
+  return SKETCH_SETTING_FIELD.test( fieldPath );
+}
+
+/**
  * A template option value changed in the panel. Throttled by `minGapMs`;
  * pitch derives from the field path when `pitchByField` is on.
  */
 export function playValueChange( fieldPath?: string ): void {
   if ( _suppressDepth > 0 ) {
+    return;
+  }
+
+  // Only the sketch's own parameters click — content items, slides, transitions
+  // and general settings stay silent (see isSoundFeedbackField).
+  if ( !fieldPath || !isSoundFeedbackField( fieldPath ) ) {
     return;
   }
 


### PR DESCRIPTION
## What & why

The editor's audible value-change feedback fired for **every** named field edit in the options form. That meant composing a deck was noisy: adding a slide, adding or editing a content item (text, specs, hud, …), tweaking a montage transition, or changing the general size/animation settings all produced a click.

The intent is for feedback to be tied to tweaking the **sketch's own parameters** — the controls under the Sketch Settings panel — not to structural/composition edits.

## Change

- Introduce a single reusable field-path rule, `isSoundFeedbackField`, in `src/lib/uiSound.ts`. It matches only sketch-parameter paths:
  - the global set: `sketch.*`
  - per-slide overrides: `slides.<n>.sketch.*`
- `playValueChange` now gates on that rule, so content items, slide/content add-remove-reorder, transitions, and the general size/animation settings stay silent.

Keeping the rule in one named predicate gives a common definition of "which field values have sound feedback", as requested — easy to reuse or extend later.

## Notes

- Action-button feedback (reset / randomize / save defaults) is unchanged: those already route through `playAction()` and are scoped to the Sketch Settings panel.
- The existing user-gesture and suppression gates are untouched.

## Tests

- Added cases in `src/lib/__tests__/uiSound.test.ts` covering: non-sketch fields stay silent even during a real gesture, global and per-slide sketch params still click, and a direct table of `isSoundFeedbackField` matches/non-matches.
- `npm run check` (lint + full Jest suite, 1449 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtxbtM8JVkv9w6neNH7v9L

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtxbtM8JVkv9w6neNH7v9L)_