### PR TITLE
Migrate hand-capture legacy titles to a shared renderLegacyTitle util

### DIFF
--- a/src/sketches/p5/sketches/hand-capture/_shared.js
+++ b/src/sketches/p5/sketches/hand-capture/_shared.js
@@ -1308,57 +1308,6 @@ export class HandCaptureScene {
     }
   }
 
-  drawTitle( {
-    title, subtitle, show = true, color
-  } = {} ) {
-    if ( !show ) {
-      return;
-    }
-
-    const p = getP5();
-    const fill = color ? p.color( ...color ) : p.color( 0 );
-
-    if ( title ) {
-      string.write(
-        title,
-        0,
-        p.height / 2,
-        {
-          size: 172,
-          strokeWeight: 0,
-          stroke: fill,
-          fill,
-          font: string.fonts.martian,
-          textAlign: [
-            p.CENTER,
-            p.CENTER
-          ],
-          blendMode: p.EXCLUSION
-        }
-      );
-    }
-
-    if ( subtitle ) {
-      string.write(
-        subtitle,
-        0,
-        ( p.height * 6 ) / 10,
-        {
-          size: 32,
-          strokeWeight: 0,
-          stroke: fill,
-          fill,
-          font: string.fonts.loraItalic,
-          textAlign: [
-            p.CENTER,
-            p.CENTER
-          ],
-          blendMode: p.EXCLUSION
-        }
-      );
-    }
-  }
-
   /** Big centered counter near the top — an implicit score for game variants. */
   drawScore( {
     value = 0, label = "", show = true, color

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v0-move/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v0-move/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -21,7 +22,6 @@ sketch.draw( () => {
   const physics = options.sketch?.physics ?? {};
   const visuals = options.sketch?.visuals ?? {};
   const hands = options.sketch?.hands ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -55,10 +55,9 @@ sketch.draw( () => {
   } );
   scene.compose();
 
-  scene.drawTitle( {
-    title: text.title ?? "move",
-    subtitle: text.subtitle ?? "hand tracking v0",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v0-move/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v0-move/options.ts
@@ -65,12 +65,9 @@ export const formValues = {
     trail: 255
   },
 
-  // Overlay text
-  text: {
-    show: true,
-    title: "move",
-    subtitle: "hand tracking v0"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "move",
+  subtitle: "hand tracking v0"
 };
 
 // UI configuration only
@@ -182,22 +179,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v1-attract/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v1-attract/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -22,7 +23,6 @@ sketch.draw( () => {
   const visuals = options.sketch?.visuals ?? {};
   const hands = options.sketch?.hands ?? {};
   const attract = options.sketch?.attract ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -56,10 +56,9 @@ sketch.draw( () => {
   } );
   scene.compose();
 
-  scene.drawTitle( {
-    title: text.title ?? "attract",
-    subtitle: text.subtitle ?? "hand tracking v1",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v1-attract/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v1-attract/options.ts
@@ -63,11 +63,9 @@ export const formValues = {
     trail: 255
   },
 
-  text: {
-    show: true,
-    title: "attract",
-    subtitle: "hand tracking v1"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "attract",
+  subtitle: "hand tracking v1"
 };
 
 export const formConfiguration: Record<string, any> = {
@@ -192,22 +190,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v15-puppet-type/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v15-puppet-type/index.js
@@ -11,6 +11,7 @@ import {
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 // ── puppet-type ────────────────────────────────────────────────────────────
 // The word is a marionette and your hand is the puppeteer. Each letter is a
@@ -55,7 +56,6 @@ sketch.draw( () => {
   const spring = options.sketch?.spring ?? {};
   const motion = options.sketch?.motion ?? {};
   const handDrawing = options.sketch?.hands ?? {};
-  const overlay = options.sketch?.overlay ?? {};
   const background = options.sketch?.backgroundColor ?? [
     12,
     12,
@@ -99,9 +99,9 @@ sketch.draw( () => {
 
   scene.compose();
 
-  scene.drawTitle( {
-    subtitle: overlay.subtitle ?? "puppet type · hand tracking v15",
-    show: overlay.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v15-puppet-type/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v15-puppet-type/options.ts
@@ -87,11 +87,9 @@ export const formValues = {
     resolution: 0.1
   },
 
-  // Overlay text
-  overlay: {
-    show: true,
-    subtitle: "puppet type · hand tracking v15"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "",
+  subtitle: "puppet type · hand tracking v15"
 };
 
 // UI configuration only
@@ -294,18 +292,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  overlay: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        component: "checkbox",
-        label: "Show text"
-      },
-      subtitle: {
-        component: "text",
-        label: "Subtitle"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v2-repulse/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v2-repulse/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -22,7 +23,6 @@ sketch.draw( () => {
   const visuals = options.sketch?.visuals ?? {};
   const hands = options.sketch?.hands ?? {};
   const repulse = options.sketch?.repulse ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -57,10 +57,9 @@ sketch.draw( () => {
   } );
   scene.compose();
 
-  scene.drawTitle( {
-    title: text.title ?? "repulse",
-    subtitle: text.subtitle ?? "hand tracking v2",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v2-repulse/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v2-repulse/options.ts
@@ -64,11 +64,9 @@ export const formValues = {
     trail: 255
   },
 
-  text: {
-    show: true,
-    title: "repulse",
-    subtitle: "hand tracking v2"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "repulse",
+  subtitle: "hand tracking v2"
 };
 
 export const formConfiguration: Record<string, any> = {
@@ -200,22 +198,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v3-restore/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v3-restore/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -22,7 +23,6 @@ sketch.draw( () => {
   const visuals = options.sketch?.visuals ?? {};
   const hands = options.sketch?.hands ?? {};
   const restore = options.sketch?.restore ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -55,10 +55,9 @@ sketch.draw( () => {
   } );
   scene.compose();
 
-  scene.drawTitle( {
-    title: text.title ?? "restore",
-    subtitle: text.subtitle ?? "hand tracking v3",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v3-restore/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v3-restore/options.ts
@@ -61,11 +61,9 @@ export const formValues = {
     dotScale: 1
   },
 
-  text: {
-    show: true,
-    title: "restore",
-    subtitle: "hand tracking v3"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "restore",
+  subtitle: "hand tracking v3"
 };
 
 export const formConfiguration: Record<string, any> = {
@@ -183,22 +181,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v5-catch/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v5-catch/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -27,7 +28,6 @@ sketch.draw( () => {
   const grab = options.sketch?.catch ?? {};
   const visuals = options.sketch?.visuals ?? {};
   const score = options.sketch?.score ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -70,9 +70,9 @@ sketch.draw( () => {
     show: score.show ?? true,
     color: background
   } );
-  scene.drawTitle( {
-    subtitle: text.subtitle ?? "catch · hand tracking v5",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v5-catch/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v5-catch/options.ts
@@ -70,11 +70,9 @@ export const formValues = {
     show: true
   },
 
-  // Overlay text
-  text: {
-    show: true,
-    subtitle: "catch · hand tracking v5"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "",
+  subtitle: "catch · hand tracking v5"
 };
 
 // UI configuration only
@@ -204,18 +202,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v6-slice/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v6-slice/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -27,7 +28,6 @@ sketch.draw( () => {
   const handDrawing = options.sketch?.hands ?? {};
   const visuals = options.sketch?.visuals ?? {};
   const score = options.sketch?.score ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -75,9 +75,9 @@ sketch.draw( () => {
     show: score.show ?? true,
     color: background
   } );
-  scene.drawTitle( {
-    subtitle: text.subtitle ?? "slice · hand tracking v6",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v6-slice/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v6-slice/options.ts
@@ -75,11 +75,9 @@ export const formValues = {
     show: true
   },
 
-  // Overlay text
-  text: {
-    show: true,
-    subtitle: "slice · hand tracking v6"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "",
+  subtitle: "slice · hand tracking v6"
 };
 
 // UI configuration only
@@ -244,18 +242,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v7-echo/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v7-echo/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -19,7 +20,6 @@ sketch.draw( () => {
   const interaction = options.sketch?.interaction ?? {};
   const handDrawing = options.sketch?.hands ?? {};
   const echo = options.sketch?.echo ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -38,10 +38,9 @@ sketch.draw( () => {
   } );
   scene.compose();
 
-  scene.drawTitle( {
-    title: text.title ?? "echo",
-    subtitle: text.subtitle ?? "hand tracking v7",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v7-echo/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v7-echo/options.ts
@@ -52,12 +52,9 @@ export const formValues = {
     ghostAlpha: 0.55
   },
 
-  // Overlay text — centered title (like the move / attract / restore sketches)
-  text: {
-    show: true,
-    title: "echo",
-    subtitle: "hand tracking v7"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "echo",
+  subtitle: "hand tracking v7"
 };
 
 // UI configuration only
@@ -133,22 +130,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v8-growing/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v8-growing/index.js
@@ -4,6 +4,7 @@ import sketch from "@/p5/utils/sketch.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 // v8 "growing" is v7's echo rebuilt on the shader-based spline pipeline (the
 // same GPU glow as `splines · interactive`) instead of the legacy CPU neonLine.
@@ -21,7 +22,6 @@ sketch.draw( () => {
   const spline = options.sketch?.spline ?? {};
   const echo = options.sketch?.echo ?? {};
   const effect = options.sketch?.effect ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -42,10 +42,9 @@ sketch.draw( () => {
     darken: effect.darken ?? 0.12
   } );
 
-  scene.drawTitle( {
-    title: text.title ?? "growing",
-    subtitle: text.subtitle ?? "hand tracking v8",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v8-growing/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v8-growing/options.ts
@@ -64,12 +64,9 @@ export const formValues = {
     darken: 0.12
   },
 
-  // Overlay text — centered title (like the move / attract / restore sketches)
-  text: {
-    show: true,
-    title: "growing",
-    subtitle: "hand tracking v8"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "growing",
+  subtitle: "hand tracking v8"
 };
 
 // UI configuration only
@@ -193,22 +190,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        label: "Show text",
-        component: "checkbox"
-      },
-      title: {
-        label: "Title",
-        component: "text"
-      },
-      subtitle: {
-        label: "Subtitle",
-        component: "text"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v9-smear/index.js
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v9-smear/index.js
@@ -10,6 +10,7 @@ import mediapipe from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   HandCaptureScene
 } from "../_shared.js";
+import renderLegacyTitle from "@/p5/utils/title/renderLegacyTitle.js";
 
 const scene = new HandCaptureScene( {
   layers: {
@@ -56,7 +57,6 @@ sketch.draw( () => {
   const brush = options.sketch?.brush ?? {};
   const trail = options.sketch?.trail ?? {};
   const handDrawing = options.sketch?.hands ?? {};
-  const text = options.sketch?.text ?? {};
   const background = options.sketch?.backgroundColor ?? options.colors?.background ?? [
     0
   ];
@@ -111,9 +111,9 @@ sketch.draw( () => {
 
   scene.compose();
 
-  scene.drawTitle( {
-    subtitle: text.subtitle ?? "smear · hand tracking v8",
-    show: text.show ?? true,
+  renderLegacyTitle( {
+    title: options.sketch?.title ?? "",
+    subtitle: options.sketch?.subtitle ?? "",
     color: background
   } );
 } );

--- a/src/sketches/p5/sketches/hand-capture/hand-tracking-v9-smear/options.ts
+++ b/src/sketches/p5/sketches/hand-capture/hand-tracking-v9-smear/options.ts
@@ -71,11 +71,9 @@ export const formValues = {
     resolution: 0.1
   },
 
-  // Overlay text
-  text: {
-    show: true,
-    subtitle: "smear · hand tracking v8"
-  }
+  // Legacy centred splash (rendered by @/p5/utils/title/renderLegacyTitle.js)
+  title: "",
+  subtitle: "smear · hand tracking v8"
 };
 
 // UI configuration only
@@ -238,18 +236,13 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  text: {
-    component: "nested-object",
-    label: "Overlay text",
-    fields: {
-      show: {
-        component: "checkbox",
-        label: "Show text"
-      },
-      subtitle: {
-        component: "text",
-        label: "Subtitle"
-      }
-    }
+  title: {
+    label: "Title",
+    component: "text"
+  },
+
+  subtitle: {
+    label: "Subtitle",
+    component: "text"
   }
 };

--- a/src/sketches/p5/sketches/photo/_photo-letter-gravity/index.js
+++ b/src/sketches/p5/sketches/photo/_photo-letter-gravity/index.js
@@ -381,7 +381,6 @@ sketch.draw( (
   // if (animation.progression < 0.2) {
   // 	string.write(
   // 		defaultTitle,
-  // 		// options.texts.title || defaultTitle,
   // 		p.width/2,
   // 		p.height/2,
   // 		{

--- a/src/sketches/p5/sketches/photo/_photo-mask-draw/index.js
+++ b/src/sketches/p5/sketches/photo/_photo-mask-draw/index.js
@@ -172,7 +172,6 @@ sketch.draw( (
   if ( animation.progression < 0.2 ) {
     string.write(
       defaultTitle,
-      // options.texts.title || defaultTitle,
       p.width / 2,
       p.height / 2,
       {

--- a/src/sketches/p5/sketches/photo/_photo-slide/index.js
+++ b/src/sketches/p5/sketches/photo/_photo-slide/index.js
@@ -197,7 +197,6 @@ sketch.draw( (
   if ( animation.progression < 0.2 ) {
     string.write(
       defaultTitle,
-      // options.texts.title || defaultTitle,
       p.width / 2,
       p.height / 2,
       {

--- a/src/sketches/p5/sketches/text/text-decomposition/index.js
+++ b/src/sketches/p5/sketches/text/text-decomposition/index.js
@@ -178,6 +178,4 @@ sketch.draw( () => {
   //     popPush: true,
   //   }
   // );
-
-  // renderTitle( options.sketch?.text ?? options.name );
 } );

--- a/src/sketches/p5/utils/title/renderLegacyTitle.js
+++ b/src/sketches/p5/utils/title/renderLegacyTitle.js
@@ -1,0 +1,61 @@
+import string from "../string.js";
+import {
+  getP5
+} from "../sketch.js";
+
+// The historical hand-capture splash: a big centred title (martian, EXCLUSION
+// blend) with an italic subtitle underneath. Kept as a shared "legacy"
+// renderer so any sketch wanting this exact style imports it instead of
+// duplicating it — the styled/animated path is the "title" content item.
+export default function renderLegacyTitle( {
+  title = "",
+  subtitle = "",
+  color
+} = {} ) {
+  if ( !title && !subtitle ) {
+    return;
+  }
+
+  const p = getP5();
+  const fill = color ? p.color( ...color ) : p.color( 0 );
+
+  if ( title ) {
+    string.write(
+      title,
+      0,
+      p.height / 2,
+      {
+        size: 172,
+        strokeWeight: 0,
+        stroke: fill,
+        fill,
+        font: string.fonts.martian,
+        textAlign: [
+          p.CENTER,
+          p.CENTER
+        ],
+        blendMode: p.EXCLUSION
+      }
+    );
+  }
+
+  if ( subtitle ) {
+    string.write(
+      subtitle,
+      0,
+      ( p.height * 6 ) / 10,
+      {
+        size: 32,
+        strokeWeight: 0,
+        stroke: fill,
+        fill,
+        font: string.fonts.loraItalic,
+        textAlign: [
+          p.CENTER,
+          p.CENTER
+        ],
+        blendMode: p.EXCLUSION
+      }
+    );
+  }
+}


### PR DESCRIPTION
Removes the last traces of the pre-content-item title system, now that `title` is a first-class content item (schema, renderer, palette).

## Changes

- **New shared util `src/sketches/p5/utils/title/renderLegacyTitle.js`** — the historical hand-capture centred splash (big martian title, EXCLUSION blend, italic subtitle), extracted verbatim from `HandCaptureScene.drawTitle` so it stays a single reusable import instead of being copied per sketch.
- **10 hand-capture sketches migrated** (v0–v3, v5–v9, v15): the nested `text` / `overlay` `{ show, title, subtitle }` blocks in `options.ts` are replaced by two flat sketch params, `title` and `subtitle` (defaults preserved per sketch, e.g. v0 keeps "move" / "hand tracking v0"); an empty string hides the corresponding line. Each `index.js` now calls `renderLegacyTitle` instead of `scene.drawTitle`.
- **`drawTitle` removed from `hand-capture/_shared.js`.**
- **Dead code cleanup**: commented `renderTitle(...)` in `text-decomposition` and commented `options.texts.title` references in the hidden `_photo-*` sketches.

Left untouched on purpose: `photo-3d-sphere`'s local `drawTitle` (an intrinsic 3D title plane, part of the photo-3d family currently being revamped) and `photo-3d-cylinder` (revamp in progress), plus sketches where `title` is the artwork's own text (`video-text`, `text-mask-with-noise-strips`).

## Verification

- `npm run check` — lint 0 errors, typecheck OK, 1721 tests passing (including the sketch-registry drift guard)
- `npm run build` — all sketch routes compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XexXT7LB1yGEwczL5YRPrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XexXT7LB1yGEwczL5YRPrn)_