### PR TITLE
feat(slides): apply a parameter block or field to all slides

### DIFF
--- a/src/components/ApplyToAllSlidesButton.tsx
+++ b/src/components/ApplyToAllSlidesButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import {
+  CopyPlus
+} from "lucide-react";
+import {
+  useFormContext
+} from "react-hook-form";
+import {
+  applyToAllSlides, canApplyToAllSlides
+} from "@/components/ClientProcessingSketch/components/SketchOptions/utils/applyToAllSlides";
+
+type ApplyToAllSlidesButtonProps = {
+  /** Full RHF path of the block/field to propagate, e.g. `slides.0.sketch.colors`. */
+  basePath: string;
+  className?: string;
+};
+
+/**
+ * Icon button that copies the current block/field value onto every other slide.
+ * Renders nothing unless we are editing a slide and there is more than one
+ * slide — so it never shows up on single-slide sketches or the global settings.
+ * Sits beside the shuffle/reset controls of a block header.
+ */
+export default function ApplyToAllSlidesButton( {
+  basePath,
+  className = "text-foreground hover:bg-theme/20 rounded transition-colors"
+}: ApplyToAllSlidesButtonProps ) {
+  const {
+    getValues,
+    setValue
+  } = useFormContext();
+
+  if ( !canApplyToAllSlides(
+    getValues,
+    basePath
+  ) ) {
+    return null;
+  }
+
+  const handleApply = ( event: React.MouseEvent ) => {
+    event.stopPropagation();
+    applyToAllSlides(
+      getValues,
+      setValue,
+      basePath
+    );
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={ handleApply }
+      className={ className }
+      title="Appliquer à tous les slides"
+    >
+      <CopyPlus className="w-3.5 h-3.5" />
+    </button>
+  );
+}

