### PR TITLE
Bind both joypad sticks (left + right)

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
@@ -504,6 +504,14 @@ export function interactionEnablePaths( source: string ): string[] {
         `${ source }.enabled`
       ];
 
+    // Right stick shares the left stick's single `joypad.enabled` flag — no
+    // per-stick flag to derive from the source id.
+    case "joypadRight":
+      return [
+        "enabled",
+        "joypad.enabled"
+      ];
+
     default:
       // Generators (oscillator / ramp / sequence / noise / random) and unknown
       // ids have no interaction source to enable.

--- a/src/lib/__tests__/embedSizing.test.ts
+++ b/src/lib/__tests__/embedSizing.test.ts
@@ -146,7 +146,8 @@ describe(
             size: {
               width: 100,
               height: 100
-            }
+            },
+            slides: undefined as unknown[] | undefined
           },
           size
         );

--- a/src/sketches/p5/utils/interaction/__tests__/channels.test.ts
+++ b/src/sketches/p5/utils/interaction/__tests__/channels.test.ts
@@ -167,6 +167,7 @@ describe(
           "gyroscope",
           "hands",
           "joypad",
+          "joypadRight",
           "midi",
           "mouse",
           "orbit",

--- a/src/sketches/p5/utils/interaction/index.js
+++ b/src/sketches/p5/utils/interaction/index.js
@@ -757,7 +757,11 @@ const _FLAT_COLLECTORS = [
   ],
   [
     "joypad",
-    _collectJoypad
+    _collectJoypadLeft
+  ],
+  [
+    "joypadRight",
+    _collectJoypadRight
   ]
 ];
 
