### PR TITLE
ssh-sketch PoC: komputery sketch rendered live over SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 /src/generated/prisma
 prisma/prisma/database.db
 /tmp
+
+# ssh-sketch PoC host key
+scripts/ssh-sketch/.host-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "lint-staged": "^16.4.0",
         "postcss": "^8",
         "prisma": "^7.8.0",
+        "ssh2": "^1.17.0",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.5",
         "typescript": "^5"
@@ -6455,6 +6456,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -6779,6 +6790,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/better-result": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.2.tgz",
@@ -6937,6 +6958,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/bullmq": {
       "version": "5.76.4",
@@ -7450,6 +7481,21 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -12344,6 +12390,14 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -14740,6 +14794,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -15753,6 +15825,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "sketch:meta": "node scripts/watch-sketches.mjs",
     "sketch:meta:write": "node scripts/watch-sketches.mjs --once",
     "sketch:clean-assets": "node scripts/remove-orphan-thumbnails.mjs",
+    "sketch:tty": "node scripts/ssh-sketch/local.mjs",
+    "sketch:ssh": "node scripts/ssh-sketch/server.mjs",
     "dev": "next dev --turbopack",
     "watch": "node scripts/dev-watch.mjs",
     "build": "next build",
@@ -90,6 +92,7 @@
     "lint-staged": "^16.4.0",
     "postcss": "^8",
     "prisma": "^7.8.0",
+    "ssh2": "^1.17.0",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.4.5",
     "typescript": "^5"

--- a/scripts/ssh-sketch/README.md
+++ b/scripts/ssh-sketch/README.md
@@ -1,0 +1,57 @@
+# ssh-sketch — PoC: a sketch over SSH
+
+`ssh <host> -p 2222` opens **ascii-pulse-v1-komputery** rendered live in the
+terminal, terminal.shop-style. No browser, no p5 — the sketch's visual core is
+a pure function of the loop phase, so it is ported natively to a grid of
+truecolor ANSI glyph cells (one terminal cell = one sketch glyph cell).
+
+## Quick try (no SSH needed)
+
+```bash
+npm run sketch:tty                  # renders in the current terminal
+npm run sketch:tty -- --palette crt # crt | hot | komputery
+npm run sketch:tty -- --mode spectrum
+npm run sketch:tty -- --bell        # terminal bell on the beat
+```
+
+`q` or `Ctrl+C` quits.
+
+## SSH server
+
+```bash
+npm run sketch:ssh                  # listens on :2222 (SSH_SKETCH_PORT to change)
+```
+
+Then from any terminal (the username picks the variant):
+
+```bash
+ssh komputery@localhost -p 2222
+ssh crt@localhost -p 2222
+ssh hot@localhost -p 2222
+ssh spectrum@localhost -p 2222
+```
+
+Any password (or none) is accepted — it's a viewer, not a shop… yet. A host
+key is generated on first run into `scripts/ssh-sketch/.host-key` (gitignored),
+so the first connection may warn about an unknown host as usual.
+
+## How it maps to the sketch
+
+- `renderer.mjs` ports `cellIntensity()` and the glyph/colour mapping of
+  `drawGrid()` from
+  `src/sketches/p5/sketches/ascii-pulse/ascii-pulse-v1-komputery/index.js`,
+  with the defaults from its `options.ts`.
+- The loop clock mirrors the app: one loop = `DURATION_DEFAULT` (12 s), 8 beats
+  per loop, phase φ ∈ [0, 1) — same seamless-loop maths, driven by wall clock.
+- Terminal cells are ~2× taller than wide, so the field is sampled on a 1×2
+  virtual pixel grid per cell to keep the radial wave circular.
+- Frames repaint every cell from cursor-home (no clear → no flicker), with the
+  alt screen + hidden cursor + autowrap-off for the session.
+
+## Files
+
+| File | Role |
+|---|---|
+| `renderer.mjs` | Pure ANSI frame renderer + frame loop (zero deps) |
+| `local.mjs` | Run in the current TTY (`--once` prints a single frame) |
+| `server.mjs` | SSH server (`ssh2`), username → variant |

