### PR TITLE
Slide thumbnails (Three.js + GSAP) and shared per-slide sketch params

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/TemplateOptions.tsx
@@ -231,7 +231,7 @@ export default function TemplateOptions( {
 
   const [
     {
-      backendRecording, sketchFormValues
+      backendRecording, sketchFormValues, engine, browserRecording
     }
   ] = useSketch();
 
@@ -245,7 +245,9 @@ export default function TemplateOptions( {
   } = useThumbnails( {
     enabled: enableThumbnails,
     persistedJob,
-    slideFields
+    slideFields,
+    engine,
+    recording: browserRecording
   } );
 
   // Slide management

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/__tests__/useThumbnails.test.tsx
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/__tests__/useThumbnails.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  act, renderHook
+} from "@testing-library/react";
+import type {
+  SketchEngine
+} from "@/engines/types";
+import {
+  useThumbnails
+} from "../useThumbnails";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeEngine( readFrame: jest.Mock ): SketchEngine {
+  return {
+    getCaptureSource: () => ( {
+      readFrame
+    } )
+  } as unknown as SketchEngine;
+}
+
+// jsdom has no real 2D backend; stub the destination context + encoder so the
+// capture path resolves deterministically to a sentinel data URL.
+function stubDestinationCanvas() {
+  jest
+    .spyOn(
+      HTMLCanvasElement.prototype,
+      "getContext"
+    )
+    .mockReturnValue( {
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: "low",
+      drawImage: jest.fn()
+    } as unknown as CanvasRenderingContext2D );
+
+  jest
+    .spyOn(
+      HTMLCanvasElement.prototype,
+      "toDataURL"
+    )
+    .mockReturnValue( "data:image/jpeg;base64,STUB" );
+}
+
+function frameCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement( "canvas" );
+
+  canvas.width = 100;
+  canvas.height = 125;
+
+  return canvas;
+}
+
+afterEach( () => {
+  jest.restoreAllMocks();
+} );
+
+/* ------------------------------------------------------------------ */
+/*  Recording gate                                                     */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "useThumbnails recording gate",
+  () => {
+    it(
+      "captures from the engine when no recording is in flight",
+      async() => {
+        stubDestinationCanvas();
+
+        const readFrame = jest.fn().mockResolvedValue( frameCanvas() );
+        const {
+          result
+        } = renderHook( () => useThumbnails( {
+          enabled: true,
+          slideFields: [
+            {
+              id: "s1"
+            }
+          ],
+          engine: makeEngine( readFrame ),
+          recording: false
+        } ) );
+
+        await act( async() => {
+          await result.current.captureThumbnail( "s1" );
+        } );
+
+        expect( readFrame ).toHaveBeenCalledTimes( 1 );
+        expect( result.current.thumbnails.s1 ).toBe( "data:image/jpeg;base64,STUB" );
+      }
+    );
+
+    it(
+      "skips capture (never touches the engine) while a recording is in flight",
+      async() => {
+        stubDestinationCanvas();
+
+        // If the gate leaked, this GSAP-style read would rasterise the shared
+        // mirror canvas the recorder is driving.
+        const readFrame = jest.fn().mockResolvedValue( frameCanvas() );
+        const {
+          result
+        } = renderHook( () => useThumbnails( {
+          enabled: true,
+          slideFields: [
+            {
+              id: "s1"
+            }
+          ],
+          engine: makeEngine( readFrame ),
+          recording: true
+        } ) );
+
+        await act( async() => {
+          await result.current.captureThumbnail( "s1" );
+        } );
+
+        expect( readFrame ).not.toHaveBeenCalled();
+        expect( result.current.thumbnails.s1 ).toBeUndefined();
+      }
+    );
+  }
+);

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useThumbnails.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/hooks/useThumbnails.ts
@@ -4,6 +4,9 @@ import {
 import {
   JobModel
 } from "@/types/recording.types";
+import type {
+  SketchEngine
+} from "@/engines/types";
 import {
   captureThumbnailFromCanvas,
   waitForSlideRendered
@@ -15,12 +18,22 @@ type UseThumbnailsProps = {
   slideFields: Array<{
     id: string;
   }>;
+  // Active engine, used to grab a current-frame canvas engine-agnostically
+  // (notably to rasterise the GSAP DOM). Optional so callers without an engine
+  // fall back to the live-canvas lookup.
+  engine?: SketchEngine | null;
+  // True while an in-browser recording/export is running. Captures are skipped
+  // then: for GSAP a capture rasterises the same singleton mirror canvas the
+  // recorder is driving, so it would collide with the in-flight recording.
+  recording?: boolean;
 };
 
 export function useThumbnails( {
   enabled,
   persistedJob,
-  slideFields
+  slideFields,
+  engine,
+  recording
 }: UseThumbnailsProps ) {
   const [
     thumbnails,
@@ -28,6 +41,14 @@ export function useThumbnails( {
   ] = useState<Record<string, string>>( {} );
   const pendingThumbnailCaptureRef = useRef<number | null>( null );
   const hasLoadedPersistedThumbnails = useRef( false );
+
+  // Keep the latest engine + recording flag in refs so the capture callbacks
+  // stay stable (they feed many effects/deps) while always reading fresh values.
+  const engineRef = useRef( engine );
+  const recordingRef = useRef( recording );
+
+  engineRef.current = engine;
+  recordingRef.current = recording;
 
   // Initialize thumbnails from persisted job
   useEffect(
@@ -151,7 +172,9 @@ export function useThumbnails( {
     async(
       slideId: string, slideIndex?: number
     ) => {
-      if ( !enabled ) {
+      // Don't capture while a recording is in flight — a GSAP capture would
+      // rasterise the same mirror canvas the recorder is driving.
+      if ( !enabled || recordingRef.current ) {
         return;
       }
 
@@ -168,7 +191,7 @@ export function useThumbnails( {
         }
       }
 
-      const dataUrl = await captureThumbnailFromCanvas();
+      const dataUrl = await captureThumbnailFromCanvas( engineRef.current );
 
       if ( dataUrl ) {
         setThumbnails( ( prev ) => ( {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/__tests__/thumbnailUtils.test.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/__tests__/thumbnailUtils.test.ts
@@ -1,8 +1,13 @@
 /**
  * @jest-environment jsdom
  */
+import type {
+  SketchEngine
+} from "@/engines/types";
 import {
+  captureThumbnailFromCanvas,
   getActiveSketchCanvas,
+  getCurrentFrameCanvas,
   waitForSlideRendered
 } from "../thumbnailUtils";
 
@@ -24,8 +29,29 @@ function mountCanvasInContainer( className: string ): HTMLCanvasElement {
   return canvas;
 }
 
+function makeCanvas(
+  width: number, height: number
+): HTMLCanvasElement {
+  const canvas = document.createElement( "canvas" );
+
+  canvas.width = width;
+  canvas.height = height;
+
+  return canvas;
+}
+
+/** Minimal engine stub exposing only the capture source used by these utils. */
+function makeEngine( readFrame: () => Promise<CanvasImageSource> ): SketchEngine {
+  return {
+    getCaptureSource: () => ( {
+      readFrame
+    } )
+  } as unknown as SketchEngine;
+}
+
 afterEach( () => {
   document.body.innerHTML = "";
+  jest.restoreAllMocks();
 } );
 
 /* ------------------------------------------------------------------ */
@@ -118,6 +144,181 @@ describe(
           0,
           80
         ) ).rejects.toThrow( /Timeout waiting for slide/ );
+      }
+    );
+
+    it(
+      "resolves for GSAP: data-slide lives on the stage, the canvas is an untracked mirror",
+      async() => {
+        // GSAP mounts a hidden mirror canvas in the container and puts
+        // `data-slide` on the stage div (not the canvas), so the canvas reads
+        // as untracked and resolves best-effort once present.
+        const container = document.createElement( "div" );
+
+        container.className = "sketch-canvas-container";
+
+        const stage = document.createElement( "div" );
+
+        stage.className = "gsap-stage";
+        stage.dataset.slide = "0";
+
+        const mirror = document.createElement( "canvas" );
+
+        mirror.className = "gsap-mirror-canvas";
+        container.append(
+          stage,
+          mirror
+        );
+        document.body.appendChild( container );
+
+        await expect( waitForSlideRendered(
+          1,
+          1000
+        ) ).resolves.toBeUndefined();
+      }
+    );
+  }
+);
+
+/* ------------------------------------------------------------------ */
+/*  getCurrentFrameCanvas                                             */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "getCurrentFrameCanvas",
+  () => {
+    it(
+      "returns the engine's freshly read frame, preferring it over any DOM canvas",
+      async() => {
+        // A stale mirror is in the DOM; the engine hands back a fresh frame.
+        // Preferring the engine read is exactly what makes GSAP thumbnails
+        // reflect the current frame instead of the mount-time still.
+        mountCanvasInContainer( "gsap-mirror-canvas" );
+
+        const fresh = makeCanvas(
+          10,
+          10
+        );
+        const readFrame = jest.fn().mockResolvedValue( fresh );
+
+        await expect( getCurrentFrameCanvas( makeEngine( readFrame ) ) ).resolves.toBe( fresh );
+        expect( readFrame ).toHaveBeenCalledTimes( 1 );
+      }
+    );
+
+    it(
+      "falls back to the DOM canvas when the engine read throws",
+      async() => {
+        const domCanvas = mountCanvasInContainer( "p5Canvas" );
+        const readFrame = jest.fn().mockRejectedValue( new Error( "not ready" ) );
+
+        await expect( getCurrentFrameCanvas( makeEngine( readFrame ) ) ).resolves.toBe( domCanvas );
+      }
+    );
+
+    it(
+      "falls back to the DOM canvas when no engine is supplied",
+      async() => {
+        const domCanvas = mountCanvasInContainer( "p5Canvas" );
+
+        await expect( getCurrentFrameCanvas( null ) ).resolves.toBe( domCanvas );
+      }
+    );
+  }
+);
+
+/* ------------------------------------------------------------------ */
+/*  captureThumbnailFromCanvas                                        */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "captureThumbnailFromCanvas",
+  () => {
+    // jsdom has no real 2D backend, so stub the destination context + encoder
+    // to exercise the source-selection + scaling logic deterministically.
+    function stubDestinationCanvas() {
+      const drawImage = jest.fn();
+
+      jest
+        .spyOn(
+          HTMLCanvasElement.prototype,
+          "getContext"
+        )
+        .mockReturnValue( {
+          imageSmoothingEnabled: false,
+          imageSmoothingQuality: "low",
+          drawImage
+        } as unknown as CanvasRenderingContext2D );
+
+      jest
+        .spyOn(
+          HTMLCanvasElement.prototype,
+          "toDataURL"
+        )
+        .mockReturnValue( "data:image/jpeg;base64,STUB" );
+
+      return {
+        drawImage
+      };
+    }
+
+    it(
+      "captures from the engine's current frame (GSAP rasterisation path)",
+      async() => {
+        const {
+          drawImage
+        } = stubDestinationCanvas();
+        const frame = makeCanvas(
+          1080,
+          1350
+        );
+        const readFrame = jest.fn().mockResolvedValue( frame );
+
+        const dataUrl = await captureThumbnailFromCanvas( makeEngine( readFrame ) );
+
+        expect( dataUrl ).toBe( "data:image/jpeg;base64,STUB" );
+        expect( readFrame ).toHaveBeenCalledTimes( 1 );
+        // Source frame is the engine's, scaled to a 240px-wide thumbnail.
+        expect( drawImage ).toHaveBeenCalledWith(
+          frame,
+          0,
+          0,
+          240,
+          300
+        );
+      }
+    );
+
+    it(
+      "captures from the live DOM canvas when no engine is supplied",
+      async() => {
+        stubDestinationCanvas();
+
+        const domCanvas = mountCanvasInContainer( "p5Canvas" );
+
+        domCanvas.width = 240;
+        domCanvas.height = 240;
+
+        await expect( captureThumbnailFromCanvas() ).resolves.toBe( "data:image/jpeg;base64,STUB" );
+      }
+    );
+
+    it(
+      "returns null when there is no frame source at all",
+      async() => {
+        await expect( captureThumbnailFromCanvas() ).resolves.toBeNull();
+      }
+    );
+
+    it(
+      "returns null when the source frame has no dimensions",
+      async() => {
+        const readFrame = jest.fn().mockResolvedValue( makeCanvas(
+          0,
+          0
+        ) );
+
+        await expect( captureThumbnailFromCanvas( makeEngine( readFrame ) ) ).resolves.toBeNull();
       }
     );
   }

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/__tests__/thumbnailUtils.test.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/__tests__/thumbnailUtils.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  getActiveSketchCanvas,
+  waitForSlideRendered
+} from "../thumbnailUtils";
+
+/* ------------------------------------------------------------------ */
+/*  Test helpers                                                        */
+/* ------------------------------------------------------------------ */
+
+function mountCanvasInContainer( className: string ): HTMLCanvasElement {
+  const container = document.createElement( "div" );
+
+  container.className = "sketch-canvas-container";
+
+  const canvas = document.createElement( "canvas" );
+
+  canvas.className = className;
+  container.appendChild( canvas );
+  document.body.appendChild( container );
+
+  return canvas;
+}
+
+afterEach( () => {
+  document.body.innerHTML = "";
+} );
+
+/* ------------------------------------------------------------------ */
+/*  getActiveSketchCanvas                                              */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "getActiveSketchCanvas",
+  () => {
+    it(
+      "resolves the p5 canvas mounted in the preview container",
+      () => {
+        const canvas = mountCanvasInContainer( "p5Canvas" );
+
+        expect( getActiveSketchCanvas() ).toBe( canvas );
+      }
+    );
+
+    it(
+      "resolves the Three.js canvas mounted in the preview container",
+      () => {
+        // The bug: the Three.js canvas is tagged `threejs-canvas`, not
+        // `p5Canvas`, so the old p5-only selector never found it.
+        const canvas = mountCanvasInContainer( "threejs-canvas" );
+
+        expect( getActiveSketchCanvas() ).toBe( canvas );
+      }
+    );
+
+    it(
+      "falls back to the legacy p5 selector when no container is present",
+      () => {
+        const canvas = document.createElement( "canvas" );
+
+        canvas.className = "p5Canvas";
+        document.body.appendChild( canvas );
+
+        expect( getActiveSketchCanvas() ).toBe( canvas );
+      }
+    );
+
+    it(
+      "returns null when no sketch canvas exists",
+      () => {
+        expect( getActiveSketchCanvas() ).toBeNull();
+      }
+    );
+  }
+);
+
+/* ------------------------------------------------------------------ */
+/*  waitForSlideRendered                                              */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "waitForSlideRendered",
+  () => {
+    it(
+      "resolves once a slide-tracked (p5) canvas reports the target slide",
+      async() => {
+        const canvas = mountCanvasInContainer( "p5Canvas" );
+
+        canvas.dataset.slide = "2";
+
+        await expect( waitForSlideRendered(
+          2,
+          1000
+        ) ).resolves.toBeUndefined();
+      }
+    );
+
+    it(
+      "resolves for an engine that does not track slides (Three.js) without waiting for the timeout",
+      async() => {
+        mountCanvasInContainer( "threejs-canvas" );
+
+        // No data-slide, no window.getCurrentSlide → best-effort resolve as
+        // soon as the canvas is up, rather than spinning until timeoutMs.
+        await expect( waitForSlideRendered(
+          0,
+          1000
+        ) ).resolves.toBeUndefined();
+      }
+    );
+
+    it(
+      "rejects when no canvas ever appears",
+      async() => {
+        await expect( waitForSlideRendered(
+          0,
+          80
+        ) ).rejects.toThrow( /Timeout waiting for slide/ );
+      }
+    );
+  }
+);

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/thumbnailUtils.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/thumbnailUtils.ts
@@ -1,3 +1,7 @@
+import type {
+  SketchEngine
+} from "@/engines/types";
+
 /**
  * Resolve the live sketch canvas rendered in the main preview, independent of
  * which engine produced it. p5 tags its canvas `p5Canvas`, Three.js tags its
@@ -5,12 +9,41 @@
  * scope to the shared preview container (`EngineSketchRenderer`), which also
  * covers any future canvas engine. Falls back to the legacy p5 selector for
  * routes that don't mount inside the container.
+ *
+ * Note: for a DOM engine (GSAP) this returns the hidden mirror canvas, whose
+ * pixels are only refreshed on demand — prefer `getCurrentFrameCanvas(engine)`
+ * when a *current* frame is needed.
  */
 export function getActiveSketchCanvas(): HTMLCanvasElement | null {
   return (
     document.querySelector<HTMLCanvasElement>( ".sketch-canvas-container canvas" ) ??
     document.querySelector<HTMLCanvasElement>( "canvas.p5Canvas" )
   );
+}
+
+/**
+ * Obtain a canvas holding the engine's *current* frame, engine-agnostically.
+ *
+ * Canvas engines (p5, Three.js) paint straight into a live `<canvas>`, so the
+ * engine's capture source hands it back as-is. GSAP renders to the DOM and has
+ * no live canvas — its capture source rasterises the current stage into a
+ * mirror canvas on read. Going through the engine (rather than a blind DOM
+ * query) is therefore what makes GSAP thumbnails reflect the current frame
+ * instead of the stale one primed at mount.
+ *
+ * Falls back to the DOM lookup when no engine is available (or its read fails),
+ * preserving the legacy behaviour for canvas engines.
+ */
+export async function getCurrentFrameCanvas( engine?: SketchEngine | null ): Promise<CanvasImageSource | null> {
+  if ( engine ) {
+    try {
+      return await engine.getCaptureSource().readFrame();
+    } catch {
+      // Fall through to the DOM lookup below (e.g. capture source not ready).
+    }
+  }
+
+  return getActiveSketchCanvas();
 }
 
 /**
@@ -90,21 +123,27 @@ export function waitForSlideRendered(
 }
 
 /**
- * Captures a thumbnail from the p5.js canvas and returns a data URL
- * Uses native Canvas API for better compatibility with Next.js/Turbopack
+ * Captures a thumbnail from the active sketch's current frame and returns a
+ * JPEG data URL. Works for every engine: `engine` is used to obtain a
+ * current-frame canvas (rasterising the DOM for GSAP), falling back to a live
+ * canvas lookup when no engine is supplied.
+ * Uses native Canvas API for better compatibility with Next.js/Turbopack.
  */
-export async function captureThumbnailFromCanvas(): Promise<string | null> {
-  const canvas = getActiveSketchCanvas();
+export async function captureThumbnailFromCanvas( engine?: SketchEngine | null ): Promise<string | null> {
+  const canvas = await getCurrentFrameCanvas( engine );
 
-  if ( !canvas ) {
+  const sourceWidth = ( canvas as HTMLCanvasElement | null )?.width ?? 0;
+  const sourceHeight = ( canvas as HTMLCanvasElement | null )?.height ?? 0;
+
+  if ( !canvas || !sourceWidth || !sourceHeight ) {
     return null;
   }
 
   try {
     // Target width for thumbnail - optimal for grid display
     const targetWidth = 240;
-    const scaleFactor = targetWidth / canvas.width;
-    const targetHeight = Math.round( canvas.height * scaleFactor );
+    const scaleFactor = targetWidth / sourceWidth;
+    const targetHeight = Math.round( sourceHeight * scaleFactor );
 
     // Create destination canvas
     const destCanvas = document.createElement( "canvas" );

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/thumbnailUtils.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/thumbnailUtils.ts
@@ -1,4 +1,19 @@
 /**
+ * Resolve the live sketch canvas rendered in the main preview, independent of
+ * which engine produced it. p5 tags its canvas `p5Canvas`, Three.js tags its
+ * WebGL canvas `threejs-canvas` — rather than hard-coding a per-engine class we
+ * scope to the shared preview container (`EngineSketchRenderer`), which also
+ * covers any future canvas engine. Falls back to the legacy p5 selector for
+ * routes that don't mount inside the container.
+ */
+export function getActiveSketchCanvas(): HTMLCanvasElement | null {
+  return (
+    document.querySelector<HTMLCanvasElement>( ".sketch-canvas-container canvas" ) ??
+    document.querySelector<HTMLCanvasElement>( "canvas.p5Canvas" )
+  );
+}
+
+/**
  * Waits for a specific slide to be rendered by checking the canvas data-slide attribute
  * This synchronizes thumbnail capture with actual slide rendering
  */
@@ -13,8 +28,7 @@ export function waitForSlideRendered(
     let matchedFrames = 0;
 
     const check = () => {
-      // Engine-agnostic canvas lookup — see captureThumbnailFromCanvas() below.
-      const canvas = document.querySelector( ".sketch-canvas-container canvas" ) as HTMLCanvasElement | null;
+      const canvas = getActiveSketchCanvas();
 
       const dataSlide = canvas?.dataset?.slide;
       const dataSlideIndex =
@@ -38,7 +52,13 @@ export function waitForSlideRendered(
         }
       }
 
-      if ( canvas && currentSlideIndex === slideIndex ) {
+      // Engines that don't report a current slide (e.g. Three.js, or a
+      // single-slide p5 sketch) can't be synchronised against `slideIndex`;
+      // once their canvas is up we consider the target rendered.
+      const slideTracked = currentSlideIndex !== undefined;
+      const slideMatched = !slideTracked || currentSlideIndex === slideIndex;
+
+      if ( canvas && slideMatched ) {
         matchedFrames += 1;
 
         // Require a couple frames so the draw loop catches up
@@ -74,10 +94,7 @@ export function waitForSlideRendered(
  * Uses native Canvas API for better compatibility with Next.js/Turbopack
  */
 export async function captureThumbnailFromCanvas(): Promise<string | null> {
-  // Every SketchEngine mounts its one live/mirror canvas inside
-  // `.sketch-canvas-container` (see EngineSketchRenderer), so this resolves
-  // to the right canvas for p5, GSAP and Three.js sketches alike.
-  const canvas = document.querySelector( ".sketch-canvas-container canvas" ) as HTMLCanvasElement;
+  const canvas = getActiveSketchCanvas();
 
   if ( !canvas ) {
     return null;

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/useLiveThumbnail.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/useLiveThumbnail.ts
@@ -1,6 +1,9 @@
 import {
   useEffect, useRef
 } from "react";
+import {
+  getActiveSketchCanvas
+} from "./thumbnailUtils";
 
 // Resolved once at module load — zero runtime cost when disabled.
 const LIVE_THUMBNAIL_ENABLED =
@@ -10,9 +13,11 @@ const TARGET_FPS = 30;
 const FRAME_INTERVAL = 1000 / TARGET_FPS;
 
 /**
- * When NEXT_PUBLIC_LIVE_THUMBNAIL=true, mirrors the main p5 canvas into
- * `thumbCanvasRef` at ~15 fps using a GPU-accelerated drawImage blit.
- * Only runs while `isActive` is true; completely idle for inactive slides.
+ * When NEXT_PUBLIC_LIVE_THUMBNAIL=true, mirrors the main sketch canvas into
+ * `thumbCanvasRef` at ~30 fps using a GPU-accelerated drawImage blit. Works
+ * for any canvas engine (p5, Three.js, …) since it resolves the live canvas
+ * via `getActiveSketchCanvas` rather than a p5-specific selector. Only runs
+ * while `isActive` is true; completely idle for inactive slides.
  *
  * Returns `LIVE_THUMBNAIL_ENABLED` so the consumer knows which element to render.
  */
@@ -44,11 +49,7 @@ export function useLiveThumbnail( {
 
         lastTime = time;
 
-        // Engine-agnostic: every SketchEngine mounts its one live/mirror
-        // canvas inside `.sketch-canvas-container` (see EngineSketchRenderer),
-        // so this finds the right canvas for p5, GSAP and Three.js alike
-        // instead of only ever matching p5's own `.p5Canvas` class.
-        const srcCanvas = document.querySelector( ".sketch-canvas-container canvas" ) as HTMLCanvasElement | null;
+        const srcCanvas = getActiveSketchCanvas();
         const thumbCanvas = thumbCanvasRef.current;
 
         if ( !srcCanvas || !thumbCanvas ) {

--- a/src/components/ClientProcessingSketch/components/TemplateOptions/utils/useLiveThumbnail.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/utils/useLiveThumbnail.ts
@@ -1,6 +1,7 @@
 import {
   useEffect, useRef
 } from "react";
+import useSketch from "@/components/ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
 import {
   getActiveSketchCanvas
 } from "./thumbnailUtils";
@@ -12,12 +13,51 @@ const LIVE_THUMBNAIL_ENABLED =
 const TARGET_FPS = 30;
 const FRAME_INTERVAL = 1000 / TARGET_FPS;
 
+/** Blit an engine frame into the thumbnail canvas, sizing it to its CSS box. */
+function blitToThumbnail(
+  frame: CanvasImageSource,
+  thumbCanvas: HTMLCanvasElement
+): void {
+  const displayW = thumbCanvas.offsetWidth;
+  const displayH = thumbCanvas.offsetHeight;
+
+  // Skip if the element isn't laid out yet
+  if ( displayW === 0 || displayH === 0 ) {
+    return;
+  }
+
+  // Sync internal buffer to CSS display size (only when it changes)
+  if ( thumbCanvas.width !== displayW || thumbCanvas.height !== displayH ) {
+    thumbCanvas.width = displayW;
+    thumbCanvas.height = displayH;
+  }
+
+  const ctx = thumbCanvas.getContext( "2d" );
+
+  if ( !ctx ) {
+    return;
+  }
+
+  ctx.drawImage(
+    frame,
+    0,
+    0,
+    displayW,
+    displayH
+  );
+}
+
 /**
- * When NEXT_PUBLIC_LIVE_THUMBNAIL=true, mirrors the main sketch canvas into
- * `thumbCanvasRef` at ~30 fps using a GPU-accelerated drawImage blit. Works
- * for any canvas engine (p5, Three.js, …) since it resolves the live canvas
- * via `getActiveSketchCanvas` rather than a p5-specific selector. Only runs
- * while `isActive` is true; completely idle for inactive slides.
+ * When NEXT_PUBLIC_LIVE_THUMBNAIL=true, mirrors the active sketch's current
+ * frame into `thumbCanvasRef` at ~30 fps. Only runs while `isActive` is true;
+ * completely idle for inactive slides.
+ *
+ * It goes through the engine's capture source rather than a raw canvas query so
+ * it works for every engine: canvas engines (p5, Three.js) hand back their live
+ * canvas as-is, while GSAP — which renders to the DOM and has no live canvas —
+ * rasterises its current stage on demand. Rasterisation is async and can be
+ * slow, so overlapping reads are skipped (the mirror self-throttles). When no
+ * engine is available yet it falls back to a direct canvas lookup.
  *
  * Returns `LIVE_THUMBNAIL_ENABLED` so the consumer knows which element to render.
  */
@@ -28,16 +68,31 @@ export function useLiveThumbnail( {
   thumbCanvasRef: React.RefObject<HTMLCanvasElement | null>;
   isActive: boolean;
 } ): boolean {
+  const [
+    {
+      engine, browserRecording
+    }
+  ] = useSketch();
   // Stable ref for the rAF id so we can cancel without adding to deps
   const rafIdRef = useRef<number | null>( null );
 
   useEffect(
     () => {
-      if ( !LIVE_THUMBNAIL_ENABLED || !isActive ) {
+      // While a browser recording/export is running, stay completely idle. For
+      // a DOM engine (GSAP) `readFrame()` rasterises the *same* singleton mirror
+      // canvas the recorder is driving, so mirroring here would double the
+      // per-frame rasterisation cost and race the recorder's own writes.
+      if ( !LIVE_THUMBNAIL_ENABLED || !isActive || browserRecording ) {
         return;
       }
 
+      // Captured once: for GSAP its methods delegate to the runtime singleton,
+      // so a single instance stays valid for the effect's lifetime.
+      const captureSource = engine?.getCaptureSource() ?? null;
+
       let lastTime = 0;
+      let readInFlight = false;
+      let cancelled = false;
 
       const loop = ( time: number ) => {
         rafIdRef.current = requestAnimationFrame( loop );
@@ -49,45 +104,61 @@ export function useLiveThumbnail( {
 
         lastTime = time;
 
-        const srcCanvas = getActiveSketchCanvas();
         const thumbCanvas = thumbCanvasRef.current;
 
-        if ( !srcCanvas || !thumbCanvas ) {
+        if ( !thumbCanvas ) {
           return;
         }
 
-        const displayW = thumbCanvas.offsetWidth;
-        const displayH = thumbCanvas.offsetHeight;
+        // No engine yet (still initialising): blit whatever live canvas is in
+        // the preview container. Canvas engines paint it continuously; for a
+        // DOM engine this is the last-primed mirror until the engine is ready.
+        if ( !captureSource ) {
+          const srcCanvas = getActiveSketchCanvas();
 
-        // Skip if the element isn't laid out yet
-        if ( displayW === 0 || displayH === 0 ) {
+          if ( srcCanvas ) {
+            blitToThumbnail(
+              srcCanvas,
+              thumbCanvas
+            );
+          }
+
           return;
         }
 
-        // Sync internal buffer to CSS display size (only when it changes)
-        if ( thumbCanvas.width !== displayW || thumbCanvas.height !== displayH ) {
-          thumbCanvas.width = displayW;
-          thumbCanvas.height = displayH;
-        }
-
-        const ctx = thumbCanvas.getContext( "2d" );
-
-        if ( !ctx ) {
+        // Don't stack rasterisations: if a (potentially slow) read is still
+        // running, let it finish before starting the next.
+        if ( readInFlight ) {
           return;
         }
 
-        ctx.drawImage(
-          srcCanvas,
-          0,
-          0,
-          displayW,
-          displayH
-        );
+        readInFlight = true;
+        captureSource
+          .readFrame()
+          .then( ( frame ) => {
+            readInFlight = false;
+
+            const live = thumbCanvasRef.current;
+
+            if ( cancelled || !frame || !live ) {
+              return;
+            }
+
+            blitToThumbnail(
+              frame,
+              live
+            );
+          } )
+          .catch( () => {
+            readInFlight = false;
+          } );
       };
 
       rafIdRef.current = requestAnimationFrame( loop );
 
       return () => {
+        cancelled = true;
+
         if ( rafIdRef.current !== null ) {
           cancelAnimationFrame( rafIdRef.current );
           rafIdRef.current = null;
@@ -96,7 +167,9 @@ export function useLiveThumbnail( {
     },
     [
       isActive,
-      thumbCanvasRef
+      thumbCanvasRef,
+      engine,
+      browserRecording
     ]
   );
 

--- a/src/engines/threejs/ThreeEngine.ts
+++ b/src/engines/threejs/ThreeEngine.ts
@@ -66,6 +66,9 @@ export class ThreeEngine implements SketchEngine {
   private runtime: ThreeRuntime | null = null;
   private listeners = new Map<string, Set<( payload: any ) => void>>();
   private unsubscribeProgression: ( () => void ) | null = null;
+  // Saved `window.setSlide` so switching back to a p5/GSAP sketch restores its
+  // binding (mirrors GsapEngine — p5 registers the global once at module load).
+  private previousSetSlide: ( ( index: number ) => void ) | undefined;
 
   private perfLoopId: number | null = null;
   private perfSample = {
@@ -189,6 +192,15 @@ export class ThreeEngine implements SketchEngine {
       renderFrame: ( index ) => this.runtime?.stepFrame( index )
     } );
 
+    // Expose the slide switch the shared UI + headless recorder call. p5 sets
+    // this from its `slides` module; the Three.js runtime is the equivalent
+    // here. Without it, switching slides never reaches the running sketch, so
+    // the options accessor keeps merging the wrong (or no) per-slide overrides.
+    if ( typeof window !== "undefined" ) {
+      this.previousSetSlide = window.setSlide;
+      window.setSlide = ( index: number ) => this.runtime?.setSlide( index );
+    }
+
     this.emit(
       "ready",
       undefined as any
@@ -199,6 +211,12 @@ export class ThreeEngine implements SketchEngine {
     this.stopPerformanceLoop();
     unregisterServerCaptureController();
     unregisterAnimationBridge();
+
+    if ( typeof window !== "undefined" &&
+      window.setSlide !== this.previousSetSlide ) {
+      window.setSlide = this.previousSetSlide as ( index: number ) => void;
+    }
+    this.previousSetSlide = undefined;
 
     this.unsubscribeProgression?.();
     this.unsubscribeProgression = null;

--- a/src/lib/__tests__/effectiveSketch.test.ts
+++ b/src/lib/__tests__/effectiveSketch.test.ts
@@ -1,0 +1,156 @@
+import {
+  resolveEffectiveSketch
+} from "../effectiveSketch";
+
+describe(
+  "resolveEffectiveSketch",
+  () => {
+    const options = {
+      sketch: {
+        roughness: 0.25,
+        metalness: 0.4,
+        color: [
+          124,
+          92,
+          255
+        ]
+      },
+      slides: [
+        {
+          id: "a",
+          sketch: {
+            roughness: 0.9
+          }
+        },
+        {
+          id: "b",
+          sketch: {
+            metalness: 1,
+            color: [
+              10,
+              20,
+              30
+            ]
+          }
+        },
+        {
+          id: "c"
+        }
+      ]
+    };
+
+    it(
+      "returns the global sketch block when there is no active slide",
+      () => {
+        expect( resolveEffectiveSketch(
+          options,
+          undefined
+        ) ).toEqual( options.sketch );
+        expect( resolveEffectiveSketch(
+          options,
+          null
+        ) ).toEqual( options.sketch );
+      }
+    );
+
+    it(
+      "merges the active slide's overrides over the global block",
+      () => {
+        // Slide 0 overrides only roughness — global metalness/color survive.
+        expect( resolveEffectiveSketch(
+          options,
+          0
+        ) ).toEqual( {
+          roughness: 0.9,
+          metalness: 0.4,
+          color: [
+            124,
+            92,
+            255
+          ]
+        } );
+      }
+    );
+
+    it(
+      "lets a later slide override multiple keys independently",
+      () => {
+        expect( resolveEffectiveSketch(
+          options,
+          1
+        ) ).toEqual( {
+          roughness: 0.25,
+          metalness: 1,
+          color: [
+            10,
+            20,
+            30
+          ]
+        } );
+      }
+    );
+
+    it(
+      "falls back to the global block for a slide with no overrides",
+      () => {
+        expect( resolveEffectiveSketch(
+          options,
+          2
+        ) ).toEqual( options.sketch );
+      }
+    );
+
+    it(
+      "wraps out-of-range and negative indices like the p5 slides module",
+      () => {
+        // 3 wraps to slide 0, -1 wraps to slide 2.
+        expect( resolveEffectiveSketch(
+          options,
+          3
+        ) ).toEqual( resolveEffectiveSketch(
+          options,
+          0
+        ) );
+        expect( resolveEffectiveSketch(
+          options,
+          -1
+        ) ).toEqual( resolveEffectiveSketch(
+          options,
+          2
+        ) );
+      }
+    );
+
+    it(
+      "returns an empty object when nothing is defined",
+      () => {
+        expect( resolveEffectiveSketch(
+          {},
+          0
+        ) ).toEqual( {} );
+        expect( resolveEffectiveSketch(
+          undefined,
+          undefined
+        ) ).toEqual( {} );
+      }
+    );
+
+    it(
+      "ignores slideIndex when the deck has no slides",
+      () => {
+        const noSlides = {
+          sketch: {
+            a: 1
+          }
+        };
+
+        expect( resolveEffectiveSketch(
+          noSlides,
+          0
+        ) ).toEqual( {
+          a: 1
+        } );
+      }
+    );
+  }
+);

--- a/src/lib/effectiveSketch.ts
+++ b/src/lib/effectiveSketch.ts
@@ -1,0 +1,47 @@
+/**
+ * Engine-agnostic resolver for a sketch's *effective* per-slide parameters.
+ *
+ * A template's tunable form values live under `options.sketch`. Once the deck
+ * has slides, each slide may override a subset of those values under
+ * `slides[i].sketch`, and the editor writes a parameter edit to the *active
+ * slide's* override — not to the global block. So an engine that keeps reading
+ * `options.sketch` directly will look frozen the moment a slide is created.
+ *
+ * This is the shared merge every engine's options accessor should go through:
+ *   - no active slide (or no slides)  → the global `sketch` block, untouched;
+ *   - active slide with overrides     → global merged with the slide's own.
+ *
+ * The p5 engine layers its montage/transition morphing on top of this (it
+ * short-circuits before calling here); GSAP and Three.js use it directly.
+ */
+export function resolveEffectiveSketch(
+  options: Record<string, any> | null | undefined,
+  slideIndex: number | null | undefined
+): Record<string, any> {
+  const globalSketch = options?.sketch ?? {};
+  const slides = options?.slides;
+
+  if (
+    slideIndex === null ||
+    slideIndex === undefined ||
+    !Array.isArray( slides ) ||
+    slides.length === 0
+  ) {
+    return globalSketch;
+  }
+
+  // Match the p5 slides module: coerce + wrap so a transiently out-of-range or
+  // negative index still resolves to a real slide instead of dropping overrides.
+  const count = slides.length;
+  const index = ( ( Math.floor( Number( slideIndex ) || 0 ) % count ) + count ) % count;
+  const slide = slides[ index ];
+
+  if ( !slide ) {
+    return globalSketch;
+  }
+
+  return {
+    ...globalSketch,
+    ...( slide.sketch ?? {} )
+  };
+}

--- a/src/templates/gsap/utils/runtime.tsx
+++ b/src/templates/gsap/utils/runtime.tsx
@@ -37,6 +37,9 @@ import {
   getEffectiveSlideSettings
 } from "@/lib/effectiveSlideSettings";
 import {
+  resolveEffectiveSketch
+} from "@/lib/effectiveSketch";
+import {
   resolveAnimation, totalFramesFor
 } from "@/lib/animationConfig";
 import {
@@ -155,15 +158,11 @@ class GsapRuntime {
     const {
       size, animation
     } = this.effectiveSettings;
-    const slide = this.activeSlideIndex !== undefined
-      ? this.options?.slides?.[ this.activeSlideIndex ]
-      : undefined;
-    const sketch = slide?.sketch
-      ? {
-        ...( this.options.sketch ?? {} ),
-        ...slide.sketch
-      }
-      : this.options.sketch;
+    // Shared, engine-agnostic per-slide merge (same resolver p5 + Three.js use).
+    const sketch = resolveEffectiveSketch(
+      this.options,
+      this.activeSlideIndex
+    );
 
     return {
       ...this.options,

--- a/src/templates/p5/utils/slides/index.js
+++ b/src/templates/p5/utils/slides/index.js
@@ -35,6 +35,10 @@ import {
   mergeSlideOverride
 } from "@/lib/effectiveSlideSettings";
 
+import {
+  resolveEffectiveSketch
+} from "@/lib/effectiveSketch";
+
 // Safe modulo that wraps negatives too
 const wrap = (
   i, n
@@ -319,12 +323,13 @@ const slides = {
       }
     }
 
-    const slideSketch = currentSlide?.sketch || {};
-
-    return {
-      ...globalSketch,
-      ...slideSketch
-    };
+    // Non-montage slides use the shared, engine-agnostic per-slide merge (the
+    // same resolver GSAP + Three.js go through) so there is a single source of
+    // truth for how a slide's overrides layer over the global sketch block.
+    return resolveEffectiveSketch(
+      optionsTarget,
+      this.index
+    );
   }
 };
 

--- a/src/templates/threejs/utils/__tests__/perSlideOptions.test.ts
+++ b/src/templates/threejs/utils/__tests__/perSlideOptions.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression test for the bug where a Three.js sketch's parameters froze the
+ * moment a slide was created: the editor writes a parameter edit to the active
+ * slide's override (`slides[i].sketch`), but the Three.js options accessor used
+ * to read the global `sketch` block directly and had no slide awareness.
+ *
+ * Exercises the real wiring: runtime.setSlide() → activeSlideIndex →
+ * options.sketch (proxy) → shared resolveEffectiveSketch.
+ */
+import sketchRuntime, {
+  getActiveSlideIndex
+} from "@/threejs/utils/sketch.js";
+import optionsProxy from "@/threejs/utils/options.js";
+import {
+  getSketchOptions
+} from "@/p5/shared/syncSketchOptions.js";
+
+// The default export is a `Proxy<{}>` (typed empty); a template reads it as a
+// loose options bag, so mirror that here for the assertions.
+const options = optionsProxy as unknown as Record<string, any>;
+
+// Replace the shared store contents in place (both modules hold the same
+// `globalThis.sketchOptions` reference, so mutating it is what they observe).
+function setStore( next: Record<string, any> ): void {
+  const store = getSketchOptions();
+
+  for ( const key of Object.keys( store ) ) {
+    delete store[ key ];
+  }
+
+  Object.assign(
+    store,
+    next
+  );
+}
+
+describe(
+  "Three.js per-slide options",
+  () => {
+    beforeEach( () => {
+      // reset() clears activeSlideIndex back to null (safe without a renderer).
+      sketchRuntime.reset();
+    } );
+
+    it(
+      "reads the global sketch block when the deck has no slides",
+      () => {
+        setStore( {
+          sketch: {
+            roughness: 0.25,
+            metalness: 0.4
+          },
+          slides: []
+        } );
+
+        expect( getActiveSlideIndex() ).toBeNull();
+        expect( options.sketch ).toEqual( {
+          roughness: 0.25,
+          metalness: 0.4
+        } );
+      }
+    );
+
+    it(
+      "defaults to slide 0 when a deck has slides but setSlide hasn't run yet",
+      () => {
+        // Guards the init race: a saved multi-slide deck loads before the studio
+        // UI wires window.setSlide, so the accessor must still resolve slide 0
+        // (matching React's effective index + p5's null→0 recovery).
+        setStore( {
+          sketch: {
+            roughness: 0.25,
+            metalness: 0.4
+          },
+          slides: [
+            {
+              id: "a",
+              sketch: {
+                roughness: 0.9
+              }
+            }
+          ]
+        } );
+
+        expect( getActiveSlideIndex() ).toBeNull();
+        expect( options.sketch ).toEqual( {
+          roughness: 0.9,
+          metalness: 0.4
+        } );
+      }
+    );
+
+    it(
+      "merges the active slide's overrides once setSlide() is called",
+      () => {
+        setStore( {
+          sketch: {
+            roughness: 0.25,
+            metalness: 0.4
+          },
+          slides: [
+            {
+              id: "a",
+              sketch: {
+                roughness: 0.9
+              }
+            }
+          ]
+        } );
+
+        sketchRuntime.setSlide( 0 );
+
+        expect( getActiveSlideIndex() ).toBe( 0 );
+        // roughness comes from the slide override; metalness stays global.
+        expect( options.sketch ).toEqual( {
+          roughness: 0.9,
+          metalness: 0.4
+        } );
+      }
+    );
+
+    it(
+      "reflects edits written to the active slide's override (the frozen-params bug)",
+      () => {
+        setStore( {
+          sketch: {
+            roughness: 0.25
+          },
+          slides: [
+            {
+              id: "a",
+              sketch: {
+                roughness: 0.25
+              }
+            }
+          ]
+        } );
+
+        sketchRuntime.setSlide( 0 );
+
+        // The user drags the roughness slider on slide 0 → editor writes the
+        // active slide's override. Before the fix the accessor ignored this.
+        const store = getSketchOptions();
+
+        store.slides[ 0 ].sketch.roughness = 0.8;
+
+        expect( options.sketch.roughness ).toBe( 0.8 );
+      }
+    );
+
+    it(
+      "falls back to global for a slide without its own overrides",
+      () => {
+        setStore( {
+          sketch: {
+            roughness: 0.25,
+            metalness: 0.4
+          },
+          slides: [
+            {
+              id: "a",
+              sketch: {
+                roughness: 0.9
+              }
+            },
+            {
+              id: "b"
+            }
+          ]
+        } );
+
+        sketchRuntime.setSlide( 1 );
+
+        expect( options.sketch ).toEqual( {
+          roughness: 0.25,
+          metalness: 0.4
+        } );
+      }
+    );
+  }
+);

--- a/src/templates/threejs/utils/options.js
+++ b/src/templates/threejs/utils/options.js
@@ -9,10 +9,36 @@
  * the baseline `options.size` / `options.animation` blocks the same way a p5
  * sketch does. Every access reads the current store, so option changes pushed
  * from the React form are reflected on the next draw with no manual wiring.
+ *
+ * `options.sketch` merges the active slide's per-slide overrides over the global
+ * block via the shared, engine-agnostic resolver — the same merge p5 does. Once
+ * the deck has slides, the editor writes a parameter edit to the active slide's
+ * override, so reading the raw global block would look frozen.
  */
 import {
   getSketchOptions
 } from "@/p5/shared/syncSketchOptions.js";
+import {
+  getActiveSlideIndex
+} from "./sketch.js";
+import {
+  resolveEffectiveSketch
+} from "@/lib/effectiveSketch";
+
+// Resolve which slide's overrides `options.sketch` should merge. A deck with
+// slides always has one active slide (React coerces its effective index to 0,
+// and the p5 engine recovers null→0), so default to the first before the studio
+// UI has wired `window.setSlide` — otherwise a freshly loaded multi-slide deck
+// would briefly render the global params instead of slide 0's.
+function activeSlideIndexFor( live ) {
+  const index = getActiveSlideIndex();
+
+  if ( index !== null && index !== undefined ) {
+    return index;
+  }
+
+  return Array.isArray( live?.slides ) && live.slides.length > 0 ? 0 : null;
+}
 
 const options = new Proxy(
   {},
@@ -23,7 +49,10 @@ const options = new Proxy(
       const live = getSketchOptions();
 
       if ( prop === "sketch" ) {
-        return live?.sketch ?? {};
+        return resolveEffectiveSketch(
+          live,
+          activeSlideIndexFor( live )
+        );
       }
 
       return live?.[ prop ];

--- a/src/templates/threejs/utils/sketch.js
+++ b/src/templates/threejs/utils/sketch.js
@@ -93,6 +93,14 @@ let container = null;
 let rafId = null;
 let frameCount = 0;
 
+// Index of the slide currently on screen, or null when the deck has no slides.
+// Driven by the shared studio UI through `ThreeEngine` → `window.setSlide`, and
+// read back by the options accessor so `options.sketch` merges this slide's
+// overrides (see @/threejs/utils/options.js). Without it, editing a parameter
+// once slides exist would look frozen — the edit lands on the slide override,
+// not the global block the accessor would otherwise return.
+let activeSlideIndex = null;
+
 // Real draw-rate measurement over a sliding window (frame deltas / elapsed),
 // used for the performance overlay.
 const fpsWindow = {
@@ -397,6 +405,7 @@ const sketch = {
     container = null;
     THREE = null;
     frameCount = 0;
+    activeSlideIndex = null;
     progressionSubscribers.clear();
     time.reset();
   },
@@ -469,6 +478,33 @@ const sketch = {
   endOpaqueCapture() {
     forcingOpaqueCapture = false;
     renderer?.setClearAlpha( 0 );
+  },
+
+  /* -- slides ----------------------------------------------------- */
+
+  // Switch to a slide. `ThreeEngine` wires the shared `window.setSlide` here so
+  // the slide carousel drives Three.js like it drives p5/GSAP. Records the index
+  // (read by the options accessor to merge per-slide overrides), tags the canvas
+  // with `data-slide` (thumbnail slide-sync + headless recorder key off it), and
+  // repaints so the switch is visible immediately even while paused.
+  setSlide( index ) {
+    const next =
+      typeof index === "number" && Number.isFinite( index ) && index >= 0
+        ? Math.floor( index )
+        : 0;
+
+    activeSlideIndex = next;
+
+    if ( renderer?.domElement ) {
+      renderer.domElement.dataset.slide = String( next );
+    }
+
+    renderOnce();
+    notifyProgression();
+  },
+
+  getActiveSlideIndex() {
+    return activeSlideIndex;
   },
 
   /* -- progression bridge ----------------------------------------- */
@@ -550,3 +586,4 @@ export const getScene = () => scene;
 export const getCamera = () => camera;
 export const getRenderer = () => renderer;
 export const getCanvas = () => renderer?.domElement ?? null;
+export const getActiveSlideIndex = () => activeSlideIndex;


### PR DESCRIPTION
This branch groups several engine-parity fixes for the multi-slide studio.

## 1. Live + static slide thumbnails for Three.js and GSAP

The client thumbnail code resolved the source canvas with the p5-only selector `canvas.p5Canvas`:

- **Three.js** tags its canvas `threejs-canvas` → nothing found. *(main since landed #223 fixing this inline; rebased on top, keeping the shared helper + `waitForSlideRendered` improvement + tests.)*
- **GSAP** renders to the DOM with no live canvas — only a hidden `.gsap-mirror-canvas` refreshed on demand → thumbnails showed the stale mount-time frame.

Changes: engine-agnostic `getActiveSketchCanvas()` (scoped to `.sketch-canvas-container`) and `getCurrentFrameCanvas(engine)` that goes through the engine's `getCaptureSource().readFrame()` (identity for p5/Three.js, a fresh DOM rasterisation for GSAP). Live loop reads async with an in-flight guard. Both paths stay idle during an in-browser recording/export (`browserRecording`) so they don't contend with the recorder on GSAP's shared mirror canvas.

## 2. Per-slide sketch parameters for Three.js (+ shared merge)

Once a deck had slides, the editor writes a parameter edit to the **active slide's** override (`slides[i].sketch`), not the global `sketch` block. The **Three.js** options accessor read the global block directly and had **no slide awareness** (nothing wired `window.setSlide`), so params (roughness, metalness, geometry…) froze the moment a slide was created. p5 did this in its slides module; GSAP inline in its runtime; Three.js nowhere.

Changes:
- New `src/lib/effectiveSketch.ts` `resolveEffectiveSketch(options, slideIndex)` — the single, engine-agnostic per-slide merge.
- Three.js runtime now tracks the active slide (`setSlide`/`getActiveSlideIndex`, tags the canvas `data-slide`); `ThreeEngine` wires `window.setSlide` (restored on destroy); the options accessor merges via the resolver and recovers to slide 0 when a deck has slides but the UI hasn't wired setSlide yet.
- GSAP and p5 delegate their previously-duplicated per-slide merge to the same resolver (p5 keeps its montage morphing layered on top).

**Follow-up (out of scope):** GSAP montage/transitions — GSAP builds its timeline once per slide (not per frame) and the montage overlays are p5-canvas rendered, so making them work in GSAP is a separate feature.

## Tests

- Cross-engine canvas resolution, engine-preferred vs DOM-fallback capture, the recording gate, the shared resolver, and a jsdom integration test driving `runtime.setSlide → options.sketch` to prove edits reach a Three.js sketch.
- `npm run check` green: 53 suites, 1497 tests. `npm run build` compiles all sketch routes. Changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)