### PR TITLE
Fix: Recording nav link stays visible after disabling BACKEND_RECORDING at runtime

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,7 @@
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json( {
+    backendRecording: process.env.BACKEND_RECORDING === "true"
+  } );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -164,7 +164,6 @@ export default function RootLayout( {
 
               <Suspense>
                 <MenuBarGate
-                  showRecordings={ process.env.BACKEND_RECORDING === "true" }
                   hasMissingThumbnails={ hasMissingThumbnails }
                   hasMissingPreviews={ hasMissingPreviews }
                 />

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -54,7 +54,6 @@ import {
 import sleep from "@/utils/sleep";
 
 type MenuBarProps = {
-  showRecordings?: boolean;
   hasMissingThumbnails?: boolean;
   hasMissingPreviews?: boolean;
 };
@@ -144,7 +143,6 @@ function Divider() {
 const itemClass = "flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-colors disabled:opacity-50";
 
 function MenuBar( {
-  showRecordings = false,
   hasMissingThumbnails = false,
   hasMissingPreviews = false
 }: MenuBarProps ) {
@@ -157,6 +155,15 @@ function MenuBar( {
   const [
     mounted,
     setMounted
+  ] = useState( false );
+
+  // `BACKEND_RECORDING` (server env) can't be reflected as a build-time
+  // constant or a static layout prop without baking last build's value into
+  // the prerendered shell, so it's fetched from a force-dynamic route at
+  // runtime instead.
+  const [
+    showRecordings,
+    setShowRecordings
   ] = useState( false );
 
   const [
@@ -197,6 +204,26 @@ function MenuBar( {
   useEffect(
     () => {
       setMounted( true );
+    },
+    []
+  );
+
+  useEffect(
+    () => {
+      let cancelled = false;
+
+      fetch( "/api/config" )
+        .then( ( res ) => res.json() )
+        .then( ( data ) => {
+          if ( !cancelled ) {
+            setShowRecordings( Boolean( data.backendRecording ) );
+          }
+        } )
+        .catch( () => {} );
+
+      return () => {
+        cancelled = true;
+      };
     },
     []
   );


### PR DESCRIPTION
## Summary

- Root cause: `src/app/layout.tsx` has no dynamic APIs (no `cookies()`/`headers()`/`searchParams`), so Next.js statically prerenders it at build time. The `showRecordings={ process.env.BACKEND_RECORDING === "true" }` prop passed to `MenuBarGate` was therefore baked into the prerendered shell at build time, just like a `NEXT_PUBLIC_*` variable — toggling `BACKEND_RECORDING` in the runtime environment (e.g. via `.env` or `docker-compose.yml`) without rebuilding the image has no effect on the "Recordings" link shown in the nav.
- Fix: added a `force-dynamic` API route (`src/app/api/config/route.ts`) that reads `process.env.BACKEND_RECORDING` on every request, and have `MenuBar` fetch it client-side on mount instead of receiving it as a server-rendered prop. This makes the nav link reflect the actual runtime env var without requiring a rebuild, while leaving the rest of the (still static) layout tree untouched.
- Removed the now-unused `showRecordings` prop from `MenuBarGate`/`layout.tsx`.

Note: `/recordings` (the route itself) was never gated by this flag — only the nav link visibility was affected.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build` — confirmed `/api/config` builds as dynamic (`ƒ`) while `/` remains static (`○`), so the fix doesn't regress static optimization elsewhere.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TKh9QSc9Catn2wca4pJ1wG)_