--- a/scripts/ssh-sketch/local.mjs
+++ b/scripts/ssh-sketch/local.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Run the komputery sketch directly in the current terminal — the quickest way
+// to see the SSH PoC's renderer without an SSH server in between.
+//
+//   node scripts/ssh-sketch/local.mjs                 # defaults (komputery)
+//   node scripts/ssh-sketch/local.mjs --palette crt   # crt | hot | komputery
+//   node scripts/ssh-sketch/local.mjs --mode spectrum # pulse | spectrum
+//   node scripts/ssh-sketch/local.mjs --fps 24 --bell
+//   node scripts/ssh-sketch/local.mjs --once          # print a single frame
+//
+// q / Ctrl+C quits.
+
+import {
+  ENTER_SCREEN,
+  LEAVE_SCREEN,
+  createRenderer,
+  startLoop
+} from "./renderer.mjs";
+
+function parseArgs( argv ) {
+  const parsed = {
+    overrides: {},
+    fps: 30,
+    bell: false,
+    once: false
+  };
+
+  for ( let i = 0; i < argv.length; i++ ) {
+    const arg = argv[ i ];
+
+    if ( arg === "--palette" ) {
+      parsed.overrides.palette = argv[ ++i ];
+    } else if ( arg === "--mode" ) {
+      parsed.overrides.colorMode = argv[ ++i ];
+    } else if ( arg === "--fps" ) {
+      parsed.fps = Number( argv[ ++i ] ) || 30;
+    } else if ( arg === "--bell" ) {
+      parsed.bell = true;
+    } else if ( arg === "--once" ) {
+      parsed.once = true;
+    }
+  }
+
+  return parsed;
+}
+
+const args = parseArgs( process.argv.slice( 2 ) );
+
+const getSize = () => ( {
+  cols: process.stdout.columns || 80,
+  rows: process.stdout.rows || 24
+} );
+
+// --once: a single frame straight to stdout (no alt screen, no loop). Handy
+// for piping, screenshots, and smoke tests on non-TTY stdout.
+if ( args.once ) {
+  const renderer = createRenderer( args.overrides );
+  const {
+    cols, rows
+  } = getSize();
+
+  process.stdout.write( renderer.frame(
+    cols,
+    rows,
+    0.4
+  ) );
+  process.stdout.write( "\x1b[0m\n" );
+  process.exit( 0 );
+}
+
+process.stdout.write( ENTER_SCREEN );
+
+const stop = startLoop( {
+  write: ( chunk ) => process.stdout.write( chunk ),
+  getSize,
+  overrides: args.overrides,
+  fps: args.fps,
+  bell: args.bell
+} );
+
+function quit( ) {
+  stop( );
+  process.stdout.write( LEAVE_SCREEN );
+  process.exit( 0 );
+}
+
+process.on(
+  "SIGINT",
+  quit
+);
+process.on(
+  "SIGTERM",
+  quit
+);
+
+if ( process.stdin.isTTY ) {
+  process.stdin.setRawMode( true );
+  process.stdin.resume( );
+  process.stdin.on(
+    "data",
+    ( data ) => {
+      const key = data.toString( );
+
+      if ( key === "q" || key === "\x03" ) {
+        quit( );
+      }
+    }
+  );
+}

