### PR TITLE
Reveal a content item's panel section when it's clicked/dragged on ca…

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -46,6 +46,9 @@ import {
   useCollapsibleStates, CollapsibleProvider
 } from "./hooks/useCollapsibleStates";
 import {
+  ContentSelectionProvider, ContentSelectionListener
+} from "./hooks/useContentItemSelection";
+import {
   usePanelDock
 } from "@/hooks/usePanelDock";
 import {
@@ -507,99 +510,106 @@ export default function TemplateOptions( {
   return (
     <FormProvider { ...methods }>
       <CollapsibleProvider>
-        {isDesktop ? (
-          <>
-            <div
-              className={ clsx(
-                "absolute",
-                // Docked: a flat, full-height rail flush to the right edge —
-                // one glass surface framing the viewport, the panels inside
-                // rendered flat and the rail scrolling as one. Floating: a
-                // card anchored in the bottom-right corner.
-                dockedDesktop
-                  ? "right-0 top-12 bottom-0 z-40 flex w-72 flex-col gap-1 p-2 glass border-l border-theme overflow-y-auto"
-                  : "right-4 bottom-4 w-64 space-y-2"
-              ) }
-              style={ dockedDesktop ? undefined : {
-                maxWidth: "calc(50% - 0.75rem)"
-              } }
-            >
-              {lifecycle.isLocked && (
-                <RecordingLockBanner
-                  state={ lifecycle.state }
-                  onClone={ handleBannerClone }
-                  cloning={ bannerCloning }
-                />
-              )}
-
-              {importBanner && (
-                <ImportSuccessBanner
-                  message={ importBanner }
-                  onDismiss={ () => setImportBanner( null ) }
-                />
-              )}
-
-              <OptionsPanel
-                methods={ methods }
-                name={ name }
-                persistedJob={ persistedJob }
-                jobStatus={ lifecycle.currentStatus }
-                onImportOptions={ handleImportOptions }
-                docked={ dockedDesktop }
-                { ...bodyProps }
-              />
-
-              {recordingSupported && (
-                <CaptureActions
-                  forwardedRef={ captureActionsRef }
-                  activeSlideIndex={ activeSlideIndex }
-                  docked={ dockedDesktop }
-                  { ...captureProps }
-                />
-              )}
-            </div>
-
-            <TemplateAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
-              <SketchSettings
-                activeSlideIndex={ activeSlideIndex }
-                activeSlideId={ activeSlideId }
-                expanded={ collapsibleStates.sketchSettings }
-                onToggle={ ( expanded ) => setSection(
-                  "sketchSettings",
-                  expanded
-                ) }
-                docked={ dockedDesktop }
-              />
-            </TemplateAssetsProvider>
-          </>
-        ) : (
-          <MobileStudioDrawer
-            expanded={ collapsibleStates.sketchSettings }
-            onToggle={ ( expanded ) => setSection(
-              "sketchSettings",
-              expanded
-            ) }
+        <ContentSelectionProvider>
+          <ContentSelectionListener
+            setSection={ setSection }
+            onSelectSlide={ handleSlideSelect }
             activeSlideIndex={ activeSlideIndex }
-            activeSlideId={ activeSlideId }
-            jobId={ jobId }
-            body={ bodyProps }
-            capture={ captureProps }
-            captureActionsRef={ captureActionsRef }
-            recordingSupported={ recordingSupported }
-            jobStatus={ lifecycle.currentStatus }
-            onImportOptions={ handleImportOptions }
-            bannerCloning={ bannerCloning }
-            onBannerClone={ handleBannerClone }
-            importBanner={ importBanner }
-            onImportBannerDismiss={ () => setImportBanner( null ) }
           />
-        )}
+          {isDesktop ? (
+            <>
+              <div
+                className={ clsx(
+                  "absolute",
+                  // Docked: a flat, full-height rail flush to the right edge —
+                  // one glass surface framing the viewport, the panels inside
+                  // rendered flat and the rail scrolling as one. Floating: a
+                  // card anchored in the bottom-right corner.
+                  dockedDesktop
+                    ? "right-0 top-12 bottom-0 z-40 flex w-72 flex-col gap-1 p-2 glass border-l border-theme overflow-y-auto"
+                    : "right-4 bottom-4 w-64 space-y-2"
+                ) }
+                style={ dockedDesktop ? undefined : {
+                  maxWidth: "calc(50% - 0.75rem)"
+                } }
+              >
+                {lifecycle.isLocked && (
+                  <RecordingLockBanner
+                    state={ lifecycle.state }
+                    onClone={ handleBannerClone }
+                    cloning={ bannerCloning }
+                  />
+                )}
 
-        {/* The central Interactive mixer — one overview of every binding, with
-            per-layer solo / mute / weight. Floats bottom-center (desktop only,
-            where it doesn't collide with the mobile drawer); hidden unless the
-            plugin is on and the scope has bindings. */}
-        {isDesktop && <InteractivePanel basePath={ sketchBasePath } />}
+                {importBanner && (
+                  <ImportSuccessBanner
+                    message={ importBanner }
+                    onDismiss={ () => setImportBanner( null ) }
+                  />
+                )}
+
+                <OptionsPanel
+                  methods={ methods }
+                  name={ name }
+                  persistedJob={ persistedJob }
+                  jobStatus={ lifecycle.currentStatus }
+                  onImportOptions={ handleImportOptions }
+                  docked={ dockedDesktop }
+                  { ...bodyProps }
+                />
+
+                {recordingSupported && (
+                  <CaptureActions
+                    forwardedRef={ captureActionsRef }
+                    activeSlideIndex={ activeSlideIndex }
+                    docked={ dockedDesktop }
+                    { ...captureProps }
+                  />
+                )}
+              </div>
+
+              <TemplateAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
+                <SketchSettings
+                  activeSlideIndex={ activeSlideIndex }
+                  activeSlideId={ activeSlideId }
+                  expanded={ collapsibleStates.sketchSettings }
+                  onToggle={ ( expanded ) => setSection(
+                    "sketchSettings",
+                    expanded
+                  ) }
+                  docked={ dockedDesktop }
+                />
+              </TemplateAssetsProvider>
+            </>
+          ) : (
+            <MobileStudioDrawer
+              expanded={ collapsibleStates.sketchSettings }
+              onToggle={ ( expanded ) => setSection(
+                "sketchSettings",
+                expanded
+              ) }
+              activeSlideIndex={ activeSlideIndex }
+              activeSlideId={ activeSlideId }
+              jobId={ jobId }
+              body={ bodyProps }
+              capture={ captureProps }
+              captureActionsRef={ captureActionsRef }
+              recordingSupported={ recordingSupported }
+              jobStatus={ lifecycle.currentStatus }
+              onImportOptions={ handleImportOptions }
+              bannerCloning={ bannerCloning }
+              onBannerClone={ handleBannerClone }
+              importBanner={ importBanner }
+              onImportBannerDismiss={ () => setImportBanner( null ) }
+            />
+          )}
+
+          {/* The central Interactive mixer — one overview of every binding, with
+              per-layer solo / mute / weight. Floats bottom-center (desktop only,
+              where it doesn't collide with the mobile drawer); hidden unless the
+              plugin is on and the scope has bindings. */}
+          {isDesktop && <InteractivePanel basePath={ sketchBasePath } />}
+        </ContentSelectionProvider>
       </CollapsibleProvider>
     </FormProvider>
   );

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ItemFormWrapper.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/ContentItems/components/ItemFormWrapper.tsx
@@ -10,6 +10,17 @@ import {
 import {
   useCollapsibleContext
 } from "@/components/ClientProcessingSketch/components/TemplateOptions/hooks/useCollapsibleStates";
+import {
+  useContentSelection
+} from "@/components/ClientProcessingSketch/components/TemplateOptions/hooks/useContentItemSelection";
+
+// Time (ms) to wait before scrolling, so the zone + item expand animations
+// (CollapsibleItem's ~200ms grid transition) settle first. Matched to the
+// pulse so the item is in view as the ring fires.
+const REVEAL_SCROLL_DELAY_MS = 240;
+// Slightly longer than the select-pulse animation (0.6s × 2) so the class is
+// removed only after it finishes.
+const REVEAL_PULSE_MS = 1300;
 
 export type ItemFormWrapperProps = {
   itemType: string;
@@ -37,14 +48,68 @@ export default function ItemFormWrapper( {
     false
   ) : undefined;
 
+  // Reveal-on-canvas-select: when this item is the one pressed on the canvas,
+  // scroll it into view and pulse its border (macOS menu-bar style).
+  const selection = useContentSelection();
+  const rootRef = React.useRef<HTMLDivElement>( null );
+  const handledNonceRef = React.useRef( -1 );
+
+  const [
+    pulsing,
+    setPulsing
+  ] = React.useState( false );
+
+  React.useEffect(
+    () => {
+      if (
+        !selection ||
+        !itemPath ||
+        selection.path !== itemPath ||
+        selection.nonce === handledNonceRef.current
+      ) {
+        return;
+      }
+
+      handledNonceRef.current = selection.nonce;
+      setPulsing( true );
+
+      const scrollTimer = setTimeout(
+        () => {
+          rootRef.current?.scrollIntoView( {
+            block: "center",
+            behavior: "smooth"
+          } );
+        },
+        REVEAL_SCROLL_DELAY_MS
+      );
+      const pulseTimer = setTimeout(
+        () => setPulsing( false ),
+        REVEAL_PULSE_MS
+      );
+
+      return () => {
+        clearTimeout( scrollTimer );
+        clearTimeout( pulseTimer );
+      };
+    },
+    [
+      selection,
+      itemPath
+    ]
+  );
+
   return (
     <CollapsibleItem
+      rootRef={ rootRef }
       expanded={ expanded }
       onToggle={ collapsibleKey ? ( isExpanded ) => setExpanded(
         collapsibleKey,
         isExpanded
       ) : undefined }
-      className="p-1 border border-theme rounded-lg bg-background "
+      className={ clsx(
+        "p-1 border border-theme rounded-lg bg-background",
+        pulsing && "animate-select-pulse motion-reduce:animate-none"
+      ) }
       header={ ( expanded ) => (
         <div
           ref={ dragBinder?.setHandleRef }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/constants/drawer-events.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/constants/drawer-events.ts
@@ -6,6 +6,17 @@
 export const OPEN_EXPORT_DRAWER_EVENT = "studio:open-export-drawer";
 
 /**
+ * Window event dispatched by the on-canvas content-item drag (contentDrag.js)
+ * when an item is pressed/grabbed, so the options panel can reveal that item's
+ * form section — open its zone (global content / the right slide), open the
+ * item, scroll it into view and pulse it. The `detail` mirrors the drag target:
+ * `{ scope: "global" | "slide:<n>", index: number | "montage-title", part }`.
+ * The literal is duplicated (not imported) in contentDrag.js — keep them in
+ * sync, the same way syncSketchOptions' "sketch-options" twin is.
+ */
+export const CONTENT_ITEM_SELECT_EVENT = "studio:content-item-select";
+
+/**
  * Root-level CSS variable holding the rendered height of the open mobile
  * drawer (0 when collapsed or on desktop). The sketch viewport subtracts it
  * from its own height so fit-to-viewport targets the visible area above the

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useContentItemSelection.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useContentItemSelection.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from "react";
+
+import {
+  useCollapsibleContext
+} from "./useCollapsibleStates";
+import type {
+  CollapsibleSection
+} from "./useCollapsibleStates";
+import {
+  CONTENT_ITEM_SELECT_EVENT
+} from "../constants/drawer-events";
+
+/**
+ * Bridges an on-canvas content-item press (dispatched by contentDrag.js as the
+ * `CONTENT_ITEM_SELECT_EVENT` window event) to the options panel: it opens the
+ * item's zone (global content, or the right slide), opens the item's form
+ * section, and publishes the item's path so the rendered ItemFormWrapper can
+ * scroll to and pulse itself.
+ *
+ * Two moving parts:
+ *  - the CONTEXT holds the currently-selected item path + a monotonically
+ *    increasing nonce (so re-selecting the same item re-triggers the effect).
+ *    Items read it via useContentSelection().
+ *  - the LISTENER hook wires the window event to the collapsible + slide
+ *    machinery. It lives in a component rendered inside both CollapsibleProvider
+ *    and ContentSelectionProvider (see TemplateOptions).
+ */
+
+// The path segment identifying a content list, derived from a drag scope.
+function scopeToBase( scope: string ): {
+  base: string;
+  section: CollapsibleSection;
+  slideIndex?: number;
+} | null {
+  if ( scope === "global" ) {
+    return {
+      base: "content",
+      section: "globalContent"
+    };
+  }
+
+  const match = /^slide:(\d+)$/.exec( scope );
+
+  if ( !match ) {
+    return null;
+  }
+
+  const slideIndex = Number( match[ 1 ] );
+
+  return {
+    base: `slides.${ slideIndex }.content`,
+    section: "slides",
+    slideIndex
+  };
+}
+
+type Selection = {
+  path: string;
+  nonce: number;
+};
+
+type ContentSelectionValue = {
+  selection: Selection | null;
+  selectPath: ( path: string ) => void;
+};
+
+const ContentSelectionContext = createContext<ContentSelectionValue | null>( null );
+
+export function ContentSelectionProvider( {
+  children
+}: {
+  children: ReactNode;
+} ) {
+  const [
+    selection,
+    setSelection
+  ] = useState<Selection | null>( null );
+
+  const nonceRef = useRef( 0 );
+
+  const selectPath = useCallback(
+    ( path: string ) => {
+      nonceRef.current += 1;
+      setSelection( {
+        path,
+        nonce: nonceRef.current
+      } );
+    },
+    []
+  );
+
+  const value = useMemo(
+    () => ( {
+      selection,
+      selectPath
+    } ),
+    [
+      selection,
+      selectPath
+    ]
+  );
+
+  return (
+    <ContentSelectionContext.Provider value={ value }>
+      {children}
+    </ContentSelectionContext.Provider>
+  );
+}
+
+/** Read the current selection (for an item to decide whether to reveal itself). */
+export function useContentSelection(): Selection | null {
+  return useContext( ContentSelectionContext )?.selection ?? null;
+}
+
+type ListenerOptions = {
+  setSection: ( section: CollapsibleSection, expanded: boolean ) => void;
+  onSelectSlide: ( index: number | undefined ) => void;
+  activeSlideIndex: number | undefined;
+};
+
+/**
+ * Subscribe to the canvas selection event and reveal the pressed item. Call
+ * from a component mounted inside CollapsibleProvider + ContentSelectionProvider.
+ */
+export function useContentSelectionListener( {
+  setSection,
+  onSelectSlide,
+  activeSlideIndex
+}: ListenerOptions ) {
+  const {
+    setExpanded
+  } = useCollapsibleContext();
+  const context = useContext( ContentSelectionContext );
+  const selectPath = context?.selectPath;
+
+  // Keep the latest callbacks in a ref so the window listener is registered
+  // once and never misses an update (the handler reads current values).
+  const latest = useRef( {
+    setSection,
+    onSelectSlide,
+    activeSlideIndex,
+    setExpanded,
+    selectPath
+  } );
+
+  latest.current = {
+    setSection,
+    onSelectSlide,
+    activeSlideIndex,
+    setExpanded,
+    selectPath
+  };
+
+  useEffect(
+    () => {
+      const handler = ( event: Event ) => {
+        const detail = ( event as CustomEvent ).detail as {
+          scope?: string;
+          index?: number | string;
+          part?: string | null;
+        } | undefined;
+
+        if ( !detail?.scope ) {
+          return;
+        }
+
+        const resolved = scopeToBase( detail.scope );
+
+        if ( !resolved ) {
+          return;
+        }
+
+        const {
+          base,
+          section,
+          slideIndex
+        } = resolved;
+        const api = latest.current;
+
+        // Switch to the owning slide first so its content list mounts.
+        if ( slideIndex !== undefined && slideIndex !== api.activeSlideIndex ) {
+          api.onSelectSlide( slideIndex );
+        }
+
+        // Open the enclosing zone (lazy-mounted until expanded).
+        api.setSection(
+          section,
+          true
+        );
+
+        // Non-numeric index (the montage title) is not a content-list item —
+        // revealing its zone/slide is as far as we can target it.
+        if ( typeof detail.index !== "number" ) {
+          return;
+        }
+
+        const itemPath = `${ base }.${ detail.index }`;
+
+        api.setExpanded(
+          `item-${ itemPath }`,
+          true
+        );
+
+        // A HUD sub-widget lives in a nested-object section of the item form;
+        // open it too so its fields are visible once the item is revealed.
+        if ( detail.part ) {
+          api.setExpanded(
+            `nested-${ itemPath }.${ detail.part }`,
+            true
+          );
+        }
+
+        api.selectPath?.( itemPath );
+      };
+
+      window.addEventListener(
+        CONTENT_ITEM_SELECT_EVENT,
+        handler
+      );
+
+      return () => window.removeEventListener(
+        CONTENT_ITEM_SELECT_EVENT,
+        handler
+      );
+    },
+    []
+  );
+}
+
+/**
+ * Thin component wrapper around useContentSelectionListener, so TemplateOptions
+ * can drop it inside the providers without turning into a hook host itself.
+ */
+export function ContentSelectionListener( props: ListenerOptions ) {
+  useContentSelectionListener( props );
+
+  return null;
+}

--- a/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
+++ b/src/templates/p5/utils/slides/__tests__/contentDrag.test.ts
@@ -263,6 +263,53 @@ describe(
     );
 
     it(
+      "announces the pressed item so the options panel can reveal it",
+      () => {
+        const events: Array<{ scope: string;
+          index: number | string;
+          part: string | null }> = [];
+        const listener = ( event: Event ) => {
+          events.push( ( event as CustomEvent ).detail );
+        };
+
+        window.addEventListener(
+          "studio:content-item-select",
+          listener
+        );
+
+        try {
+          // Press on the item (its anchor at 500,500).
+          pressAt(
+            "pointerdown",
+            500,
+            500
+          );
+
+          expect( events ).toHaveLength( 1 );
+          expect( events[ 0 ] ).toEqual( {
+            scope: "global",
+            index: 0,
+            part: null
+          } );
+
+          // A press that misses every item announces nothing.
+          pressAt(
+            "pointerdown",
+            50,
+            50
+          );
+
+          expect( events ).toHaveLength( 1 );
+        } finally {
+          window.removeEventListener(
+            "studio:content-item-select",
+            listener
+          );
+        }
+      }
+    );
+
+    it(
       "moves the item and persists the new position on release",
       () => {
         pressAt(

--- a/src/templates/p5/utils/slides/contentDrag.js
+++ b/src/templates/p5/utils/slides/contentDrag.js
@@ -709,6 +709,28 @@ function setCursor( value ) {
   }
 }
 
+// Tell the options panel which item was just pressed on the canvas, so it can
+// reveal that item's form section (open its zone/slide, open + scroll to it,
+// and pulse it). Fires on grab — covering both a click and the start of a drag.
+// The event name is duplicated in the React constant CONTENT_ITEM_SELECT_EVENT
+// (constants/drawer-events.ts) — keep the two literals in sync.
+function emitContentItemSelect( target ) {
+  if ( typeof window === "undefined" || !target ) {
+    return;
+  }
+
+  window.dispatchEvent( new CustomEvent(
+    "studio:content-item-select",
+    {
+      detail: {
+        scope: target.scope,
+        index: target.index,
+        part: target.part ?? null
+      }
+    }
+  ) );
+}
+
 // ── Pointer handlers (capture phase on window, ahead of the viewport) ───────
 
 function onPointerDown( event ) {
@@ -756,6 +778,9 @@ function onPointerDown( event ) {
   event.preventDefault();
 
   const target = targets[ hit ];
+
+  // Surface the pressed item in the options panel (click or drag-start).
+  emitContentItemSelect( target );
 
   activeDrag = {
     pointerId: event.pointerId,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,17 @@ export default {
             backgroundColor: "transparent"
           }
         },
+        // macOS menu-bar-style attention pulse: an inset accent ring that swells
+        // and fades a couple of times. Inset so it never gets clipped by the
+        // options panel's overflow, and it doesn't disturb layout.
+        "select-pulse": {
+          "0%, 100%": {
+            boxShadow: "inset 0 0 0 0 hsl(var(--focus) / 0)"
+          },
+          "50%": {
+            boxShadow: "inset 0 0 0 2px hsl(var(--focus) / 0.9)"
+          }
+        },
         "gradient-shift": {
           "0%, 100%": {
             "background-position": "0% 50%"
@@ -173,6 +184,7 @@ export default {
         "pulse-soft": "pulse-soft 1.5s ease-in-out infinite",
         slideInFromTop: "slideInFromTop 0.5s ease-out",
         highlightFade: "highlightFade 1s ease-out",
+        "select-pulse": "select-pulse 0.6s ease-in-out 2",
         "gradient-shift": "gradient-shift 8s ease-in-out infinite",
         marquee: "marquee 30s linear infinite",
         "marquee-slow": "marquee 60s linear infinite",


### PR DESCRIPTION
…nvas

Pressing or dragging a content item on the canvas now surfaces its form section in the options panel: it opens the right zone (global content, or switches to and opens the owning slide), opens the item, scrolls it into view and gives it a brief macOS-menu-bar-style pulse.

- contentDrag: on grab (click or drag-start) dispatch a `studio:content-item- select` window event with the drag target's { scope, index, part }.
- useContentItemSelection: a small provider + listener that maps the event to the collapsible + slide machinery — open section, select slide, open the item (and any HUD sub-widget's nested section), then publish the item path.
- ItemFormWrapper: when its path is selected, scroll its row into view (after the expand animation settles) and pulse it; exposes the row via rootRef.
- tailwind: add a `select-pulse` inset-ring keyframe (clip-safe, layout-inert).

Non-item targets (the montage title) reveal their zone/slide as far as they can be addressed. Adds a test asserting the select event fires on grab and stays silent on a miss.


Claude-Session: https://claude.ai/code/session_01BWxd8o4G7w54iNJpw1UDXP