@@ -842,8 +846,9 @@ export function getPointersDebug( opts ) {
  *   - fingers→ one group per detected finger (joint chain, base → fingertip)
  *   - body   → one group per detected pose  (wrist→elbow→shoulder→…→wrist)
  *   - face   → one group per detected face  (ear→eye→nose→mouth→eye→ear arc)
- *   - orbit / perlinNoise / audio / touch / midi / joypad / mouse / gyroscope
+ *   - orbit / perlinNoise / audio / touch / midi / mouse / gyroscope
  *            → one group holding that source's points
+ *   - joypad → one group per stick (left → "joypad", right → "joypadRight")
  *
  * Set `opts.smoothing` (0..1) to temporally smooth each group/point so jittery
  * camera landmarks produce calm curves.
@@ -953,7 +958,11 @@ export function getPointerGroups( opts ) {
   );
   addPerPoint(
     "joypad",
-    _collectJoypad
+    _collectJoypadLeft
+  );
+  addPerPoint(
+    "joypadRight",
+    _collectJoypadRight
   );
 
   return _smoothGroups(
@@ -2501,29 +2510,22 @@ export function getInteractionMetrics( opts = options.sketch?.interaction ?? {} 
   return computeInteractionMetrics( opts );
 }
 
-function _collectJoypad(
-  opts, p, out
-) {
-  const joypad = opts.joypad;
-
-  if ( !joypad?.enabled ) {
-    return;
+// Gamepads matching `opts.joypad`, up to `count` (deviceId "" = any connected
+// pad; identical controllers share an id, so several may still match). Shared
+// by the left/right stick collectors so both read the same resolved pad set.
+function _resolveJoypads( joypad ) {
+  if ( !joypad?.enabled || typeof navigator.getGamepads !== "function" ) {
+    return [];
   }
 
-  if ( typeof navigator.getGamepads !== "function" ) {
-    return;
-  }
-
-  const gamepads = navigator.getGamepads();
   const maxCount = joypad.count ?? 1;
-  const deadzone = joypad.deadzone ?? 0.1;
-  // "" reads any connected pad; a specific id restricts to matching pads
-  // (identical controllers share an id, so several may still match).
   const deviceId = joypad.deviceId || "";
-  let added = 0;
+  const matched = [];
 
-  for ( let i = 0; i < gamepads.length && added < maxCount; i++ ) {
-    const gp = gamepads[ i ];
+  for ( const gp of navigator.getGamepads() ) {
+    if ( matched.length >= maxCount ) {
+      break;
+    }
 
     if ( !gp || !gp.connected ) {
       continue;
@@ -2533,9 +2535,24 @@ function _collectJoypad(
       continue;
     }
 
-    // Left stick: axes[0] = X, axes[1] = Y
-    let axisX = gp.axes[ 0 ] ?? 0;
-    let axisY = gp.axes[ 1 ] ?? 0;
+    matched.push( gp );
+  }
+
+  return matched;
+}
+
+// Reads one stick's pair of axes, applying the deadzone and mapping to canvas
+// space. `axisIndexX`/`axisIndexY` select the left stick (0, 1) or the right
+// stick (2, 3).
+function _collectJoypadStick(
+  opts, p, out, axisIndexX, axisIndexY
+) {
+  const joypad = opts.joypad;
+  const deadzone = joypad?.deadzone ?? 0.1;
+
+  for ( const gp of _resolveJoypads( joypad ) ) {
+    let axisX = gp.axes[ axisIndexX ] ?? 0;
+    let axisY = gp.axes[ axisIndexY ] ?? 0;
 
     if ( Math.abs( axisX ) < deadzone ) {
       axisX = 0;
@@ -2561,6 +2578,32 @@ function _collectJoypad(
         p.height
       )
     ) );
-    added++;
   }
+}
+
+// Left stick: axes[0] = X, axes[1] = Y.
+function _collectJoypadLeft(
+  opts, p, out
+) {
+  _collectJoypadStick(
+    opts,
+    p,
+    out,
+    0,
+    1
+  );
+}
+
+// Right stick: axes[2] = X, axes[3] = Y. Active by default alongside the left
+// stick whenever `joypad.enabled` is on — no separate flag to flip.
+function _collectJoypadRight(
+  opts, p, out
+) {
+  _collectJoypadStick(
+    opts,
+    p,
+    out,
+    2,
+    3
+  );
 }

--- a/src/sketches/p5/utils/interaction/overlay.js
+++ b/src/sketches/p5/utils/interaction/overlay.js
@@ -86,7 +86,12 @@ export const INTERACTION_SOURCE_COLORS = {
     77,
     182,
     172
-  ] // teal-green
+  ], // teal-green
+  joypadRight: [
+    255,
+    202,
+    40
+  ] // amber
 };
 
 export const INTERACTION_SOURCE_LABELS = {
@@ -102,7 +107,8 @@ export const INTERACTION_SOURCE_LABELS = {
   gyroscope: "Gyroscope",
   midi: "MIDI",
   audio: "Audio (Mic)",
-  joypad: "Joypad / Gamepad"
+  joypad: "Joypad / Gamepad (left stick)",
+  joypadRight: "Joypad / Gamepad (right stick)"
 };
 
 const DEFAULT_COLOR = [

--- a/src/sketches/p5/utils/interaction/sources.js
+++ b/src/sketches/p5/utils/interaction/sources.js
@@ -79,7 +79,12 @@ export const INTERACTION_SOURCES = [
   {
     id: "joypad",
     type: "vector2d",
-    label: "Joypad"
+    label: "Joypad · Left stick"
+  },
+  {
+    id: "joypadRight",
+    type: "vector2d",
+    label: "Joypad · Right stick"
   },
 
   // ── Semantic audio scalars (from getAudio().bands) ────────────────────────
@@ -222,7 +227,8 @@ export const FLAT_SOURCE_IDS = [
   "gyroscope",
   "midi",
   "audio",
-  "joypad"
+  "joypad",
+  "joypadRight"
 ];
 
 // The getAudio().bands keys exposed as `audio.<band>` scalar channels.


### PR DESCRIPTION
## Summary

- The joypad interaction handler only ever sampled `axes[0]`/`axes[1]` (the left stick) — the right stick was never bindable.
- Both sticks are now active by default whenever `interaction.joypad.enabled` is on. No new option to flip — this is additive, not a new mode.
- `src/sketches/p5/utils/interaction/index.js`: extracted the gamepad-resolution logic out of the old `_collectJoypad` into `_resolveJoypads()` + `_collectJoypadStick()`, then registered two flat-collector entries — `"joypad"` (left stick, tag unchanged for backward compatibility with existing bindings/sketches) and `"joypadRight"` (new).
- `src/sketches/p5/utils/interaction/sources.js`: added `joypadRight` as its own top-level vector2d channel family (kept separate from `joypad` rather than nested as `joypad.right`) so the binding picker shows distinct X / Y / Magnitude / Angle projections per stick instead of colliding under one `<optgroup>`.
- `bindingUtils.ts`: `joypadRight` auto-enables through the same single `joypad.enabled` flag as the left stick (there's no per-stick enable flag).
- `overlay.js`: per-stick debug color + legend label so the interaction debug overlay distinguishes the two sticks.

The existing device selector (`joypad.deviceId`, the `joypad-device-select` field) is unchanged — it still picks which physical gamepad to read from. This PR only adds the second stick as a bindable source on that gamepad.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (full suite — 1698 tests passing, including updated parity tests in `channels.test.ts`)
- [x] `npm run build` (compiles every sketch route)
- [ ] Manual check with a physical gamepad connected: confirm `joypadRight` shows up as a separate group in the binding source picker and tracks the right stick independently from `joypad` (left stick)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah5Ztp78ZdHjHxCZ5eefRD)_