### PR TITLE
feat(breakdown): sound on change for the breakdown content item

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -534,6 +534,138 @@ const dotsPatternFields: ItemFormConfig = {
   }
 };
 
+// Sound-on-change panel, shared by the specs and breakdown items: both narrate
+// value changes (specs when a line's value changes, breakdown when a parameter
+// locks into place) and drive the same click synth off the same SpecsSoundSchema.
+const soundOnChangeField: FieldConfig = {
+  label: "Sound on change",
+  component: "nested-object",
+  fields: {
+    enabled: {
+      label: "Enabled",
+      component: "checkbox"
+    },
+    preset: {
+      label: "Click sound",
+      component: "select",
+      options: SPECS_SOUND_PRESETS.map( ( presetName ) => ( {
+        value: presetName,
+        label: presetName
+      } ) )
+    },
+    volume: {
+      label: "Volume",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.05
+    },
+    pitch: {
+      label: "Pitch (×)",
+      component: "slider",
+      min: 0.25,
+      max: 4,
+      step: 0.05
+    },
+    pitchVariation: {
+      label: "Humanize (random pitch)",
+      component: "slider",
+      min: 0,
+      max: 1,
+      step: 0.05
+    },
+    linePitchSpread: {
+      label: "Pitch spread by line (octaves)",
+      component: "slider",
+      min: -1,
+      max: 1,
+      step: 0.05
+    },
+    minInterval: {
+      label: "Stagger between clicks (s)",
+      component: "slider",
+      min: 0,
+      max: 0.5,
+      step: 0.01
+    },
+    lineCooldown: {
+      label: "Per-line cooldown (s)",
+      component: "slider",
+      min: 0,
+      max: 2,
+      step: 0.05
+    },
+    maxBurst: {
+      label: "Max queued clicks",
+      component: "slider",
+      min: 1,
+      max: 32,
+      step: 1
+    },
+    repeat: {
+      label: "Repeat",
+      component: "conditional-group",
+      conditionalOn: "mode",
+      hideNone: true,
+      typeSelector: {
+        label: "Mode",
+        options: [
+          {
+            value: "once",
+            label: "Once per change"
+          },
+          {
+            value: "count",
+            label: "Burst (N clicks)"
+          },
+          {
+            value: "while-highlighted",
+            label: "While highlighted"
+          }
+        ]
+      },
+      configs: {
+        once: {},
+        count: {
+          times: {
+            label: "Clicks per change",
+            component: "slider",
+            min: 2,
+            max: 16,
+            step: 1
+          },
+          interval: {
+            label: "Interval (s)",
+            component: "slider",
+            min: 0.02,
+            max: 2,
+            step: 0.01
+          },
+          pitchStep: {
+            label: "Pitch ramp per click (octaves)",
+            component: "slider",
+            min: -0.5,
+            max: 0.5,
+            step: 0.01
+          }
+        },
+        "while-highlighted": {
+          interval: {
+            label: "Interval (s)",
+            component: "slider",
+            min: 0.02,
+            max: 2,
+            step: 0.01
+          }
+        }
+      },
+
+      // @ts-expect-error schema carries a .default() wrapper, like VisualOptions
+      schema: SpecsSoundRepeatSchema
+    }
+  }
+};
+
 // Main configuration object
 // The top-level keys MUST match the 'type' in your Zod discriminated union
 export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
@@ -714,6 +846,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       component: "select",
       options: blendSelectOptions
     },