--- a/scripts/ssh-sketch/renderer.mjs
+++ b/scripts/ssh-sketch/renderer.mjs
@@ -1,0 +1,357 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// ssh-sketch renderer — a native terminal port of ascii-pulse-v1-komputery.
+//
+// The sketch's visual core (`cellIntensity` + the glyph/colour mapping in
+// `drawGrid`) is a pure function of the loop phase φ, so it ports 1:1 from the
+// p5 canvas to a terminal cell grid: one character cell = one glyph cell. The
+// only geometric twist is that terminal cells are ~twice as tall as they are
+// wide, so the field is sampled on a virtual pixel grid where a cell is 1×2 —
+// keeping the radial wave circular instead of egg-shaped.
+//
+// Zero dependencies: emits raw ANSI (truecolor SGR + cursor addressing). The
+// same `frame()` feeds both the local TTY runner and the SSH server.
+//
+// Source of truth for the maths: the sketch at
+// src/sketches/p5/sketches/ascii-pulse/ascii-pulse-v1-komputery/index.js and
+// its defaults in options.ts — keep them in sync if the sketch evolves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TAU = Math.PI * 2;
+
+// Mirrors DURATION_DEFAULT (src/lib/animationConfig.ts): one loop = 12 s.
+export const LOOP_SECONDS = 12;
+
+// Terminal cells are roughly twice as tall as wide; sample the field on a
+// virtual pixel grid of 1×2 per cell so radial geometry stays circular.
+const CELL_ASPECT = 2;
+
+// Same bold flat palettes as the sketch.
+export const PALETTES = {
+  komputery: [
+    [
+      255,
+      59,
+      48
+    ],
+    [
+      255,
+      204,
+      0
+    ],
+    [
+      0,
+      122,
+      255
+    ],
+    [
+      52,
+      199,
+      89
+    ],
+    [
+      175,
+      82,
+      222
+    ]
+  ],
+  crt: [
+    [
+      0,
+      255,
+      140
+    ],
+    [
+      0,
+      200,
+      255
+    ],
+    [
+      245,
+      245,
+      245
+    ]
+  ],
+  hot: [
+    [
+      255,
+      45,
+      85
+    ],
+    [
+      255,
+      149,
+      0
+    ],
+    [
+      255,
+      214,
+      10
+    ]
+  ]
+};
+
+// Defaults mirrored from the sketch's options.ts formValues.
+export const DEFAULTS = {
+  ramp: " .:-=+*#%@",
+  waveCycles: 3,
+  radialFreq: 5,
+  arms: 3,
+  baseWeight: 0.75,
+  contrast: 1.4,
+  beatsPerLoop: 8,
+  reach: 0.95,
+  ringWidth: 0.12,
+  pulseStrength: 1.1,
+  thump: 0.25,
+  palette: "komputery",
+  colorMode: "pulse",
+  baseColor: [
+    90,
+    100,
+    120
+  ],
+  ringColorBoost: 2.2,
+  backgroundColor: [
+    8,
+    8,
+    10
+  ]
+};
+
+// Straight port of the sketch's cellIntensity(): base radial+arm wave, plus the
+// expanding beat ring, plus a whole-grid thump — all periodic in φ.
+function cellIntensity(
+  field, px, py, minDim, cx, cy
+) {
+  const nx = ( px - cx ) / minDim;
+  const ny = ( py - cy ) / minDim;
+  const r = Math.hypot(
+    nx,
+    ny
+  );
+  const angle = Math.atan2(
+    ny,
+    nx
+  );
+
+  const base = 0.5 + 0.5 * Math.sin( TAU * ( field.waveCycles * field.phase - r * field.radialFreq ) + field.arms * angle );
+
+  const ringDelta = ( r - field.rippleRadius ) / field.ringWidth;
+  const ring = field.env * Math.exp( -ringDelta * ringDelta );
+
+  let intensity = field.baseWeight * base +
+    field.pulseStrength * ring +
+    field.thump * field.env;
+
+  intensity = 0.5 + ( intensity - 0.5 ) * field.contrast;
+
+  return {
+    intensity: Math.max(
+      0,
+      Math.min(
+        1,
+        intensity
+      )
+    ),
+    ring
+  };
+}
+
+// Beat clock, identical to the sketch's resolveField(): playhead in beats, and
+// a sin(π·beatFrac) envelope that is zero at every beat boundary.
+export function resolveBeat(
+  phase, beatsPerLoop
+) {
+  const playhead = phase * beatsPerLoop;
+  const beatIndex = Math.floor( playhead ) % beatsPerLoop;
+  const beatFrac = playhead - Math.floor( playhead );
+
+  return {
+    beatIndex,
+    beatFrac,
+    env: Math.sin( beatFrac * Math.PI )
+  };
+}
+
+export function createRenderer( overrides = {} ) {
+  const o = {
+    ...DEFAULTS,
+    ...overrides
+  };
+  const palette = PALETTES[ o.palette ] ?? PALETTES.komputery;
+  const rampMax = o.ramp.length - 1;
+  const spectrum = o.colorMode === "spectrum";
+
+  // One frame of ANSI for a cols×rows terminal at loop phase ∈ [0, 1).
+  // Starts with cursor-home and repaints every cell, so frames fully replace
+  // each other with no clear (flicker-free).
+  function frame(
+    cols, rows, phase
+  ) {
+    const beat = resolveBeat(
+      phase,
+      o.beatsPerLoop
+    );
+    const field = {
+      phase,
+      env: beat.env,
+      beatIndex: beat.beatIndex,
+      rippleRadius: beat.beatFrac * o.reach,
+      ringWidth: o.ringWidth,
+      pulseStrength: o.pulseStrength,
+      thump: o.thump,
+      waveCycles: o.waveCycles,
+      radialFreq: o.radialFreq,
+      arms: o.arms,
+      baseWeight: o.baseWeight,
+      contrast: o.contrast
+    };
+
+    const width = cols;
+    const height = rows * CELL_ASPECT;
+    const minDim = Math.min(
+      width,
+      height
+    );
+    const cx = width / 2;
+    const cy = height / 2;
+    const beatColor = palette[ beat.beatIndex % palette.length ];
+    const [
+      bgR,
+      bgG,
+      bgB
+    ] = o.backgroundColor;
+
+    const lines = [];
+
+    for ( let row = 0; row < rows; row++ ) {
+      const py = ( row + 0.5 ) * CELL_ASPECT;
+
+      let line = `\x1b[48;2;${ bgR };${ bgG };${ bgB }m`;
+      let lastFg = "";
+
+      for ( let col = 0; col < cols; col++ ) {
+        const px = col + 0.5;
+        const {
+          intensity, ring
+        } = cellIntensity(
+          field,
+          px,
+          py,
+          minDim,
+          cx,
+          cy
+        );
+
+        if ( intensity <= 0.02 ) {
+          line += " ";
+          continue;
+        }
+
+        const glyph = o.ramp.charAt( Math.round( intensity * rampMax ) );
+
+        if ( glyph === " " ) {
+          line += " ";
+          continue;
+        }
+
+        const brightness = 0.35 + 0.65 * intensity;
+
+        let r;
+        let g;
+        let b;
+
+        if ( spectrum ) {
+          const bandIndex = ( Math.floor( intensity * palette.length ) + beat.beatIndex ) % palette.length;
+          const band = palette[ bandIndex ];
+
+          r = band[ 0 ] * brightness;
+          g = band[ 1 ] * brightness;
+          b = band[ 2 ] * brightness;
+        } else {
+          const mix = Math.min(
+            1,
+            ring * o.ringColorBoost
+          );
+
+          r = ( o.baseColor[ 0 ] + ( beatColor[ 0 ] - o.baseColor[ 0 ] ) * mix ) * brightness;
+          g = ( o.baseColor[ 1 ] + ( beatColor[ 1 ] - o.baseColor[ 1 ] ) * mix ) * brightness;
+          b = ( o.baseColor[ 2 ] + ( beatColor[ 2 ] - o.baseColor[ 2 ] ) * mix ) * brightness;
+        }
+
+        // Quantize slightly so smooth gradients don't re-emit an SGR per cell.
+        const fg = `\x1b[38;2;${ Math.round( r / 4 ) * 4 };${ Math.round( g / 4 ) * 4 };${ Math.round( b / 4 ) * 4 }m`;
+
+        if ( fg !== lastFg ) {
+          line += fg;
+          lastFg = fg;
+        }
+
+        line += glyph;
+      }
+
+      lines.push( line );
+    }
+
+    return `\x1b[H${ lines.join( "\r\n" ) }\x1b[0m`;
+  }
+
+  return {
+    frame,
+    options: o
+  };
+}
+
+// Session-scoped terminal bootstrapping / teardown around the frame loop:
+// alt screen, hidden cursor, autowrap off (so painting the last column never
+// wraps), and the reverse on the way out.
+export const ENTER_SCREEN = "\x1b[?1049h\x1b[?25l\x1b[?7l\x1b[2J";
+export const LEAVE_SCREEN = "\x1b[0m\x1b[?7h\x1b[?25h\x1b[?1049l";
+
+// Drives frame() against a wall clock at ~fps, calling write( ansi ). Returns
+// a stop() that also tells the caller whether a beat advanced (for the bell).
+export function startLoop( {
+  write,
+  getSize,
+  overrides = {},
+  fps = 30,
+  bell = false,
+  now = () => Date.now()
+} ) {
+  const renderer = createRenderer( overrides );
+  const beatsPerLoop = renderer.options.beatsPerLoop;
+
+  let lastBeat = -1;
+
+  const timer = setInterval(
+    () => {
+      const phase = ( now() / 1000 % LOOP_SECONDS ) / LOOP_SECONDS;
+      const {
+        cols, rows
+      } = getSize();
+
+      let out = renderer.frame(
+        cols,
+        rows,
+        phase
+      );
+
+      if ( bell ) {
+        const beat = resolveBeat(
+          phase,
+          beatsPerLoop
+        );
+
+        if ( beat.beatIndex !== lastBeat ) {
+          lastBeat = beat.beatIndex;
+          out += "\x07";
+        }
+      }
+
+      write( out );
+    },
+    Math.round( 1000 / fps )
+  );
+
+  return () => clearInterval( timer );
+}

