### PR TITLE
Make braid-v2-wire-mesh loop seamless and drop its fog option

### DIFF
--- a/src/sketches/p5/sketches/braid/braid-v2-wire-mesh/index.js
+++ b/src/sketches/p5/sketches/braid/braid-v2-wire-mesh/index.js
@@ -49,7 +49,12 @@ import {
 // The fabric scrolls a WHOLE, EVEN number of rows per loop (the weave pattern
 // repeats every 2 rows), and each row's shuttle sweep is a pure function of
 // that row's distance above the front — so the frame at uT = TAU is identical
-// to uT = 0.
+// to uT = 0. Hue bands obey the same rule (see v3-chainmail): a weft row's
+// palette index may only repeat on a period that DIVIDES the rows scrolled per
+// loop, so weft bands run mod 4 when the scroll is a multiple of 4 rows and
+// fall back to row parity (mod 2) otherwise — a fixed mod 4 would shift the
+// colours by 2 bands at the seam whenever scrollRows ≡ 2 (mod 4). Warp
+// columns never scroll, so they keep their 4 bands unconditionally.
 //
 // Orientation reuses the family's vector2d → screen-roll (uRoll), so the mesh
 // can be woven in any on-screen direction, front and shuttle included.
@@ -68,6 +73,7 @@ const FRAGMENT = `
   uniform float uFrontY;      // weaving-front height (world y)
   uniform float uFrontW;      // warp crimp ramp half-width
   uniform float uHalfW;       // shuttle sweep span (covers the visible width)
+  uniform float uWeftHueMod;  // weft hue-band period (divides scrollRows: 4 or 2)
   uniform float uCentreLipschitz; // CPU safety divisor for the march
 
   ${ IRIDESCENT_GLSL }
@@ -123,14 +129,16 @@ const FRAGMENT = `
   }
 
   // Wire identity for the palette: warp and weft each cycle a few hue bands,
-  // offset from each other so the two families read distinctly.
+  // offset from each other so the two families read distinctly. The weft's
+  // band period must divide the rows scrolled per loop (CPU-picked: 4 or 2),
+  // or the colours jump at the loop seam.
   float nearestPipe(vec3 p) {
     float scrollY = uT * uScrollVel;
 
     if (weftDistance(p, scrollY) < warpDistance(p, scrollY)) {
       float i = floor((p.y + scrollY) / uSpacing + 0.5);
 
-      return mod(i, 4.0);
+      return mod(i, uWeftHueMod);
     }
 
     float j = floor(p.x / uSpacing + 0.5);
@@ -176,6 +184,11 @@ sketch.draw( () => {
   // The plain-weave pattern repeats every 2 rows, so the scroll must advance a
   // whole EVEN number of rows per loop for the seam to be invisible.
   const scrollRows = 2 * Math.round( ( ( mesh.scrollRows ?? 2 ) * timeScale ) / 2 );
+
+  // The weft's hue-band period must divide the rows scrolled per loop, or the
+  // bands land shifted when the loop restarts: full 4-band cycle when the
+  // scroll allows it, row parity otherwise.
+  const weftHueMod = Math.abs( scrollRows ) % 4 === 0 ? 4 : 2;
 
   // Hue scroll — whole palette periods per loop (same rule as the siblings).
   const hueSpread = colors.hueSpread ?? 2;
@@ -250,6 +263,7 @@ sketch.draw( () => {
       uFrontY: frontY,
       uFrontW: frontW,
       uHalfW: halfW,
+      uWeftHueMod: weftHueMod,
       uCentreLipschitz: centreLipschitz,
       uCamDist: camDist,
       uFocal: focal,
@@ -272,7 +286,7 @@ sketch.draw( () => {
       uFresnelPower: light.fresnelPower ?? 3,
       uRimStrength: light.rimStrength ?? 0.7,
       uShadowSoft: light.shadowSoftness ?? 20,
-      uFogDensity: camera.fogDensity ?? 0.15,
+      uFogDensity: 0, // the shared shading chunk needs it — this sketch keeps fog off
       uFogStart: camDist,
       uMaxDist: camDist + 10,
       uAberration: aberration.amount ?? 2,

--- a/src/sketches/p5/sketches/braid/braid-v2-wire-mesh/options.ts
+++ b/src/sketches/p5/sketches/braid/braid-v2-wire-mesh/options.ts
@@ -19,8 +19,7 @@ export const formValues = {
     distance: 8.2,
     fov: 20,
     pitch: -0.55,
-    yaw: -0.74,
-    fogDensity: 0.035
+    yaw: -0.74
   },
   colors: {
     hueSpeed: 0,
@@ -157,13 +156,6 @@ export const formConfiguration: Record<string, any> = {
         min: -3.1416,
         max: 3.1416,
         step: 0.01
-      },
-      fogDensity: {
-        label: "Fog density",
-        component: "slider",
-        min: 0,
-        max: 0.6,
-        step: 0.005
       }
     }
   },


### PR DESCRIPTION
## What

Two changes to `braid-v2-wire-mesh`:

1. **Perfect seamless loop.** The weft hue bands ran `mod(i, 4.0)` on the material row index, while the fabric scroll only guarantees an **even** number of rows per loop. Whenever `scrollRows ≡ 2 (mod 4)` — including the default of 2 — the colours landed shifted by two bands when the loop restarted, which is exactly the intermittent colour jump at the seam. The band period now adapts to the scroll (same rule v3-chainmail already follows): a full 4-band cycle when the scrolled rows are a multiple of 4, row parity (2 bands) otherwise, passed to the shader as `uWeftHueMod`. Warp columns never scroll, so they keep their 4 bands unconditionally.
2. **Fog density option removed.** The `camera.fogDensity` slider and default are gone from `options.ts`; the shared shading chunk still declares the uniform, so the sketch passes `uFogDensity: 0`.

## Verification

- `npm run check` (lint + typecheck + 1721 tests) and `npm run build` pass.
- Headless canvas capture with the deterministic recording clock: the frame at loop phase 0 vs phase 1 is pixel-identical (mean channel diff 0.001/255, no pixel above noise), while a mid-loop control frame differs on 65% of pixels — confirming the comparison is sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sR6t3VcV3gE1tkXPYWXr3

---
_Generated by [Claude Code](https://claude.ai/code/session_012sR6t3VcV3gE1tkXPYWXr3)_