+    sound: soundOnChangeField,
     build: {
       label: "Breakdown engine",
       component: "nested-object",
@@ -1041,134 +1174,7 @@ export const formConfig: Record<ContentItem[ "type" ], ItemFormConfig> = {
       // @ts-expect-error schema carries a .default() wrapper, like VisualOptions
       schema: SpecsHighlightSchema
     },
-    sound: {
-      label: "Sound on change",
-      component: "nested-object",
-      fields: {
-        enabled: {
-          label: "Enabled",
-          component: "checkbox"
-        },
-        preset: {
-          label: "Click sound",
-          component: "select",
-          options: SPECS_SOUND_PRESETS.map( ( presetName ) => ( {
-            value: presetName,
-            label: presetName
-          } ) )
-        },
-        volume: {
-          label: "Volume",
-          component: "slider",
-          min: 0,
-          max: 1,
-          step: 0.05
-        },
-        pitch: {
-          label: "Pitch (×)",
-          component: "slider",
-          min: 0.25,
-          max: 4,
-          step: 0.05
-        },
-        pitchVariation: {
-          label: "Humanize (random pitch)",
-          component: "slider",
-          min: 0,
-          max: 1,
-          step: 0.05
-        },
-        linePitchSpread: {
-          label: "Pitch spread by line (octaves)",
-          component: "slider",
-          min: -1,
-          max: 1,
-          step: 0.05
-        },
-        minInterval: {
-          label: "Stagger between clicks (s)",
-          component: "slider",
-          min: 0,
-          max: 0.5,
-          step: 0.01
-        },
-        lineCooldown: {
-          label: "Per-line cooldown (s)",
-          component: "slider",
-          min: 0,
-          max: 2,
-          step: 0.05
-        },
-        maxBurst: {
-          label: "Max queued clicks",
-          component: "slider",
-          min: 1,
-          max: 32,
-          step: 1
-        },
-        repeat: {
-          label: "Repeat",
-          component: "conditional-group",
-          conditionalOn: "mode",
-          hideNone: true,
-          typeSelector: {
-            label: "Mode",
-            options: [
-              {
-                value: "once",
-                label: "Once per change"
-              },
-              {
-                value: "count",
-                label: "Burst (N clicks)"
-              },
-              {
-                value: "while-highlighted",
-                label: "While highlighted"
-              }
-            ]
-          },
-          configs: {
-            once: {},
-            count: {
-              times: {
-                label: "Clicks per change",
-                component: "slider",
-                min: 2,
-                max: 16,
-                step: 1
-              },
-              interval: {
-                label: "Interval (s)",
-                component: "slider",
-                min: 0.02,
-                max: 2,
-                step: 0.01
-              },
-              pitchStep: {
-                label: "Pitch ramp per click (octaves)",
-                component: "slider",
-                min: -0.5,
-                max: 0.5,
-                step: 0.01
-              }
-            },
-            "while-highlighted": {
-              interval: {
-                label: "Interval (s)",
-                component: "slider",
-                min: 0.02,
-                max: 2,
-                step: 0.01
-              }
-            }
-          },
-
-          // @ts-expect-error schema carries a .default() wrapper, like VisualOptions
-          schema: SpecsSoundRepeatSchema
-        }
-      }
-    }
+    sound: soundOnChangeField
   },
   hud: {
     fill: {

--- a/src/sketches/p5/utils/slides/common/__tests__/breakdownSound.test.ts
+++ b/src/sketches/p5/utils/slides/common/__tests__/breakdownSound.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Behavioural tests for the breakdown sound scheduler: the lock-edge detection
+ * that turns each parameter settling into a click, the clean intro (no click on
+ * first sighting), the per-loop re-fire when values relock, and the
+ * backwards-clock reset that keeps deterministic captures from being silenced
+ * by editing-session state.
+ *
+ * The scheduler polls a caller-provided clock and delegates the actual queueing
+ * to an injected specs scheduler, so no Web Audio (or audio engine import) is
+ * needed here.
+ */
+
+// The module chain (breakdownSound → specsSound) imports the audio engine only
+// for its default instance; stub it so the sketch/p5 import chain never loads.
+jest.mock(
+  "../../../audio.js",
+  () => ( {
+    __esModule: true,
+    default: {
+      trigger: jest.fn()
+    }
+  } )
+);
+
+import {
+  createBreakdownSoundScheduler
+} from "../breakdownSound.js";
+import {
+  createSpecsSoundScheduler
+} from "../specsSound.js";
+
+const baseSound = {
+  enabled: true,
+  preset: "click",
+  volume: 0.5,
+  pitch: 1,
+  pitchVariation: 0,
+  linePitchSpread: 0,
+  minInterval: 0.05,
+  lineCooldown: 0.15,
+  maxBurst: 12,
+  repeat: {
+    mode: "once"
+  }
+};
+
+function makeScheduler() {
+  const fired: any[] = [];
+  const inner = createSpecsSoundScheduler(
+    ( params: any ) => fired.push( params ),
+    () => 0.5 // deterministic "random"
+  );
+  const scheduler = createBreakdownSoundScheduler( inner );
+
+  return {
+    fired,
+    scheduler
+  };
+}
+
+const oneStep = ( paths: string[] ) => [
+  {
+    paths
+  }
+];
+
+const leafMap = ( entries: Record<string, number> ) => new Map( Object.entries( entries ) );
+
+describe(
+  "createBreakdownSoundScheduler",
+  () => {
+    it(
+      "clicks when a leaf locks (progress crosses to 1)",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const animSteps = oneStep( [
+          "count"
+        ] );
+
+        // First sighting mid-animation: baseline only, no click.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.4
+            } ),
+            now: 1
+          }
+        );
+        expect( fired ).toHaveLength( 0 );
+
+        // Still animating: no click.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.9
+            } ),
+            now: 1.02
+          }
+        );
+        expect( fired ).toHaveLength( 0 );
+
+        // Locks this frame: one click, due immediately.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 1.04
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+        expect( fired[ 0 ] ).toMatchObject( {
+          preset: "click",
+          gain: 0.5,
+          rate: 1
+        } );
+      }
+    );
+
+    it(
+      "never clicks on a first sighting that is already locked (clean intro)",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const animSteps = oneStep( [
+          "seed"
+        ] );
+
+        // A leaf already at 1 when first seen (a past step) never animated.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              seed: 1
+            } ),
+            now: 1
+          }
+        );
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              seed: 1
+            } ),
+            now: 1.02
+          }
+        );
+
+        expect( fired ).toHaveLength( 0 );
+      }
+    );
+
+    it(
+      "re-fires on the next loop when a locked leaf relocks",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const animSteps = oneStep( [
+          "count"
+        ] );
+
+        // Lock during loop 1.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.5
+            } ),
+            now: 1
+          }
+        );
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 1.1
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        // Loop wraps: the value unlocks (progress falls) then locks again.
+        // The clock keeps climbing during live playback, so this is NOT a
+        // backwards-clock reset.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.3
+            } ),
+            now: 5
+          }
+        );
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 5.1
+          }
+        );
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+
+    it(
+      "staggers simultaneous locks across a step by minInterval",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const animSteps = oneStep( [
+          "a",
+          "b",
+          "c"
+        ] );
+
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              a: 0.5,
+              b: 0.5,
+              c: 0.5
+            } ),
+            now: 1
+          }
+        );
+        // All three lock on the same frame — staggered, not stacked.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              a: 1,
+              b: 1,
+              c: 1
+            } ),
+            now: 1.1
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              a: 1,
+              b: 1,
+              c: 1
+            } ),
+            now: 1.16
+          }
+        );
+        expect( fired ).toHaveLength( 2 );
+
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              a: 1,
+              b: 1,
+              c: 1
+            } ),
+            now: 1.3
+          }
+        );
+        expect( fired ).toHaveLength( 3 );
+      }
+    );
+
+    it(
+      "spreads pitch across the whole breakdown in octaves",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const sound = {
+          ...baseSound,
+          linePitchSpread: 1
+        };
+        // Two steps, three leaves total: first and last span one octave.
+        const animSteps = [
+          {
+            paths: [
+              "first",
+              "middle"
+            ]
+          },
+          {
+            paths: [
+              "last"
+            ]
+          }
+        ];
+
+        scheduler.noteFrame(
+          sound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              first: 0.5,
+              middle: 0.5,
+              last: 0.5
+            } ),
+            now: 1
+          }
+        );
+        // Lock the first leaf.
+        scheduler.noteFrame(
+          sound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              first: 1,
+              middle: 0.5,
+              last: 0.5
+            } ),
+            now: 1.1
+          }
+        );
+        // Lock the last leaf a beat later (past the cooldown).
+        scheduler.noteFrame(
+          sound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              first: 1,
+              middle: 0.5,
+              last: 1
+            } ),
+            now: 2
+          }
+        );
+
+        expect( fired[ 0 ].rate ).toBeCloseTo( 1 );
+        expect( fired[ 1 ].rate ).toBeCloseTo( 2 );
+      }
+    );
+
+    it(
+      "resets its edge state when the clock jumps backwards (capture restart)",
+      () => {
+        const {
+          fired, scheduler
+        } = makeScheduler();
+        const animSteps = oneStep( [
+          "count"
+        ] );
+
+        // Editing session far in the future: lock once.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.5
+            } ),
+            now: 500
+          }
+        );
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 500.1
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        // Deterministic capture resets the sketch clock to ~0. The first
+        // post-reset frame rebaselines (no click), even though it is locked…
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 0.05
+          }
+        );
+        expect( fired ).toHaveLength( 1 );
+
+        // …and the next real lock clicks again.
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 0.4
+            } ),
+            now: 0.1
+          }
+        );
+        scheduler.noteFrame(
+          baseSound,
+          {
+            animSteps,
+            leafT: leafMap( {
+              count: 1
+            } ),
+            now: 0.2
+          }
+        );
+        expect( fired ).toHaveLength( 2 );
+      }
+    );
+  }
+);

