### PR TITLE
Add resolution and margin controls to the sketch share modal

### DIFF
--- a/src/components/EmbedSketch/EmbedSketchClient.tsx
+++ b/src/components/EmbedSketch/EmbedSketchClient.tsx
@@ -25,11 +25,20 @@ import {
   deepMerge, structuredClone
 } from "@/p5/shared/utils.js";
 import {
-  parseEmbedHash, resolveAutoplay
+  EMBED_SIZE_FILL, parseEmbedHash, resolveAutoplay
 } from "@/lib/embedOptions";
 import type {
-  AutoplayPolicy
+  AutoplayPolicy, EmbedSize
 } from "@/lib/embedOptions";
+import {
+  applyEmbedSize, isSameSize, resolveFillSize
+} from "@/lib/embedSizing";
+import type {
+  EmbedFrameSize
+} from "@/lib/embedSizing";
+import {
+  FIT_MARGIN_FACTOR
+} from "@/components/ScalableViewport/utils/zoomCalculations";
 
 // The control strip pulls in the whole FieldRenderer subtree (RHF + every
 // Controlled* input). Load it as its own chunk, mounted only when the URL asks
@@ -74,6 +83,7 @@ export default function EmbedSketchClient( {
   width,
   height
 }: EmbedSketchClientProps ) {
+  const rootRef = useRef<HTMLDivElement | null>( null );
   const containerRef = useRef<HTMLDivElement | null>( null );
   const engineRef = useRef<SketchEngine | null>( null );
   const [
@@ -102,14 +112,17 @@ export default function EmbedSketchClient( {
 
   // Parse the URL fragment once: `#o=` is merged over the template defaults for
   // the initial mount, `#c=` selects which fields to expose as live controls,
-  // `#a=` is the autoplay policy.
+  // `#a=` is the autoplay policy, `#s=` / `#m=` shape the frame (resolution and
+  // whether the sketch is inset from its edges).
   const {
-    mountOptions, controls, autoplay
+    mountOptions, controls, autoplay, size, margin
   } = useMemo(
     () => {
-      const merged = structuredClone( baseOptions ) as SketchOption;
+      let merged = structuredClone( baseOptions ) as SketchOption;
       let hashControls: string[] | null = null;
       let hashAutoplay: AutoplayPolicy = "on";
+      let hashSize: EmbedSize | null = null;
+      let hashMargin = false;
 
       if ( typeof window !== "undefined" ) {
         const parsed = parseEmbedHash( window.location.hash );
@@ -121,18 +134,122 @@ export default function EmbedSketchClient( {
           );
         }
 
+        // A fixed resolution can be applied up front; `fill` needs the frame
+        // measured first and is written in by the mount effect below.
+        if ( parsed.size && parsed.size !== EMBED_SIZE_FILL ) {
+          merged = applyEmbedSize(
+            merged,
+            parsed.size
+          );
+        }
+
         hashControls = parsed.controls;
         hashAutoplay = parsed.autoplay;
+        hashSize = parsed.size;
+        hashMargin = parsed.margin;
       }
 
       return {
         mountOptions: merged,
         controls: hashControls,
-        autoplay: hashAutoplay
+        autoplay: hashAutoplay,
+        size: hashSize,
+        margin: hashMargin
       };
     },
     [
       baseOptions
+    ]
+  );
+
+  const fillFrame = size === EMBED_SIZE_FILL;
+  // With a margin the sketch keeps the studio's gutter; without one it sits
+  // flush against the frame. In fill mode there is no room to scale into, so
+  // the inset is baked into the resolution instead (see `resolveFillSize`).
+  const marginFactor = margin ? FIT_MARGIN_FACTOR : 1;
+
+  // Fill mode: the canvas resolution *is* the frame's box, so it is measured
+  // (not parsed) and re-applied whenever the host resizes the iframe. The first
+  // measurement lands in a ref before `fillReady` flips, so the engine boots at
+  // the right size; later ones are pushed through the options bus, which resizes
+  // the live canvas instead of remounting the sketch.
+  const fillSizeRef = useRef<EmbedFrameSize | null>( null );
+  const [
+    fillReady,
+    setFillReady
+  ] = useState( false );
+  const [
+    resolutionKey,
+    setResolutionKey
+  ] = useState( () => `${ mountOptions.size?.width ?? width }x${ mountOptions.size?.height ?? height }` );
+
+  useEffect(
+    () => {
+      const frame = rootRef.current;
+
+      if ( !fillFrame || !frame ) {
+        return;
+      }
+
+      const apply = async() => {
+        const next = resolveFillSize(
+          frame.clientWidth,
+          frame.clientHeight,
+          marginFactor
+        );
+
+        if ( isSameSize(
+          fillSizeRef.current,
+          next
+        ) ) {
+          return;
+        }
+
+        const isFirst = fillSizeRef.current === null;
+
+        fillSizeRef.current = next;
+        setResolutionKey( `${ next.width }x${ next.height }` );
+
+        if ( isFirst ) {
+          setFillReady( true );
+          return;
+        }
+
+        const {
+          setSketchOptions
+        } = await import( "@/lib/syncSketchOptions" );
+        const resized = applyEmbedSize(
+          mountOptions,
+          next
+        );
+
+        setSketchOptions(
+          {
+            size: resized.size,
+            ...( Array.isArray( resized.slides )
+              ? {
+                slides: resized.slides
+              }
+              : {} )
+          },
+          "embed"
+        );
+      };
+
+      void apply();
+
+      const observer = new ResizeObserver( () => {
+        void apply();
+      } );
+
+      observer.observe( frame );
+
+      return () => observer.disconnect();
+    },
+    [
+      fillFrame,
+      marginFactor,
+      mountOptions
     ]
   );
 
@@ -183,7 +300,11 @@ export default function EmbedSketchClient( {
 
   useEffect(
     () => {
-      if ( !started || !containerRef.current ) {
+      // In fill mode the frame has to be measured before the engine can boot at
+      // the right resolution — `fillReady` flips once that first measurement is
+      // in. Subsequent measurements deliberately stay out of this effect's deps:
+      // a resize must not remount the sketch.
+      if ( !started || !containerRef.current || ( fillFrame && !fillReady ) ) {
         return;
       }
 
@@ -199,11 +320,18 @@ export default function EmbedSketchClient( {
         handleReady
       );
 
+      const initialOptions = fillSizeRef.current
+        ? applyEmbedSize(
+          mountOptions,
+          fillSizeRef.current
+        )
+        : mountOptions;
+
       instance
         .init(
           containerRef.current,
           name,
-          mountOptions
+          initialOptions
         )
         .catch( ( error ) => {
           console.error(
@@ -226,14 +354,17 @@ export default function EmbedSketchClient( {
       started,
       engineId,
       name,
-      mountOptions
+      mountOptions,
+      fillFrame,
+      fillReady
     ]
   );
 
   // Live updates: a parent frame can swap the `#o=` fragment (Keystatic preview,
   // a "reset" link) and the sketch re-parameterises without a reload. Recompute
   // the full sketch params from defaults + the new delta so removing an override
-  // heals back to its default.
+  // heals back to its default. Only params are live: `#s=` / `#m=` shape the
+  // canvas and the layout it boots with, so they are read once, at mount.
   useEffect(
     () => {
       const onHashChange = async() => {
@@ -273,7 +404,7 @@ export default function EmbedSketchClient( {
   );
 
   return (
-    <div className="embed-root">
+    <div className="embed-root" ref={ rootRef }>
       {decided && !started && (
         <EmbedPoster
           thumbnailUrl={ thumbnailUrl }
@@ -288,8 +419,12 @@ export default function EmbedSketchClient( {
           <ScalableViewport
             showZoomControls={ false }
             lockInteractions
-            resolutionKey={ `${ width }x${ height }` }
+            resolutionKey={ resolutionKey }
             isReady={ ready }
+            // Fill mode already sized the canvas to the frame — lay it out 1:1
+            // rather than fitting a canvas that is, by construction, the frame.
+            actualPixels={ fillFrame }
+            fitMarginFactor={ marginFactor }
           >
             <div ref={ containerRef } className="sketch-canvas-container" />
           </ScalableViewport>

--- a/src/components/ScalableViewport/ScalableViewport.tsx
+++ b/src/components/ScalableViewport/ScalableViewport.tsx
@@ -36,6 +36,7 @@ export default function ScalableViewport( {
   zoomControlsContainer = null,
   fullscreen,
   actualPixels = false,
+  fitMarginFactor,
   onInteractionStart,
   onInteractionEnd
 }: {
@@ -50,6 +51,9 @@ export default function ScalableViewport( {
   // Auto-layout at 1:1 (actual pixels) instead of the padded fit — used in bare
   // fullscreen so a screen-sized canvas fills the display exactly.
   actualPixels?: boolean;
+  // Fraction of the viewport a "fit" fills. Defaults to the studio's padded
+  // 0.9; pass 1 for a flush, gutter-free fit (embeds without a margin).
+  fitMarginFactor?: number;
   // In the docked workspace layout the zoom controls render flat and portal
   // into the top bar (`zoomControlsContainer`) instead of floating top-right.
   docked?: boolean;
@@ -109,7 +113,8 @@ export default function ScalableViewport( {
       contentRef,
       transform,
       setTransform,
-      animateTo
+      animateTo,
+      fitMarginFactor
     } );
 
   // Auto-layout used by the resize/resolution observers below. Bare fullscreen

--- a/src/components/ScalableViewport/hooks/useViewportActions.ts
+++ b/src/components/ScalableViewport/hooks/useViewportActions.ts
@@ -8,6 +8,7 @@ import {
   calculateFitToViewport,
   calculateActualPixels,
   calculateZoomTarget,
+  FIT_MARGIN_FACTOR,
   ZOOM_STEP_FACTOR
 } from "../utils/zoomCalculations";
 
@@ -27,6 +28,8 @@ interface UseViewportActionsProps {
     contentElement: HTMLDivElement | null
   ) => void;
   animateTo: ( targetX: number, targetY: number, targetScale: number ) => void;
+  /** Fraction of the viewport a fit fills — 1 puts the content flush with the edges. */
+  fitMarginFactor?: number;
 }
 
 export function useViewportActions( {
@@ -34,7 +37,8 @@ export function useViewportActions( {
   contentRef,
   transform,
   setTransform,
-  animateTo
+  animateTo,
+  fitMarginFactor = FIT_MARGIN_FACTOR
 }: UseViewportActionsProps ) {
   const applyLayout = useCallback(
     (
@@ -83,11 +87,20 @@ export function useViewportActions( {
 
   const fitToViewport = useCallback(
     ( animate = false ) => applyLayout(
-      calculateFitToViewport,
+      (
+        contentWidth, contentHeight, viewportWidth, viewportHeight
+      ) => calculateFitToViewport(
+        contentWidth,
+        contentHeight,
+        viewportWidth,
+        viewportHeight,
+        fitMarginFactor
+      ),
       animate
     ),
     [
-      applyLayout
+      applyLayout,
+      fitMarginFactor
     ]
   );
 

--- a/src/components/ScalableViewport/utils/__tests__/zoomCalculations.test.ts
+++ b/src/components/ScalableViewport/utils/__tests__/zoomCalculations.test.ts
@@ -87,6 +87,24 @@ describe(
     );
 
     it(
+      "fills the limiting dimension edge-to-edge with a margin factor of 1",
+      () => {
+        const result = calculateFitToViewport(
+          200,
+          100,
+          1000,
+          1000,
+          1
+        );
+
+        // No gutter: ( 1000 / 200 ) * 1 = 5, so the content spans the full width.
+        expect( result.scale ).toBeCloseTo( 5 );
+        expect( result.x ).toBeCloseTo( 0 );
+        expect( result.y ).toBeCloseTo( ( 1000 - 100 * 5 ) / 2 );
+      }
+    );
+
+    it(
       "returns the identity transform for empty content",
       () => {
         expect( calculateFitToViewport(

--- a/src/components/ScalableViewport/utils/zoomCalculations.ts
+++ b/src/components/ScalableViewport/utils/zoomCalculations.ts
@@ -10,6 +10,11 @@ export const MAX_SCALE = 6;
 // matching the exponential factor used by wheel zoom.
 export const ZOOM_STEP_FACTOR = 1.25;
 
+// Fraction of the viewport a "fit" fills. The studio leaves a gutter so the
+// canvas edges read against the workspace; surfaces that want the sketch flush
+// with its frame (the embed, by default) pass 1.
+export const FIT_MARGIN_FACTOR = 0.9;
+
 export function calculateZoomTarget(
   newScale: number,
   clientX: number,
@@ -46,7 +51,8 @@ export function calculateFitToViewport(
   contentWidth: number,
   contentHeight: number,
   viewportWidth: number,
-  viewportHeight: number
+  viewportHeight: number,
+  marginFactor: number = FIT_MARGIN_FACTOR
 ): TransformState {
   if ( contentWidth === 0 || contentHeight === 0 ) {
     return {
@@ -61,7 +67,7 @@ export function calculateFitToViewport(
   const bestFitScale = Math.min(
     widthRatio,
     heightRatio
-  ) * 0.9;
+  ) * marginFactor;
   const newScale = clamp(
     bestFitScale,
     MIN_SCALE,

--- a/src/components/SketchPage/SketchShareDialog.tsx
+++ b/src/components/SketchPage/SketchShareDialog.tsx
@@ -12,16 +12,25 @@ import {
 } from "react-dom";
 import useSketch from "../ClientProcessingSketch/components/SketchProvider/hooks/useSketch";
 import {
-  buildEmbedHash, diffSketchOptions
+  buildEmbedHash, diffSketchOptions, EMBED_SIZE_FILL, parseEmbedSize
 } from "@/lib/embedOptions";
 import type {
-  AutoplayPolicy
+  AutoplayPolicy, EmbedSize
 } from "@/lib/embedOptions";
 import {
   EMBED_CONTROLS_ALL
 } from "@/lib/embedControls";
+import {
+  formatOptions
+} from "@/components/ClientProcessingSketch/components/SketchOptions/components/RootSettings/constants/root-field-config";
+import {
+  isFullscreenFormatValue
+} from "@/lib/fullscreen/constants";
 
 type ControlsMode = "none" | "all" | "custom";
+
+/** Sentinel select value meaning "whatever the editor canvas is set to". */
+const SIZE_CHOICE_EDITOR = "";
 
 /**
  * Share / embed affordance for the preview page. Serialises the CURRENT sketch
@@ -52,6 +61,14 @@ export default function SketchShareDialog() {
     autoplay,
     setAutoplay
   ] = useState<AutoplayPolicy>( "on" );
+  const [
+    sizeChoice,
+    setSizeChoice
+  ] = useState<string>( SIZE_CHOICE_EDITOR );
+  const [
+    margin,
+    setMargin
+  ] = useState( false );
   const [
     copied,
     setCopied
@@ -144,20 +161,85 @@ export default function SketchShareDialog() {
     ]
   );
 
+  // Resolution presets, minus the fullscreen sentinels the canvas-size select
+  // uses — those drive the Fullscreen API, which means nothing inside a frame.
+  const sizePresets = useMemo(
+    () => {
+      const groups = new Map<string, {
+        label: string;
+        value: string;
+      }[]>();
+
+      for ( const option of formatOptions ) {
+        if ( isFullscreenFormatValue( option.value ) ) {
+          continue;
+        }
+
+        const group = option.group ?? "Other";
+
+        if ( !groups.has( group ) ) {
+          groups.set(
+            group,
+            []
+          );
+        }
+
+        groups.get( group )!.push( {
+          label: option.label,
+          value: String( option.value )
+        } );
+      }
+
+      return [
+        ...groups.entries()
+      ];
+    },
+    []
+  );
+
+  const canvasWidth = options.size?.width ?? 1080;
+  const canvasHeight = options.size?.height ?? 1350;
+  const canvasSize = useMemo(
+    () => ( {
+      width: canvasWidth,
+      height: canvasHeight
+    } ),
+    [
+      canvasWidth,
+      canvasHeight
+    ]
+  );
+
+  // "Match the editor" tracks the live canvas size instead of freezing a value,
+  // so tweaking the format in the editor updates the link as you look at it.
+  const embedSize: EmbedSize = sizeChoice === SIZE_CHOICE_EDITOR
+    ? canvasSize
+    : parseEmbedSize( sizeChoice ) ?? canvasSize;
+  const fillFrame = embedSize === EMBED_SIZE_FILL;
+
   const embedPath = `/embed/${ engineId }/${ category ? `${ category }/` : "" }${ name }`;
   const hash = buildEmbedHash(
     delta,
     controls,
     {
-      autoplay
+      autoplay,
+      size: embedSize,
+      margin
     }
   );
   const link = `${ origin }${ embedPath }${ hash }`;
 
-  const width = options.size?.width ?? 1080;
-  const height = options.size?.height ?? 1350;
+  // The frame box the snippet suggests: a fixed resolution dictates its own
+  // ratio; in fill mode nothing does, so the editor canvas seeds a sane box the
+  // host is free to change — the sketch re-sizes to whatever it ends up being.
+  const frame = fillFrame ? canvasSize : embedSize;
+  // The snippet is HTML, so the hash's `&` separators have to be escaped — a
+  // sanitiser or validator on the host side would otherwise mangle the URL.
   const iframeSnippet =
-    `<iframe\n  src="${ link }"\n  style="width:100%; aspect-ratio:${ width }/${ height }; border:0"\n  allow="camera; microphone"\n  loading="lazy"\n></iframe>`;
+    `<iframe\n  src="${ link.replace(
+      /&/g,
+      "&amp;"
+    ) }"\n  style="width:100%; aspect-ratio:${ frame.width }/${ frame.height }; border:0"\n  allow="camera; microphone"\n  loading="lazy"\n></iframe>`;
 
   const changedCount = Object.keys( delta ).length;
 
@@ -240,6 +322,63 @@ export default function SketchShareDialog() {
               ? "Sharing the default look. Tweak the sketch first to bake your settings into the link."
               : `${ changedCount } setting${ changedCount === 1 ? "" : "s" } changed from the defaults will be baked into the link.`}
           </p>
+
+          {/* Frame — resolution + margin */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-foreground/50">
+              Frame
+            </span>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-foreground/60">Resolution</span>
+              <select
+                value={ sizeChoice }
+                onChange={ ( event ) => setSizeChoice( event.target.value ) }
+                className={ clsx(
+                  "w-full cursor-pointer rounded-xl border border-border bg-hover/30 px-2.5 py-2 text-sm text-foreground",
+                  "focus:outline-none focus:ring-1 focus:ring-focus"
+                ) }
+              >
+                <option value={ SIZE_CHOICE_EDITOR }>
+                  {`Match the editor (${ canvasWidth } × ${ canvasHeight })`}
+                </option>
+                <option value={ EMBED_SIZE_FILL }>
+                  Fill the frame — follow the iframe size
+                </option>
+                {sizePresets.map( ( [
+                  groupLabel,
+                  presets
+                ] ) => (
+                  <optgroup key={ groupLabel } label={ groupLabel }>
+                    {presets.map( ( preset ) => (
+                      <option key={ preset.value } value={ preset.value }>
+                        {preset.label}
+                      </option>
+                    ) )}
+                  </optgroup>
+                ) )}
+              </select>
+            </label>
+
+            <p className="text-xs text-foreground/50">
+              {fillFrame
+                ? "The canvas is re-drawn at the iframe's own size and follows it on resize — nothing is letterboxed."
+                : "The canvas renders at this resolution and is scaled to fit the iframe."}
+            </p>
+
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground">
+              <input
+                type="checkbox"
+                checked={ margin }
+                onChange={ () => setMargin( ( current ) => !current ) }
+                className="h-4 w-4 accent-foreground"
+              />
+              Leave a margin around the sketch
+            </label>
+            <p className="text-xs text-foreground/50">
+              Off by default: the sketch sits flush against the frame edges.
+            </p>
+          </div>
 
           {/* Controls exposure */}
           <div className="flex flex-col gap-2">

--- a/src/lib/__tests__/embedOptions.test.ts
+++ b/src/lib/__tests__/embedOptions.test.ts
@@ -2,8 +2,11 @@ import {
   buildEmbedHash,
   decodeEmbedOptions,
   diffSketchOptions,
+  EMBED_SIZE_FILL,
   encodeEmbedOptions,
+  formatEmbedSize,
   parseEmbedHash,
+  parseEmbedSize,
   resolveAutoplay
 } from "@/lib/embedOptions";
 
@@ -103,12 +106,16 @@ describe(
         expect( parseEmbedHash( "" ) ).toEqual( {
           options: null,
           controls: null,
-          autoplay: "on"
+          autoplay: "on",
+          size: null,
+          margin: false
         } );
         expect( parseEmbedHash( "#" ) ).toEqual( {
           options: null,
           controls: null,
-          autoplay: "on"
+          autoplay: "on",
+          size: null,
+          margin: false
         } );
 
         const controlsOnly = parseEmbedHash( "#c=a.b , c.d ,," );
@@ -170,6 +177,111 @@ describe(
           }
         ) ).autoplay ).toBe( "desktop" );
         expect( parseEmbedHash( "#a=bogus" ).autoplay ).toBe( "on" );
+      }
+    );
+
+    it(
+      "carries a fixed resolution and round-trips it",
+      () => {
+        const hash = buildEmbedHash(
+          {},
+          [],
+          {
+            size: {
+              width: 1920,
+              height: 1080
+            }
+          }
+        );
+
+        expect( hash ).toBe( "#s=1920x1080" );
+        expect( parseEmbedHash( hash ).size ).toEqual( {
+          width: 1920,
+          height: 1080
+        } );
+      }
+    );
+
+    it(
+      "carries the fill sentinel",
+      () => {
+        const hash = buildEmbedHash(
+          {},
+          [],
+          {
+            size: EMBED_SIZE_FILL
+          }
+        );
+
+        expect( hash ).toBe( "#s=fill" );
+        expect( parseEmbedHash( hash ).size ).toBe( EMBED_SIZE_FILL );
+      }
+    );
+
+    it(
+      "carries the margin flag, omitting the default (no margin)",
+      () => {
+        expect( buildEmbedHash(
+          {},
+          [],
+          {
+            margin: false
+          }
+        ) ).toBe( "" );
+
+        const hash = buildEmbedHash(
+          {},
+          [],
+          {
+            margin: true
+          }
+        );
+
+        expect( hash ).toBe( "#m=1" );
+        expect( parseEmbedHash( hash ).margin ).toBe( true );
+      }
+    );
+  }
+);
+
+describe(
+  "parseEmbedSize",
+  () => {
+    it(
+      "accepts the fill sentinel and a well-formed W×H",
+      () => {
+        expect( parseEmbedSize( EMBED_SIZE_FILL ) ).toBe( EMBED_SIZE_FILL );
+        expect( parseEmbedSize( "1080x1350" ) ).toEqual( {
+          width: 1080,
+          height: 1350
+        } );
+      }
+    );
+
+    it(
+      "rejects malformed, empty, or out-of-range values so the sketch's own size stands",
+      () => {
+        expect( parseEmbedSize( null ) ).toBeNull();
+        expect( parseEmbedSize( "" ) ).toBeNull();
+        expect( parseEmbedSize( "wide" ) ).toBeNull();
+        expect( parseEmbedSize( "1080" ) ).toBeNull();
+        expect( parseEmbedSize( "1080x" ) ).toBeNull();
+        expect( parseEmbedSize( "-10x20" ) ).toBeNull();
+        expect( parseEmbedSize( "10x10" ) ).toBeNull();
+        expect( parseEmbedSize( "99999x1080" ) ).toBeNull();
+      }
+    );
+
+    it(
+      "round-trips through formatEmbedSize",
+      () => {
+        const size = {
+          width: 768,
+          height: 1366
+        };
+
+        expect( parseEmbedSize( formatEmbedSize( size ) ) ).toEqual( size );
+        expect( formatEmbedSize( EMBED_SIZE_FILL ) ).toBe( EMBED_SIZE_FILL );
       }
     );
   }

--- a/src/lib/__tests__/embedSizing.test.ts
+++ b/src/lib/__tests__/embedSizing.test.ts
@@ -1,0 +1,198 @@
+import {
+  applyEmbedSize, isSameSize, resolveFillSize
+} from "@/lib/embedSizing";
+import {
+  EMBED_SIZE_MAX, EMBED_SIZE_MIN
+} from "@/lib/embedOptions";
+
+describe(
+  "resolveFillSize",
+  () => {
+    it(
+      "matches the frame exactly with no margin",
+      () => {
+        expect( resolveFillSize(
+          800,
+          451
+        ) ).toEqual( {
+          width: 800,
+          height: 451
+        } );
+      }
+    );
+
+    it(
+      "insets the canvas inside the frame when a margin is asked for",
+      () => {
+        expect( resolveFillSize(
+          1000,
+          500,
+          0.9
+        ) ).toEqual( {
+          width: 900,
+          height: 450
+        } );
+      }
+    );
+
+    it(
+      "rounds to whole pixels",
+      () => {
+        expect( resolveFillSize(
+          333.4,
+          199.6
+        ) ).toEqual( {
+          width: 333,
+          height: 200
+        } );
+      }
+    );
+
+    it(
+      "clamps a collapsed or oversized frame into the schema's bounds",
+      () => {
+        expect( resolveFillSize(
+          0,
+          0
+        ) ).toEqual( {
+          width: EMBED_SIZE_MIN,
+          height: EMBED_SIZE_MIN
+        } );
+
+        expect( resolveFillSize(
+          99999,
+          99999
+        ) ).toEqual( {
+          width: EMBED_SIZE_MAX,
+          height: EMBED_SIZE_MAX
+        } );
+      }
+    );
+  }
+);
+
+describe(
+  "applyEmbedSize",
+  () => {
+    const size = {
+      width: 1920,
+      height: 1080
+    };
+
+    it(
+      "writes the size without mutating the source options",
+      () => {
+        const options = {
+          size: {
+            width: 1080,
+            height: 1350
+          },
+          sketch: {
+            seed: 3
+          }
+        };
+        const next = applyEmbedSize(
+          options,
+          size
+        );
+
+        expect( next.size ).toEqual( size );
+        expect( next.sketch ).toEqual( {
+          seed: 3
+        } );
+        expect( options.size ).toEqual( {
+          width: 1080,
+          height: 1350
+        } );
+      }
+    );
+
+    it(
+      "rewrites slide overrides, which would otherwise mask the global size",
+      () => {
+        const next = applyEmbedSize(
+          {
+            size: {
+              width: 1080,
+              height: 1350
+            },
+            slides: [
+              {
+                id: "a",
+                size: {
+                  width: 500,
+                  height: 500
+                }
+              },
+              {
+                id: "b"
+              }
+            ]
+          },
+          size
+        );
+
+        expect( next.slides[ 0 ].size ).toEqual( size );
+        // No override to begin with — the slide already follows the global size.
+        expect( next.slides[ 1 ].size ).toBeUndefined();
+      }
+    );
+
+    it(
+      "leaves a slide-less options tree alone",
+      () => {
+        const next = applyEmbedSize(
+          {
+            size: {
+              width: 100,
+              height: 100
+            }
+          },
+          size
+        );
+
+        expect( next.slides ).toBeUndefined();
+      }
+    );
+  }
+);
+
+describe(
+  "isSameSize",
+  () => {
+    it(
+      "compares by value and treats a missing side as different",
+      () => {
+        expect( isSameSize(
+          {
+            width: 10,
+            height: 20
+          },
+          {
+            width: 10,
+            height: 20
+          }
+        ) ).toBe( true );
+
+        expect( isSameSize(
+          {
+            width: 10,
+            height: 20
+          },
+          {
+            width: 10,
+            height: 21
+          }
+        ) ).toBe( false );
+
+        expect( isSameSize(
+          null,
+          {
+            width: 10,
+            height: 20
+          }
+        ) ).toBe( false );
+      }
+    );
+  }
+);

--- a/src/lib/embedOptions.ts
+++ b/src/lib/embedOptions.ts
@@ -20,6 +20,14 @@
  *   a  optional autoplay policy: absent → "on" (default), "off" → never
  *      autoplay, "desktop" → autoplay on desktop only (off on touch/mobile).
  *      `prefers-reduced-motion` always wins over this at runtime.
+ *   s  optional canvas resolution: `<width>x<height>` pins the sketch to that
+ *      size, `fill` sizes the canvas to the iframe itself (and re-sizes it as
+ *      the frame resizes). Absent → the sketch's own stored size.
+ *   m  optional margin: `1` insets the sketch from the frame edges (the studio
+ *      viewport's padded fit). Absent → edge-to-edge, no gutter.
+ *
+ * `o` is live — swapping it re-parameterises the running sketch. `s` and `m`
+ * shape the canvas itself and are read once, at load.
  *
  * base64url (RFC 4648 §5) is used instead of raw `encodeURIComponent(JSON)` so
  * the payload never contains characters a CMS, markdown renderer, or copy-paste
@@ -29,6 +37,16 @@
 export const EMBED_OPTIONS_HASH_KEY = "o";
 export const EMBED_CONTROLS_HASH_KEY = "c";
 export const EMBED_AUTOPLAY_HASH_KEY = "a";
+export const EMBED_SIZE_HASH_KEY = "s";
+export const EMBED_MARGIN_HASH_KEY = "m";
+
+/** Token used by the `s=` key to mean "match the frame". */
+export const EMBED_SIZE_FILL = "fill";
+
+// Mirrors SketchSizeSchema's bounds — a hand-edited URL must not be able to
+// push the canvas outside what the studio itself allows.
+export const EMBED_SIZE_MIN = 50;
+export const EMBED_SIZE_MAX = 8192;
 
 /**
  * Autoplay policy baked into a share URL.
@@ -38,6 +56,17 @@ export const EMBED_AUTOPLAY_HASH_KEY = "a";
  */
 export type AutoplayPolicy = "on" | "off" | "desktop";
 
+/**
+ * Canvas resolution baked into a share URL.
+ * - `{ width, height }` — a fixed resolution, fit into the frame
+ * - `"fill"`            — track the iframe's own box, re-sizing with it
+ * - `null`              — leave the sketch's stored size alone
+ */
+export type EmbedSize = {
+  width: number;
+  height: number;
+} | typeof EMBED_SIZE_FILL;
+
 export type EmbedHash = {
   /** Decoded sketch-params delta, or null when absent/undecodable. */
   options: Record<string, unknown> | null;
@@ -45,6 +74,10 @@ export type EmbedHash = {
   controls: string[] | null;
   /** Autoplay policy; defaults to "on" when absent or unrecognised. */
   autoplay: AutoplayPolicy;
+  /** Canvas resolution override, or null when the sketch's own size stands. */
+  size: EmbedSize | null;
+  /** Whether the sketch is inset from the frame edges. Defaults to false. */
+  margin: boolean;
 };
 
 /* ---- base64url ---------------------------------------------------- */
@@ -174,6 +207,48 @@ export function diffSketchOptions(
   return diff === UNCHANGED || !isPlainObject( diff ) ? {} : diff;
 }
 
+/* ---- size ---------------------------------------------------------- */
+
+/**
+ * Parse an `s=` token into a resolution. Returns null for anything that is not
+ * `fill` or a pair of in-range integers, so a mangled URL degrades to "use the
+ * sketch's own size" instead of booting a 0×0 (or 40000×40000) canvas.
+ */
+export function parseEmbedSize( value: string | null | undefined ): EmbedSize | null {
+  if ( !value ) {
+    return null;
+  }
+
+  if ( value === EMBED_SIZE_FILL ) {
+    return EMBED_SIZE_FILL;
+  }
+
+  const match = /^(\d+)x(\d+)$/i.exec( value.trim() );
+
+  if ( !match ) {
+    return null;
+  }
+
+  const width = Number( match[ 1 ] );
+  const height = Number( match[ 2 ] );
+  const inRange = ( side: number ) =>
+    Number.isFinite( side ) && side >= EMBED_SIZE_MIN && side <= EMBED_SIZE_MAX;
+
+  if ( !inRange( width ) || !inRange( height ) ) {
+    return null;
+  }
+
+  return {
+    width,
+    height
+  };
+}
+
+/** Serialise a resolution back into its `s=` token. Inverse of `parseEmbedSize`. */
+export function formatEmbedSize( size: EmbedSize ): string {
+  return size === EMBED_SIZE_FILL ? EMBED_SIZE_FILL : `${ size.width }x${ size.height }`;
+}
+
 /* ---- hash parsing ------------------------------------------------- */
 
 /**
@@ -199,21 +274,26 @@ export function parseEmbedHash( hash: string ): EmbedHash {
       : null,
     autoplay: rawAutoplay === "off" || rawAutoplay === "desktop"
       ? rawAutoplay
-      : "on"
+      : "on",
+    size: parseEmbedSize( params.get( EMBED_SIZE_HASH_KEY ) ),
+    margin: params.get( EMBED_MARGIN_HASH_KEY ) === "1"
   };
 }
 
 /**
  * Build the embed URL fragment from a sketch-params delta, an optional control
- * whitelist, and optional extras (autoplay policy). Inverse of `parseEmbedHash`.
- * Returns "" when there is nothing to encode (so a default share produces a
- * clean, hashless URL). Default-valued extras (`autoplay: "on"`) are omitted.
+ * whitelist, and optional extras (autoplay policy, resolution, margin). Inverse
+ * of `parseEmbedHash`. Returns "" when there is nothing to encode (so a default
+ * share produces a clean, hashless URL). Default-valued extras
+ * (`autoplay: "on"`, `margin: false`) are omitted.
  */
 export function buildEmbedHash(
   delta: Record<string, unknown>,
   controls?: string[],
   extra?: {
     autoplay?: AutoplayPolicy;
+    size?: EmbedSize | null;
+    margin?: boolean;
   }
 ): string {
   const params = new URLSearchParams();
@@ -237,6 +317,20 @@ export function buildEmbedHash(
     params.set(
       EMBED_AUTOPLAY_HASH_KEY,
       extra.autoplay
+    );
+  }
+
+  if ( extra?.size ) {
+    params.set(
+      EMBED_SIZE_HASH_KEY,
+      formatEmbedSize( extra.size )
+    );
+  }
+
+  if ( extra?.margin ) {
+    params.set(
+      EMBED_MARGIN_HASH_KEY,
+      "1"
     );
   }
 

--- a/src/lib/embedSizing.ts
+++ b/src/lib/embedSizing.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolution helpers for the `/embed` route.
+ *
+ * A share URL can pin the canvas to a fixed resolution (`#s=1920x1080`) or ask
+ * it to track the iframe itself (`#s=fill`). Both end up as a plain
+ * `{ width, height }` written onto the options tree before the engine boots —
+ * these helpers do that translation, and nothing else.
+ */
+import clamp from "@/utils/clamp";
+import {
+  EMBED_SIZE_MAX, EMBED_SIZE_MIN
+} from "@/lib/embedOptions";
+
+export type EmbedFrameSize = {
+  width: number;
+  height: number;
+};
+
+/**
+ * Turn a measured frame box into a canvas resolution.
+ *
+ * `marginFactor` insets the canvas inside the frame (1 = flush, 0.9 = the
+ * studio's gutter): in fill mode the margin is baked into the resolution
+ * itself, since the canvas *is* the frame and there is nothing left to scale.
+ * Sides are rounded to whole pixels and clamped to the schema's bounds, so a
+ * collapsed (0-height) frame still yields a bootable canvas.
+ */
+export function resolveFillSize(
+  frameWidth: number,
+  frameHeight: number,
+  marginFactor = 1
+): EmbedFrameSize {
+  const side = ( value: number ) => clamp(
+    Math.round( value * marginFactor ),
+    EMBED_SIZE_MIN,
+    EMBED_SIZE_MAX
+  );
+
+  return {
+    width: side( frameWidth ),
+    height: side( frameHeight )
+  };
+}
+
+/**
+ * Write `size` onto an options tree, non-destructively.
+ *
+ * Slides carry their own optional `size` override which *masks* the global one
+ * (see `mergeSlideOverride`), so a deck would otherwise ignore the requested
+ * resolution — every slide that defines a size is rewritten too. Slides without
+ * an override are left alone: they already follow the global size.
+ */
+export function applyEmbedSize<T extends Record<string, any>>(
+  options: T,
+  size: EmbedFrameSize
+): T {
+  const slides = options?.slides;
+  const next: Record<string, any> = {
+    ...options,
+    size: {
+      ...size
+    }
+  };
+
+  if ( Array.isArray( slides ) && slides.length > 0 ) {
+    next.slides = slides.map( ( slide ) =>
+      slide && typeof slide === "object" && slide.size
+        ? {
+          ...slide,
+          size: {
+            ...size
+          }
+        }
+        : slide );
+  }
+
+  return next as T;
+}
+
+/** True when two resolutions are the same — used to skip no-op resize churn. */
+export function isSameSize(
+  a: EmbedFrameSize | null | undefined,
+  b: EmbedFrameSize | null | undefined
+): boolean {
+  return Boolean( a && b && a.width === b.width && a.height === b.height );
+}


### PR DESCRIPTION
## What

The share dialog baked the sketch's own canvas size into every embed and always inherited the studio viewport's 10% fit gutter, so a shared iframe came back letterboxed with no way to change either. This adds both knobs to the modal.

**Frame** section in the share dialog:

- **Resolution** select — *Match the editor (W × H)* (default, tracks the live canvas size), *Fill the frame — follow the iframe size*, plus every canvas-size preset (Square / Portrait / Landscape), reusing `formatOptions` minus the fullscreen sentinels.
- **Margin** checkbox — off by default, so the sketch sits flush against the frame edges.

## How

Two new hash keys in the `/embed` URL codec:

| key | meaning |
|---|---|
| `s` | `<width>x<height>` pins the canvas to a resolution; `fill` sizes it to the iframe itself and re-sizes it as the host resizes the frame |
| `m` | `1` keeps the studio's inset; absent means edge-to-edge |

Both are read once at mount — unlike `o=`, they shape the canvas rather than its parameters. Malformed or out-of-range values fall back to the sketch's own size.

- `ScalableViewport` takes a `fitMarginFactor` prop so the gutter is a property of the surface instead of a constant baked into `calculateFitToViewport`. The studio keeps its `0.9`; the embed passes `1` unless `#m=1`.
- Fill mode measures the frame, boots the engine at that resolution, and pushes later resizes through the options bus (`setSketchOptions`) so the canvas resizes without remounting the sketch. Per-slide `size` overrides are rewritten too, since they'd otherwise mask the global size.
- The snippet's `aspect-ratio` box follows the chosen resolution, and its URL now escapes `&` so a host-side sanitiser can't mangle the hash.

## Verification

`npm run check` (lint + 1717 tests) and `npm run build` pass. New unit tests cover the `s`/`m` codec round-trip, size validation, `resolveFillSize`, `applyEmbedSize`, and the fit-margin factor.

Driven headlessly against the production build (`/embed/p5/semaphore/semaphore-v0-dots` in an 800×450 frame):

| case | canvas buffer | on screen | gutter |
|---|---|---|---|
| default | 1080×1350 | 360×450 | none |
| `#m=1` | 1080×1350 | 324×405 | 238 / 22.5 |
| `#s=fill` | 800×450 | 800×450 | none |
| `#s=fill&m=1` | 720×405 | 720×405 | 40 / 22.5 |
| `#s=1920x1080` | 1920×1080 | 800×450 | none |

Resizing the frame to 1024×300 while in fill mode moves the canvas buffer to 1024×300 without a remount.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3UWMACLJCnBQW55yUcyih)_