### PR TITLE
Standardize the JSON field type (upload + edit)

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/ControlledJsonInput.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/ControlledJsonInput.tsx
@@ -1,27 +1,62 @@
 import React, {
-  useMemo
+  useMemo, useRef, useState
 } from "react";
 import {
   Controller, useFormContext
 } from "react-hook-form";
+import {
+  RotateCcw, Upload
+} from "lucide-react";
+import clsx from "clsx";
+import {
+  CONTROL_CARD_CLASS,
+  CONTROL_CARD_HEADER_CLASS,
+  CONTROL_RESET_BUTTON_CLASS
+} from "../constants/control-bar";
 
 type ControlledJsonInputProps = {
   name: string;
   textareaClassName: string;
+  label?: string;
+  isModified?: boolean;
+  onReset?: ( event: React.MouseEvent ) => void;
   config: {
     component: "json";
     rows?: number;
+    /** `accept` attribute for the upload input. Defaults to `.json`. */
+    accept?: string;
   };
 };
 
+/**
+ * The official "json" field type: a small file-picker that loads a `.json`
+ * file from disk plus a text editor for pasting / hand-editing. Mirrors the
+ * standardized asset kinds (images, videos, audios) so a sketch declares
+ * `component: "json"` and gets both affordances for free.
+ *
+ * The stored value is the parsed JSON (object/array/primitive) once it is
+ * valid, or the raw string while the user is mid-edit — consumers should
+ * accept both (see `parseWavetable`, which takes a string or an object).
+ */
 export default function ControlledJsonInput( {
-  name, textareaClassName, config
+  name,
+  textareaClassName,
+  label,
+  isModified = false,
+  onReset,
+  config
 }: ControlledJsonInputProps ) {
   const {
     control,
     setError,
     clearErrors
   } = useFormContext();
+
+  const fileInputRef = useRef<HTMLInputElement>( null );
+  const [
+    fileName,
+    setFileName
+  ] = useState<string | null>( null );
 
   // Memoize the helper functions to avoid recreating them on every render
   const {
@@ -64,37 +99,124 @@ export default function ControlledJsonInput( {
       control={ control }
       render={ ( {
         field
-      } ) => (
-        <textarea
-          className={ textareaClassName }
-          rows={ config.rows ?? 4 }
-          value={ formatValue( field.value ) }
-          onChange={ ( e ) => {
-            // Store the raw text during editing to allow invalid JSON temporarily
-            field.onChange( e.target.value );
-          } }
-          onBlur={ ( e ) => {
-            field.onBlur();
+      } ) => {
+        // Read a picked file into the field: parse it when valid, otherwise
+        // keep the raw text so the user can fix it in the editor below.
+        const loadFile = async( file: File ) => {
+          const text = await file.text();
 
-            const trimmed = e.target.value.trim();
+          setFileName( file.name );
 
-            try {
-              const parsed = parseValue( trimmed );
+          try {
+            const parsed = parseValue( text );
 
-              field.onChange( parsed );
-              clearErrors( name );
-            } catch {
-              setError(
-                name,
-                {
-                  type: "validate",
-                  message: "Invalid JSON"
+            field.onChange( parsed );
+            clearErrors( name );
+          } catch {
+            field.onChange( text );
+            setError(
+              name,
+              {
+                type: "validate",
+                message: "Invalid JSON in the uploaded file"
+              }
+            );
+          }
+        };
+
+        return (
+          <div className={ CONTROL_CARD_CLASS }>
+            <div className={ CONTROL_CARD_HEADER_CLASS }>
+              <span className="flex min-w-0 items-center gap-1">
+                {label && (
+                  <span
+                    className={ clsx(
+                      "truncate",
+                      isModified ? "font-medium text-foreground" : "text-label"
+                    ) }
+                  >
+                    {label}
+                  </span>
+                )}
+              </span>
+
+              <span className="flex shrink-0 items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={ () => fileInputRef.current?.click() }
+                  title="Load a .json file from your computer"
+                  className={ clsx(
+                    CONTROL_RESET_BUTTON_CLASS,
+                    "inline-flex items-center gap-1"
+                  ) }
+                >
+                  <Upload className="h-3.5 w-3.5 md:h-3 md:w-3" />
+                  <span>Upload .json</span>
+                </button>
+
+                {isModified && onReset && (
+                  <button
+                    type="button"
+                    tabIndex={ -1 }
+                    title="Reset to saved value"
+                    onClick={ onReset }
+                    className={ CONTROL_RESET_BUTTON_CLASS }
+                  >
+                    <RotateCcw className="h-3.5 w-3.5 md:h-3 md:w-3" />
+                  </button>
+                )}
+
+                <input
+                  ref={ fileInputRef }
+                  type="file"
+                  accept={ config.accept ?? "application/json,.json" }
+                  className="hidden"
+                  onChange={ ( e ) => {
+                    const file = e.target.files?.[ 0 ];
+
+                    if ( file ) {
+                      void loadFile( file );
+                    }
+
+                    // Clear so re-picking the same file still fires onChange.
+                    e.target.value = "";
+                  } }
+                />
+              </span>
+            </div>
+
+            <textarea
+              className={ textareaClassName }
+              rows={ config.rows ?? 4 }
+              value={ formatValue( field.value ) }
+              onChange={ ( e ) => {
+                // Store the raw text during editing to allow invalid JSON temporarily
+                field.onChange( e.target.value );
+              } }
+              onBlur={ ( e ) => {
+                field.onBlur();
+
+                const trimmed = e.target.value.trim();
+
+                try {
+                  const parsed = parseValue( trimmed );
+
+                  field.onChange( parsed );
+                  clearErrors( name );
+                } catch {
+                  setError(
+                    name,
+                    {
+                      type: "validate",
+                      message: "Invalid JSON"
+                    }
+                  );
                 }
-              );
-            }
-          } }
-        />
-      ) }
+              } }
+            />
+          </div>
+        );
+      } }
     />
   );
 }

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -124,9 +124,15 @@ interface HiddenConfig extends BaseConfig {
   component: "hidden";
 }
 