--- a/src/sketches/p5/utils/slides/common/breakdownSound.js
+++ b/src/sketches/p5/utils/slides/common/breakdownSound.js
@@ -1,0 +1,112 @@
+import {
+  createSpecsSoundScheduler
+} from "./specsSound.js";
+
+/**
+ * Sound-on-change for the breakdown overlay. The breakdown narrates a diff one
+ * step at a time; each animated parameter LOCKS into its final value at a
+ * scheduled point in the loop. This turns every such lock into a click through
+ * the shared specs sound scheduler — so a breakdown audibly clicks its way to
+ * the settled sketch, group by group, and (because it routes through
+ * `audio.trigger("click", …)` like every other feedback sound) the clicks are
+ * logged during deterministic capture and baked into the exported video.
+ *
+ * "Change" here means a leaf's eased progress crossing to 1 (locked). Detection
+ * is a per-path edge: prev < 1 → now >= 1. First sightings never fire — a leaf
+ * that is already locked when first seen (a past step, or the baseline frame
+ * after a loop wrap) never animated — so the intro stays clean and the loop
+ * re-fires each pass as the values relock. The scheduler owns the staggering,
+ * per-line cooldown, burst cap and repeat modes: identical knobs to the specs
+ * sound panel, driven by the same SpecsSoundSchema options.
+ */
+
+export function createBreakdownSoundScheduler( scheduler = createSpecsSoundScheduler() ) {
+  // path -> last eased progress seen (lock-edge detection).
+  let lastT = new Map();
+  // Backwards-clock detection (capture restart, deck reset).
+  let lastNow = -Infinity;
+
+  const reset = () => {
+    scheduler.reset();
+    lastT = new Map();
+    lastNow = -Infinity;
+  };
+
+  return {
+    reset,
+
+    /**
+     * Click for every leaf that locked on THIS frame, then flush due clicks.
+     * Call once per drawn frame.
+     *
+     * @param {object} sound  The breakdown item's `sound` options (SpecsSoundSchema).
+     * @param {object} args
+     * @param {{ paths: string[] }[]} args.animSteps  Ordered steps; their flat
+     *   leaf list gives each path a stable index/count for `linePitchSpread`.
+     * @param {Map<string, number>} args.leafT  path -> eased progress (0..1).
+     * @param {number} args.now  Sketch clock in seconds (`time.seconds()`).
+     */
+    noteFrame(
+      sound, {
+        animSteps, leafT, now
+      }
+    ) {
+      // A capture restart / deck reset rewinds the sketch clock; drop stale
+      // edge state so the first post-reset frame only rebaselines (no click).
+      if ( now + 0.5 < lastNow ) {
+        reset();
+      }
+
+      lastNow = now;
+
+      // Flat, ordered leaf list: index + total drive the pitch spread across
+      // the WHOLE breakdown (earlier steps sit at one end of the gradient).
+      const paths = [];
+
+      for ( const step of animSteps ) {
+        for ( const path of step.paths ) {
+          paths.push( path );
+        }
+      }
+
+      const lineCount = paths.length;
+
+      paths.forEach( (
+        path, index
+      ) => {
+        const t = leafT.get( path ) ?? 1;
+        const prev = lastT.get( path );
+
+        lastT.set(
+          path,
+          t
+        );
+
+        // Fire only on the lock EDGE, and never on a first sighting (prev
+        // undefined) — a leaf already at 1 when first seen never animated.
+        if ( prev !== undefined && prev < 1 && t >= 1 ) {
+          scheduler.noteChange(
+            sound,
+            {
+              label: path,
+              index,
+              lineCount,
+              now
+            }
+          );
+        }
+      } );
+
+      scheduler.update( now );
+    },
+
+    /** Number of queued clicks (test / debug seam). */
+    pending() {
+      return scheduler.pending();
+    }
+  };
+}
+
+// Shared instance for the breakdown overlay renderer. Module scope mirrors
+// specsSound: the breakdown is in practice a single item.
+export default createBreakdownSoundScheduler();

