### PR TITLE
Add undo/redo to the template editor page

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/SketchOptions.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/SketchOptions.tsx
@@ -24,6 +24,9 @@ import type {
 } from "./components/CaptureActions";
 import useBrowserRecordingSupported from "./components/CaptureActions/hooks/useBrowserRecordingSupported";
 import OptionsPanel from "./components/OptionsPanel";
+import {
+  FormUndoRedo
+} from "./components/FormUndoRedo";
 import RecordingLockBanner from "./components/RecordingLockBanner";
 import ImportSuccessBanner from "./components/ImportSuccessBanner";
 import SketchSettings from "./components/SketchSettings/SketchSettings";
@@ -511,108 +514,115 @@ export default function SketchOptions( {
 
   return (
     <FormProvider { ...methods }>
-      <CollapsibleProvider>
-        <ContentSelectionProvider>
-          <ContentSelectionListener
-            setSection={ setSection }
-            onSelectSlide={ handleSlideSelect }
-            activeSlideIndex={ activeSlideIndex }
-          />
-          {isDesktop ? (
-            <>
-              <div
-                className={ clsx(
-                  "absolute",
-                  // Docked: a flat, full-height rail flush to the right edge —
-                  // one glass surface framing the viewport, the panels inside
-                  // rendered flat and the rail scrolling as one. Floating: a
-                  // card anchored in the bottom-right corner.
-                  dockedDesktop
-                    ? "right-0 top-12 bottom-0 z-40 flex w-72 flex-col gap-1 p-2 glass border-l border-theme overflow-y-auto"
-                    : "right-4 bottom-4 w-64 space-y-2"
-                ) }
-                style={ dockedDesktop ? undefined : {
-                  maxWidth: "calc(50% - 0.75rem)"
-                } }
-              >
-                {lifecycle.isLocked && (
-                  <RecordingLockBanner
-                    state={ lifecycle.state }
-                    onClone={ handleBannerClone }
-                    cloning={ bannerCloning }
-                  />
-                )}
-
-                {importBanner && (
-                  <ImportSuccessBanner
-                    message={ importBanner }
-                    onDismiss={ () => setImportBanner( null ) }
-                  />
-                )}
-
-                <OptionsPanel
-                  methods={ methods }
-                  name={ name }
-                  persistedJob={ persistedJob }
-                  jobStatus={ lifecycle.currentStatus }
-                  onImportOptions={ handleImportOptions }
-                  docked={ dockedDesktop }
-                  { ...bodyProps }
-                />
-
-                {recordingSupported && (
-                  <CaptureActions
-                    forwardedRef={ captureActionsRef }
-                    activeSlideIndex={ activeSlideIndex }
-                    docked={ dockedDesktop }
-                    { ...captureProps }
-                  />
-                )}
-              </div>
-
-              <SketchAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
-                <SketchSettings
-                  activeSlideIndex={ activeSlideIndex }
-                  activeSlideId={ activeSlideId }
-                  expanded={ collapsibleStates.sketchSettings }
-                  onToggle={ ( expanded ) => setSection(
-                    "sketchSettings",
-                    expanded
-                  ) }
-                  docked={ dockedDesktop }
-                />
-              </SketchAssetsProvider>
-            </>
-          ) : (
-            <MobileStudioDrawer
-              expanded={ collapsibleStates.sketchSettings }
-              onToggle={ ( expanded ) => setSection(
-                "sketchSettings",
-                expanded
-              ) }
+      {/* Undo/redo history over the whole options form. Auto-captures a
+          snapshot 400ms after the user stops editing (form fields as well as
+          sketch-driven changes like canvas drags, which sync into the form),
+          and wires Cmd/Ctrl+Z / Shift+Z hotkeys. Undo/redo replay through
+          reset(), which propagates to the sketch like an options import. */}
+      <FormUndoRedo autoCapture="debounced">
+        <CollapsibleProvider>
+          <ContentSelectionProvider>
+            <ContentSelectionListener
+              setSection={ setSection }
+              onSelectSlide={ handleSlideSelect }
               activeSlideIndex={ activeSlideIndex }
-              activeSlideId={ activeSlideId }
-              jobId={ jobId }
-              body={ bodyProps }
-              capture={ captureProps }
-              captureActionsRef={ captureActionsRef }
-              recordingSupported={ recordingSupported }
-              jobStatus={ lifecycle.currentStatus }
-              onImportOptions={ handleImportOptions }
-              bannerCloning={ bannerCloning }
-              onBannerClone={ handleBannerClone }
-              importBanner={ importBanner }
-              onImportBannerDismiss={ () => setImportBanner( null ) }
             />
-          )}
+            {isDesktop ? (
+              <>
+                <div
+                  className={ clsx(
+                    "absolute",
+                    // Docked: a flat, full-height rail flush to the right edge —
+                    // one glass surface framing the viewport, the panels inside
+                    // rendered flat and the rail scrolling as one. Floating: a
+                    // card anchored in the bottom-right corner.
+                    dockedDesktop
+                      ? "right-0 top-12 bottom-0 z-40 flex w-72 flex-col gap-1 p-2 glass border-l border-theme overflow-y-auto"
+                      : "right-4 bottom-4 w-64 space-y-2"
+                  ) }
+                  style={ dockedDesktop ? undefined : {
+                    maxWidth: "calc(50% - 0.75rem)"
+                  } }
+                >
+                  {lifecycle.isLocked && (
+                    <RecordingLockBanner
+                      state={ lifecycle.state }
+                      onClone={ handleBannerClone }
+                      cloning={ bannerCloning }
+                    />
+                  )}
 
-          {/* The central Interactive mixer — one overview of every binding, with
+                  {importBanner && (
+                    <ImportSuccessBanner
+                      message={ importBanner }
+                      onDismiss={ () => setImportBanner( null ) }
+                    />
+                  )}
+
+                  <OptionsPanel
+                    methods={ methods }
+                    name={ name }
+                    persistedJob={ persistedJob }
+                    jobStatus={ lifecycle.currentStatus }
+                    onImportOptions={ handleImportOptions }
+                    docked={ dockedDesktop }
+                    { ...bodyProps }
+                  />
+
+                  {recordingSupported && (
+                    <CaptureActions
+                      forwardedRef={ captureActionsRef }
+                      activeSlideIndex={ activeSlideIndex }
+                      docked={ dockedDesktop }
+                      { ...captureProps }
+                    />
+                  )}
+                </div>
+
+                <SketchAssetsProvider scope="global" assetsName="assets" jobId={ jobId }>
+                  <SketchSettings
+                    activeSlideIndex={ activeSlideIndex }
+                    activeSlideId={ activeSlideId }
+                    expanded={ collapsibleStates.sketchSettings }
+                    onToggle={ ( expanded ) => setSection(
+                      "sketchSettings",
+                      expanded
+                    ) }
+                    docked={ dockedDesktop }
+                  />
+                </SketchAssetsProvider>
+              </>
+            ) : (
+              <MobileStudioDrawer
+                expanded={ collapsibleStates.sketchSettings }
+                onToggle={ ( expanded ) => setSection(
+                  "sketchSettings",
+                  expanded
+                ) }
+                activeSlideIndex={ activeSlideIndex }
+                activeSlideId={ activeSlideId }
+                jobId={ jobId }
+                body={ bodyProps }
+                capture={ captureProps }
+                captureActionsRef={ captureActionsRef }
+                recordingSupported={ recordingSupported }
+                jobStatus={ lifecycle.currentStatus }
+                onImportOptions={ handleImportOptions }
+                bannerCloning={ bannerCloning }
+                onBannerClone={ handleBannerClone }
+                importBanner={ importBanner }
+                onImportBannerDismiss={ () => setImportBanner( null ) }
+              />
+            )}
+
+            {/* The central Interactive mixer — one overview of every binding, with
               per-layer solo / mute / weight. Floats bottom-center (desktop only,
               where it doesn't collide with the mobile drawer); hidden unless the
               plugin is on and the scope has bindings. */}
-          {isDesktop && <InteractivePanel basePath={ sketchBasePath } />}
-        </ContentSelectionProvider>
-      </CollapsibleProvider>
+            {isDesktop && <InteractivePanel basePath={ sketchBasePath } />}
+          </ContentSelectionProvider>
+        </CollapsibleProvider>
+      </FormUndoRedo>
     </FormProvider>
   );
 }

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/EXAMPLES.md
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/EXAMPLES.md
@@ -21,7 +21,6 @@ function BasicForm() {
         maxHistory={50}
         hotkeys
         autoCapture="debounced"
-        captureInitial
       >
         <UndoRedo />
       </FormUndoRedo>
@@ -371,7 +370,6 @@ function SketchOptions() {
           "slides",
           "animation"
         ]}
-        captureInitial
         usePatches={true}
         debug={process.env.NODE_ENV === "development"}
       >

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/FormUndoRedo.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/FormUndoRedo.tsx
@@ -4,9 +4,6 @@ import React from "react";
 import {
   useFormContext, FieldValues
 } from "react-hook-form";
-import {
-  nanoid
-} from "nanoid";
 
 import FormUndoRedoContext from "./contexts/FormUndoRedoContext";
 import {
@@ -33,10 +30,20 @@ export type FormUndoRedoProps<T extends FieldValues = FieldValues> =
     children?: React.ReactNode;
   };
 
+// Batch ids only need to be unique within a session; a counter plus a random
+// suffix avoids pulling in an id library for this.
+let batchIdCounter = 0;
+
+const createBatchId = () =>
+  `batch-${ ++batchIdCounter }-${ Math.random().toString( 36 )
+    .slice(
+      2,
+      8
+    ) }`;
+
 export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
   maxHistory = 50,
   hotkeys = true,
-  captureInitial = false,
   autoCapture = "off",
   debounceMs = 400,
   watchPaths,
@@ -83,9 +90,14 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
     totalOperations: 0
   } );
 
+  const [
+    debugEnabled,
+    setDebugEnabled
+  ] = React.useState( debug );
+
   const debugLog = React.useCallback(
     ( ...args: any[] ) => {
-      if ( debug ) {
+      if ( debugEnabled ) {
         console.log(
           "[FormUndoRedo]",
           ...args
@@ -93,7 +105,7 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
       }
     },
     [
-      debug
+      debugEnabled
     ]
   );
 
@@ -259,9 +271,18 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
       }
 
       const previous = lastCommittedRef.current;
+
+      if ( !previous ) {
+        // Nothing to undo back to — just adopt the new state as the baseline.
+        setCommitted( current );
+        return;
+      }
+
+      // The past stack holds the state *before* each change, so a single undo
+      // restores it. Patches (previous → current) describe the change itself.
       const entry = createHistoryEntry(
-        current,
-        usePatches ? previous || undefined : undefined,
+        previous,
+        usePatches ? current : undefined,
         description,
         undefined,
         currentBatchIdRef.current || undefined
@@ -435,6 +456,11 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
 
       try {
         const targetEntry = targetStack[ index ];
+        const currentEntry = createHistoryEntry(
+          snapshot(),
+          usePatches ? targetEntry.state : undefined,
+          direction === "past" ? "Redo point" : "Undo point"
+        );
 
         reset(
           targetEntry.state,
@@ -442,11 +468,14 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
         );
         setCommitted( targetEntry.state );
 
-        // Reorganize stacks
+        // Reorganize stacks. Equivalent to repeated undo/redo down to the
+        // target: skipped entries land on the opposite stack in reverse
+        // (pop-from-the-end) order, with the pre-jump state on top-most.
         if ( direction === "past" ) {
           stacks.future = [
-            ...stacks.past.slice( index + 1 ),
-            ...stacks.future
+            ...stacks.future,
+            currentEntry,
+            ...stacks.past.slice( index + 1 ).reverse()
           ];
           stacks.past = stacks.past.slice(
             0,
@@ -455,12 +484,13 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
         } else {
           stacks.past = [
             ...stacks.past,
-            ...stacks.future.slice(
-              0,
-              index
-            )
+            currentEntry,
+            ...stacks.future.slice( index + 1 ).reverse()
           ];
-          stacks.future = stacks.future.slice( index + 1 );
+          stacks.future = stacks.future.slice(
+            0,
+            index
+          );
         }
 
         syncFlags();
@@ -485,8 +515,10 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
     [
       reset,
       resetOptions,
+      snapshot,
       setCommitted,
       syncFlags,
+      usePatches,
       debugLog
     ]
   );
@@ -513,7 +545,7 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
 
   const startBatch = React.useCallback(
     ( description?: string ): string => {
-      const batchId = nanoid( 8 );
+      const batchId = createBatchId();
 
       currentBatchIdRef.current = batchId;
       currentBatchDescriptionRef.current = description || null;
@@ -609,10 +641,6 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
     []
   );
 
-  const [
-    debugEnabled,
-    setDebugEnabled
-  ] = React.useState( debug );
   const enableDebug = React.useCallback(
     ( enabled: boolean ) => {
       setDebugEnabled( enabled );
@@ -625,25 +653,11 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
     () => {
       loadPersistedHistory();
 
-      const initial = snapshot();
-
-      setCommitted( initial );
-
-      if ( captureInitial ) {
-        const entry = createHistoryEntry(
-          initial,
-          undefined,
-          "Initial state"
-        );
-
-        stacksRef.current.past.push( entry );
-        syncFlags();
-      }
+      setCommitted( snapshot() );
 
       debugLog(
         "Initialized",
         {
-          captureInitial,
           autoCapture,
           maxHistory,
           usePatches
@@ -652,13 +666,11 @@ export default function FormUndoRedo<T extends FieldValues = FieldValues>( {
     },
     [
       autoCapture,
-      captureInitial,
       debugLog,
       loadPersistedHistory,
       maxHistory,
       setCommitted,
       snapshot,
-      syncFlags,
       usePatches
     ]
   );

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/README.md
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/README.md
@@ -52,7 +52,6 @@ function MyForm() {
         autoCapture="debounced"
         debounceMs={400}
         watchPaths={["content", "slides"]}
-        captureInitial
       >
         <UndoRedo />
       </FormUndoRedo>
@@ -69,7 +68,6 @@ function MyForm() {
 type FormUndoRedoConfig = {
   maxHistory?: number;              // Max history entries (default: 50)
   hotkeys?: boolean;                // Enable Cmd/Ctrl+Z shortcuts (default: true)
-  captureInitial?: boolean;         // Capture initial state (default: false)
   autoCapture?: "off" | "debounced" | "immediate"; // Auto-capture mode (default: "off")
   debounceMs?: number;              // Debounce delay in ms (default: 400)
   watchPaths?: string[];            // Specific paths to track (default: all)

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/__tests__/FormUndoRedo.test.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/__tests__/FormUndoRedo.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import {
+  act, renderHook
+} from "@testing-library/react";
+import {
+  FormProvider, useForm, useFormContext
+} from "react-hook-form";
+
+import FormUndoRedo from "../FormUndoRedo";
+import useFormUndoRedo from "../hooks/useFormUndoRedo";
+
+/* ------------------------------------------------------------------ */
+/*  Harness                                                             */
+/* ------------------------------------------------------------------ */
+
+// autoCapture="immediate" keeps the tests synchronous (no debounce timers);
+// the debounced mode funnels into the same capture() path.
+function Wrapper( {
+  children
+}: React.PropsWithChildren ) {
+  const methods = useForm( {
+    defaultValues: {
+      title: "initial",
+      nested: {
+        count: 0
+      }
+    }
+  } );
+
+  return (
+    <FormProvider { ...methods }>
+      <FormUndoRedo autoCapture="immediate" hotkeys={ false }>
+        {children}
+      </FormUndoRedo>
+    </FormProvider>
+  );
+}
+
+function renderHarness() {
+  return renderHook(
+    () => ( {
+      history: useFormUndoRedo(),
+      form: useFormContext()
+    } ),
+    {
+      wrapper: Wrapper
+    }
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe(
+  "FormUndoRedo",
+  () => {
+    it(
+      "starts with no history",
+      () => {
+        const {
+          result
+        } = renderHarness();
+
+        expect( result.current.history.canUndo ).toBe( false );
+        expect( result.current.history.canRedo ).toBe( false );
+      }
+    );
+
+    it(
+      "a single undo restores the state before the last change",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "edited"
+          );
+        } );
+
+        expect( result.current.history.canUndo ).toBe( true );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "initial" );
+        expect( result.current.history.canUndo ).toBe( false );
+        expect( result.current.history.canRedo ).toBe( true );
+      }
+    );
+
+    it(
+      "redo restores the undone change",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "edited"
+          );
+        } );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        await act( async() => {
+          result.current.history.redo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "edited" );
+        expect( result.current.history.canUndo ).toBe( true );
+        expect( result.current.history.canRedo ).toBe( false );
+      }
+    );
+
+    it(
+      "walks a multi-step history in both directions",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "one"
+          );
+        } );
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "two"
+          );
+        } );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "one" );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "initial" );
+        expect( result.current.history.canUndo ).toBe( false );
+
+        await act( async() => {
+          result.current.history.redo();
+        } );
+
+        await act( async() => {
+          result.current.history.redo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "two" );
+        expect( result.current.history.canRedo ).toBe( false );
+      }
+    );
+
+    it(
+      "a new change after undo clears the redo stack",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "one"
+          );
+        } );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.history.canRedo ).toBe( true );
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "fresh"
+          );
+        } );
+
+        expect( result.current.history.canRedo ).toBe( false );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "initial" );
+      }
+    );
+
+    it(
+      "tracks nested paths and restores them on undo",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "nested.count",
+            5
+          );
+        } );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        expect( result.current.form.getValues( "nested.count" ) ).toBe( 0 );
+      }
+    );
+
+    it(
+      "runSilently suppresses history capture",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.history.runSilently( () => {
+            result.current.form.setValue(
+              "title",
+              "silent"
+            );
+          } );
+        } );
+
+        expect( result.current.form.getValues( "title" ) ).toBe( "silent" );
+        expect( result.current.history.canUndo ).toBe( false );
+      }
+    );
+
+    it(
+      "clear drops both stacks",
+      async() => {
+        const {
+          result
+        } = renderHarness();
+
+        await act( async() => {
+          result.current.form.setValue(
+            "title",
+            "one"
+          );
+        } );
+
+        await act( async() => {
+          result.current.history.undo();
+        } );
+
+        await act( async() => {
+          result.current.history.clear();
+        } );
+
+        expect( result.current.history.canUndo ).toBe( false );
+        expect( result.current.history.canRedo ).toBe( false );
+      }
+    );
+  }
+);

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/types/FormUndoRedo.types.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/types/FormUndoRedo.types.ts
@@ -71,7 +71,6 @@ export type FormUndoRedoContextType<T = any> = {
 export type FormUndoRedoConfig = {
   maxHistory?: number;
   hotkeys?: boolean;
-  captureInitial?: boolean;
   autoCapture?: FormUndoRedoAutoCaptureMode;
   debounceMs?: number;
   watchPaths?: string[];

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/MobileStudioDrawer.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/MobileStudioDrawer.tsx
@@ -16,6 +16,7 @@ import SketchAssetsProvider from "./SketchAssetsProvider/SketchAssetsProvider";
 import RecordingLockBanner from "./RecordingLockBanner";
 import ImportSuccessBanner from "./ImportSuccessBanner";
 import OptionsImportExport from "./CaptureActions/components/OptionsImportExport";
+import UndoRedo from "./UndoRedo";
 import CaptureActions, {
   type CaptureActionsRef
 } from "./CaptureActions";
@@ -237,6 +238,10 @@ export default function MobileStudioDrawer( {
                     {tab.label}
                   </button>
                 ) )}
+              </div>
+
+              <div className="shrink-0 px-1">
+                <UndoRedo />
               </div>
 
               <button

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/OptionsPanel.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/OptionsPanel.tsx
@@ -32,6 +32,7 @@ const SlideEditor = dynamic( () => import( "./SlideEditor" ) );
 
 import ContentArrayProvider from "./ContentArrayProvider/ContentArrayProvider";
 import OptionsImportExport from "./CaptureActions/components/OptionsImportExport";
+import UndoRedo from "./UndoRedo";
 import initOptions from "@/utils/initOptions";
 import type {
   CollapsibleSection, CollapsibleStates
@@ -243,6 +244,8 @@ export default function OptionsPanel( {
         expanded, title
       ) => (
         <div className="flex gap-1">
+          <UndoRedo />
+
           <OptionsImportExport
             options={ options }
             name={ name }

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/UndoRedo.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/UndoRedo.tsx
@@ -4,6 +4,12 @@ import {
 
 import useFormUndoRedo from "@/components/ClientProcessingSketch/components/SketchOptions/components/FormUndoRedo/hooks/useFormUndoRedo";
 
+/**
+ * Undo/redo buttons for the sketch options form. Must render inside
+ * <FormUndoRedo /> (which itself lives inside the form's FormProvider).
+ * Clicks stop propagation so the buttons can sit in collapsible headers
+ * without toggling them.
+ */
 export default function UndoRedo() {
   const {
     redo, undo, canUndo, canRedo
@@ -12,21 +18,31 @@ export default function UndoRedo() {
   return (
     <div className="flex gap-1">
       <button
-        onClick={ undo }
+        type="button"
+        onClick={ ( e ) => {
+          e.stopPropagation();
+          undo();
+        } }
         disabled={ !canUndo }
-        className="p-0.5 rounded-xl bg-background border border-theme text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+        className="text-xs flex items-center text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
         title={ canUndo ? "Undo (Cmd/Ctrl+Z)" : "No history to undo" }
+        aria-label="Undo"
       >
-        <Undo className="h-3" />
+        <Undo className="h-3.5" />
       </button>
 
       <button
-        onClick={ redo }
+        type="button"
+        onClick={ ( e ) => {
+          e.stopPropagation();
+          redo();
+        } }
         disabled={ !canRedo }
-        className="p-0.5 rounded-xl bg-background border border-theme text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+        className="text-xs flex items-center text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
         title={ canRedo ? "Redo (Cmd/Ctrl+Shift+Z)" : "No history to redo" }
+        aria-label="Redo"
       >
-        <Redo className="h-3" />
+        <Redo className="h-3.5" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds an undo/redo feature to the template editor page (`/templates/[engine]/[...sketch]`), covering the whole options form: template settings, global content, slides, sketch settings — including sketch-driven edits that sync into the form (canvas content drags, draggable points), since those flow through the same form state.

- **Undo / redo buttons** in the desktop options panel header (floating and docked layouts, next to Export/Import) and in the mobile studio drawer header.
- **Hotkeys**: `Cmd/Ctrl+Z` to undo, `Cmd/Ctrl+Shift+Z` or `Cmd/Ctrl+Y` to redo (skipped while typing in an input).
- History snapshots are captured 400 ms after the user stops editing (debounced, max 50 entries); undo/redo replay through `react-hook-form`'s `reset()`, which propagates to the running sketch exactly like an options import does.

## Implementation

The repo already contained an unmounted `FormUndoRedo` module. This PR wires it in (`TemplateOptions` wraps its subtree in the provider inside `FormProvider`) and fixes the blockers that kept it dead code:

- Removed the `nanoid` import — not a project dependency, so mounting the module previously broke the build. Replaced with a local batch-id helper.
- Fixed the history-stack semantics: the past stack stored *post-change* snapshots, so the first undo press was a no-op that re-applied the current state. It now stores the *pre-change* state, making undo/redo symmetric one-press operations.
- Fixed `jumpTo` to preserve the pre-jump state and use correct pop order when reorganizing stacks.
- Removed the `captureInitial` flag (meaningless under the corrected semantics) and made `enableDebug` actually toggle logging.
- Restyled the `UndoRedo` buttons to match the panel-header buttons and stop click propagation so they can sit inside collapsible headers.

## Testing

- New unit suite `FormUndoRedo.test.tsx` (8 tests): single/multi-step undo & redo, redo-stack clearing on new edits, nested paths, `runSilently`, `clear`.
- `npm run check` (lint + 1533 tests) and `npm run build` pass.
- Verified end-to-end with Playwright against the built app: buttons enable/disable correctly, undo/redo restore and re-apply values, hotkeys work, multi-step history walks both directions, and the change propagates to the live sketch. Checked on both the desktop layout and the mobile drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTiKtgfkWL1Fz6pQgG1xKR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTiKtgfkWL1Fz6pQgG1xKR)_