### PR TITLE
docs: capabilities brainstorm

### DIFF
--- a/docs/CAPABILITIES_BRAINSTORM.md
+++ b/docs/CAPABILITIES_BRAINSTORM.md
@@ -12,158 +12,170 @@ multi-week arc.
 
 ---
 
-## Where we are today
+## North star: a zero-install, client-side creator tool
 
-- **Engine-agnostic core** (`src/engines/types.ts`) with three engines registered — but
-  only **p5 is mature** (267 sketches). GSAP (2 real sketches) and Three.js (1) are
-  skeletal despite sharing the full recording + form contract.
-- **Two recording pipelines**: client (webm/gif/mp4 + optional audio, via
-  `mediabunny`/`gif.js`) and server (Playwright → ffmpeg, **mp4 only**).
+The direction is **not** a hosted render farm. Front-end recording already works very
+well — mp4, webm + audio, and it records on a phone — to the point where backend
+recording is barely needed day-to-day. The ambition is for **followers/users to use the
+front-end recording directly**: tap a link, tweak a visual, record, post — with **no
+Docker / Redis / Postgres / install**. The heavy backend (BullMQ + Playwright + S3) stays
+as the *owner's* private power tool; the **product is the client-side loop**.
+
+Everything below is filtered through that lens. Server-side "render-as-a-service" is
+explicitly deprioritized (see the end).
+
+### Where we are today
+- **Front-end recording is the mature, mobile-capable path** — `RealtimeRecorder` +
+  `AsyncLoopRecorder` producing webm/gif/mp4 (+ optional audio) via `mediabunny`/`gif.js`,
+  all client-side. This already runs on a phone.
+- **Rich interaction bindings** (12 vector sources + audio/gesture scalars: webcam, hands,
+  face, body, mic, orbit, noise, gyroscope, MIDI, joypad) — but they live under
+  `src/templates/p5/utils/`, so they're **p5-only** today.
 - **A typed, discriminated-union form system** — every sketch declares `formValues` +
-  `formConfiguration`. This is effectively a per-sketch JSON schema, and it's the single
-  most under-exploited asset in the repo (see AI, below).
-- **Rich interaction bindings** (12 vector sources + audio/gesture scalars) — but they
-  live under `src/templates/p5/utils/`, so they're **p5-only**.
-- **Single-tenant persistence**: `Template → TemplateSnapshot → Job`. **No user, auth,
-  sharing, or collaboration** models exist.
-
-The three biggest bets below each turn one of those facts into a product surface.
+  `formConfiguration` (effectively a per-sketch JSON schema). Under-exploited.
+- **Single-tenant persistence** (`Template → TemplateSnapshot → Job`) and a PWA baseline
+  already exist — but the core create→record→export loop does **not fundamentally need
+  the database** to run.
 
 ---
 
 ## 🎯 The three biggest bets
 
-### 1. An AI/LLM layer over the form schema
-There is **zero AI in the codebase today**, yet every sketch already publishes a typed
-parameter schema (`formConfiguration`) and we already capture frames as base64 PNG
-(`captureFrame`). That's the exact shape a modern LLM tool-use / structured-output loop
-wants. Concrete surfaces:
+### 1. The viral loop: URL-encoded share + remix links
+This is *the* feature for a creator audience, and it needs **no backend**. Encode a
+sketch + its options into a shareable URL (already sketched in TODO: *sharable sketch
+link with baked-in options* / *readonly mode*).
 
-- **Natural language → parameters.** "Make it darker, slower, three slides about summer
-  sale" → an LLM emits a validated patch against the sketch's `formValues`. The
-  `formConfiguration` *is* the tool schema; the Zod validators are the guardrail.
-- **Describe-the-vibe → pick a template.** With 267 sketches + `metadata.json`, an LLM
-  can select the right sketch *and* seed its options from a one-line brief.
-- **Vision-in-the-loop refinement.** Render a frame → send the PNG to a vision model →
-  "increase contrast, recenter the title" → apply another param patch → re-render. A
-  closed critique loop, built entirely on `captureFrame` + `updateOptions`.
-- **AI copy + palettes.** Auto-generate title/caption text per platform, and derive
-  palettes from an uploaded image (`sharp` + `exifreader` are already installed).
+- `/t/p5/<sketch>?o=<encoded-options>` opens **exactly** what you made — on a phone, with
+  no account and no server call. Options live in the URL (and/or `localStorage`).
+- Follower opens → tweaks → records → downloads → posts *their* version. Put the link in
+  the TikTok bio / video description and the loop closes.
+- Every export offers a **"remix this"** link back to the template, so viewers become
+  makers. This is what turns "cool videos on your feed" into "your followers making
+  videos with your tool."
+- Keep assets client-side for the zero-install path (object URLs / IndexedDB), so an
+  uploaded image never needs S3.
 