--- a/scripts/ssh-sketch/server.mjs
+++ b/scripts/ssh-sketch/server.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// ssh-sketch PoC server — `ssh <host> -p 2222` opens the komputery sketch
+// rendered live in your terminal, terminal.shop-style.
+//
+//   node scripts/ssh-sketch/server.mjs        # listens on :2222
+//   SSH_SKETCH_PORT=2345 node scripts/ssh-sketch/server.mjs
+//
+// The SSH *username* selects the variant, so the "path" lives in the address:
+//
+//   ssh komputery@localhost -p 2222   # default palette
+//   ssh crt@localhost -p 2222         # terminal-green palette
+//   ssh hot@localhost -p 2222         # red/orange/yellow palette
+//   ssh spectrum@localhost -p 2222    # spectrum colour mode
+//
+// Any auth is accepted (it's a viewer, not a shop… yet). q / Ctrl+C quits.
+// The host key is generated on first run into scripts/ssh-sketch/.host-key
+// (gitignored).
+
+import fs from "fs";
+import path from "path";
+import {
+  generateKeyPairSync
+} from "crypto";
+import {
+  fileURLToPath
+} from "url";
+
+import {
+  ENTER_SCREEN,
+  LEAVE_SCREEN,
+  PALETTES,
+  startLoop
+} from "./renderer.mjs";
+
+const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
+const HOST_KEY_PATH = path.join(
+  __dirname,
+  ".host-key"
+);
+const PORT = Number( process.env.SSH_SKETCH_PORT ) || 2222;
+
+let ssh2;
+
+try {
+  const imported = await import( "ssh2" );
+
+  ssh2 = imported.default ?? imported;
+} catch {
+  console.error( "The ssh2 package is required for the SSH server:" );
+  console.error( "  npm install --save-dev ssh2" );
+  console.error( "(or try the renderer without SSH: node scripts/ssh-sketch/local.mjs)" );
+  process.exit( 1 );
+}
+
+function loadHostKey( ) {
+  if ( fs.existsSync( HOST_KEY_PATH ) ) {
+    return fs.readFileSync( HOST_KEY_PATH );
+  }
+
+  const {
+    privateKey
+  } = generateKeyPairSync(
+    "rsa",
+    {
+      modulusLength: 2048,
+      privateKeyEncoding: {
+        type: "pkcs1",
+        format: "pem"
+      },
+      publicKeyEncoding: {
+        type: "pkcs1",
+        format: "pem"
+      }
+    }
+  );
+
+  fs.writeFileSync(
+    HOST_KEY_PATH,
+    privateKey,
+    {
+      mode: 0o600
+    }
+  );
+
+  return privateKey;
+}
+
+// The SSH username picks the sketch variant — palettes by name, plus
+// "spectrum" for the banded colour mode.
+function overridesForUser( username = "" ) {
+  const name = username.toLowerCase( );
+
+  if ( name === "spectrum" ) {
+    return {
+      colorMode: "spectrum"
+    };
+  }
+
+  if ( PALETTES[ name ] ) {
+    return {
+      palette: name
+    };
+  }
+
+  return {};
+}
+
+const server = new ssh2.Server(
+  {
+    hostKeys: [
+      loadHostKey( )
+    ]
+  },
+  ( client ) => {
+    let username = "";
+
+    client.on(
+      "authentication",
+      ( ctx ) => {
+        username = ctx.username || "";
+        ctx.accept( );
+      }
+    );
+
+    client.on(
+      "error",
+      ( error ) => {
+        console.error(
+          "client error:",
+          error.message
+        );
+      }
+    );
+
+    client.on(
+      "ready",
+      ( ) => {
+        client.on(
+          "session",
+          ( acceptSession ) => {
+            const session = acceptSession( );
+            const size = {
+              cols: 80,
+              rows: 24
+            };
+
+            session.on(
+              "pty",
+              (
+                acceptPty, rejectPty, info
+              ) => {
+                size.cols = info.cols || 80;
+                size.rows = info.rows || 24;
+                acceptPty?.( );
+              }
+            );
+
+            session.on(
+              "window-change",
+              (
+                acceptResize, rejectResize, info
+              ) => {
+                size.cols = info.cols || size.cols;
+                size.rows = info.rows || size.rows;
+                acceptResize?.( );
+              }
+            );
+
+            session.on(
+              "shell",
+              ( acceptShell ) => {
+                const stream = acceptShell( );
+
+                stream.write( ENTER_SCREEN );
+
+                const stop = startLoop( {
+                  write: ( chunk ) => stream.write( chunk ),
+                  getSize: ( ) => size,
+                  overrides: overridesForUser( username )
+                } );
+
+                const quit = ( ) => {
+                  stop( );
+                  stream.write( LEAVE_SCREEN );
+                  stream.end( );
+                };
+
+                stream.on(
+                  "data",
+                  ( data ) => {
+                    const key = data.toString( );
+
+                    if ( key === "q" || key === "\x03" ) {
+                      quit( );
+                    }
+                  }
+                );
+
+                stream.on(
+                  "close",
+                  ( ) => stop( )
+                );
+              }
+            );
+          }
+        );
+      }
+    );
+  }
+);
+
+server.listen(
+  PORT,
+  "0.0.0.0",
+  ( ) => {
+    console.log( `ssh-sketch listening on port ${ PORT }` );
+    console.log( `  ssh komputery@localhost -p ${ PORT }` );
+    console.log( `  ssh crt@localhost -p ${ PORT }` );
+    console.log( `  ssh hot@localhost -p ${ PORT }` );
+    console.log( `  ssh spectrum@localhost -p ${ PORT }` );
+  }
+);