--- a/src/components/ApplyToAllSlidesButton.tsx
+++ b/src/components/ApplyToAllSlidesButton.tsx
@@ -53,7 +53,7 @@ export default function ApplyToAllSlidesButton( {
       type="button"
       onClick={ handleApply }
       className={ className }
-      title="Appliquer à tous les slides"
+      title="Apply to all slides"
     >
       <CopyPlus className="w-3.5 h-3.5" />
     </button>

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldContextMenu.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldContextMenu.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import React, {
+  useCallback, useEffect, useState
+} from "react";
+import {
+  createPortal
+} from "react-dom";
+
+export type FieldContextMenuItem = {
+  label: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  onClick: () => void;
+};
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Lightweight right-click context menu state. Kept out of the render tree until
+ * opened so fields carry zero permanent visual weight — the anti-clutter goal
+ * for per-field actions like "apply this value to all slides".
+ */
+export function useFieldContextMenu(): {
+  position: Position | null;
+  open: ( event: React.MouseEvent ) => void;
+  close: () => void;
+} {
+  const [
+    position,
+    setPosition
+  ] = useState<Position | null>( null );
+
+  const open = useCallback(
+    ( event: React.MouseEvent ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setPosition( {
+        x: event.clientX,
+        y: event.clientY
+      } );
+    },
+    []
+  );
+
+  const close = useCallback(
+    () => setPosition( null ),
+    []
+  );
+
+  return {
+    position,
+    open,
+    close
+  };
+}
+
+type FieldContextMenuProps = {
+  position: Position;
+  items: FieldContextMenuItem[];
+  onClose: () => void;
+};
+
+/**
+ * Portal-rendered menu positioned at the cursor. Closes on outside click,
+ * scroll, resize or Escape. Styling mirrors the app's other floating menus.
+ */
+export default function FieldContextMenu( {
+  position,
+  items,
+  onClose
+}: FieldContextMenuProps ) {
+  useEffect(
+    () => {
+      const handleKey = ( event: KeyboardEvent ) => {
+        if ( event.key === "Escape" ) {
+          onClose();
+        }
+      };
+
+      window.addEventListener(
+        "keydown",
+        handleKey
+      );
+      window.addEventListener(
+        "resize",
+        onClose
+      );
+      window.addEventListener(
+        "scroll",
+        onClose,
+        true
+      );
+
+      return () => {
+        window.removeEventListener(
+          "keydown",
+          handleKey
+        );
+        window.removeEventListener(
+          "resize",
+          onClose
+        );
+        window.removeEventListener(
+          "scroll",
+          onClose,
+          true
+        );
+      };
+    },
+    [
+      onClose
+    ]
+  );
+
+  if ( typeof document === "undefined" ) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      {/* Full-screen catcher closes the menu on any outside interaction. */}
+      <div
+        className="fixed inset-0 z-[80]"
+        onClick={ onClose }
+        onContextMenu={ ( event ) => {
+          event.preventDefault();
+          onClose();
+        } }
+      />
+      <div
+        className="fixed z-[81] min-w-52 overflow-hidden rounded-xl border border-border bg-background/95 backdrop-blur-xl shadow-xl py-1"
+        style={ {
+          top: position.y,
+          left: position.x
+        } }
+        onClick={ ( event ) => event.stopPropagation() }
+      >
+        {items.map( ( item ) => {
+          const Icon = item.icon;
+
+          return (
+            <button
+              key={ item.label }
+              type="button"
+              onClick={ () => {
+                item.onClick();
+                onClose();
+              } }
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-foreground hover:bg-hover transition-colors"
+            >
+              {Icon && <Icon className="w-3.5 h-3.5 shrink-0" />}
+              <span className="truncate">
+                {item.label}
+              </span>
+            </button>
+          );
+        } )}
+      </div>
+    </>,
+    document.body
+  );
+}

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
@@ -1,5 +1,5 @@
 import {
-  ChevronDown, RotateCcw
+  ChevronDown, CopyPlus, RotateCcw
 } from "lucide-react";
 import clsx from "clsx";
 import {
@@ -37,6 +37,13 @@ import ControlledJoypadDeviceSelect
   from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/ControlledJoypadDeviceSelect";
 import CollapsibleItem from "@/components/CollapsibleItem";
 import RandomizeSettingsButton from "@/components/RandomizeSettingsButton";
+import ApplyToAllSlidesButton from "@/components/ApplyToAllSlidesButton";
+import FieldContextMenu, {
+  useFieldContextMenu
+} from "./FieldContextMenu";
+import {
+  applyToAllSlides, canApplyToAllSlides
+} from "../utils/applyToAllSlides";
 import BindingAffordance
   from "./ContentItems/components/BindingAffordance/BindingAffordance";
 import {
@@ -135,6 +142,39 @@ export default function FieldRenderer( {
         shouldTouch: true,
         shouldValidate: true
       }
+    );
+  };
+
+  // Right-click a field (or block) to apply its value to every other slide.
+  // Only active in a multi-slide context, and never over editable inputs — so
+  // the native menu (copy/paste/spellcheck) is preserved and no permanent icon
+  // is added to each row.
+  const contextMenu = useFieldContextMenu();
+
+  const canApply = canApplyToAllSlides(
+    getValues,
+    registeredName
+  );
+
+  const handleFieldContextMenu = ( event: React.MouseEvent ) => {
+    if ( !canApply ) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
+
+    if ( target.closest( "input, textarea, [contenteditable=\"true\"]" ) ) {
+      return;
+    }
+
+    contextMenu.open( event );
+  };
+
+  const handleApplyToAllSlides = () => {
+    applyToAllSlides(
+      getValues,
+      setValue,
+      registeredName
     );
   };
 
@@ -390,6 +430,10 @@ export default function FieldRenderer( {
                     basePath={ registeredName }
                     className="text-foreground p-2 md:p-0.5 hover:bg-theme/20 rounded-md transition-colors"
                   />
+                  <ApplyToAllSlidesButton
+                    basePath={ registeredName }
+                    className="text-foreground p-2 md:p-0.5 hover:bg-theme/20 rounded-md transition-colors"
+                  />
                 </div>
               </div>
             ) }
@@ -623,7 +667,25 @@ export default function FieldRenderer( {
   ) : null;
 
   return (
-    <div className="text-sm md:text-xs">
+    <div
+      className="text-sm md:text-xs"
+      onContextMenu={ handleFieldContextMenu }
+    >
+      {contextMenu.position && (
+        <FieldContextMenu
+          position={ contextMenu.position }
+          onClose={ contextMenu.close }
+          items={ [
+            {
+              label: config.label
+                ? `Appliquer « ${ config.label } » à tous les slides`
+                : "Appliquer à tous les slides",
+              icon: CopyPlus,
+              onClick: handleApplyToAllSlides
+            }
+          ] }
+        />
+      )}
       {needsOuterLabel &&
         config.label &&
         !hideLabel && (

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/FieldRenderer.tsx
@@ -156,18 +156,38 @@ export default function FieldRenderer( {
     registeredName
   );
 
-  const handleFieldContextMenu = ( event: React.MouseEvent ) => {
+  // Whether this field should host the "apply to all slides" affordances:
+  // a multi-slide context, and not over an editable input (whose native menu
+  // and pointer behaviour we leave alone).
+  const canContextApply = ( target: EventTarget | null ): boolean => {
     if ( !canApply ) {
-      return;
+      return false;
     }
 
-    const target = event.target as HTMLElement;
+    const element = target as HTMLElement | null;
 
-    if ( target.closest( "input, textarea, [contenteditable=\"true\"]" ) ) {
+    return !element?.closest( "input, textarea, [contenteditable=\"true\"]" );
+  };
+
+  const handleFieldContextMenu = ( event: React.MouseEvent ) => {
+    if ( !canContextApply( event.target ) ) {
       return;
     }
 
     contextMenu.open( event );
+  };
+
+  // Swallow the secondary-button press before it reaches the underlying control.
+  // Custom controls (e.g. the slider's pointer-driven drag) don't filter the
+  // mouse button, so a right-click would otherwise change the value on
+  // pointerdown — before the context menu even opens. Capturing here stops the
+  // synthetic event from reaching the child handlers.
+  const handleSecondaryButtonCapture = ( event: React.PointerEvent | React.MouseEvent ) => {
+    if ( event.button !== 2 || !canContextApply( event.target ) ) {
+      return;
+    }
+
+    event.stopPropagation();
   };
 
   const handleApplyToAllSlides = () => {
@@ -669,6 +689,8 @@ export default function FieldRenderer( {
   return (
     <div
       className="text-sm md:text-xs"
+      onPointerDownCapture={ handleSecondaryButtonCapture }
+      onMouseDownCapture={ handleSecondaryButtonCapture }
       onContextMenu={ handleFieldContextMenu }
     >
       {contextMenu.position && (
@@ -678,8 +700,8 @@ export default function FieldRenderer( {
           items={ [
             {
               label: config.label
-                ? `Appliquer « ${ config.label } » à tous les slides`
-                : "Appliquer à tous les slides",
+                ? `Apply "${ config.label }" to all slides`
+                : "Apply to all slides",
               icon: CopyPlus,
               onClick: handleApplyToAllSlides
             }

--- a/src/components/ClientProcessingSketch/components/SketchOptions/utils/__tests__/applyToAllSlides.test.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/utils/__tests__/applyToAllSlides.test.ts
@@ -1,0 +1,359 @@
+import type {
+  FieldValues, UseFormGetValues, UseFormSetValue
+} from "react-hook-form";
+import {
+  applyToAllSlides,
+  canApplyToAllSlides,
+  countSlides,
+  parseSlidePath
+} from "../applyToAllSlides";
+
+/* ------------------------------------------------------------------ */
+/*  Minimal in-memory stand-in for the RHF getValues/setValue pair.     */
+/* ------------------------------------------------------------------ */
+
+function makeForm( initial: Record<string, unknown> ): {
+  store: Record<string, unknown>;
+  getValues: UseFormGetValues<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
+} {
+  const store = structuredClone( initial );
+
+  const getValues = ( ( path?: string ) => {
+    if ( path === undefined ) {
+      return store;
+    }
+
+    return path
+      .split( "." )
+      .reduce<any>(
+        (
+          acc, key
+        ) => ( acc == null ? acc : acc[ key ] ),
+        store
+      );
+  } ) as UseFormGetValues<FieldValues>;
+
+  const setValue = ( (
+    path: string, value: unknown
+  ) => {
+    const keys = path.split( "." );
+    const last = keys.pop() as string;
+    const parent = keys.reduce<any>(
+      (
+        acc, key
+      ) => acc[ key ],
+      store
+    );
+
+    parent[ last ] = value;
+  } ) as UseFormSetValue<FieldValues>;
+
+  return {
+    store,
+    getValues,
+    setValue
+  };
+}
+
+function makeSlides() {
+  return {
+    slides: [
+      {
+        sketch: {
+          colors: {
+            primary: [
+              10,
+              10,
+              10
+            ]
+          },
+          backgroundColor: [
+            0,
+            0,
+            0
+          ]
+        }
+      },
+      {
+        sketch: {
+          colors: {
+            primary: [
+              20,
+              20,
+              20
+            ]
+          },
+          backgroundColor: [
+            1,
+            1,
+            1
+          ]
+        }
+      },
+      {
+        sketch: {
+          colors: {
+            primary: [
+              30,
+              30,
+              30
+            ]
+          },
+          backgroundColor: [
+            2,
+            2,
+            2
+          ]
+        }
+      }
+    ]
+  };
+}
+
+describe(
+  "parseSlidePath",
+  () => {
+    it(
+      "parses a nested block path",
+      () => {
+        expect( parseSlidePath( "slides.2.sketch.colors" ) ).toEqual( {
+          index: 2,
+          suffix: ".colors"
+        } );
+      }
+    );
+
+    it(
+      "parses a deep field path",
+      () => {
+        expect( parseSlidePath( "slides.0.sketch.colors.primary" ) ).toEqual( {
+          index: 0,
+          suffix: ".colors.primary"
+        } );
+      }
+    );
+
+    it(
+      "parses a whole-sketch path with an empty suffix",
+      () => {
+        expect( parseSlidePath( "slides.1.sketch" ) ).toEqual( {
+          index: 1,
+          suffix: ""
+        } );
+      }
+    );
+
+    it(
+      "returns null for the global sketch path",
+      () => {
+        expect( parseSlidePath( "sketch.colors" ) ).toBeNull();
+      }
+    );
+  }
+);
+
+describe(
+  "countSlides / canApplyToAllSlides",
+  () => {
+    it(
+      "counts slides",
+      () => {
+        const {
+          getValues
+        } = makeForm( makeSlides() );
+
+        expect( countSlides( getValues ) ).toBe( 3 );
+      }
+    );
+
+    it(
+      "is enabled for a slide path when more than one slide exists",
+      () => {
+        const {
+          getValues
+        } = makeForm( makeSlides() );
+
+        expect( canApplyToAllSlides(
+          getValues,
+          "slides.0.sketch.colors"
+        ) ).toBe( true );
+      }
+    );
+
+    it(
+      "is disabled with a single slide",
+      () => {
+        const {
+          getValues
+        } = makeForm( {
+          slides: [
+            makeSlides().slides[ 0 ]
+          ]
+        } );
+
+        expect( canApplyToAllSlides(
+          getValues,
+          "slides.0.sketch.colors"
+        ) ).toBe( false );
+      }
+    );
+
+    it(
+      "is disabled for a global (non-slide) path",
+      () => {
+        const {
+          getValues
+        } = makeForm( makeSlides() );
+
+        expect( canApplyToAllSlides(
+          getValues,
+          "sketch.colors"
+        ) ).toBe( false );
+      }
+    );
+  }
+);
+
+describe(
+  "applyToAllSlides",
+  () => {
+    it(
+      "copies a block onto every other slide and returns the count",
+      () => {
+        const {
+          store, getValues, setValue
+        } = makeForm( makeSlides() );
+
+        const applied = applyToAllSlides(
+          getValues,
+          setValue,
+          "slides.0.sketch.colors"
+        );
+
+        expect( applied ).toBe( 2 );
+
+        const slides = ( store.slides as any[] );
+
+        expect( slides[ 1 ].sketch.colors.primary ).toEqual( [
+          10,
+          10,
+          10
+        ] );
+        expect( slides[ 2 ].sketch.colors.primary ).toEqual( [
+          10,
+          10,
+          10
+        ] );
+        // The source slide is untouched.
+        expect( slides[ 0 ].sketch.colors.primary ).toEqual( [
+          10,
+          10,
+          10
+        ] );
+        // Unrelated fields on other slides are preserved.
+        expect( slides[ 1 ].sketch.backgroundColor ).toEqual( [
+          1,
+          1,
+          1
+        ] );
+      }
+    );
+
+    it(
+      "propagates a single global field only",
+      () => {
+        const {
+          store, getValues, setValue
+        } = makeForm( makeSlides() );
+
+        applyToAllSlides(
+          getValues,
+          setValue,
+          "slides.1.sketch.backgroundColor"
+        );
+
+        const slides = ( store.slides as any[] );
+
+        expect( slides[ 0 ].sketch.backgroundColor ).toEqual( [
+          1,
+          1,
+          1
+        ] );
+        expect( slides[ 2 ].sketch.backgroundColor ).toEqual( [
+          1,
+          1,
+          1
+        ] );
+        // colors blocks stay per-slide.
+        expect( slides[ 0 ].sketch.colors.primary ).toEqual( [
+          10,
+          10,
+          10
+        ] );
+        expect( slides[ 2 ].sketch.colors.primary ).toEqual( [
+          30,
+          30,
+          30
+        ] );
+      }
+    );
+
+    it(
+      "deep-clones so slides don't share references",
+      () => {
+        const {
+          store, getValues, setValue
+        } = makeForm( makeSlides() );
+
+        applyToAllSlides(
+          getValues,
+          setValue,
+          "slides.0.sketch.colors"
+        );
+
+        const slides = ( store.slides as any[] );
+
+        expect( slides[ 1 ].sketch.colors ).not.toBe( slides[ 0 ].sketch.colors );
+
+        // Mutating slide 1 must not bleed into slide 2.
+        slides[ 1 ].sketch.colors.primary[ 0 ] = 999;
+        expect( slides[ 2 ].sketch.colors.primary[ 0 ] ).toBe( 10 );
+      }
+    );
+
+    it(
+      "does nothing for a non-slide path",
+      () => {
+        const {
+          getValues, setValue
+        } = makeForm( makeSlides() );
+
+        expect( applyToAllSlides(
+          getValues,
+          setValue,
+          "sketch.colors"
+        ) ).toBe( 0 );
+      }
+    );
+
+    it(
+      "does nothing with a single slide",
+      () => {
+        const {
+          getValues, setValue
+        } = makeForm( {
+          slides: [
+            makeSlides().slides[ 0 ]
+          ]
+        } );
+
+        expect( applyToAllSlides(
+          getValues,
+          setValue,
+          "slides.0.sketch.colors"
+        ) ).toBe( 0 );
+      }
+    );
+  }
+);

--- a/src/components/ClientProcessingSketch/components/SketchOptions/utils/applyToAllSlides.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/utils/applyToAllSlides.ts
@@ -1,0 +1,109 @@
+import type {
+  FieldValues, UseFormGetValues, UseFormSetValue
+} from "react-hook-form";
+import deepClone from "@/utils/deepClone";
+
+/**
+ * Cross-slide parameter propagation.
+ *
+ * Each slide stores a full copy of the sketch parameters under
+ * `slides.<index>.sketch`. These helpers take the value currently held at a
+ * field/block path on the *active* slide and write it onto the same relative
+ * path of every other slide — so a user can tweak, say, the `colors` block (or
+ * a single global field like `backgroundColor`) once and apply it everywhere.
+ *
+ * The change goes through `setValue`, so a single Undo reverts the whole
+ * propagation via the existing form history.
+ */
+
+const SLIDE_SKETCH_PATH = /^slides\.(\d+)\.sketch(?:\.(.+))?$/;
+
+type ParsedSlidePath = {
+  /** Index of the slide the path points at. */
+  index: number;
+  /** Relative path within a slide's `sketch`, dot-prefixed (`""` for the whole sketch). */
+  suffix: string;
+};
+
+/**
+ * Parses a RHF field path of the shape `slides.<index>.sketch[.<suffix>]`.
+ * Returns `null` for anything that isn't a slide-scoped sketch path (e.g. the
+ * global `sketch.…` path used when no slide is active).
+ */
+export function parseSlidePath( fullPath: string ): ParsedSlidePath | null {
+  const match = SLIDE_SKETCH_PATH.exec( fullPath );
+
+  if ( !match ) {
+    return null;
+  }
+
+  return {
+    index: Number( match[ 1 ] ),
+    suffix: match[ 2 ] ? `.${ match[ 2 ] }` : ""
+  };
+}
+
+/** Number of slides currently in the form, or 0 when there are none. */
+export function countSlides( getValues: UseFormGetValues<FieldValues> ): number {
+  const slides = getValues( "slides" );
+
+  return Array.isArray( slides ) ? slides.length : 0;
+}
+
+/**
+ * Whether an "apply to all slides" action is meaningful for this path — i.e. we
+ * are editing a slide and there is at least one *other* slide to apply to.
+ */
+export function canApplyToAllSlides(
+  getValues: UseFormGetValues<FieldValues>,
+  fullPath: string
+): boolean {
+  return parseSlidePath( fullPath ) !== null && countSlides( getValues ) > 1;
+}
+
+/**
+ * Copies the value at `fullPath` (on its own slide) onto the matching path of
+ * every other slide. Returns the number of slides written to (0 when the path
+ * isn't slide-scoped or there is only a single slide).
+ */
+export function applyToAllSlides(
+  getValues: UseFormGetValues<FieldValues>,
+  setValue: UseFormSetValue<FieldValues>,
+  fullPath: string
+): number {
+  const parsed = parseSlidePath( fullPath );
+
+  if ( !parsed ) {
+    return 0;
+  }
+
+  const slides = getValues( "slides" );
+
+  if ( !Array.isArray( slides ) || slides.length < 2 ) {
+    return 0;
+  }
+
+  const value = getValues( fullPath );
+
+  let applied = 0;
+
+  for ( let index = 0; index < slides.length; index++ ) {
+    if ( index === parsed.index ) {
+      continue;
+    }
+
+    setValue(
+      `slides.${ index }.sketch${ parsed.suffix }`,
+      deepClone( value ),
+      {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true
+      }
+    );
+
+    applied++;
+  }
+
+  return applied;
+}


### PR DESCRIPTION
## Contexte

Un template peut contenir plusieurs **slides**, chaque slide étant une copie complète des paramètres du sketch (`slides.<i>.sketch`) — c'est ce qui permet de créer des variantes. Il manquait un moyen de propager **un même bloc** (ex. `colors`) ou **un champ global** (ex. `backgroundColor`) sur *tous* les slides : il fallait refaire le réglage slide par slide.

Cette PR ajoute une action « **Appliquer à tous les slides** » qui prend la valeur du bloc/champ du slide actif et l'écrit sur tous les autres.

## Approche

On se greffe sur les affordances déjà présentes (reset / shuffle) plutôt que d'ajouter une nouvelle zone d'UI, pour ne pas alourdir l'interface :

| Portée | Mécanisme |
|---|---|
| **Bloc** (`nested-object` : colors, camera, time…) | Icône `CopyPlus` inline à côté de shuffle/reset dans l'en-tête du bloc |
| **Champ individuel + champ global** (`backgroundColor`) | Entrée de **menu contextuel (clic droit)** sur la ligne du champ — zéro poids visuel permanent |
| **Panneau entier** | *Volontairement exclu* (rendrait les slides identiques) |

Garde-fous :
- Les contrôles n'apparaissent **que si le template a plus d'un slide** et qu'on édite bien un slide.
- La propagation passe par `setValue`, donc **annulable en un seul Undo** via l'historique du formulaire existant.
- Le menu contextuel ne s'ouvre pas au-dessus d'un `input`/`textarea` éditable → le menu natif (copier/coller) est préservé.

## Fonctionnement

Un champ en contexte slide a un chemin `slides.<i>.sketch.<suffixe>`. La propagation lit la valeur courante et fait `setValue("slides.<j>.sketch.<suffixe>", deepClone(valeur))` pour chaque autre slide `j`.

## Fichiers

- `applyToAllSlides.ts` — logique pure (parse du chemin, comptage, propagation), **testée unitairement**.
- `ApplyToAllSlidesButton.tsx` — bouton icône calqué sur `RandomizeSettingsButton`, rendu conditionnel.
- `FieldContextMenu.tsx` — menu contextuel léger positionné au curseur (portal, fermeture au clic dehors / Escape / scroll).
- `FieldRenderer.tsx` — câblage : icône dans l'en-tête `nested-object` + `onContextMenu` sur le wrapper de champ.
- `applyToAllSlides.test.ts` — 13 tests (parse, gating mono/multi-slide, propagation bloc & champ global, deep-clone, no-op hors contexte).

## Vérification

- `npm run check` (lint + test) : ✅ 58 suites / 1615 tests.
- `npm run build` : ✅ compile toutes les routes sketch.

### Points laissés ouverts
- Icône retenue : `CopyPlus` (ajustable).
- Pas de confirmation avant écrasement (l'Undo suffit) — à ajouter si souhaité.
- Extension future possible : vrai copier→coller pour cibler *un* slide précis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjgaMxQfSq5pZDAALsNid9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjgaMxQfSq5pZDAALsNid9)_