-*Why it fits:* the typed schema means the model outputs *validated data*, not free text —
-low hallucination surface, deterministic apply. **Effort: M** for NL→params (one endpoint
-+ a chat panel), **L** for the vision loop. Highest wow-per-effort in the repo.
+*Why it fits:* it's a serializer + a public viewer route over state we already hold in the
+client. **Effort: M.** Highest strategic value for the stated goal.
 
-### 2. Render-as-a-service: data → video at scale
-The `Snapshot → Job → BullMQ → S3` chain is already a headless render farm with a UI
-bolted on. Expose it as an API and it becomes an automation product (TODO already points
-here: *N8n integration*, *API cleanup + OpenAPI*, *batch recordings*).
+### 2. Ship it as a zero-install, mobile-native experience
+Make "no install" literally true and make the phone experience feel native.
 
-- **Public REST + OpenAPI + API keys** on `POST /api/recordings/enqueue`. (TODO)
-- **Batch / matrix export.** One template + a CSV/JSON/Sheet of rows → N personalized
-  videos ("500 name-tagged clips", "one card per product"). This is the killer B2B use of
-  a parametric renderer.
-- **Data-bound fields.** Bind a form field to a live source (Sheet, API, RSS) so content
-  auto-populates — "today's stats/weather/standings" visuals.
-- **Scheduled / recurring renders** (cron) → the missing "content engine" piece; pairs
-  naturally with the webhook/N8n work.
+- **Deploy the client to the edge (e.g. Vercel).** The create→tweak→record→export path is
+  all client-side, so it can be a public URL with the heavy backend staying local/optional.
+  Feature-detect the backend: if absent, hide the recordings dashboard + backend-record
+  button, keep everything else.
+- **Lean into the PWA** (`PWA_*` docs already exist). "Add to Home Screen" → app-like on a
+  phone with zero App Store friction. This *is* the distribution story.
+- **Mobile-first editing, not just recording.** Recording works on phone; *tweaking a form
+  of number fields with a thumb* does not. Wins: on-canvas drag/pinch instead of typing
+  (TODO: *drag items*, *resize/snap*), a curated **"quick controls"** set per template
+  (3–5 params, not 30), bottom-sheet UI, big touch targets.
+- **Vertical-first.** Default to **9:16** and a one-tap "export for TikTok".
 
-*Why it fits:* no new rendering code — it's an API + fan-out over the existing job model.
-**Effort: M** for the API + keys, **M–L** for batch/data-binding.
+*Why it fits:* mostly UX + deployment work over an already-client-side loop. **Effort:
+M–L**, incremental.
 
-### 3. Social-native output presets
-We're a *social* templates tool that currently exports a single mp4 at one size. The
-highest-value, most contained win:
+### 3. Interaction bindings as the content hook
+The webcam/hand/face/audio-reactive bindings are secretly the best TikTok asset in the
+repo: "point your camera / wave your hand / it reacts to the music" is *inherently*
+shareable, it's client-side, and `RealtimeRecorder` already records the live performance.
 
-- **Multi-aspect auto-reframe.** One options set → 1:1, 9:16, 16:9, 4:5 in one job (TODO:
-  *different output sizes / aspect ratios*). Requires a "safe-area" concept in sketches.
-- **Transparent / alpha output.** WebM VP9-alpha, ProRes 4444, or PNG sequence — so a
-  sketch can be an *overlay* in CapCut/Premiere/After Effects. Big unlock for motion
-  designers; the server path is mp4-only today.
-- **Format & quality expansion on the server:** GIF/APNG/WebP, HEVC, configurable
-  CRF/bitrate, audio loudness normalization.
+- Elevate reactive templates as the **flagship demos** — record a hand- or audio-driven
+  sketch on a phone and post it.
+- **Audio-reactive to trending sounds** — a natural fit for the platform.
+- Longer arc: **lift the bindings out of `p5/utils` into the engine-agnostic layer** so
+  GSAP/Three.js sketches get the same reactivity (see §4).
 