### PR DESCRIPTION
## What

terminal.shop-style proof of concept: `ssh <host> -p 2222` opens **ascii-pulse-v1-komputery** running live in the terminal — no browser, no p5.

The sketch's visual core (`cellIntensity()` + the glyph/colour mapping of `drawGrid()`) is a pure function of the loop phase φ, so it ports 1:1 onto a truecolor ANSI glyph grid: one terminal cell = one sketch glyph cell, sampled on a 1×2 virtual pixel grid so the radial wave stays circular despite tall terminal cells. Same 12 s loop clock (`DURATION_DEFAULT`), same 8-beats-per-loop pulse, same seamless-loop maths.

## Try it

```bash
# instant, no SSH needed — renders in the current terminal
npm run sketch:tty
npm run sketch:tty -- --palette crt --bell

# the real thing
npm run sketch:ssh          # listens on :2222
ssh komputery@localhost -p 2222
ssh crt@localhost -p 2222   # username picks the variant: komputery/crt/hot/spectrum
```

`q` or `Ctrl+C` quits (clean alt-screen teardown).

## Files

| File | Role |
|---|---|
| `scripts/ssh-sketch/renderer.mjs` | Zero-dep ANSI frame renderer + frame loop (port of the sketch maths + `options.ts` defaults) |
| `scripts/ssh-sketch/local.mjs` | Run in the current TTY (`--palette`, `--mode`, `--fps`, `--bell`, `--once`) |
| `scripts/ssh-sketch/server.mjs` | SSH server (`ssh2`, devDependency); PTY size + `window-change` handled; host key generated on first run (gitignored) |

## Verification

- `--once` smoke test: correct ANSI (alt screen, truecolor SGR, glyph ramp), field shows the expected 3-arm radial wave
- E2E with a real SSH client (`ssh2` `Client`): handshake → auth → PTY → shell → ~1.6 MB of frames over 2 s → resize honoured → `q` ends the stream with clean screen restore
- `npm run check`: 0 lint errors, 1698 tests pass (2 pre-existing warnings in unrelated files)

## Notes / next steps

- PoC scope: viewer only — auth accepts anything, one hardcoded sketch. A "menu" TUI (pick a sketch à la terminal.shop shop page) would be the natural next step.
- The renderer duplicates the sketch maths on purpose (terminal port, no p5); if the sketch evolves, `renderer.mjs` notes it must follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQBBjvdqwNHXHVvh5etGPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQBBjvdqwNHXHVvh5etGPa)_