### PR TITLE
Clarify binding popover source picker labels

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
@@ -5,7 +5,7 @@ import {
   Popover, PopoverButton, PopoverPanel
 } from "@headlessui/react";
 import {
-  Activity, Plus, RotateCcw, Trash2, X
+  Activity, ChevronDown, Plus, RotateCcw, Trash2, X
 } from "lucide-react";
 import clsx from "clsx";
 import {
@@ -147,6 +147,15 @@ export default function BindingAffordance( {
   const bound = layers.length > 0;
   const sourceOptions = channelSourceOptions( kind );
   const domain = fieldDomain( config );
+
+  // The selected input source's full "Family · Detail" label — shown only on
+  // the closed control, since the open list already groups by family under
+  // an <optgroup> heading (a short label there would be redundant).
+  const selectedSourceOption = binding && sourceOptions.find( ( option ) => option.value === encodeSource(
+    binding.source,
+    binding.project
+  ) );
+  const selectedSourceLabel = selectedSourceOption?.label ?? binding?.source ?? "";
 
   // Path of the selected binding object in the form; sub-fields (mapping.min,
   // smoothing, enabled…) are edited in place so they round-trip like any other
@@ -551,38 +560,52 @@ export default function BindingAffordance( {
               )}
 
               {category === "input" && (
-                <select
-                  value={ encodeSource(
-                    binding.source,
-                    binding.project
-                  ) }
-                  onChange={ ( e ) => {
-                    const {
-                      source, project
-                    } = decodeSource( e.target.value );
+                <div className="relative">
+                  {/* Visible, non-interactive: shows the full "Family · Detail"
+                      label so the source's group stays legible once collapsed —
+                      the native <select> below would otherwise only echo back
+                      the short, group-less option text. */}
+                  <div
+                    aria-hidden
+                    className="flex h-8 w-full items-center justify-between gap-1 rounded-md border border-theme bg-background px-2 text-foreground"
+                  >
+                    <span className="truncate">{selectedSourceLabel}</span>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-label" />
+                  </div>
+                  <select
+                    value={ encodeSource(
+                      binding.source,
+                      binding.project
+                    ) }
+                    onChange={ ( e ) => {
+                      const {
+                        source, project
+                      } = decodeSource( e.target.value );
 
-                    setField(
-                      "source",
-                      source
-                    );
-                    setField(
-                      "project",
-                      project ?? null
-                    );
-                    enableSourceInputs( source );
-                  } }
-                  className="h-8 w-full rounded-md border border-theme bg-background px-2 text-foreground"
-                >
-                  {channelSourceGroups( kind ).map( ( group ) => (
-                    <optgroup key={ group.key } label={ group.label }>
-                      {group.options.map( ( option ) => (
-                        <option key={ option.value } value={ option.value }>
-                          {sourceOptionShortLabel( option )}
-                        </option>
-                      ) )}
-                    </optgroup>
-                  ) )}
-                </select>
+                      setField(
+                        "source",
+                        source
+                      );
+                      setField(
+                        "project",
+                        project ?? null
+                      );
+                      enableSourceInputs( source );
+                    } }
+                    aria-label="Source"
+                    className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                  >
+                    {channelSourceGroups( kind ).map( ( group ) => (
+                      <optgroup key={ group.key } label={ group.label }>
+                        {group.options.map( ( option ) => (
+                          <option key={ option.value } value={ option.value }>
+                            {sourceOptionShortLabel( option )}
+                          </option>
+                        ) )}
+                      </optgroup>
+                    ) )}
+                  </select>
+                </div>
               )}
 
               {category === "oscillator" && (

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
@@ -396,7 +396,7 @@ export const SOURCE_CATEGORIES: Array<{
 }> = [
   {
     value: "input",
-    label: "Input"
+    label: "Interaction Inputs"
   },
   {
     value: "oscillator",


### PR DESCRIPTION
## Summary
- Rename the binding popover's source-category select option from "Input" to "Interaction Inputs" (plural), to make clear this category drives the modulation from live interaction inputs (mouse, touch, audio, hands, …).
- Once an input source is selected and the second `<select>` (grouped by family via `<optgroup>`) is collapsed, show its full "Family · Detail" label (e.g. "Audio · Level") instead of just the detail ("Level"), so the source's family stays identifiable from outside the dropdown. The open list is unchanged — it still shows short labels under each `<optgroup>` heading, since the group name is already visible there.
- Implemented via a small overlay: a non-interactive label span shows the full "Family · Detail" text, with an invisible native `<select>` (still using `<optgroup>` + short labels) layered on top for interaction — the same pattern already used by `ControlledSourceSelect`.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (1717 tests passed)
- [ ] Manual check in the browser: open a bindable parameter's popover, pick "Interaction Inputs", select e.g. `Audio › Level`, confirm the collapsed control reads "Audio · Level" while the open dropdown still groups by family with short option labels.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VfNoUYpr51H9iQJR9LXCEQ)_