-*Why it fits:* the capture layer is format-agnostic already (client does 3 formats); this
-is mostly encoder plumbing + a reframe abstraction. **Effort: S–M** per format.
+*Why it fits:* the capability already exists and already records; this is
+productization + curation, not new infra. **Effort: S** to feature them, **M** to lift
+them cross-engine.
+
+> ⚠️ **The assumption all three rest on: cross-device support.** "Works on everyone's
+> phone" lives or dies on **iOS Safari** — MediaRecorder/WebCodecs (mp4/webm) and
+> MediaPipe hand/face tracking are both historically finicky there. It works on *our*
+> phone; validate it works on *followers'* phones **before** building the share loop on
+> top of it. This is the load-bearing test.
 
 ---
 
 ## The full menu, by theme
 
-### 4. Make the engine abstraction actually pay off
-We built a clean `SketchEngine` interface and then only populated p5. Options:
+### 4. Make the engine abstraction pay off (client-side)
+We built a clean `SketchEngine` interface and only populated p5 (267 sketches vs. GSAP's
+2, Three.js's 1). All of this is client-side and serves the zero-install goal.
 
-- **Lift interaction bindings into the engine-agnostic layer.** Today webcam/audio/gesture
-  modulation is trapped in `src/templates/p5/utils/`. Moved up, GSAP and Three.js sketches
-  get reactive params for free. **Effort: M.**
-- **Flesh out Three.js** (3D kinetic type, particle fields, GLSL scenes) and **GSAP/DOM**
-  (kinetic typography, HTML/CSS social cards). The contract already supports recording +
-  forms. **Effort: L, incremental.**
-- **A first-class shader sketch type.** A GLSL-fragment template where `uniform`
-  declarations auto-map to form fields (Shadertoy-style, but parameterized + recordable).
-  Very high visual ceiling for low code. **Effort: M.**
-- **Lottie and pure-HTML engines** (both in TODO) — cheap, crisp, text-heavy templates
-  that don't need a canvas.
+- **Lift interaction bindings into the engine-agnostic layer.** Today reactivity is
+  trapped in `src/templates/p5/utils/`. Moved up, GSAP + Three.js sketches get
+  webcam/audio/gesture modulation for free. **Effort: M.**
+- **A first-class GLSL-shader sketch type** where `uniform` declarations auto-map to form
+  fields (Shadertoy-style, but parameterized + recordable). Huge visual ceiling, low code,
+  great on GPU-capable phones. **Effort: M.**
+- **Grow Three.js / GSAP / Lottie / HTML templates** (all in TODO) — the recording + form
+  contract already supports them. **Effort: L, incremental.**
 
-### 5. Distribution: sharing, embedding, accounts
-The whole app is single-tenant with no way to share out. This is the platform gap.
+### 5. AI, but client-friendly
+Still the "wow" feature — and it does **not** need the render farm.
 
-- **Read-only shareable links** with baked-in options + a public viewer (TODO:
-  *sharable sketch link* / *readonly mode*). Smallest step, biggest reach. **Effort: M.**
-- **Embeddable iframe / oEmbed** — drop a *live, parametric* sketch onto any page or
-  Notion/blog. Differentiates from "export a file" tools. **Effort: M.**
-- **User accounts + per-user scoping** (TODO: *multi-user support*) — the prerequisite for
-  everything below and for a hosted offering. **Effort: L.**
-- **Template gallery / marketplace** — publish sketches + presets, remix others'. Turns a
-  personal library into a community. **Effort: L.**
-- **Real-time co-editing of a template's options** (multiplayer params). Ambitious, but
-  the options object is small and diff-friendly. **Effort: L.**
+- **Natural language → validated param patch.** "Darker, slower, 3 slides about X" → a
+  patch against the sketch's `formValues`. The `formConfiguration` *is* the tool schema;
+  the Zod validators are the guardrail, so the model emits *validated data*, not free text.
+  One serverless/edge route (or bring-your-own-key). **Effort: M.**
+- **Describe-the-vibe → pick a template** from the 267 sketches + `metadata.json`.
+- **Vision-in-the-loop** (later): render a frame → vision model critiques → apply another
+  patch → re-render. Built on the existing `captureFrame` + `updateOptions`. **Effort: L.**
 
-### 6. Authoring & editor UX
-Deepen the creative tool for people who live in it.
+### 6. Social-native output (all client-side)
+- **Multi-aspect export** — 9:16 / 1:1 / 4:5 / 16:9 from one options set (TODO: *different
+  output sizes*). Needs a "safe-area" concept in sketches. **Effort: M.**
+- **Format & quality choices** the client codec supports (webm-alpha where available,
+  bitrate/quality), plus GIF for quick loops. **Effort: S.**
+- **One-tap platform presets** (TikTok 9:16, Reels, Shorts) with sensible durations.
 
-- **Timeline / keyframe editor.** Animate *any* param across the loop with a curve editor.
-  We already have `easing` fields and slide-to-slide morphing — this generalizes it into
-  real keyframing. **Effort: L.** High impact for power users.
-- **On-canvas direct manipulation** — drag/resize/rotate/snap items instead of typing
-  numbers (TODO: *drag items*, *resize/snap guides*, *crop/rotate*). **Effort: M–L.**
-- **Preset & variation browser.** Save named presets per template; "randomize seed";
-  render a **contact sheet** of N variations as thumbnails to pick from. Pairs beautifully
-  with the batch renderer and with AI. **Effort: S–M.**
-- **Brand kits.** Reusable palette + logo + font sets applied across any template
-  (missing entirely today). The feature agencies/creators ask for first. **Effort: M.**
-- **Embedded Monaco editor** (TODO) — live-edit sketch code with hot reload; a natural
-  home for AI-assisted sketch scaffolding.
+### 7. Authoring & editor UX
+- **Preset & variation browser** — save named presets per template; "randomize seed";
+  a **contact sheet** of N variations to pick from. Pairs with AI + the share loop, and
+  gives followers instant novelty. **Effort: S–M.**
+- **Brand kits** — reusable palette + logo + font sets applied across templates (missing
+  entirely today). **Effort: M.**
+- **Timeline / keyframe editor** — animate *any* param across the loop with a curve editor;
+  generalizes the existing easing fields + slide-morphing into real keyframing. **Effort:
+  L.** Power-user depth.
 
-### 7. Audio & reactivity (beyond live)
-Live audio bindings exist; the offline/deterministic side is open.
+### 8. Audio & reactivity (beyond live)
+- **Upload-a-track → auto music video.** Offline beat/onset/spectral analysis drives params
+  deterministically, then records a synced visualizer — the deterministic half of the
+  audio-reactive story that's currently realtime-only. **Effort: M.**
 
-- **Upload-a-track → auto music video.** Offline beat/onset/spectral analysis drives
-  params deterministically, then renders a synced visualizer. Today reactivity is realtime
-  only; deterministic capture of audio-reactive sketches is the missing half. **Effort: M.**
-- **Waveform / spectrogram sketch primitives** + a TTS voiceover track layered into the
-  montage (a text-to-speech MCP is available in this workspace).
+### 9. Distribution & light social layer (optional, later)
+Only if/when the zero-install loop proves out:
 
-### 8. Ops, quality & trust
-Less glamorous, but gates the "hosted product" step (all flagged in `ARCHITECTURE.md` as
-recommended-not-built):
+- **Public gallery** of your templates that followers browse on mobile and open directly.
+- **"Made with" attribution** stamp/link on exports — organic growth.
+- **Accounts + a template gallery/marketplace** (TODO: *multi-user support*) — the platform
+  build-out, deferred until the client loop is winning.
 
-- **Rate limiting + API auth** before any public API ships.
-- **Observability**: queue length, avg render time, success/fail rates (Sentry is in
-  TODO). Renders fail in interesting ways; you'll want the metrics.
-- **Asset dedup by hash** (TODO) + stale-job recovery hardening.
-- **A visual-regression harness** for sketches — deterministic capture means you can
-  snapshot-diff a frame per sketch in CI and catch "I broke 40 templates" before shipping.
+---
+
+## Explicitly deprioritized: render-as-a-service
+
+The `Snapshot → Job → BullMQ → S3` chain is a capable headless render farm, and it stays —
+as the **owner's** private tool for heavy/batch jobs. But exposing it as a public API,
+data-driven batch export, and scheduled renders is **not** the direction: it pulls toward
+infrastructure and installation, which is the opposite of the zero-install creator goal.
+Keep it maintained; don't invest in productizing it right now.
 
 ---
 
 ## If I had to sequence it
 
-1. **NL → params (AI)** — fastest path to a "wow", leverages the schema we already have.
-2. **Multi-aspect + alpha output** — contained, directly serves the social mission.
-3. **Read-only share links + embeds** — unlocks distribution with no auth dependency.
-4. **Render API + batch/data-driven** — turns the tool into a platform.
-5. **Accounts, then marketplace / collab** — the platform build-out.
+1. **Validate cross-device recording** (iOS Safari especially) — this gates everything.
+2. **URL-encoded share/remix links** — the viral loop, no backend.
+3. **Deploy to the edge + PWA polish** — make "no install" literally true.
+4. **Feature the reactive templates + mobile-first quick-controls** — the content hooks.
+5. **NL → params (AI)** — the wow, as one serverless route.
+6. **Multi-aspect / vertical-first export** — on-platform output.
 
-Threaded throughout: **lift interaction bindings to the engine layer** and **grow
-three.js/GSAP/shader templates**, so the abstraction we built starts earning its keep.
+Threaded throughout: **lift interaction bindings to the engine layer** so the reactivity
+that makes great content isn't locked to p5.

--- a/docs/CAPABILITIES_BRAINSTORM.md
+++ b/docs/CAPABILITIES_BRAINSTORM.md
@@ -1,0 +1,169 @@
+# Capabilities Brainstorm
+
+A forward-looking menu of *capability bets* for `p5-templates` — where the product
+could grow next, grounded in what the codebase already is.
+
+**How this relates to `TODO.md`:** `TODO.md` is the granular, task-level backlog
+(source of truth for "what's queued"). This doc sits one level up — it groups the
+opportunities into themes, calls out the highest-leverage bets, and explains *why each
+one fits the architecture we already paid for*. Where an idea overlaps an existing TODO
+item, it's noted. Effort tags are rough: **S** = days, **M** = a week or two, **L** = a
+multi-week arc.
+
+---
+
+## Where we are today
+
+- **Engine-agnostic core** (`src/engines/types.ts`) with three engines registered — but
+  only **p5 is mature** (267 sketches). GSAP (2 real sketches) and Three.js (1) are
+  skeletal despite sharing the full recording + form contract.
+- **Two recording pipelines**: client (webm/gif/mp4 + optional audio, via
+  `mediabunny`/`gif.js`) and server (Playwright → ffmpeg, **mp4 only**).
+- **A typed, discriminated-union form system** — every sketch declares `formValues` +
+  `formConfiguration`. This is effectively a per-sketch JSON schema, and it's the single
+  most under-exploited asset in the repo (see AI, below).
+- **Rich interaction bindings** (12 vector sources + audio/gesture scalars) — but they
+  live under `src/templates/p5/utils/`, so they're **p5-only**.
+- **Single-tenant persistence**: `Template → TemplateSnapshot → Job`. **No user, auth,
+  sharing, or collaboration** models exist.
+
+The three biggest bets below each turn one of those facts into a product surface.
+
+---
+
+## 🎯 The three biggest bets
+
+### 1. An AI/LLM layer over the form schema
+There is **zero AI in the codebase today**, yet every sketch already publishes a typed
+parameter schema (`formConfiguration`) and we already capture frames as base64 PNG
+(`captureFrame`). That's the exact shape a modern LLM tool-use / structured-output loop
+wants. Concrete surfaces:
+
+- **Natural language → parameters.** "Make it darker, slower, three slides about summer
+  sale" → an LLM emits a validated patch against the sketch's `formValues`. The
+  `formConfiguration` *is* the tool schema; the Zod validators are the guardrail.
+- **Describe-the-vibe → pick a template.** With 267 sketches + `metadata.json`, an LLM
+  can select the right sketch *and* seed its options from a one-line brief.
+- **Vision-in-the-loop refinement.** Render a frame → send the PNG to a vision model →
+  "increase contrast, recenter the title" → apply another param patch → re-render. A
+  closed critique loop, built entirely on `captureFrame` + `updateOptions`.
+- **AI copy + palettes.** Auto-generate title/caption text per platform, and derive
+  palettes from an uploaded image (`sharp` + `exifreader` are already installed).
+
+*Why it fits:* the typed schema means the model outputs *validated data*, not free text —
+low hallucination surface, deterministic apply. **Effort: M** for NL→params (one endpoint
++ a chat panel), **L** for the vision loop. Highest wow-per-effort in the repo.
+
+### 2. Render-as-a-service: data → video at scale
+The `Snapshot → Job → BullMQ → S3` chain is already a headless render farm with a UI
+bolted on. Expose it as an API and it becomes an automation product (TODO already points
+here: *N8n integration*, *API cleanup + OpenAPI*, *batch recordings*).
+
+- **Public REST + OpenAPI + API keys** on `POST /api/recordings/enqueue`. (TODO)
+- **Batch / matrix export.** One template + a CSV/JSON/Sheet of rows → N personalized
+  videos ("500 name-tagged clips", "one card per product"). This is the killer B2B use of
+  a parametric renderer.
+- **Data-bound fields.** Bind a form field to a live source (Sheet, API, RSS) so content
+  auto-populates — "today's stats/weather/standings" visuals.
+- **Scheduled / recurring renders** (cron) → the missing "content engine" piece; pairs
+  naturally with the webhook/N8n work.
+
+*Why it fits:* no new rendering code — it's an API + fan-out over the existing job model.
+**Effort: M** for the API + keys, **M–L** for batch/data-binding.
+
+### 3. Social-native output presets
+We're a *social* templates tool that currently exports a single mp4 at one size. The
+highest-value, most contained win:
+
+- **Multi-aspect auto-reframe.** One options set → 1:1, 9:16, 16:9, 4:5 in one job (TODO:
+  *different output sizes / aspect ratios*). Requires a "safe-area" concept in sketches.
+- **Transparent / alpha output.** WebM VP9-alpha, ProRes 4444, or PNG sequence — so a
+  sketch can be an *overlay* in CapCut/Premiere/After Effects. Big unlock for motion
+  designers; the server path is mp4-only today.
+- **Format & quality expansion on the server:** GIF/APNG/WebP, HEVC, configurable
+  CRF/bitrate, audio loudness normalization.
+
+*Why it fits:* the capture layer is format-agnostic already (client does 3 formats); this
+is mostly encoder plumbing + a reframe abstraction. **Effort: S–M** per format.
+
+---
+
+## The full menu, by theme
+
+### 4. Make the engine abstraction actually pay off
+We built a clean `SketchEngine` interface and then only populated p5. Options:
+
+- **Lift interaction bindings into the engine-agnostic layer.** Today webcam/audio/gesture
+  modulation is trapped in `src/templates/p5/utils/`. Moved up, GSAP and Three.js sketches
+  get reactive params for free. **Effort: M.**
+- **Flesh out Three.js** (3D kinetic type, particle fields, GLSL scenes) and **GSAP/DOM**
+  (kinetic typography, HTML/CSS social cards). The contract already supports recording +
+  forms. **Effort: L, incremental.**
+- **A first-class shader sketch type.** A GLSL-fragment template where `uniform`
+  declarations auto-map to form fields (Shadertoy-style, but parameterized + recordable).
+  Very high visual ceiling for low code. **Effort: M.**
+- **Lottie and pure-HTML engines** (both in TODO) — cheap, crisp, text-heavy templates
+  that don't need a canvas.
+
+### 5. Distribution: sharing, embedding, accounts
+The whole app is single-tenant with no way to share out. This is the platform gap.
+
+- **Read-only shareable links** with baked-in options + a public viewer (TODO:
+  *sharable sketch link* / *readonly mode*). Smallest step, biggest reach. **Effort: M.**
+- **Embeddable iframe / oEmbed** — drop a *live, parametric* sketch onto any page or
+  Notion/blog. Differentiates from "export a file" tools. **Effort: M.**
+- **User accounts + per-user scoping** (TODO: *multi-user support*) — the prerequisite for
+  everything below and for a hosted offering. **Effort: L.**
+- **Template gallery / marketplace** — publish sketches + presets, remix others'. Turns a
+  personal library into a community. **Effort: L.**
+- **Real-time co-editing of a template's options** (multiplayer params). Ambitious, but
+  the options object is small and diff-friendly. **Effort: L.**
+
+### 6. Authoring & editor UX
+Deepen the creative tool for people who live in it.
+
+- **Timeline / keyframe editor.** Animate *any* param across the loop with a curve editor.
+  We already have `easing` fields and slide-to-slide morphing — this generalizes it into
+  real keyframing. **Effort: L.** High impact for power users.
+- **On-canvas direct manipulation** — drag/resize/rotate/snap items instead of typing
+  numbers (TODO: *drag items*, *resize/snap guides*, *crop/rotate*). **Effort: M–L.**
+- **Preset & variation browser.** Save named presets per template; "randomize seed";
+  render a **contact sheet** of N variations as thumbnails to pick from. Pairs beautifully
+  with the batch renderer and with AI. **Effort: S–M.**
+- **Brand kits.** Reusable palette + logo + font sets applied across any template
+  (missing entirely today). The feature agencies/creators ask for first. **Effort: M.**
+- **Embedded Monaco editor** (TODO) — live-edit sketch code with hot reload; a natural
+  home for AI-assisted sketch scaffolding.
+
+### 7. Audio & reactivity (beyond live)
+Live audio bindings exist; the offline/deterministic side is open.
+
+- **Upload-a-track → auto music video.** Offline beat/onset/spectral analysis drives
+  params deterministically, then renders a synced visualizer. Today reactivity is realtime
+  only; deterministic capture of audio-reactive sketches is the missing half. **Effort: M.**
+- **Waveform / spectrogram sketch primitives** + a TTS voiceover track layered into the
+  montage (a text-to-speech MCP is available in this workspace).
+
+### 8. Ops, quality & trust
+Less glamorous, but gates the "hosted product" step (all flagged in `ARCHITECTURE.md` as
+recommended-not-built):
+
+- **Rate limiting + API auth** before any public API ships.
+- **Observability**: queue length, avg render time, success/fail rates (Sentry is in
+  TODO). Renders fail in interesting ways; you'll want the metrics.
+- **Asset dedup by hash** (TODO) + stale-job recovery hardening.
+- **A visual-regression harness** for sketches — deterministic capture means you can
+  snapshot-diff a frame per sketch in CI and catch "I broke 40 templates" before shipping.
+
+---
+
+## If I had to sequence it
+
+1. **NL → params (AI)** — fastest path to a "wow", leverages the schema we already have.
+2. **Multi-aspect + alpha output** — contained, directly serves the social mission.
+3. **Read-only share links + embeds** — unlocks distribution with no auth dependency.
+4. **Render API + batch/data-driven** — turns the tool into a platform.
+5. **Accounts, then marketplace / collab** — the platform build-out.
+
+Threaded throughout: **lift interaction bindings to the engine layer** and **grow
+three.js/GSAP/shader templates**, so the abstraction we built starts earning its keep.


### PR DESCRIPTION
## What

Adds `docs/CAPABILITIES_BRAINSTORM.md` — a forward-looking, theme-grouped menu of *capability bets*, in response to a "what else can we do?" brainstorm. It complements the granular `TODO.md` with higher-level opportunities, each grounded in the current architecture.

## North star

Centered on a **zero-install, client-side creator tool**: followers tap a link on their phone, tweak a visual, record, and post — no Docker/Redis/Postgres. Front-end recording (mp4/webm + audio, mobile-capable) is the product; the heavy backend stays as the owner's private tool. Server-side render-as-a-service is **explicitly deprioritized**.

## Three biggest bets

1. **The viral loop — URL-encoded share + remix links.** `/t/p5/<sketch>?o=<encoded-options>` opens exactly what you made, no account/DB/server call. Follower tweaks → records → posts their version; every export offers a "remix this" link back. (Overlaps TODO: *sharable sketch link*.)
2. **Ship it zero-install + mobile-native.** Deploy the client to the edge, lean into the existing PWA ("Add to Home Screen"), and make *editing* thumb-friendly (on-canvas drag/pinch, curated quick-controls, 9:16 vertical-first).
3. **Interaction bindings as the content hook.** Webcam/hand/face/audio-reactive sketches are inherently viral, client-side, and already recorded by `RealtimeRecorder` — feature them as flagship demos; lift them out of `p5/utils` so GSAP/Three.js get reactivity too.

⚠️ Load-bearing assumption called out in the doc: **cross-device support (iOS Safari especially)** for MediaRecorder/WebCodecs + MediaPipe tracking — validate before building the share loop on top of it.

**Also covered:** client-friendly AI (NL → validated param patch via one serverless route, leaning on the typed `formConfiguration`), a GLSL-shader sketch type, multi-aspect/vertical export, preset/variation browser, brand kits, keyframe editor, offline audio-reactive rendering, and an optional later social layer (gallery/accounts). Ends with a suggested sequencing.

## Notes

- Docs-only change (no code; markdown path is CI-ignored).
- Opened as a **draft** — a brainstorm to react to, not a plan to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)