### PR TITLE
Add 25 and 50 fps options

### DIFF
--- a/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
+++ b/src/components/ClientProcessingSketch/components/TemplateOptions/components/RootSettings/constants/root-field-config.ts
@@ -130,8 +130,10 @@ export const framerateOptions = [
   5,
   10,
   24,
+  25,
   30,
   48,
+  50,
   60,
   120,
   240


### PR DESCRIPTION
## Summary
Added 25 and 50 fps options to the framerate selector dropdown to support additional video standards and use cases.

## Changes
- Expanded framerate options from 9 to 11 choices: 1, 5, 10, 24, **25**, 30, 48, **50**, 60, 120, 240
- 25 fps is commonly used in PAL video standards
- 50 fps is useful for high-frame-rate PAL content

## Test plan
- [ ] Verify framerate dropdown displays all 11 options in correct order
- [ ] Verify selecting 25 fps works correctly in recordings
- [ ] Verify selecting 50 fps works correctly in recordings
- [ ] Verify linting and tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKrrJb9HiNusvhhD15NVWc)_