### PR TITLE
Embed & share sketches: /embed route, control strip, share dialog, autoplay/poster (phases 1–4)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,27 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_INTERACTION_BINDINGS: process.env.INTERACTION_BINDINGS
   },
 
+  // Allow the /embed route to be framed by other sites (the whole point of an
+  // embed). Every other route keeps the browser default (same-origin framing
+  // only). Restrict which origins may embed by setting EMBED_FRAME_ANCESTORS
+  // (space-separated, e.g. "https://portfolio.example https://staging.example");
+  // defaults to "*" so a fresh install works as a public widget out of the box.
+  async headers() {
+    const frameAncestors = process.env.EMBED_FRAME_ANCESTORS?.trim() || "*";
+
+    return [
+      {
+        source: "/embed/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: `frame-ancestors ${ frameAncestors }`
+          }
+        ]
+      }
+    ];
+  },
+
   // The gallery/editor moved from /templates to /sketches. Permanent (308)
   // redirects keep every previously shared link, bookmark, and indexed URL
   // alive — including old recording jobs whose stored path still starts with

--- a/src/app/embed/[engine]/[...sketch]/page.tsx
+++ b/src/app/embed/[engine]/[...sketch]/page.tsx
@@ -1,0 +1,119 @@
+import type {
+  Metadata
+} from "next";
+import {
+  notFound
+} from "next/navigation";
+import React from "react";
+
+import {
+  isKnownEngine
+} from "@/engines/engineCatalog";
+import {
+  findSketchMeta
+} from "@/engines/metadata";
+import {
+  OptionsSchema
+} from "@/types/sketch.types";
+import {
+  getJSONSketchOptions,
+  getSketchMeta
+} from "@/utils/getSketchOptions";
+import EmbedSketchClient from "@/components/EmbedSketch/EmbedSketchClient";
+
+/* ------------------------------------------------------------------ */
+/*  Route params                                                       */
+/* ------------------------------------------------------------------ */
+type RouteParams = {
+  engine: string;
+  sketch: string[]; // catch-all: ["category", "name"] or ["name"]
+};
+
+export const revalidate = 0;
+
+/* ------------------------------------------------------------------ */
+/*  Metadata — embeds are framed inside other pages, never indexed as  */
+/*  standalone documents.                                              */
+/* ------------------------------------------------------------------ */
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    robots: {
+      index: false,
+      follow: false
+    }
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page — a chrome-free, stateless sketch host.                       */
+/*                                                                     */
+/*  Mirrors the studio page's base-option construction (schema         */
+/*  defaults + persisted options.json + form defaults on `.sketch`)    */
+/*  so a sketch boots identically, then hands off to the client, which */
+/*  layers the URL-fragment delta on top. No job, no snapshot, no DB.  */
+/* ------------------------------------------------------------------ */
+export default async function EmbedPage( {
+  params
+}: {
+  params: Promise<RouteParams>;
+} ) {
+  const {
+    engine: engineId, sketch: sketchSegments
+  } = await params;
+
+  if ( !isKnownEngine( engineId ) ) {
+    return notFound();
+  }
+
+  const sketchName = sketchSegments[ sketchSegments.length - 1 ];
+  const sketchMeta = findSketchMeta(
+    sketchName,
+    engineId
+  );
+
+  if ( !sketchMeta ) {
+    return notFound();
+  }
+
+  const sketchOptions = OptionsSchema.parse( {} );
+
+  const {
+    formValues
+  } = await getSketchMeta(
+    sketchName,
+    engineId
+  );
+
+  const jsonOptions = await getJSONSketchOptions(
+    sketchName,
+    engineId
+  );
+
+  if ( jsonOptions ) {
+    Object.assign(
+      sketchOptions,
+      jsonOptions
+    );
+  }
+
+  if ( formValues ) {
+    Object.assign(
+      sketchOptions,
+      {
+        sketch: structuredClone( formValues )
+      }
+    );
+  }
+
+  sketchOptions.name = sketchName;
+
+  return (
+    <EmbedSketchClient
+      engineId={ engineId }
+      name={ sketchName }
+      baseOptions={ sketchOptions }
+      width={ sketchOptions.size.width }
+      height={ sketchOptions.size.height }
+    />
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,6 +117,22 @@
     display: block;
 }
 
+/* Embeddable sketch host (/embed route): canvas-only, fills the frame, no
+   editor affordances. Sits over the shared layout's <main>. */
+.embed-root {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: #000;
+}
+
+.embed-root .sketch-canvas-container canvas:hover,
+.embed-root .sketch-canvas-container .sketch-surface:hover {
+    outline: none;
+}
+
 .glass {
     @apply bg-background/80;
     backdrop-filter: blur(0.9rem);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 import GoogleAnalyticsTracker from "@/components/GoogleAnalyticsTracker";
-import MenuBar from "@/components/MenuBar";
+import MenuBarGate from "@/components/MenuBarGate";
 import {
   MenuBarSlotProvider
 } from "@/components/MenuBarPortal";
@@ -163,7 +163,7 @@ export default function RootLayout( {
               <main className="h-full overflow-auto overscroll-contain relative">{children}</main>
 
               <Suspense>
-                <MenuBar
+                <MenuBarGate
                   showRecordings={ process.env.BACKEND_RECORDING === "true" }
                   hasMissingThumbnails={ hasMissingThumbnails }
                   hasMissingPreviews={ hasMissingPreviews }

--- a/src/components/EmbedSketch/EmbedSketchClient.tsx
+++ b/src/components/EmbedSketch/EmbedSketchClient.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import "@/engines/index"; // register p5/gsap/threejs in the browser bundle
+
+import {
+  useEffect, useMemo, useRef, useState
+} from "react";
+import {
+  getEngine
+} from "@/engines/registry";
+import type {
+  SketchEngine
+} from "@/engines/types";
+import type {
+  SketchOption
+} from "@/types/sketch.types";
+import ScalableViewport from "@/components/ScalableViewport/ScalableViewport";
+import {
+  deepMerge, structuredClone
+} from "@/p5/shared/utils.js";
+import {
+  parseEmbedHash
+} from "@/lib/embedOptions";
+
+type EmbedSketchClientProps = {
+  engineId: string;
+  name: string;
+  /** Template defaults (OptionsSchema base + form defaults on `.sketch`). */
+  baseOptions: SketchOption;
+  width: number;
+  height: number;
+};
+
+/**
+ * Standalone, chrome-free sketch host for the `/embed` route.
+ *
+ * Deliberately does NOT use SketchContext / SketchPage: it drives the engine
+ * directly, so the heavy editor surface (RHF form, capture actions →
+ * mediabunny/gif.js, thumbnails, dev-watch) never enters the embed bundle. The
+ * only weight is the engine core + p5 itself. Interaction is preserved — the
+ * viewport is fit-to-frame but its pan/zoom gestures are locked, so pointer and
+ * touch events reach the canvas for camera/mic/orbit-driven sketches.
+ */
+export default function EmbedSketchClient( {
+  engineId,
+  name,
+  baseOptions,
+  width,
+  height
+}: EmbedSketchClientProps ) {
+  const containerRef = useRef<HTMLDivElement | null>( null );
+  const [
+    ready,
+    setReady
+  ] = useState( false );
+
+  // Merge the URL-fragment delta over the template defaults for the initial
+  // mount. Reading location.hash during render is stable for the mount, and the
+  // container markup is identical with or without a hash, so there is no
+  // hydration mismatch.
+  const mountOptions = useMemo(
+    () => {
+      const merged = structuredClone( baseOptions ) as SketchOption;
+
+      if ( typeof window !== "undefined" ) {
+        const {
+          options
+        } = parseEmbedHash( window.location.hash );
+
+        if ( options ) {
+          merged.sketch = deepMerge(
+            merged.sketch ?? {},
+            options
+          );
+        }
+      }
+
+      return merged;
+    },
+    [
+      baseOptions
+    ]
+  );
+
+  useEffect(
+    () => {
+      if ( !containerRef.current ) {
+        return;
+      }
+
+      const registration = getEngine( engineId );
+      const instance: SketchEngine = registration.createEngine();
+
+      const handleReady = () => setReady( true );
+
+      instance.on(
+        "ready",
+        handleReady
+      );
+
+      instance
+        .init(
+          containerRef.current,
+          name,
+          mountOptions
+        )
+        .catch( ( error ) => {
+          console.error(
+            `[EmbedSketchClient] init failed for "${ engineId }/${ name }"`,
+            error
+          );
+        } );
+
+      return () => {
+        instance.off(
+          "ready",
+          handleReady
+        );
+        instance.destroy();
+        setReady( false );
+      };
+    },
+    [
+      engineId,
+      name,
+      mountOptions
+    ]
+  );
+
+  // Live updates: a parent frame can swap the `#o=` fragment (Keystatic preview,
+  // a "reset" link) and the sketch re-parameterises without a reload. Recompute
+  // the full sketch params from defaults + the new delta so removing an override
+  // heals back to its default.
+  useEffect(
+    () => {
+      const onHashChange = async() => {
+        const {
+          options
+        } = parseEmbedHash( window.location.hash );
+
+        const {
+          setSketchOptions
+        } = await import( "@/lib/syncSketchOptions" );
+
+        setSketchOptions(
+          {
+            sketch: deepMerge(
+              structuredClone( baseOptions.sketch ?? {} ),
+              options ?? {}
+            )
+          },
+          "embed"
+        );
+      };
+
+      window.addEventListener(
+        "hashchange",
+        onHashChange
+      );
+
+      return () =>
+        window.removeEventListener(
+          "hashchange",
+          onHashChange
+        );
+    },
+    [
+      baseOptions
+    ]
+  );
+
+  return (
+    <div className="embed-root">
+      <ScalableViewport
+        showZoomControls={ false }
+        lockInteractions
+        resolutionKey={ `${ width }x${ height }` }
+        isReady={ ready }
+      >
+        <div ref={ containerRef } className="sketch-canvas-container" />
+      </ScalableViewport>
+    </div>
+  );
+}

--- a/src/components/MenuBarGate.tsx
+++ b/src/components/MenuBarGate.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import {
+  usePathname
+} from "next/navigation";
+import type React from "react";
+import MenuBar from "@/components/MenuBar";
+
+/**
+ * Renders the global `MenuBar` everywhere except the `/embed` route, which is a
+ * chrome-free sketch host meant to be framed inside other sites. The root
+ * layout is shared across every route, so this client gate is the lightest way
+ * to suppress the nav on embeds without splitting the layout tree.
+ */
+export default function MenuBarGate( props: React.ComponentProps<typeof MenuBar> ) {
+  const pathname = usePathname();
+
+  if ( pathname?.startsWith( "/embed" ) ) {
+    return null;
+  }
+
+  return <MenuBar { ...props } />;
+}

--- a/src/lib/__tests__/embedOptions.test.ts
+++ b/src/lib/__tests__/embedOptions.test.ts
@@ -1,0 +1,131 @@
+import {
+  buildEmbedHash,
+  decodeEmbedOptions,
+  encodeEmbedOptions,
+  parseEmbedHash
+} from "@/lib/embedOptions";
+
+describe(
+  "embedOptions codec",
+  () => {
+    it(
+      "round-trips a nested delta through encode/decode",
+      () => {
+        const delta = {
+          noise: {
+            seed: 42,
+            falloff: 0.6
+          },
+          grid: {
+            rows: 120
+          },
+          backgroundColor: [
+            0,
+            0,
+            0,
+            255
+          ]
+        };
+
+        expect( decodeEmbedOptions( encodeEmbedOptions( delta ) ) ).toEqual( delta );
+      }
+    );
+
+    it(
+      "produces a URL-safe token (no +, /, or = padding)",
+      () => {
+        const token = encodeEmbedOptions( {
+          a: "?&=/+ ",
+          b: "ïüçé"
+        } );
+
+        expect( token ).not.toMatch( /[+/=]/ );
+      }
+    );
+
+    it(
+      "is unicode-safe",
+      () => {
+        const delta = {
+          label: "café — naïve — 日本語 — 🎨"
+        };
+
+        expect( decodeEmbedOptions( encodeEmbedOptions( delta ) ) ).toEqual( delta );
+      }
+    );
+
+    it(
+      "returns null for malformed input instead of throwing",
+      () => {
+        expect( decodeEmbedOptions( "not-valid-base64!!!" ) ).toBeNull();
+        expect( decodeEmbedOptions( encodeEmbedOptions( [
+          1,
+          2
+        ] as unknown as Record<string, unknown> ) ) ).toBeNull(); // arrays rejected
+        expect( decodeEmbedOptions( "" ) ).toBeNull();
+      }
+    );
+
+    it(
+      "parses a full hash into options and controls",
+      () => {
+        const hash = buildEmbedHash(
+          {
+            noise: {
+              seed: 7
+            }
+          },
+          [
+            "noise.seed",
+            "grid.rows"
+          ]
+        );
+
+        const parsed = parseEmbedHash( hash );
+
+        expect( parsed.options ).toEqual( {
+          noise: {
+            seed: 7
+          }
+        } );
+        expect( parsed.controls ).toEqual( [
+          "noise.seed",
+          "grid.rows"
+        ] );
+      }
+    );
+
+    it(
+      "tolerates a leading # and missing keys",
+      () => {
+        expect( parseEmbedHash( "" ) ).toEqual( {
+          options: null,
+          controls: null
+        } );
+        expect( parseEmbedHash( "#" ) ).toEqual( {
+          options: null,
+          controls: null
+        } );
+
+        const controlsOnly = parseEmbedHash( "#c=a.b , c.d ,," );
+
+        expect( controlsOnly.options ).toBeNull();
+        expect( controlsOnly.controls ).toEqual( [
+          "a.b",
+          "c.d"
+        ] );
+      }
+    );
+
+    it(
+      "builds an empty hash when there is nothing to encode",
+      () => {
+        expect( buildEmbedHash( {} ) ).toBe( "" );
+        expect( buildEmbedHash(
+          {},
+          []
+        ) ).toBe( "" );
+      }
+    );
+  }
+);

--- a/src/lib/embedOptions.ts
+++ b/src/lib/embedOptions.ts
@@ -1,0 +1,167 @@
+/**
+ * URL codec for embeddable sketches.
+ *
+ * The embed route (`/embed/[engine]/[...sketch]`) is fully stateless: the
+ * sketch parameters that differ from the template defaults travel in the URL
+ * fragment, never the query string, so they never reach the server, survive a
+ * static host, and carry no privacy footprint. There is no database, no preset
+ * id, no round-trip.
+ *
+ * Wire format — everything lives in the hash:
+ *
+ *   /embed/p5/noise-strips/noise-strips-v1#o=<base64url>&c=noise.seed,grid.rows
+ *
+ *   o  base64url( JSON( sketch-params delta ) ) — merged over the template's
+ *      `formValues` defaults at mount. Only the changed values need to be
+ *      encoded, which keeps typical share URLs short; a full `sketch` object is
+ *      equally valid (it just merges over defaults that already match).
+ *   c  optional comma-separated whitelist of field paths to expose as live
+ *      controls in the embed (consumed in a later phase — parsed here so the
+ *      wire format is stable from the start).
+ *
+ * base64url (RFC 4648 §5) is used instead of raw `encodeURIComponent(JSON)` so
+ * the payload never contains characters a CMS, markdown renderer, or copy-paste
+ * step might mangle, and so it reads as one opaque token.
+ */
+
+export const EMBED_OPTIONS_HASH_KEY = "o";
+export const EMBED_CONTROLS_HASH_KEY = "c";
+
+export type EmbedHash = {
+  /** Decoded sketch-params delta, or null when absent/undecodable. */
+  options: Record<string, unknown> | null;
+  /** Field paths to expose as controls, or null when unspecified. */
+  controls: string[] | null;
+};
+
+/* ---- base64url ---------------------------------------------------- */
+
+function bytesToBase64Url( bytes: Uint8Array ): string {
+  let binary = "";
+
+  for ( let i = 0; i < bytes.length; i++ ) {
+    binary += String.fromCharCode( bytes[ i ] );
+  }
+
+  return btoa( binary )
+    .replace(
+      /\+/g,
+      "-"
+    )
+    .replace(
+      /\//g,
+      "_"
+    )
+    .replace(
+      /=+$/,
+      ""
+    );
+}
+
+function base64UrlToBytes( value: string ): Uint8Array {
+  const normalized = value
+    .replace(
+      /-/g,
+      "+"
+    )
+    .replace(
+      /_/g,
+      "/"
+    );
+  const padded = normalized + "=".repeat( ( 4 - ( normalized.length % 4 ) ) % 4 );
+  const binary = atob( padded );
+  const bytes = new Uint8Array( binary.length );
+
+  for ( let i = 0; i < binary.length; i++ ) {
+    bytes[ i ] = binary.charCodeAt( i );
+  }
+
+  return bytes;
+}
+
+/* ---- encode / decode ---------------------------------------------- */
+
+/**
+ * Encode a sketch-params delta into the opaque `o=` token. Unicode-safe.
+ */
+export function encodeEmbedOptions( delta: Record<string, unknown> ): string {
+  const json = JSON.stringify( delta ?? {} );
+
+  return bytesToBase64Url( new TextEncoder().encode( json ) );
+}
+
+/**
+ * Decode an `o=` token back into a plain object. Returns null on any malformed
+ * input (bad base64, non-JSON, or a non-object payload) so a corrupted URL
+ * degrades to "render the defaults" instead of throwing.
+ */
+export function decodeEmbedOptions( encoded: string ): Record<string, unknown> | null {
+  try {
+    const json = new TextDecoder().decode( base64UrlToBytes( encoded ) );
+    const parsed = JSON.parse( json );
+
+    if ( parsed && typeof parsed === "object" && !Array.isArray( parsed ) ) {
+      return parsed as Record<string, unknown>;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/* ---- hash parsing ------------------------------------------------- */
+
+/**
+ * Parse an embed URL fragment (with or without the leading `#`) into its
+ * decoded options delta and control whitelist.
+ */
+export function parseEmbedHash( hash: string ): EmbedHash {
+  const params = new URLSearchParams( hash.replace(
+    /^#/,
+    ""
+  ) );
+  const rawOptions = params.get( EMBED_OPTIONS_HASH_KEY );
+  const rawControls = params.get( EMBED_CONTROLS_HASH_KEY );
+
+  return {
+    options: rawOptions ? decodeEmbedOptions( rawOptions ) : null,
+    controls: rawControls
+      ? rawControls
+        .split( "," )
+        .map( ( path ) => path.trim() )
+        .filter( Boolean )
+      : null
+  };
+}
+
+/**
+ * Build the embed URL fragment from a sketch-params delta and an optional
+ * control whitelist. Inverse of `parseEmbedHash`. Returns "" when there is
+ * nothing to encode (so a default share produces a clean, hashless URL).
+ */
+export function buildEmbedHash(
+  delta: Record<string, unknown>,
+  controls?: string[]
+): string {
+  const params = new URLSearchParams();
+  const hasDelta = delta && Object.keys( delta ).length > 0;
+
+  if ( hasDelta ) {
+    params.set(
+      EMBED_OPTIONS_HASH_KEY,
+      encodeEmbedOptions( delta )
+    );
+  }
+
+  if ( controls && controls.length > 0 ) {
+    params.set(
+      EMBED_CONTROLS_HASH_KEY,
+      controls.join( "," )
+    );
+  }
+
+  const query = params.toString();
+
+  return query ? `#${ query }` : "";
+}


### PR DESCRIPTION
## What & why

The **embed / share** feature: reuse a sketch outside the Sketchbook app — e.g. framed inside a portfolio post (Astro + Keystatic) — with its parameters, a live control strip, and playback all controlled from the link.

A chrome-free, **stateless** sketch host lives at `/embed/[engine]/[...sketch]`. No database, no preset id, no server round-trip: everything travels in the **URL fragment**.

```
/embed/p5/noise-strips/noise-strips-v1#o=<base64url delta>&c=grid.rows,noise.seed&a=off
```

- `#o=` — base64url JSON *delta* over the template defaults, merged at mount.
- `#c=` — optional whitelist of fields to expose as **live controls** (`*` = all).
- `#a=` — autoplay policy: absent = `on`, `off`, or `desktop` (off on mobile).

## Phase 1 — the embed route
- **`src/lib/embedOptions.ts`** — base64url codec + hash parse/build. Malformed input → `null`. Unit-tested.
- **`EmbedSketchClient.tsx`** — drives the `SketchEngine` directly (no `SketchContext`/`SketchPage`), so the editor surface (RHF form, capture actions → mediabunny/gif.js, thumbnails, dev-watch) never enters the embed bundle. Fit-to-frame via `ScalableViewport` with pan/zoom **locked**, so pointer/touch events reach the canvas — **interaction (webcam/mic/orbit) preserved**.
- **`page.tsx`** — mirrors the studio's base-option construction; `noindex`.
- **`MenuBarGate`** — hides the global nav on `/embed`.
- **`next.config.ts`** — `Content-Security-Policy: frame-ancestors` on `/embed`, via `EMBED_FRAME_ANCESTORS` (default `*`).

## Phase 2 — the control strip
- **`src/lib/embedControls.ts`** — resolves the `#c=` whitelist against `formConfiguration` into fields under `sketch.*`; dotted paths walk `nested-object` groups; `*` = all. Unit-tested.
- **`EmbedControlPanel.tsx`** — collapsible glass panel using the **same `FieldRenderer` the studio uses** (in the required `FormProvider` + `CollapsibleProvider`), pushing edits to the options store (rAF-throttled) so the sketch updates live. Loaded via dynamic import, only when `#c=` is present.

## Phase 3 — the share dialog
- **`diffSketchOptions`** (`embedOptions.ts`) — minimal delta of current params vs defaults, so share URLs stay short. Unit-tested.
- **`SketchShareDialog.tsx`** — Share button + modal on the preview page. Produces a copyable **link** and **`<iframe>` snippet**; the author picks control exposure (none / all / custom subset). Hosted in `EngineControls` (floating island + docked top bar).

## Phase 4 — autoplay, poster, play/pause, preview link
- **`resolveAutoplay(policy, { reducedMotion, mobile })`** (`embedOptions.ts`) — reduced-motion always wins (accessibility), then the explicit policy, then the desktop/mobile split. Unit-tested.
- **`EmbedSketchClient`** — resolves autoplay after mount from the live environment (`prefers-reduced-motion`, `pointer: coarse`). When false, the engine — and **p5** — are **not mounted**; only a poster shows, so an idle embed costs just the thumbnail. A start-decision flag guards SSR/first render against hydration mismatch. Once running, a **play/pause toggle** stops the draw loop (CPU/battery) without unmounting.
- **`EmbedPoster.tsx`** — thumbnail (fit like the canvas) + a sober centred play badge; the whole poster starts the sketch. Neutral fallback when there's no thumbnail.
- **`EmbedPlaybackToggle.tsx`** — small glass play/pause control, bottom-right.
- **`page.tsx`** — passes the thumbnail URL (`getSketchThumbnailURL`) + `hasThumbnail`.
- **`SketchShareDialog`** — an **Autoplay** radio group (Play automatically / Off — click to play / Auto on desktop only), with a reduced-motion note, baked into the link; plus an **Open** button next to Copy to preview the embed in a new tab.

## Deliberately kept vs dropped
- **Dropped:** backend recording / preset / snapshot / DB coupling — none touched. Options are URL-encoded, matching the fully-frontend workflow.
- **Kept:** MediaPipe / interaction, so camera-driven sketches embed and stay interactive.

## Verification
- `npm run check` — lint clean (2 pre-existing warnings, unrelated), **1581 tests pass** (codec, control-resolver, delta, and autoplay-resolution tests).
- `npm run build` — succeeds; embed route **133 kB** first-load JS (control panel + form machinery lazy-loaded) vs the studio editor's 145 kB.
- **Runtime (headless Chromium), verified per phase:**
  - Route renders, `#o=`/`#c=` applied, `frame-ancestors *` header, no nav, no console errors.
  - Control strip renders the whitelisted fields; a slider drag updates the live store.
  - Share dialog generates the link + iframe snippet; produced URLs render.
  - Autoplay matrix: default autoplays; `#a=off`, reduced-motion, and `#a=desktop`-on-touch all show the poster with **p5 unloaded**; clicking starts it; the toggle flips play/pause; `#a=desktop` on desktop autoplays. Share dialog emits `#a=off` and exposes the Open affordance.

## Not in this PR (next phase)
- Keystatic custom block + Astro `<iframe>` snippet (portfolio repo, out of scope here) — consumes this exact URL format.

## Try it
```html
<iframe
  src="https://your-sketchbook.app/embed/p5/noise-strips/noise-strips-v1#c=grid.rows,noise.seed&a=desktop"
  style="width:100%; aspect-ratio: 1080/1350; border:0"
  allow="camera; microphone"
  loading="lazy"></iframe>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL2rAJbs7G5hk3EkxinYBw