--- a/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
+++ b/src/sketches/p5/utils/slides/common/drawSlideBreakdown.js
@@ -2,6 +2,8 @@ import string from "../../string.js";
 import sketch, {
   getP5
 } from "../../sketch.js";
+import time from "../../time.js";
+import breakdownSound from "./breakdownSound.js";
 import {
   getBreakdownRuntimeState
 } from "../breakdown/index.js";
@@ -119,6 +121,23 @@ export default function drawSlideBreakdown( breakdownOption ) {
   // differs.
   if ( !animSteps.length ) {
     return;
+  }
+
+  // Sound on change: click as each parameter locks into place. Scheduled off
+  // the same runtime state the overlay draws, so a click can never drift from
+  // the value it narrates. Runs regardless of the drawing early-returns below
+  // (outro fade, missing step) so the last step's clicks still flush.
+  const sound = breakdownOption.sound;
+
+  if ( sound?.enabled ) {
+    breakdownSound.noteFrame(
+      sound,
+      {
+        animSteps,
+        leafT,
+        now: time.seconds()
+      }
+    );
   }
 
   const {

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -584,7 +584,11 @@ export const BreakdownItemSchema = z.object( {
   backgroundRadius: z.number().min( 0 )
     .max( 200 )
     .default( 0 ),
-  blend: Blend.default( "source-over" )
+  blend: Blend.default( "source-over" ),
+  // Sound on change — the breakdown narrates a diff one step at a time; each
+  // parameter clicks into place as its value locks. Reuses the specs
+  // sound-on-change schema (same click synth, staggering and repeat knobs).
+  sound: SpecsSoundSchema
 } );
 
 export const TextItemSchema = z.object( {


### PR DESCRIPTION
## What & why

The **specs** content item has a "Sound on change" panel that clicks whenever a listed value changes. The **breakdown** item — which narrates a parameter diff one step at a time and visibly stabilizes the sketch group by group — had no equivalent audio feedback. This adds the same sound-on-change controls to the breakdown item, so it audibly clicks its way to the settled sketch.

## Changes

- **Schema** (`sketch.types.ts`): add `sound: SpecsSoundSchema` to `BreakdownItemSchema`, reusing the specs sound-on-change schema (same click synth, staggering, cooldown, burst cap and repeat modes). Defaults keep it **off**, so existing decks stay silent.
- **Form config** (`field-config.ts`): extract the sound-on-change field into a shared `soundOnChangeField` const and reference it from both the `specs` and `breakdown` form configs — no duplication. The no-orphan-field guard in `breakdownItem.test.ts` covers the new field automatically.
- **`breakdownSound.js`** (new): a lock-edge detector over the breakdown runtime state's per-leaf progress, delegating the queueing to the shared specs sound scheduler. A click fires the frame a parameter's eased progress crosses to `1` (locks into place). First sightings never fire (clean intro), the loop re-fires as values relock each pass, and a backwards clock resets edge state so deterministic captures aren't silenced by editing-session state.
- **`drawSlideBreakdown.js`**: schedule the sound off the same runtime state the overlay draws, so a click can never drift from the value it narrates. Placed before the drawing early-returns (outro fade / missing step) so the last step's clicks still flush.

Because everything routes through `audio.trigger("click", …)` — the same path as the specs overlay and montage transitions — clicks that play live while editing are also logged during deterministic capture and baked into the exported video's soundtrack.

## Testing

- New `breakdownSound.test.ts`: lock detection, clean intro (no click on first sighting), per-loop re-fire, `minInterval` staggering of simultaneous locks, octave pitch spread across the whole breakdown, and the backwards-clock reset.
- `npm run check` (lint + 1698 tests) — green.
- `npm run build` — green (compiles every sketch route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzebxMUYf4bsNbaqxaq4qw)_