### PR TITLE
Add background color + radius to slide title, specs and HUD overlays

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -614,6 +614,10 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       label: "Background",
       component: "color"
     },
+    backgroundStroke: {
+      label: "Background stroke",
+      component: "color"
+    },
     backgroundRadius: {
       label: "Background radius",
       component: "slider",
@@ -971,6 +975,10 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     },
     backgroundColor: {
       label: "Background",
+      component: "color"
+    },
+    backgroundStroke: {
+      label: "Background stroke",
       component: "color"
     },
     backgroundRadius: {

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -610,6 +610,17 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       label: "Fill",
       component: "color"
     },
+    backgroundColor: {
+      label: "Background",
+      component: "color"
+    },
+    backgroundRadius: {
+      label: "Background radius",
+      component: "slider",
+      min: 0,
+      max: 200,
+      step: 1
+    },
     font: {
       label: "Font",
       component: "select",
@@ -957,6 +968,17 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
     fill: {
       label: "Default fill",
       component: "color"
+    },
+    backgroundColor: {
+      label: "Background",
+      component: "color"
+    },
+    backgroundRadius: {
+      label: "Background radius",
+      component: "slider",
+      min: 0,
+      max: 200,
+      step: 1
     },
     font: hudFontField,
     blend: hudBlendField,

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
@@ -578,6 +578,11 @@ function SlideTitleControls( {
             label="Background"
           />
 
+          <ResettableColor
+            name={ `${ titleBase }.backgroundStroke` }
+            label="Background stroke"
+          />
+
           <ResettableSlider
             name={ `${ titleBase }.backgroundRadius` }
             label="Background radius"

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/SlideTransitionSettings.tsx
@@ -573,6 +573,19 @@ function SlideTitleControls( {
 
           <ResettableColor name={ `${ titleBase }.fill` } label="Fill" />
 
+          <ResettableColor
+            name={ `${ titleBase }.backgroundColor` }
+            label="Background"
+          />
+
+          <ResettableSlider
+            name={ `${ titleBase }.backgroundRadius` }
+            label="Background radius"
+            min={ 0 }
+            max={ 200 }
+            step={ 1 }
+          />
+
           <BarSelect
             name={ `${ titleBase }.style` }
             label="Style"

--- a/src/sketches/p5/utils/hud/widgets/badge.js
+++ b/src/sketches/p5/utils/hud/widgets/badge.js
@@ -5,6 +5,7 @@ import {
 import {
   anchoredRect,
   getFont,
+  paintWidgetBackground,
   reportWidgetBounds,
   resolveAnchor,
   toColor,
@@ -103,6 +104,15 @@ export default function badge(
       rect.y,
       rect.w,
       rect.h
+    );
+
+    paintWidgetBackground(
+      style,
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h,
+      size
     );
 
     string.write(

--- a/src/sketches/p5/utils/hud/widgets/common.js
+++ b/src/sketches/p5/utils/hud/widgets/common.js
@@ -190,16 +190,23 @@ export function paintWidgetBackground(
   style, x, y, w, h, size = 12
 ) {
   const padX = size * 0.35;
-  const padTop = size * 0.25;
-  const padBottom = size * 0.3;
+  const padY = size * 0.3;
 
   drawItemBackground( {
     x: x - padX,
-    y: y - padTop,
+    y: y - padY,
     w: w + padX * 2,
-    h: h + padTop + padBottom,
+    h: h + padY * 2,
     color: style?.background,
-    radius: style?.backgroundRadius ?? 0
+    radius: style?.backgroundRadius ?? 0,
+    stroke: style?.backgroundStroke,
+    strokeWeight: Math.min(
+      Math.max(
+        1,
+        size * 0.06
+      ),
+      4
+    )
   } );
 }
 

--- a/src/sketches/p5/utils/hud/widgets/common.js
+++ b/src/sketches/p5/utils/hud/widgets/common.js
@@ -6,6 +6,7 @@ import sketch, {
 import {
   reportItemPartBounds
 } from "../../slides/common/itemBoundsRegistry.js";
+import drawItemBackground from "../../slides/common/drawItemBackground.js";
 
 export const FALLBACK_FILL = [
   0,
@@ -176,6 +177,30 @@ export function reportWidgetBounds(
     w,
     h
   );
+}
+
+/**
+ * Paint the shared HUD background panel behind one widget's readout, using the
+ * rectangle it just reported. `size` is the widget's font size, driving the
+ * padding so the chip hugs the text. A no-op unless the HUD item sets a
+ * non-transparent `backgroundColor` (see drawSlideHud). Call it right after
+ * reportWidgetBounds, before drawing the widget's own marks.
+ */
+export function paintWidgetBackground(
+  style, x, y, w, h, size = 12
+) {
+  const padX = size * 0.35;
+  const padTop = size * 0.25;
+  const padBottom = size * 0.3;
+
+  drawItemBackground( {
+    x: x - padX,
+    y: y - padTop,
+    w: w + padX * 2,
+    h: h + padTop + padBottom,
+    color: style?.background,
+    radius: style?.backgroundRadius ?? 0
+  } );
 }
 
 /**

--- a/src/sketches/p5/utils/hud/widgets/counter.js
+++ b/src/sketches/p5/utils/hud/widgets/counter.js
@@ -7,6 +7,7 @@ import {
   anchoredRect,
   formatValue,
   getFont,
+  paintWidgetBackground,
   reportWidgetBounds,
   resolveAnchor,
   toColor,
@@ -84,6 +85,15 @@ export default function counter(
       rect.y,
       rect.w,
       rect.h
+    );
+
+    paintWidgetBackground(
+      style,
+      rect.x,
+      rect.y,
+      rect.w,
+      rect.h,
+      s
     );
 
     string.write(

--- a/src/sketches/p5/utils/hud/widgets/gauge.js
+++ b/src/sketches/p5/utils/hud/widgets/gauge.js
@@ -7,6 +7,7 @@ import {
 import {
   formatValue,
   getFont,
+  paintWidgetBackground,
   reportWidgetBounds,
   resolveBlock,
   toColor,
@@ -53,6 +54,15 @@ export default function gauge(
       blockY,
       barW,
       blockH
+    );
+
+    paintWidgetBackground(
+      style,
+      blockX,
+      blockY,
+      barW,
+      blockH,
+      s
     );
 
     const fill = toColor(

--- a/src/sketches/p5/utils/hud/widgets/sparkline.js
+++ b/src/sketches/p5/utils/hud/widgets/sparkline.js
@@ -10,6 +10,7 @@ import {
 import {
   formatValue,
   getFont,
+  paintWidgetBackground,
   reportWidgetBounds,
   resolveBlock,
   toColor,
@@ -57,6 +58,15 @@ export default function sparkline(
       blockY,
       boxW,
       blockH
+    );
+
+    paintWidgetBackground(
+      style,
+      blockX,
+      blockY,
+      boxW,
+      blockH,
+      s
     );
 
     const fill = toColor(

--- a/src/sketches/p5/utils/hud/widgets/swatch.js
+++ b/src/sketches/p5/utils/hud/widgets/swatch.js
@@ -5,6 +5,7 @@ import {
 } from "../sources.js";
 import {
   getFont,
+  paintWidgetBackground,
   reportWidgetBounds,
   resolveBlock,
   toColor,
@@ -71,6 +72,15 @@ export default function swatch(
       blockY,
       blockW,
       chip
+    );
+
+    paintWidgetBackground(
+      style,
+      blockX,
+      blockY,
+      blockW,
+      chip,
+      s
     );
 
     const textFill = toColor(

--- a/src/sketches/p5/utils/slides/common/drawItemBackground.js
+++ b/src/sketches/p5/utils/slides/common/drawItemBackground.js
@@ -3,11 +3,75 @@ import {
 } from "../../sketch.js";
 
 /**
+ * Tight vertical glyph box of a single line of `text` drawn at (x, y) with the
+ * TOP text baseline (how the overlays lay out their text). Returns
+ * { top, bottom } in canvas pixels.
+ *
+ * Uses the loaded p5.Font's real glyph bounds (font.textBounds) when available
+ * — the robust path, so the panel hugs the actual caps/descenders instead of
+ * the nominal em box (which reads as "more space on top than bottom"). Falls
+ * back to ascent/descent metrics when the font is still loading.
+ */
+export function measureVerticalTextBox(
+  font, text, x, y, size
+) {
+  const p = getP5();
+
+  p.push();
+  p.textFont( font );
+  p.textSize( size );
+  p.textAlign(
+    p.LEFT,
+    p.TOP
+  );
+
+  let top = y;
+  let bottom = y + size;
+
+  if ( font && typeof font.textBounds === "function" && font.font && text ) {
+    try {
+      const box = font.textBounds(
+        text,
+        x,
+        y,
+        size
+      );
+
+      if ( box && Number.isFinite( box.y ) && Number.isFinite( box.h ) ) {
+        top = box.y;
+        bottom = box.y + box.h;
+      }
+    } catch {
+      // Fall back to metrics below on any font-internal failure.
+      const asc = p.textAscent();
+      const desc = p.textDescent();
+
+      top = y;
+      bottom = y + asc + desc;
+    }
+  } else {
+    const asc = p.textAscent();
+    const desc = p.textDescent();
+
+    top = y;
+    bottom = y + asc + desc;
+  }
+
+  p.pop();
+
+  return {
+    top,
+    bottom
+  };
+}
+
+/**
  * Draw a rounded background panel behind a content-item's text block (slide
  * title, specs, HUD widgets). Shared so the three overlays paint an identical
- * chip: an rgba `color` (a fully transparent one — the default — draws
- * nothing), a corner `radius` in pixels (clamped to the panel's half-size), and
- * an `alpha` multiplier (0..1) so overlays that fade carry the panel with them.
+ * chip: an rgba `color` fill and an optional rgba `stroke` outline (both
+ * default transparent — draw nothing), a corner `radius` in pixels (clamped to
+ * the panel's half-size), and an `alpha` multiplier (0..1) so overlays that
+ * fade carry the panel with them.
  *
  * Drawn under a normal BLEND mode so a semi-transparent black actually darkens
  * the pixels underneath, independent of the item's own blend mode.
@@ -19,29 +83,24 @@ export default function drawItemBackground( {
   h,
   color,
   radius = 0,
-  alpha = 1
+  alpha = 1,
+  stroke,
+  strokeWeight = 0
 } ) {
-  if ( !Array.isArray( color ) || w <= 0 || h <= 0 ) {
+  if ( w <= 0 || h <= 0 ) {
     return;
   }
 
-  const baseAlpha = color[ 3 ] ?? 255;
-  const finalAlpha = baseAlpha * alpha;
+  const fillAlpha = Array.isArray( color ) ? ( color[ 3 ] ?? 255 ) * alpha : 0;
+  const hasStroke = Array.isArray( stroke ) && strokeWeight > 0;
+  const strokeAlpha = hasStroke ? ( stroke[ 3 ] ?? 255 ) * alpha : 0;
 
-  // A transparent panel (default) paints nothing — the common case.
-  if ( finalAlpha <= 0 ) {
+  // A fully transparent panel (the default) paints nothing — the common case.
+  if ( fillAlpha <= 0 && strokeAlpha <= 0 ) {
     return;
   }
 
   const p = getP5();
-  const fill = p.color(
-    color[ 0 ] ?? 0,
-    color[ 1 ] ?? 0,
-    color[ 2 ] ?? 0
-  );
-
-  fill.setAlpha( finalAlpha );
-
   const r = Math.max(
     0,
     Math.min(
@@ -54,8 +113,34 @@ export default function drawItemBackground( {
   p.push();
   p.blendMode( p.BLEND );
   p.rectMode( p.CORNER );
-  p.noStroke();
-  p.fill( fill );
+
+  if ( fillAlpha > 0 ) {
+    const fill = p.color(
+      color[ 0 ] ?? 0,
+      color[ 1 ] ?? 0,
+      color[ 2 ] ?? 0
+    );
+
+    fill.setAlpha( fillAlpha );
+    p.fill( fill );
+  } else {
+    p.noFill();
+  }
+
+  if ( strokeAlpha > 0 ) {
+    const line = p.color(
+      stroke[ 0 ] ?? 0,
+      stroke[ 1 ] ?? 0,
+      stroke[ 2 ] ?? 0
+    );
+
+    line.setAlpha( strokeAlpha );
+    p.stroke( line );
+    p.strokeWeight( strokeWeight );
+  } else {
+    p.noStroke();
+  }
+
   p.rect(
     x,
     y,

--- a/src/sketches/p5/utils/slides/common/drawItemBackground.js
+++ b/src/sketches/p5/utils/slides/common/drawItemBackground.js
@@ -1,0 +1,67 @@
+import {
+  getP5
+} from "../../sketch.js";
+
+/**
+ * Draw a rounded background panel behind a content-item's text block (slide
+ * title, specs, HUD widgets). Shared so the three overlays paint an identical
+ * chip: an rgba `color` (a fully transparent one — the default — draws
+ * nothing), a corner `radius` in pixels (clamped to the panel's half-size), and
+ * an `alpha` multiplier (0..1) so overlays that fade carry the panel with them.
+ *
+ * Drawn under a normal BLEND mode so a semi-transparent black actually darkens
+ * the pixels underneath, independent of the item's own blend mode.
+ */
+export default function drawItemBackground( {
+  x,
+  y,
+  w,
+  h,
+  color,
+  radius = 0,
+  alpha = 1
+} ) {
+  if ( !Array.isArray( color ) || w <= 0 || h <= 0 ) {
+    return;
+  }
+
+  const baseAlpha = color[ 3 ] ?? 255;
+  const finalAlpha = baseAlpha * alpha;
+
+  // A transparent panel (default) paints nothing — the common case.
+  if ( finalAlpha <= 0 ) {
+    return;
+  }
+
+  const p = getP5();
+  const fill = p.color(
+    color[ 0 ] ?? 0,
+    color[ 1 ] ?? 0,
+    color[ 2 ] ?? 0
+  );
+
+  fill.setAlpha( finalAlpha );
+
+  const r = Math.max(
+    0,
+    Math.min(
+      radius,
+      w / 2,
+      h / 2
+    )
+  );
+
+  p.push();
+  p.blendMode( p.BLEND );
+  p.rectMode( p.CORNER );
+  p.noStroke();
+  p.fill( fill );
+  p.rect(
+    x,
+    y,
+    w,
+    h,
+    r
+  );
+  p.pop();
+}

--- a/src/sketches/p5/utils/slides/common/drawSlideHud.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideHud.js
@@ -46,6 +46,12 @@ export default function drawSlideHud( item ) {
       0,
       0
     ],
+    backgroundStroke: item.backgroundStroke ?? [
+      0,
+      0,
+      0,
+      0
+    ],
     backgroundRadius: item.backgroundRadius ?? 0
   };
 

--- a/src/sketches/p5/utils/slides/common/drawSlideHud.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideHud.js
@@ -37,7 +37,16 @@ export default function drawSlideHud( item ) {
       255
     ],
     font: item.font ?? "spaceMonoRegular",
-    blend: item.blend ?? "source-over"
+    blend: item.blend ?? "source-over",
+    // Shared background panel painted behind each boxed widget's readout.
+    // Transparent by default (draws nothing); see paintWidgetBackground.
+    background: item.backgroundColor ?? [
+      0,
+      0,
+      0,
+      0
+    ],
+    backgroundRadius: item.backgroundRadius ?? 0
   };
 
   for ( const key of WIDGET_ORDER ) {

--- a/src/sketches/p5/utils/slides/common/drawSlideSpecs.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideSpecs.js
@@ -7,6 +7,7 @@ import time from "../../time.js";
 import buildSpecsLines from "./specsData.js";
 import computeSpecsHeats from "./specsChanges.js";
 import specsSound from "./specsSound.js";
+import drawItemBackground from "./drawItemBackground.js";
 import {
   reportItemBounds
 } from "./itemBoundsRegistry.js";
@@ -405,15 +406,15 @@ export default function drawSlideSpecs( specsOption ) {
   const originX = p.width * ( specsOption.position?.x ?? 0.05 );
   const originY = p.height * ( specsOption.position?.y ?? 0.06 );
 
+  const blockW = Math.max(
+    ...lines.map( ( line ) => measureWidth( `${ line.label }: ${ line.value }` ) ),
+    size * 4
+  );
+
   // Approximate drawn block (origin, stacked lines) for the on-canvas drag's
   // hit-test. Ticker style shows one line, boot-log all of them — the full
   // block is a generous, stable grab zone for both.
   if ( lines.length > 0 ) {
-    const blockW = Math.max(
-      ...lines.map( ( line ) => measureWidth( `${ line.label }: ${ line.value }` ) ),
-      size * 4
-    );
-
     reportItemBounds(
       originX,
       originY - size,
@@ -421,6 +422,24 @@ export default function drawSlideSpecs( specsOption ) {
       lines.length * lineStep + size * 2
     );
   }
+
+  // Background panel behind the block, drawn first so text sits on top. Height
+  // tracks the shown lines — one for the ticker, the whole list for boot-log —
+  // and it fades with the overlay alpha.
+  const bgLineCount = specsOption.style === "ticker" ? 1 : lines.length;
+  const bgPadX = size * 0.4;
+  const bgPadTop = size * 0.35;
+  const bgPadBottom = size * 0.35;
+
+  drawItemBackground( {
+    x: originX - bgPadX,
+    y: originY - bgPadTop,
+    w: blockW + bgPadX * 2,
+    h: ( bgLineCount - 1 ) * lineStep + size + bgPadTop + bgPadBottom,
+    color: specsOption.backgroundColor,
+    radius: specsOption.backgroundRadius ?? 0,
+    alpha: alpha / 255
+  } );
 
   if ( specsOption.style === "ticker" ) {
     // Single line cycling through all parameters. In permanent mode the reveal

--- a/src/sketches/p5/utils/slides/common/drawSlideSpecs.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideSpecs.js
@@ -7,7 +7,9 @@ import time from "../../time.js";
 import buildSpecsLines from "./specsData.js";
 import computeSpecsHeats from "./specsChanges.js";
 import specsSound from "./specsSound.js";
-import drawItemBackground from "./drawItemBackground.js";
+import drawItemBackground, {
+  measureVerticalTextBox
+} from "./drawItemBackground.js";
 import {
   reportItemBounds
 } from "./itemBoundsRegistry.js";
@@ -425,20 +427,48 @@ export default function drawSlideSpecs( specsOption ) {
 
   // Background panel behind the block, drawn first so text sits on top. Height
   // tracks the shown lines — one for the ticker, the whole list for boot-log —
-  // and it fades with the overlay alpha.
+  // and it fades with the overlay alpha. The vertical extent comes from the
+  // real glyph bounds of the first/last visible line (measureVerticalTextBox),
+  // so the panel hugs the text symmetrically instead of the nominal em box.
   const bgLineCount = specsOption.style === "ticker" ? 1 : lines.length;
-  const bgPadX = size * 0.4;
-  const bgPadTop = size * 0.35;
-  const bgPadBottom = size * 0.35;
+  const lastLineIndex = Math.min(
+    bgLineCount - 1,
+    lines.length - 1
+  );
+  const firstText = `${ lines[ 0 ].label }: ${ lines[ 0 ].value }`;
+  const lastText = `${ lines[ lastLineIndex ].label }: ${ lines[ lastLineIndex ].value }`;
+  const firstBox = measureVerticalTextBox(
+    font,
+    firstText,
+    originX,
+    originY,
+    size
+  );
+  const lastBox = measureVerticalTextBox(
+    font,
+    lastText,
+    originX,
+    originY + lastLineIndex * lineStep,
+    size
+  );
+  const bgPad = size * 0.35;
 
   drawItemBackground( {
-    x: originX - bgPadX,
-    y: originY - bgPadTop,
-    w: blockW + bgPadX * 2,
-    h: ( bgLineCount - 1 ) * lineStep + size + bgPadTop + bgPadBottom,
+    x: originX - bgPad,
+    y: firstBox.top - bgPad,
+    w: blockW + bgPad * 2,
+    h: lastBox.bottom - firstBox.top + bgPad * 2,
     color: specsOption.backgroundColor,
     radius: specsOption.backgroundRadius ?? 0,
-    alpha: alpha / 255
+    alpha: alpha / 255,
+    stroke: specsOption.backgroundStroke,
+    strokeWeight: Math.min(
+      Math.max(
+        1,
+        size * 0.06
+      ),
+      4
+    )
   } );
 
   if ( specsOption.style === "ticker" ) {

--- a/src/sketches/p5/utils/slides/montageTitle/index.js
+++ b/src/sketches/p5/utils/slides/montageTitle/index.js
@@ -14,7 +14,9 @@ import {
 import {
   reportItemBounds
 } from "../common/itemBoundsRegistry.js";
-import drawItemBackground from "../common/drawItemBackground.js";
+import drawItemBackground, {
+  measureVerticalTextBox
+} from "../common/drawItemBackground.js";
 import {
   resolveMontageTitlePosition
 } from "../contentDrag.js";
@@ -516,17 +518,58 @@ export default function drawMontageTitle(
 
     // Background panel behind the label, drawn before chrome/text so both sit
     // on top. Transparent by default; a colour keeps a light label readable.
-    const bgPadX = size * 0.35;
-    const bgPadTop = size * 0.2;
-    const bgPadBottom = size * 0.3;
+    // Vertical extent from the real glyph bounds so the panel hugs the caps and
+    // descenders symmetrically instead of the nominal em box.
+    const {
+      top: bgTop,
+      bottom: bgBottom
+    } = measureVerticalTextBox(
+      font,
+      shownText,
+      shownLeft,
+      anchorY,
+      size
+    );
+
+    let bgLeft = shownLeft;
+    let bgRight = shownLeft + shownWidth;
+
+    // The bracket style draws "[" / "]" outside the label box, so the panel has
+    // to reach out to enclose them (plus a couple of pixels of breathing room)
+    // — the other styles paint within or below the label box already.
+    if ( title.style === "bracket" ) {
+      p.push();
+      p.textFont( font );
+      p.textSize( size );
+      const bracketGap = size * 0.35;
+      const openWidth = p.textWidth( "[" );
+      const closeWidth = p.textWidth( "]" );
+
+      p.pop();
+
+      const bracketMargin = 2;
+
+      bgLeft -= bracketGap + openWidth + bracketMargin;
+      bgRight += bracketGap + closeWidth + bracketMargin;
+    }
+
+    const bgPad = size * 0.28;
 
     drawItemBackground( {
-      x: shownLeft - bgPadX,
-      y: anchorY - bgPadTop,
-      w: shownWidth + bgPadX * 2,
-      h: size + bgPadTop + bgPadBottom,
+      x: bgLeft - bgPad,
+      y: bgTop - bgPad,
+      w: bgRight - bgLeft + bgPad * 2,
+      h: bgBottom - bgTop + bgPad * 2,
       color: title.backgroundColor,
-      radius: title.backgroundRadius ?? 0
+      radius: title.backgroundRadius ?? 0,
+      stroke: title.backgroundStroke,
+      strokeWeight: Math.min(
+        Math.max(
+          1,
+          size * 0.05
+        ),
+        4
+      )
     } );
 
     // The panel paints under BLEND; p5's 2D pop() does not restore blendMode,

--- a/src/sketches/p5/utils/slides/montageTitle/index.js
+++ b/src/sketches/p5/utils/slides/montageTitle/index.js
@@ -14,6 +14,7 @@ import {
 import {
   reportItemBounds
 } from "../common/itemBoundsRegistry.js";
+import drawItemBackground from "../common/drawItemBackground.js";
 import {
   resolveMontageTitlePosition
 } from "../contentDrag.js";
@@ -500,16 +501,37 @@ export default function drawMontageTitle(
 
     p.pop();
 
+    const shownLeft = alignLeft(
+      anchorX,
+      shownWidth,
+      title.align
+    );
+
     reportItemBounds(
-      alignLeft(
-        anchorX,
-        shownWidth,
-        title.align
-      ),
+      shownLeft,
       anchorY,
       shownWidth,
       size
     );
+
+    // Background panel behind the label, drawn before chrome/text so both sit
+    // on top. Transparent by default; a colour keeps a light label readable.
+    const bgPadX = size * 0.35;
+    const bgPadTop = size * 0.2;
+    const bgPadBottom = size * 0.3;
+
+    drawItemBackground( {
+      x: shownLeft - bgPadX,
+      y: anchorY - bgPadTop,
+      w: shownWidth + bgPadX * 2,
+      h: size + bgPadTop + bgPadBottom,
+      color: title.backgroundColor,
+      radius: title.backgroundRadius ?? 0
+    } );
+
+    // The panel paints under BLEND; p5's 2D pop() does not restore blendMode,
+    // so re-assert the title's blend before the label draws over it.
+    p.blendMode( title.blend ?? "source-over" );
   }
 
   if ( !changing ) {

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -385,11 +385,13 @@ export const SpecsItemSchema = z.object( {
     0,
     0
   ] ),
-  // Optional outline around that panel. Transparent by default (no border).
+  // Optional outline around that panel. Defaults to the text fill colour with
+  // zero opacity (so it draws nothing) — raise the alpha to reveal a border in
+  // the same colour as the text.
   backgroundStroke: RGBA.default( [
     0,
-    0,
-    0,
+    255,
+    120,
     0
   ] ),
   // Corner radius of that panel, in pixels. 0 = sharp rectangle.
@@ -976,11 +978,13 @@ export const HudItemSchema = z.object( {
     0,
     0
   ] ),
-  // Optional outline around each widget's panel. Transparent by default.
+  // Optional outline around each widget's panel. Defaults to the fill colour
+  // with zero opacity (draws nothing) — raise the alpha to reveal a border in
+  // the same colour as the readout.
   backgroundStroke: RGBA.default( [
     0,
-    0,
-    0,
+    255,
+    120,
     0
   ] ),
   // Corner radius of those panels, in pixels. 0 = sharp rectangle.
@@ -1164,11 +1168,13 @@ export const SlideTitleSchema = z.object( {
     0,
     0
   ] ),
-  // Optional outline around that panel. Transparent by default (no border).
+  // Optional outline around that panel. Defaults to the label fill colour with
+  // zero opacity (draws nothing) — raise the alpha to reveal a border in the
+  // same colour as the label.
   backgroundStroke: RGBA.default( [
     0,
-    0,
-    0,
+    255,
+    120,
     0
   ] ),
   // Corner radius of that panel, in pixels. 0 = sharp rectangle.

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -385,6 +385,13 @@ export const SpecsItemSchema = z.object( {
     0,
     0
   ] ),
+  // Optional outline around that panel. Transparent by default (no border).
+  backgroundStroke: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
   // Corner radius of that panel, in pixels. 0 = sharp rectangle.
   backgroundRadius: z.number().min( 0 )
     .max( 200 )
@@ -969,6 +976,13 @@ export const HudItemSchema = z.object( {
     0,
     0
   ] ),
+  // Optional outline around each widget's panel. Transparent by default.
+  backgroundStroke: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
   // Corner radius of those panels, in pixels. 0 = sharp rectangle.
   backgroundRadius: z.number().min( 0 )
     .max( 200 )
@@ -1142,8 +1156,16 @@ export const SlideTitleSchema = z.object( {
   ] ),
   // Panel painted behind the label. Transparent black by default (draws
   // nothing) — set a colour (e.g. a solid dark) to keep a light label readable
-  // over busy sketches.
+  // over busy sketches. For the "bracket" style the panel extends to enclose
+  // the [ ] glyphs too.
   backgroundColor: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
+  // Optional outline around that panel. Transparent by default (no border).
+  backgroundStroke: RGBA.default( [
     0,
     0,
     0,

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -377,6 +377,18 @@ export const SpecsItemSchema = z.object( {
     255,
     120
   ] ),
+  // Panel painted behind the specs block. Transparent black by default (draws
+  // nothing) — set a colour to keep the text readable over busy sketches.
+  backgroundColor: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
+  // Corner radius of that panel, in pixels. 0 = sharp rectangle.
+  backgroundRadius: z.number().min( 0 )
+    .max( 200 )
+    .default( 0 ),
   blend: Blend.default( "source-over" ),
   position: Vec2.default( {
     x: 0.05,
@@ -947,6 +959,20 @@ export const HudItemSchema = z.object( {
     120,
     255
   ] ),
+  // Panel painted behind each widget's readout. Transparent black by default
+  // (draws nothing) — set a colour to keep the telemetry readable over busy
+  // sketches. Applies to the boxed widgets, not the full-canvas crosshairs /
+  // bounding-box overlays.
+  backgroundColor: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
+  // Corner radius of those panels, in pixels. 0 = sharp rectangle.
+  backgroundRadius: z.number().min( 0 )
+    .max( 200 )
+    .default( 0 ),
   font: z.string().default( "spaceMonoRegular" ),
   blend: Blend.default( "source-over" ),
   badge: HudBadgeSchema,
@@ -1114,6 +1140,19 @@ export const SlideTitleSchema = z.object( {
     255,
     120
   ] ),
+  // Panel painted behind the label. Transparent black by default (draws
+  // nothing) — set a colour (e.g. a solid dark) to keep a light label readable
+  // over busy sketches.
+  backgroundColor: RGBA.default( [
+    0,
+    0,
+    0,
+    0
+  ] ),
+  // Corner radius of that panel, in pixels. 0 = sharp rectangle.
+  backgroundRadius: z.number().min( 0 )
+    .max( 200 )
+    .default( 0 ),
   blend: Blend.default( "source-over" ),
   style: z.enum( TITLE_DISPLAY_STYLES ).default( "bracket" ),
 


### PR DESCRIPTION
## What & why

The montage transition **Slide title**, the **specs** content item and the **HUD** content item only exposed a text/fill colour. Over busy sketches the text becomes unreadable — there was no way to put a backing panel behind it. This adds a configurable background panel (colour + corner radius) to all three, so you can, e.g., set a solid dark background and a white label.

## Changes

**Schema (`src/types/sketch.types.ts`)**
- Added `backgroundColor` (RGBA, default transparent black `[0,0,0,0]` → draws nothing) and `backgroundRadius` (pixels, `0`–`200`, default `0`) to `SlideTitleSchema`, `SpecsItemSchema` and `HudItemSchema`. Existing decks heal in with the transparent default, so nothing changes visually until a colour is set.

**Rendering**
- New shared helper `slides/common/drawItemBackground.js` — paints a rounded rect under a normal `BLEND` mode (so a semi-transparent black actually darkens the pixels beneath, independent of the item's own blend mode); radius is clamped to the panel's half-size; a fully transparent colour is a no-op.
- **Montage title** (`montageTitle/index.js`) — panel drawn behind the shown label, then the title's blend mode is re-asserted (p5's 2D `pop()` doesn't restore `blendMode`).
- **Specs** (`drawSlideSpecs.js`) — panel behind the block; height tracks the shown lines (one for ticker, the whole list for boot-log) and fades with the overlay alpha.
- **HUD** — shared `paintWidgetBackground` helper in `hud/widgets/common.js` paints a chip behind each boxed widget (badge, gauge, sparkline, counter, swatch) using the rect it already reports; the full-canvas crosshairs / bounding-box overlays are intentionally left untouched. `drawSlideHud.js` threads the colour/radius into the per-widget `style`.

**UI**
- Montage title panel (`SlideTransitionSettings.tsx`): added **Background** colour + **Background radius** slider after Fill.
- Specs and HUD form configs (`field-config.ts`): added the same two controls.

## Testing

- `npm run lint` — clean (only 2 pre-existing warnings in untouched files)
- `npm test` — 1601 passed
- `npm run build` — succeeds

## Notes

Defaults are fully backward-compatible: transparent black + radius 0 renders exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPaVeoQyLjNTEXHm6xWH3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPaVeoQyLjNTEXHm6xWH3D)_