+// The standardized JSON field, on par with the asset kinds (images, videos,
+// audios). Renders an "Upload .json" file picker plus a text editor; the
+// stored value is the parsed JSON once valid, or the raw string mid-edit.
 interface JsonConfig extends BaseConfig {
   component: "json";
+  /** Rows for the text editor. Defaults to 4. */
   rows?: number;
+  /** `accept` attribute for the file picker. Defaults to `.json`. */
+  accept?: string;
 }
 
 interface ImagesStackConfig extends BaseConfig {

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
@@ -487,18 +487,14 @@ export default function FieldRenderer( {
 
       case "json":
         return (
-          <div className={ CONTROL_CARD_CLASS }>
-            <CardLabelHeader
-              label={ inlineLabel }
-              isModified={ isModified }
-              onReset={ handleReset }
-            />
-            <ControlledJsonInput
-              config={ config }
-              name={ registeredName }
-              textareaClassName={ `${ CONTROL_CARD_TEXTAREA_CLASS } font-mono` }
-            />
-          </div>
+          <ControlledJsonInput
+            config={ config }
+            name={ registeredName }
+            label={ inlineLabel }
+            isModified={ isModified }
+            onReset={ handleReset }
+            textareaClassName={ `${ CONTROL_CARD_TEXTAREA_CLASS } font-mono` }
+          />
         );
 
       case "item-list":

--- a/src/sketches/p5/sketches/audio/wavetable-v1/index.js
+++ b/src/sketches/p5/sketches/audio/wavetable-v1/index.js
@@ -256,19 +256,25 @@ function morphAt(
 }
 
 /**
- * Table source priority: pasted .json (textarea) → bundled preset → generator
- * spec. A broken paste falls back to the generator instead of blanking the
- * sketch.
+ * Table source priority: custom .json (uploaded or pasted) → bundled preset →
+ * generator spec. A broken payload falls back to the generator instead of
+ * blanking the sketch.
+ *
+ * The `json` field stores parsed JSON once valid, or the raw string while the
+ * user is mid-edit, so accept both — `parseWavetable` already does.
  */
 function resolveTable( o ) {
   const io = o.io ?? {};
-  const customJson = ( io.customJson ?? "" ).trim();
+  const customJson = io.customJson;
+  const hasCustom = typeof customJson === "string"
+    ? customJson.trim().length > 0
+    : customJson != null && typeof customJson === "object";
 
-  if ( customJson ) {
+  if ( hasCustom ) {
     try {
       return parseWavetable( customJson );
     } catch {
-      // Invalid paste — fall through to the configured source.
+      // Invalid payload — fall through to the configured source.
     }
   }
 

--- a/src/sketches/p5/sketches/audio/wavetable-v1/options.ts
+++ b/src/sketches/p5/sketches/audio/wavetable-v1/options.ts
@@ -347,8 +347,8 @@ export const formConfiguration: Record<string, any> = {
         options: SOURCE_OPTIONS
       },
       customJson: {
-        label: "Custom wavetable .json (paste to load — wins over source)",
-        component: "textarea"
+        label: "Custom wavetable .json (upload or paste — wins over source)",
+        component: "json"
       }
     }
   },


### PR DESCRIPTION
## What & why

The wavetable sketch introduced a JSON options field (paste-a-`.json` textarea). This promotes `component: "json"` to a **first-class, officially recognized field type** — on par with the standardized asset kinds (images, videos, audios) — so any sketch can declare `component: "json"` and get a consistent, smart JSON control.

## What the field does now

- **Upload `.json`** — a file picker that loads a `.json` file from the user's computer (e.g. a wavetable exported by our own system) straight into the field.
- **Text editor** — the existing textarea for pasting / hand-editing, kept as-is.

The stored value is the parsed JSON once it's valid, or the raw string while the user is mid-edit (so invalid input isn't lost). Invalid JSON surfaces a validation message instead of blanking the field.

## Changes

- **`ControlledJsonInput`** now owns its full card chrome (label, **Upload .json** button, reset, textarea). Uploading reads the file, parses it when valid, or keeps the raw text so the user can fix it in the editor.
- **`FieldRenderer`** — the `json` case delegates fully to `ControlledJsonInput`.
- **`field-config.ts`** — document `JsonConfig` and add an optional `accept` (defaults to `.json`).
- **`wavetable-v1`** — switch `io.customJson` from `textarea` to the `json` field; `resolveTable` now accepts a parsed-object value as well as a string (`parseWavetable` already handles both).

## Follow-ups (out of scope)

Per the request, this is intentionally a simple text field for now. A future iteration could open a modal with a proper JSON editor library for a roomier editing experience.

## Verification

- `npm run lint` — clean (2 pre-existing warnings in unrelated util files)
- `npm test` — 1535 passed
- `npm run build` — succeeds (compiles every sketch route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtzLqEX5me7EpAntxwhpKG)_