### PR TITLE
Add dragon-corridor v4 — mandala kaleidoscope & v5 — maelström vortex

### DIFF
--- a/src/generated/sketchModuleRegistry.ts
+++ b/src/generated/sketchModuleRegistry.ts
@@ -79,6 +79,7 @@ export const sketchModuleLoaders: Record<string, SketchModuleLoader> = {
   "p5:dragon-corridor/dragon-corridor-v1": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v1/index.js" ),
   "p5:dragon-corridor/dragon-corridor-v2-holes": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v2-holes/index.js" ),
   "p5:dragon-corridor/dragon-corridor-v3-grid": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js" ),
+  "p5:dragon-corridor/dragon-corridor-v4-mandala": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js" ),
   "p5:empty-sketch": () => import( "@/p5/sketches/empty-sketch/index.js" ),
   "p5:face-capture/face-mesh-v1": () => import( "@/p5/sketches/face-capture/face-mesh-v1/index.js" ),
   "p5:flowers-shaders/flowers-shaders-v1-melted": () => import( "@/p5/sketches/flowers-shaders/flowers-shaders-v1-melted/index.js" ),

--- a/src/generated/sketchModuleRegistry.ts
+++ b/src/generated/sketchModuleRegistry.ts
@@ -80,6 +80,7 @@ export const sketchModuleLoaders: Record<string, SketchModuleLoader> = {
   "p5:dragon-corridor/dragon-corridor-v2-holes": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v2-holes/index.js" ),
   "p5:dragon-corridor/dragon-corridor-v3-grid": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js" ),
   "p5:dragon-corridor/dragon-corridor-v4-mandala": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js" ),
+  "p5:dragon-corridor/dragon-corridor-v5-maelstrom": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js" ),
   "p5:empty-sketch": () => import( "@/p5/sketches/empty-sketch/index.js" ),
   "p5:face-capture/face-mesh-v1": () => import( "@/p5/sketches/face-capture/face-mesh-v1/index.js" ),
   "p5:flowers-shaders/flowers-shaders-v1-melted": () => import( "@/p5/sketches/flowers-shaders/flowers-shaders-v1-melted/index.js" ),

--- a/src/generated/sketchOptionsRegistry.ts
+++ b/src/generated/sketchOptionsRegistry.ts
@@ -99,6 +99,7 @@ export const sketchFormLoaders: Record<string, SketchModuleLoader> = {
   "p5:dragon-corridor/dragon-corridor-v2-holes": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v2-holes/options" ),
   "p5:dragon-corridor/dragon-corridor-v3-grid": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/options" ),
   "p5:dragon-corridor/dragon-corridor-v4-mandala": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options" ),
+  "p5:dragon-corridor/dragon-corridor-v5-maelstrom": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/options" ),
   "p5:empty-sketch": () => import( "@/p5/sketches/empty-sketch/options" ),
   "p5:face-capture/face-mesh-v1": () => import( "@/p5/sketches/face-capture/face-mesh-v1/options" ),
   "p5:flowers-shaders/flowers-shaders-v1-melted": () => import( "@/p5/sketches/flowers-shaders/flowers-shaders-v1-melted/options" ),

--- a/src/generated/sketchOptionsRegistry.ts
+++ b/src/generated/sketchOptionsRegistry.ts
@@ -98,6 +98,7 @@ export const sketchFormLoaders: Record<string, SketchModuleLoader> = {
   "p5:dragon-corridor/dragon-corridor-v1": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v1/options" ),
   "p5:dragon-corridor/dragon-corridor-v2-holes": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v2-holes/options" ),
   "p5:dragon-corridor/dragon-corridor-v3-grid": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/options" ),
+  "p5:dragon-corridor/dragon-corridor-v4-mandala": () => import( "@/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options" ),
   "p5:empty-sketch": () => import( "@/p5/sketches/empty-sketch/options" ),
   "p5:face-capture/face-mesh-v1": () => import( "@/p5/sketches/face-capture/face-mesh-v1/options" ),
   "p5:flowers-shaders/flowers-shaders-v1-melted": () => import( "@/p5/sketches/flowers-shaders/flowers-shaders-v1-melted/options" ),

--- a/src/sketches/metadata.json
+++ b/src/sketches/metadata.json
@@ -3610,5 +3610,17 @@
     "hiddenFromGallery": false,
     "mtime": "2026-07-27T19:28:37.113Z",
     "ctime": "2026-07-27T19:25:08.541Z"
+  },
+  {
+    "name": "dragon-corridor-v5-maelstrom",
+    "engine": "p5",
+    "category": "dragon-corridor",
+    "hasSketchForm": true,
+    "hasThumbnail": false,
+    "hasPreview": false,
+    "hiddenFromHome": false,
+    "hiddenFromGallery": false,
+    "mtime": "2026-07-27T20:34:08.406Z",
+    "ctime": "2026-07-27T20:30:34.355Z"
   }
 ]

--- a/src/sketches/metadata.json
+++ b/src/sketches/metadata.json
@@ -3598,5 +3598,17 @@
     "hiddenFromGallery": false,
     "mtime": "2026-07-22T12:31:29.184Z",
     "ctime": "2026-07-22T12:30:59.480Z"
+  },
+  {
+    "name": "dragon-corridor-v4-mandala",
+    "engine": "p5",
+    "category": "dragon-corridor",
+    "hasSketchForm": true,
+    "hasThumbnail": false,
+    "hasPreview": false,
+    "hiddenFromHome": false,
+    "hiddenFromGallery": false,
+    "mtime": "2026-07-27T19:28:37.113Z",
+    "ctime": "2026-07-27T19:25:08.541Z"
   }
 ]

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js
@@ -62,7 +62,7 @@ import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MAX_SEQ = 24; // max crossings per loop (uniform array size)
-const ARC_SAMPLES = 9; // tapered capsules sampled per arc
+const ARC_SAMPLES = 10; // tapered capsules sampled per arc
 const MAX_STEPS = 96; // sphere-trace iterations per ray
 const SURF_EPS = 0.0012; // hit threshold (world units)
 const MAX_DIST = 40.0; // ray cutoff / far plane
@@ -214,6 +214,25 @@ const FRAGMENT = `
     return vec3(xz.x, E.x * sin(PI * w), xz.y);
   }
 
+  // Analytic (unnormalised) centreline tangent at the same parameter — the
+  // Hermite derivative plus the vertical arc's slope. Adjacent capsules share
+  // their sample tangents, so the braid frame built on them is CONTINUOUS
+  // along the whole body (chord-based frames would jump at every joint and
+  // chop the pipes into segments).
+  vec3 arcTangent(float k, float u, vec4 P, vec4 M, vec4 E) {
+    float dwell = E.x > 0.0 ? uHes : 0.0;
+    float w = warpApex(u, dwell);
+    float w2 = w * w;
+    float g00 = 6.0 * w2 - 6.0 * w;
+    float g10 = 3.0 * w2 - 4.0 * w + 1.0;
+    float g01 = -6.0 * w2 + 6.0 * w;
+    float g11 = 3.0 * w2 - 2.0 * w;
+
+    vec2 xz = P.xy * g00 + M.xy * g10 + P.zw * g01 + M.zw * g11;
+
+    return vec3(xz.x, E.x * PI * cos(PI * w), xz.y);
+  }
+
   // Pipe radius at a distance behind the head: tail taper, head swell and the
   // travelling pulse. All body-anchored, so the loop closes by construction.
   float pipeRadiusAt(float behind) {
@@ -221,7 +240,11 @@ const FRAGMENT = `
     float hb = behind / max(uHeadLen, 0.05);
     float r = uPipeRadius * mix(0.08, 1.0, taper);
 
-    r *= 1.0 + uHeadBulge * exp(-hb * hb);
+    // The swell only appears where the braid has already merged into one
+    // head — swelling separate pipes would bead them into a grape cluster.
+    float mg = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+
+    r *= 1.0 + uHeadBulge * exp(-hb * hb) * (1.0 - mg);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
 
     return r;
@@ -239,9 +262,11 @@ const FRAGMENT = `
   // One braided capsule segment. Instead of one tube per pipe, the angle
   // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
   // per capsule): a single circle distance then covers every pipe of the
-  // bundle, so the cost is independent of how many pipes there are. Slightly
-  // non-metric (taper, twist) — uLip covers the shortfall.
-  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
+  // bundle, so the cost is independent of how many pipes there are. The frame
+  // rides the SMOOTH end tangents (shared between neighbouring capsules), so
+  // the pipes flow seamlessly across the joints. Slightly non-metric (taper,
+  // twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB, vec3 tA, vec3 tB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
     float bb = max(dot(ba, ba), 1e-8);
@@ -255,7 +280,9 @@ const FRAGMENT = `
       return length(q) - (pr + br);
     }
 
-    vec3 T = ba * inversesqrt(bb);
+    vec3 Tm = mix(tA, tB, h);
+    float tl = dot(Tm, Tm);
+    vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
     vec3 refUp = normalize(mix(
       vec3(0.0, 1.0, 0.0),
       vec3(1.0, 0.0, 0.0),
@@ -311,15 +338,18 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, E);
+      vec3 tPrev = arcTangent(k, u0, P, M, E);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, E);
+        vec3 tCur = arcTangent(k, un, P, M, E);
         float bCur = uHead - (k + un);
 
-        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur));
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }
@@ -363,24 +393,29 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, E);
+      vec3 tPrev = arcTangent(k, u0, P, M, E);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, E);
+        vec3 tCur = arcTangent(k, un, P, M, E);
         float bCur = uHead - (k + un);
-        float d = braidCap(p, prev, cur, bPrev, bCur);
+        float d = braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur);
 
         if (d < best) {
           best = d;
 
-          // Recover the owning pipe from the winning capsule's fold.
+          // Recover the owning pipe from the winning capsule's fold, in the
+          // same smooth-tangent frame braidCap used.
           vec3 pa = p - prev;
           vec3 ba = cur - prev;
           float bb = max(dot(ba, ba), 1e-8);
           float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
           vec3 q = pa - ba * h;
-          vec3 T = ba * inversesqrt(bb);
+          vec3 Tm = mix(tPrev, tCur, h);
+          float tl = dot(Tm, Tm);
+          vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
           vec3 refUp = normalize(mix(
             vec3(0.0, 1.0, 0.0),
             vec3(1.0, 0.0, 0.0),
@@ -400,6 +435,7 @@ const FRAGMENT = `
 
         uPrev = un;
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/index.js
@@ -39,11 +39,13 @@ import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 //     crossing (v2's swimDip) so the body always threads dead-centre.
 //
 //   • The dragon — a finite snake this time: tapered tail, swelling head, a
-//     travelling radius pulse, and the braid rendered as iridescent stripe
-//     shading (angle around the local tangent) instead of separate tubes. The
-//     body is marched as a chain of tapered capsules sampled along the arcs;
-//     every pattern on it is anchored to the HEAD (distance-behind-head), so
-//     loop closure is automatic and only time phases need cycle snapping.
+//     travelling radius pulse, and the v1/v2 PIPE BRAID around the free
+//     centreline: each capsule segment folds the angle around its local axis
+//     by the pipe count (the untwist trick, per capsule), so the bundle of
+//     twisted tubes costs the same as a single one. The braid unwinds into
+//     the rounded head exactly like v2. Every pattern is anchored to the HEAD
+//     (distance-behind-head), so loop closure is automatic and only time
+//     phases need cycle snapping.
 //
 //   • Cameras — orbit (see the whole plate and the dragon making its
 //     choices), top (straight-down whack-a-mole view), follow (chase cam
@@ -88,7 +90,7 @@ const FRAGMENT = `
   uniform float uSwimDip;     // how completely the sway pauses at each crossing
 
   // ── Body radii ──
-  uniform float uBodyRadius;
+  uniform float uPipeRadius;
   uniform float uTailLen;     // crossings over which the tail tapers away
   uniform float uHeadBulge;   // head swell amount
   uniform float uHeadLen;     // head swell falloff (in crossings behind the head)
@@ -98,12 +100,13 @@ const FRAGMENT = `
   uniform float uBoundPad;    // CPU-computed inflation for the per-arc bound
   uniform float uLip;         // CPU-computed safety divisor for the march
 
-  // ── Braid stripes (shading-only pipes) ──
-  uniform float uStripes;     // stripe count around the body (0 = plain skin)
-  uniform float uStripeDepth; // groove darkening between stripes
-  uniform float uTwist;       // stripe winding (rad per crossing along the body)
-  uniform float uSpin;        // stripe rotation over time (whole turns per loop)
-  uniform float uStripeHueShift;
+  // ── Pipe braid (the v1/v2 bundle, wound around the free centreline) ──
+  uniform float uPipeCount;   // pipes in the bundle (1 = plain snake)
+  uniform float uBraidRadius; // bundle orbit radius (0 = pipes merged)
+  uniform float uBraidMerge;  // body length over which the braid unwinds into the head
+  uniform float uTwist;       // braid winding (rad per crossing along the body)
+  uniform float uSpin;        // braid rotation over time (whole turns per loop)
+  uniform float uPipeHueShift;
 
   // ── Ice plate ──
   uniform vec2  uPlaneHalf;   // plate half-extents (xz)
@@ -211,12 +214,12 @@ const FRAGMENT = `
     return vec3(xz.x, E.x * sin(PI * w), xz.y);
   }
 
-  // Body radius at a distance behind the head: tail taper, head swell and the
+  // Pipe radius at a distance behind the head: tail taper, head swell and the
   // travelling pulse. All body-anchored, so the loop closes by construction.
-  float bodyRadiusAt(float behind) {
+  float pipeRadiusAt(float behind) {
     float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
     float hb = behind / max(uHeadLen, 0.05);
-    float r = uBodyRadius * mix(0.08, 1.0, taper);
+    float r = uPipeRadius * mix(0.08, 1.0, taper);
 
     r *= 1.0 + uHeadBulge * exp(-hb * hb);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
@@ -224,14 +227,51 @@ const FRAGMENT = `
     return r;
   }
 
-  // Tapered capsule (radius lerped along the axis). Slightly non-metric when
-  // the radii differ — uLip covers the shortfall.
-  float coneCap(vec3 p, vec3 a, vec3 b, float r1, float r2) {
+  // Braid orbit radius: the bundle unwinds into a single rounded head over
+  // uBraidMerge (exactly v2's head merge) and collapses again at the tail tip.
+  float braidRadiusAt(float behind) {
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+    float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
+
+    return uBraidRadius * merge * taper;
+  }
+
+  // One braided capsule segment. Instead of one tube per pipe, the angle
+  // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
+  // per capsule): a single circle distance then covers every pipe of the
+  // bundle, so the cost is independent of how many pipes there are. Slightly
+  // non-metric (taper, twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
-    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+    float bb = max(dot(ba, ba), 1e-8);
+    float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+    vec3 q = pa - ba * h;
+    float behind = mix(bA, bB, h);
+    float pr = pipeRadiusAt(behind);
+    float br = braidRadiusAt(behind);
 
-    return length(pa - ba * h) - mix(r1, r2, h);
+    if (uPipeCount < 1.5 || br < 0.004) {
+      return length(q) - (pr + br);
+    }
+
+    vec3 T = ba * inversesqrt(bb);
+    vec3 refUp = normalize(mix(
+      vec3(0.0, 1.0, 0.0),
+      vec3(1.0, 0.0, 0.0),
+      smoothstep(0.8, 0.98, abs(T.y))
+    ));
+    vec3 fN = normalize(cross(refUp, T));
+    vec3 fB = cross(T, fN);
+    vec3 perp = q - T * dot(q, T);
+    float rho = length(perp);
+    float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+    float psi = phi + uTwist * behind + uSpin;
+    float sector = TAU / uPipeCount;
+    float pm = mod(psi + 0.5 * sector, sector) - 0.5 * sector;
+    float d2 = dot(q, q) + br * br - 2.0 * rho * br * cos(pm);
+
+    return sqrt(max(d2, 0.0)) - pr;
   }
 
   // ── Dragon SDF ────────────────────────────────────────────────────────────
@@ -271,16 +311,16 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, E);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, E);
-        float rCur = bodyRadiusAt(uHead - (k + un));
+        float bCur = uHead - (k + un);
 
-        best = min(best, coneCap(p, prev, cur, rPrev, rCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
@@ -288,13 +328,14 @@ const FRAGMENT = `
   }
 
   // Same walk, recomputed once at the hit point, returning the winning body
-  // coordinate for the stripe shading.
-  float dragonS(vec3 p) {
+  // coordinate and which pipe of the bundle owns the hit (for its hue band).
+  vec2 dragonInfo(vec3 p) {
     float sTail = uHead - uBodyLen;
     float kStart = floor(sTail);
     float kLast = floor(uHead) + 0.5;
     float best = 1e9;
     float sBest = uHead;
+    float pipeBest = 0.0;
 
     for (int i = 0; i < ${ MAX_SEQ }; i++) {
       if (float(i) >= uSeqLen) { break; }
@@ -322,51 +363,48 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, E);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, E);
-        float rCur = bodyRadiusAt(uHead - (k + un));
-
-        vec3 pa = p - prev;
-        vec3 ba = cur - prev;
-        float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
-        float d = length(pa - ba * h) - mix(rPrev, rCur, h);
+        float bCur = uHead - (k + un);
+        float d = braidCap(p, prev, cur, bPrev, bCur);
 
         if (d < best) {
           best = d;
+
+          // Recover the owning pipe from the winning capsule's fold.
+          vec3 pa = p - prev;
+          vec3 ba = cur - prev;
+          float bb = max(dot(ba, ba), 1e-8);
+          float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+          vec3 q = pa - ba * h;
+          vec3 T = ba * inversesqrt(bb);
+          vec3 refUp = normalize(mix(
+            vec3(0.0, 1.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            smoothstep(0.8, 0.98, abs(T.y))
+          ));
+          vec3 fN = normalize(cross(refUp, T));
+          vec3 fB = cross(T, fN);
+          vec3 perp = q - T * dot(q, T);
+          float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+          float behind = mix(bPrev, bCur, h);
+          float psi = phi + uTwist * behind + uSpin;
+          float sector = TAU / max(uPipeCount, 1.0);
+
           sBest = k + mix(uPrev, un, h);
+          pipeBest = mod(floor(psi / sector + 0.5), max(uPipeCount, 1.0));
         }
 
         uPrev = un;
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
-    return sBest;
-  }
-
-  // Exact centreline point at an arbitrary body coordinate — one constant-index
-  // pass over the arrays, used only at the hit for smooth stripe shading (the
-  // per-capsule chords would band the stripes at every joint).
-  vec3 pathPointAt(float s) {
-    float k = floor(s);
-    float ki = mod(k, uSeqLen);
-    vec4 P = vec4(0.0);
-    vec4 M = vec4(0.0);
-    vec4 E = vec4(0.0);
-
-    for (int i = 0; i < ${ MAX_SEQ }; i++) {
-      if (abs(float(i) - ki) < 0.5) {
-        P = uArcP[i];
-        M = uArcM[i];
-        E = uArcE[i];
-      }
-    }
-
-    return arcPoint(k, s - k, P, M, E);
+    return vec2(sBest, pipeBest);
   }
 
   // 4-tap tetrahedron normal.
@@ -398,43 +436,18 @@ const FRAGMENT = `
     return clamp(1.0 - 2.5 * occ, 0.0, 1.0);
   }
 
-  // Iridescent wet-scale shading. The braid is painted on: stripes wind around
-  // the local tangent (angle in a tangent frame), shifting hue and denting the
-  // lighting between them, so the body still reads as a bundle of pipes.
+  // Iridescent wet-tube shading, v2 style: each pipe of the braid carries its
+  // own hue band, fading out where the bundle merges into the head so the
+  // colours flow seamlessly into it.
   vec3 shadeDragon(vec3 pos, vec3 n, vec3 rd) {
-    float sB = dragonS(pos);
-    vec3 core = pathPointAt(sB);
-    vec3 axis = normalize(
-      pathPointAt(sB + 0.03) - pathPointAt(sB - 0.03) + vec3(1e-6)
-    );
-
-    float behind = max(uHead - sB, 0.0);
-
-    // Reference vector blended smoothly as the body goes vertical, so the
-    // stripe frame never snaps mid-dive.
-    vec3 refUp = normalize(mix(
-      vec3(0.0, 1.0, 0.0),
-      vec3(1.0, 0.0, 0.0),
-      smoothstep(0.8, 0.98, abs(axis.y))
-    ));
-    vec3 fN = normalize(cross(refUp, axis));
-    vec3 fB = cross(axis, fN);
-    vec3 rad = pos - core;
-    float phi = atan(dot(rad, fB), dot(rad, fN) + 1e-5);
-
-    float band = 0.0;
-    float groove = 0.0;
-
-    if (uStripes > 0.5) {
-      band = cos(phi * uStripes - behind * uTwist + uSpin);
-      groove = 0.5 - 0.5 * band;
-    }
+    vec2 info = dragonInfo(pos);
+    float behind = max(uHead - info.x, 0.0);
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
 
     float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), uFresnelPower);
-    float phase = behind * uLengthHueShift + uHueSpeed + band * uStripeHueShift;
+    float phase = behind * uLengthHueShift + uHueSpeed
+      + info.y * uPipeHueShift * merge;
     vec3 base = iridescent(phase + uShimmer * fres);
-
-    base *= 1.0 - uStripeDepth * groove;
 
     float diff = max(dot(n, uLightDir), 0.0);
     vec3 hlf = normalize(uLightDir - rd);
@@ -830,13 +843,32 @@ sketch.draw( () => {
     ),
     crossings - 1.2
   );
-  const bodyRadius = Math.max(
-    Math.min(
-      dragon.bodyRadius ?? 0.14,
-      holeRadius * 0.9 - 0.02
+  // The whole bundle (orbit + pipe) must fit through the holes: when the
+  // requested braid exceeds the passage, both radii scale down together.
+  const pipeCount = Math.min(
+    Math.max(
+      Math.round( dragon.pipes ?? 5 ),
+      1
     ),
-    0.03
+    8
   );
+  const pipeRadiusRaw = Math.max(
+    dragon.pipeRadius ?? 0.06,
+    0.02
+  );
+  const braidRadiusRaw = Math.max(
+    dragon.braidRadius ?? 0.1,
+    0
+  );
+  const holeFit = Math.max(
+    holeRadius * 0.9 - 0.02,
+    0.05
+  );
+  const bundle = pipeRadiusRaw + braidRadiusRaw;
+  const bundleScale = bundle > holeFit ? holeFit / bundle : 1;
+  const pipeRadius = pipeRadiusRaw * bundleScale;
+  const braidRadius = braidRadiusRaw * bundleScale;
+  const braidMerge = dragon.braidMerge ?? 0.5;
   const headBulge = dragon.headBulge ?? 0.35;
   const headLen = dragon.headLength ?? 0.6;
   const tailLen = Math.min(
@@ -870,9 +902,7 @@ sketch.draw( () => {
     1
   );
 
-  const stripes = Math.round( dragon.stripes ?? 5 );
-  const stripeDepth = dragon.stripeDepth ?? 0.35;
-  const twist = ( p.TAU * ( dragon.twist ?? 3 ) ) / bodyLen;
+  const twist = ( p.TAU * ( dragon.twist ?? 2 ) ) / bodyLen;
   const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
 
   // ── March safety ───────────────────────────────────────────────────────────
@@ -898,13 +928,27 @@ sketch.draw( () => {
     swimAmpX,
     swimAmpZ
   );
-  const maxR = bodyRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
+  const maxR = braidRadius
+    + pipeRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
   const overshoot = ( 8 / 27 ) * maxTangent;
   const boundPad = maxR + overshoot + swimLen + 0.05;
 
   // Lipschitz divisor: the tapered-capsule approximation plus the pulse, head
-  // swell and tail taper slopes along the body.
-  const lipschitz = 1.3 + bodyRadius * (
+  // swell and tail taper slopes, and the braid's own twist gradient (pipe
+  // positions rotate along the body, steepening the field between pipes).
+  let minChord = Infinity;
+
+  for ( const arc of arcs ) {
+    minChord = Math.min(
+      minChord,
+      Math.hypot(
+        arc.p1[ 0 ] - arc.p0[ 0 ],
+        arc.p1[ 1 ] - arc.p0[ 1 ]
+      )
+    );
+  }
+
+  const lipschitz = 1.3 + pipeRadius * (
     radiusPulse * pulseFreq
     + headBulge / Math.max(
       headLen,
@@ -913,6 +957,15 @@ sketch.draw( () => {
     + 1 / Math.max(
       tailLen,
       0.3
+    )
+  ) + braidRadius * (
+    twist / Math.max(
+      minChord,
+      0.4
+    )
+    + 1 / Math.max(
+      braidMerge,
+      0.25
     )
   );
 
@@ -1345,7 +1398,7 @@ sketch.draw( () => {
       uSwimT: swimT,
       uSwimPhase: swimPhase,
       uSwimDip: swimDip,
-      uBodyRadius: bodyRadius,
+      uPipeRadius: pipeRadius,
       uTailLen: tailLen,
       uHeadBulge: headBulge,
       uHeadLen: headLen,
@@ -1354,11 +1407,12 @@ sketch.draw( () => {
       uPulseT: t * pulseTravelInt,
       uBoundPad: boundPad,
       uLip: lipschitz,
-      uStripes: stripes,
-      uStripeDepth: stripeDepth,
+      uPipeCount: pipeCount,
+      uBraidRadius: braidRadius,
+      uBraidMerge: braidMerge,
       uTwist: twist,
       uSpin: t * spinTurns,
-      uStripeHueShift: colors.stripeHueShift ?? 0.35,
+      uPipeHueShift: colors.pipeHueShift ?? 0.33,
       uPlaneHalf: [
         planeHalfX,
         planeHalfZ

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v3-grid/options.ts
@@ -10,16 +10,17 @@ export const formValues = {
   },
   dragon: {
     bodyLength: 4,
-    bodyRadius: 0.14,
+    pipes: 5,
+    pipeRadius: 0.06,
+    braidRadius: 0.1,
+    braidMerge: 0.5,
     headBulge: 0.35,
     headLength: 0.6,
     tailLength: 1.6,
     radiusPulse: 0.18,
     pulseWaves: 5,
     pulseTravel: -4,
-    stripes: 5,
-    stripeDepth: 0.35,
-    twist: 3,
+    twist: 2,
     spin: -2
   },
   motion: {
@@ -76,7 +77,7 @@ export const formValues = {
     hueSpread: 1.55,
     huePhase: 1.17,
     bodyHueWaves: 1.5,
-    stripeHueShift: 0.35,
+    pipeHueShift: 0.33,
     shimmer: 1.1,
     saturation: 0.9,
     brightness: 1.05
@@ -169,12 +170,33 @@ export const formConfiguration: Record<string, any> = {
         max: 12,
         step: 0.5
       },
-      bodyRadius: {
-        label: "Body radius (auto-fits the holes)",
+      pipes: {
+        label: "Pipes (braid bundle size)",
         component: "slider",
-        min: 0.04,
-        max: 0.3,
-        step: 0.01
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      pipeRadius: {
+        label: "Pipe radius (bundle auto-fits the holes)",
+        component: "slider",
+        min: 0.02,
+        max: 0.2,
+        step: 0.005
+      },
+      braidRadius: {
+        label: "Braid radius (pipe orbit)",
+        component: "slider",
+        min: 0,
+        max: 0.25,
+        step: 0.005
+      },
+      braidMerge: {
+        label: "Head merge (braid → head)",
+        component: "slider",
+        min: 0.1,
+        max: 2,
+        step: 0.05
       },
       headBulge: {
         label: "Head swell",
@@ -218,29 +240,15 @@ export const formConfiguration: Record<string, any> = {
         max: 6,
         step: 0.01
       },
-      stripes: {
-        label: "Braid stripes (0 = plain skin)",
-        component: "slider",
-        min: 0,
-        max: 8,
-        step: 1
-      },
-      stripeDepth: {
-        label: "Stripe groove depth",
-        component: "slider",
-        min: 0,
-        max: 0.8,
-        step: 0.01
-      },
       twist: {
-        label: "Stripe twist (turns along the body)",
+        label: "Braid twist (turns along the body)",
         component: "slider",
         min: 0,
         max: 8,
         step: 0.05
       },
       spin: {
-        label: "Stripe spin (snaps to whole turns/loop)",
+        label: "Braid spin (snaps to whole turns/loop)",
         component: "slider",
         min: -4,
         max: 4,
@@ -583,8 +591,8 @@ export const formConfiguration: Record<string, any> = {
         max: 4,
         step: 0.05
       },
-      stripeHueShift: {
-        label: "Stripe hue shift",
+      pipeHueShift: {
+        label: "Pipe hue shift",
         component: "slider",
         min: -2,
         max: 2,

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
@@ -51,7 +51,7 @@ import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MAX_SEQ = 16; // max waypoints per loop (uniform array size)
-const ARC_SAMPLES = 9; // tapered capsules sampled per arc
+const ARC_SAMPLES = 10; // tapered capsules sampled per arc
 const MAX_STEPS = 88; // sphere-trace iterations per ray
 const SURF_EPS = 0.0012; // hit threshold (world units)
 const MAX_DIST = 30.0; // ray cutoff / far plane
@@ -190,6 +190,25 @@ const FRAGMENT = `
     return vec3(xy, z);
   }
 
+  // Analytic (unnormalised) centreline tangent at the same parameter — the
+  // Hermite derivative in the cell plane and in depth. Adjacent capsules
+  // share their sample tangents, so the braid frame built on them is
+  // CONTINUOUS along the whole body (chord-based frames would jump at every
+  // joint and chop the pipes into segments).
+  vec3 arcTangent(float k, float u, vec4 P, vec4 M, vec4 Z) {
+    float w = mix(u, u * u * (3.0 - 2.0 * u), uPose);
+    float w2 = w * w;
+    float g00 = 6.0 * w2 - 6.0 * w;
+    float g10 = 3.0 * w2 - 4.0 * w + 1.0;
+    float g01 = -6.0 * w2 + 6.0 * w;
+    float g11 = 3.0 * w2 - 2.0 * w;
+
+    vec2 xy = P.xy * g00 + M.xy * g10 + P.zw * g01 + M.zw * g11;
+    float z = Z.x * g00 + Z.z * g10 + Z.y * g01 + Z.w * g11;
+
+    return vec3(xy, z);
+  }
+
   // Pipe radius at a distance behind the head — tail taper, head swell,
   // travelling pulse. Body-anchored, so the loop closes by construction.
   float pipeRadiusAt(float behind) {
@@ -197,7 +216,11 @@ const FRAGMENT = `
     float hb = behind / max(uHeadLen, 0.05);
     float r = uPipeRadius * mix(0.08, 1.0, taper);
 
-    r *= 1.0 + uHeadBulge * exp(-hb * hb);
+    // The swell only appears where the braid has already merged into one
+    // head — swelling separate pipes would bead them into a grape cluster.
+    float mg = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+
+    r *= 1.0 + uHeadBulge * exp(-hb * hb) * (1.0 - mg);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
 
     return r;
@@ -215,9 +238,11 @@ const FRAGMENT = `
   // One braided capsule segment. Instead of one tube per pipe, the angle
   // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
   // per capsule): a single circle distance then covers every pipe of the
-  // bundle, so the cost is independent of how many pipes there are. Slightly
-  // non-metric (taper, twist) — uLip covers the shortfall.
-  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
+  // bundle, so the cost is independent of how many pipes there are. The frame
+  // rides the SMOOTH end tangents (shared between neighbouring capsules), so
+  // the pipes flow seamlessly across the joints. Slightly non-metric (taper,
+  // twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB, vec3 tA, vec3 tB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
     float bb = max(dot(ba, ba), 1e-8);
@@ -231,7 +256,9 @@ const FRAGMENT = `
       return length(q) - (pr + br);
     }
 
-    vec3 T = ba * inversesqrt(bb);
+    vec3 Tm = mix(tA, tB, h);
+    float tl = dot(Tm, Tm);
+    vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
     vec3 refUp = normalize(mix(
       vec3(0.0, 1.0, 0.0),
       vec3(1.0, 0.0, 0.0),
@@ -285,15 +312,18 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, Z);
+      vec3 tPrev = arcTangent(k, u0, P, M, Z);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
+        vec3 tCur = arcTangent(k, un, P, M, Z);
         float bCur = uHead - (k + un);
 
-        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur));
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }
@@ -413,24 +443,29 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, Z);
+      vec3 tPrev = arcTangent(k, u0, P, M, Z);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
+        vec3 tCur = arcTangent(k, un, P, M, Z);
         float bCur = uHead - (k + un);
-        float d = braidCap(p, prev, cur, bPrev, bCur);
+        float d = braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur);
 
         if (d < best) {
           best = d;
 
-          // Recover the owning pipe from the winning capsule's fold.
+          // Recover the owning pipe from the winning capsule's fold, in the
+          // same smooth-tangent frame braidCap used.
           vec3 pa = p - prev;
           vec3 ba = cur - prev;
           float bb = max(dot(ba, ba), 1e-8);
           float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
           vec3 qq = pa - ba * h;
-          vec3 T = ba * inversesqrt(bb);
+          vec3 Tm = mix(tPrev, tCur, h);
+          float tl = dot(Tm, Tm);
+          vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
           vec3 refUp = normalize(mix(
             vec3(0.0, 1.0, 0.0),
             vec3(1.0, 0.0, 0.0),
@@ -450,6 +485,7 @@ const FRAGMENT = `
 
         uPrev = un;
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }
@@ -803,14 +839,14 @@ sketch.draw( () => {
   // ── The dance ──────────────────────────────────────────────────────────────
   const flow = Math.min(
     Math.max(
-      path.flow ?? 0.65,
+      path.flow ?? 0.78,
       0
     ),
     1
   );
   const pose = Math.min(
     Math.max(
-      path.pose ?? 0.5,
+      path.pose ?? 0.4,
       0
     ),
     1
@@ -853,11 +889,11 @@ sketch.draw( () => {
     8
   );
   const pipeRadius = Math.max(
-    dragon.pipeRadius ?? 0.05,
+    dragon.pipeRadius ?? 0.04,
     0.02
   );
   const braidRadius = Math.max(
-    dragon.braidRadius ?? 0.12,
+    dragon.braidRadius ?? 0.09,
     0
   );
   const braidMerge = dragon.braidMerge ?? 0.5;
@@ -887,7 +923,7 @@ sketch.draw( () => {
   const swimAmpY = path.swimY ?? 0.05;
   const swimPhase = path.swimPhase ?? 1.6;
 
-  const twist = ( p.TAU * ( dragon.twist ?? 1.5 ) ) / bodyLen;
+  const twist = ( p.TAU * ( dragon.twist ?? 0.8 ) ) / bodyLen;
   const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
 
   // ── March safety ───────────────────────────────────────────────────────────

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
@@ -1,0 +1,1226 @@
+import options from "@/p5/utils/options.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
+import animation from "@/p5/utils/animation.js";
+import audio from "@/p5/utils/audio.js";
+import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dragon-corridor v4 — "mandala". The dragon becomes the entire scene: a
+// kaleidoscope chamber folds space around the z axis, so the ONE dragon
+// dancing inside a single angular cell is replicated into a living rosette of
+// iridescent dragons in perfect N-fold (optionally mirrored) symmetry — a
+// rose window whose tracery is alive.
+//
+//   • The fold — polar domain folding in the fragment shader. The dragon's
+//     path is generated INSIDE one cell (a wedge of TAU/sectors, or half that
+//     with mirror symmetry on), and every marched sample point is folded back
+//     into that cell before evaluating the v3-style capsule-chain SDF. Near
+//     the two cell borders the folded evaluation alone would overestimate the
+//     distance to the neighbouring copies (crack artifacts exactly where
+//     twins kiss), so the two mirror/rotation neighbours are ALSO evaluated —
+//     but only when a cheap plane-distance gate says they could be closer
+//     than the best so far, which keeps the usual cost at ~one evaluation.
+//
+//   • The dance — a seeded chain of K waypoints per loop inside the cell
+//     (radius alternating inner/outer for a petalled rhythm, plus a little
+//     depth relief), joined by a cyclic 3D Hermite spline. "pose" makes the
+//     dragon settle on each waypoint before whipping to the next — the
+//     mandala repeatedly locks into a figure, holds it, and dissolves it —
+//     while "flow" rounds the whole dance into one continuous calligraphy.
+//
+//   • The rose window — an analytic stained-glass disc behind the dragons
+//     (the v2/v3 frosted vocabulary): iridescent cells by ring and folded
+//     angle, dark lead lines with a glow option along every ring and sector
+//     seam, a bright hub, and the dragons casting their own coloured light
+//     onto the glass as they pass.
+//
+//   • Cameras — STATIC by default: "facade" looks at the rosette dead-on like
+//     a rose window; "oblique" is a fixed three-quarter view that reveals the
+//     depth relief; "drift" is the only moving one (whole orbits per loop,
+//     for those who want motion). The mandala's own rotation is a separate
+//     whole-turns-per-loop option, 0 by default.
+//
+// ── Looping ──────────────────────────────────────────────────────────────────
+// The head advances by exactly K waypoints per loop over a cyclic path, and
+// every pattern on the body (pulse, swim, hue) is anchored to the head, so
+// loop closure is automatic. Time-driven rates (stripe spin, pulse travel,
+// swim travel, hue scroll, mandala spin, camera drift) are snapped to whole
+// cycles per loop, so the last frame reproduces the first.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_SEQ = 16; // max waypoints per loop (uniform array size)
+const ARC_SAMPLES = 9; // tapered capsules sampled per arc
+const MAX_STEPS = 88; // sphere-trace iterations per ray
+const SURF_EPS = 0.0012; // hit threshold (world units)
+const MAX_DIST = 30.0; // ray cutoff / far plane
+
+const FRAGMENT = `
+  const float SURF_EPS = ${ SURF_EPS.toFixed( 4 ) };
+  const float MAX_DIST = ${ MAX_DIST.toFixed( 4 ) };
+
+  // ── Path / sequence ──
+  uniform float uSeqLen;      // K = waypoints per loop
+  uniform float uHead;        // head parameter, in waypoints
+  uniform float uBodyLen;     // body length, in waypoints (< K)
+  uniform vec4  uArcP[${ MAX_SEQ }]; // xy = start waypoint, zw = end (cell plane)
+  uniform vec4  uArcM[${ MAX_SEQ }]; // xy / zw = Hermite tangents (pre-scaled by flow)
+  uniform vec4  uArcZ[${ MAX_SEQ }]; // x/y = start/end depth, z/w = depth tangents
+
+  // ── Path shaping ──
+  uniform float uPose;        // settle on each waypoint (0 = uniform glide)
+  uniform vec2  uSwimAmp;     // swim sway amplitude (cell x, y)
+  uniform float uSwimFreq;    // sway spatial freq (rad per waypoint, body-anchored)
+  uniform float uSwimT;       // sway travel phase (whole cycles per loop)
+  uniform float uSwimPhase;   // second-axis sway phase offset
+
+  // ── Body radii ──
+  uniform float uBodyRadius;
+  uniform float uTailLen;     // waypoints over which the tail tapers away
+  uniform float uHeadBulge;   // head swell amount
+  uniform float uHeadLen;     // head swell falloff (waypoints behind the head)
+  uniform float uRadiusPulse; // travelling swell of the body radius
+  uniform float uPulseFreq;   // swell spatial freq (rad per waypoint)
+  uniform float uPulseT;      // swell travel phase (whole cycles per loop)
+  uniform float uBoundPad;    // CPU-computed inflation for the per-arc bound
+  uniform float uLip;         // CPU-computed safety divisor for the march
+
+  // ── Braid stripes (shading-only pipes) ──
+  uniform float uStripes;     // stripe count around the body (0 = plain skin)
+  uniform float uStripeDepth; // groove darkening between stripes
+  uniform float uTwist;       // stripe winding (rad per waypoint along the body)
+  uniform float uSpin;        // stripe rotation over time (whole turns per loop)
+  uniform float uStripeHueShift;
+
+  // ── Kaleidoscope fold ──
+  uniform float uSectorAngle; // TAU / sectors
+  uniform float uCellAngle;   // canonical cell: sector (rotation) or sector/2 (mirror)
+  uniform float uMirror;      // 1 = dihedral (mirrored) symmetry
+  uniform float uMandalaSpin; // whole-turns-per-loop rotation of the whole rosette
+  uniform float uSectorHueShift; // per-sector hue offset (0 = uniform copies)
+  uniform float uRInner;      // dragon annulus bounds for the march early-out
+  uniform float uROuter;
+  uniform float uZPad;
+
+  // ── Rose window (stained-glass backdrop) ──
+  uniform float uBackAlpha;
+  uniform float uBackDepth;   // plane sits at z = −uBackDepth
+  uniform float uBackRadius;
+  uniform float uRings;       // stained-glass rings across the disc
+  uniform float uBackHueShift;
+  uniform float uBackHuePhase;
+  uniform float uBackBrightness;
+  uniform float uCenterGlow;  // bright hub, light through the window
+  uniform float uLeadDark;    // dark lead lines on ring/sector seams
+  uniform float uLeadGlow;    // glowing rim on those same seams
+  uniform float uGlassFrost;
+  uniform float uFrostScale;
+  uniform float uDragonGlow;  // coloured light the dragons cast on the glass
+
+  // ── Camera (full basis computed on the CPU) ──
+  uniform vec3  uCamPos;
+  uniform vec3  uCamFwd;
+  uniform vec3  uCamRight;
+  uniform vec3  uCamUp;
+  uniform float uFocal;
+
+  // ── Iridescent palette (shared vocabulary with v1/v2/v3) ──
+  uniform float uHueSpeed;
+  uniform float uHueSpread;
+  uniform float uHuePhase;
+  uniform float uLengthHueShift;
+  uniform float uShimmer;
+  uniform float uSaturation;
+  uniform float uBrightness;
+
+  // ── Lighting ──
+  uniform vec3  uLightDir;
+  uniform float uAmbient;
+  uniform float uDiffuse;
+  uniform float uSpecular;
+  uniform float uSpecPower;
+  uniform float uFresnelPower;
+  uniform float uRimStrength;
+
+  uniform float uFogDensity;
+  uniform vec3  uBgColor;
+
+  // Oil-slick / thin-film iridescence — identical palette to v1/v2/v3.
+  vec3 iridescent(float t) {
+    vec3 spectrum = 0.5 + 0.5 * cos(
+      TAU * (uHueSpread * t + vec3(0.0, 0.33, 0.67)) + uHuePhase
+    );
+
+    float luma = dot(spectrum, vec3(0.299, 0.587, 0.114));
+
+    return clamp(mix(vec3(luma), spectrum, uSaturation) * uBrightness, 0.0, 1.0);
+  }
+
+  float segDist3(vec3 p, vec3 a, vec3 b) {
+    vec3 pa = p - a;
+    vec3 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+
+    return length(pa - ba * h);
+  }
+
+  // Centreline point of arc k at local parameter u — cyclic 3D Hermite inside
+  // the cell, with the pose warp (settle on each waypoint) and the swim sway.
+  vec3 arcPoint(float k, float u, vec4 P, vec4 M, vec4 Z) {
+    float w = mix(u, u * u * (3.0 - 2.0 * u), uPose);
+    float w2 = w * w;
+    float w3 = w2 * w;
+    float h00 = 2.0 * w3 - 3.0 * w2 + 1.0;
+    float h10 = w3 - 2.0 * w2 + w;
+    float h01 = -2.0 * w3 + 3.0 * w2;
+    float h11 = w3 - w2;
+
+    vec2 xy = P.xy * h00 + M.xy * h10 + P.zw * h01 + M.zw * h11;
+    float z = Z.x * h00 + Z.z * h10 + Z.y * h01 + Z.w * h11;
+
+    float behind = uHead - (k + u);
+
+    xy += uSwimAmp * vec2(
+      sin(behind * uSwimFreq - uSwimT),
+      sin(behind * uSwimFreq - uSwimT + uSwimPhase)
+    );
+
+    return vec3(xy, z);
+  }
+
+  // Body radius at a distance behind the head — tail taper, head swell,
+  // travelling pulse. Body-anchored, so the loop closes by construction.
+  float bodyRadiusAt(float behind) {
+    float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
+    float hb = behind / max(uHeadLen, 0.05);
+    float r = uBodyRadius * mix(0.08, 1.0, taper);
+
+    r *= 1.0 + uHeadBulge * exp(-hb * hb);
+    r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
+
+    return r;
+  }
+
+  // Tapered capsule (radius lerped along the axis); uLip covers the shortfall.
+  float coneCap(vec3 p, vec3 a, vec3 b, float r1, float r2) {
+    vec3 pa = p - a;
+    vec3 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+
+    return length(pa - ba * h) - mix(r1, r2, h);
+  }
+
+  // ── Dragon SDF (one copy, evaluated in cell space) ────────────────────────
+  // Same slot walk as v3: each uniform slot hosts at most one active arc
+  // k ≡ i (mod K) because the body is shorter than the loop, so the arrays
+  // are only ever indexed by the loop variable (WebGL1-safe).
+  float mapDragonSingle(vec3 p) {
+    float sTail = uHead - uBodyLen;
+    float kStart = floor(sTail);
+    float kLast = floor(uHead) + 0.5;
+    float best = 1e9;
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (float(i) >= uSeqLen) { break; }
+
+      float k = float(i) + uSeqLen * ceil((kStart - float(i)) / uSeqLen);
+
+      if (k > kLast) { continue; }
+
+      float u0 = max(sTail - k, 0.0);
+      float u1 = min(uHead - k, 1.0);
+
+      if (u1 - u0 < 1e-4) { continue; }
+
+      vec4 P = uArcP[i];
+      vec4 M = uArcM[i];
+      vec4 Z = uArcZ[i];
+
+      float bound = segDist3(
+        p,
+        vec3(P.xy, Z.x),
+        vec3(P.zw, Z.y)
+      ) - uBoundPad;
+
+      if (bound > best) { continue; }
+
+      vec3 prev = arcPoint(k, u0, P, M, Z);
+      float rPrev = bodyRadiusAt(uHead - (k + u0));
+
+      for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
+        float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
+        vec3 cur = arcPoint(k, un, P, M, Z);
+        float rCur = bodyRadiusAt(uHead - (k + un));
+
+        best = min(best, coneCap(p, prev, cur, rPrev, rCur));
+        prev = cur;
+        rPrev = rCur;
+      }
+    }
+
+    return best / uLip;
+  }
+
+  // ── Kaleidoscope fold ─────────────────────────────────────────────────────
+  // Fold the sample point into the canonical cell and evaluate the single
+  // dragon there; the two neighbouring copies (across each cell border) are
+  // evaluated only when the exact distance-to-border gate says they could
+  // beat the current best — the fold stays crack-free where twins touch, at
+  // ~one evaluation almost everywhere.
+  float mapScene(vec3 p) {
+    float c = cos(uMandalaSpin);
+    float s = sin(uMandalaSpin);
+    vec2 xy = vec2(c * p.x + s * p.y, -s * p.x + c * p.y);
+    float r = length(xy);
+
+    // Conservative annulus bound — big cheap steps through empty space.
+    float bound = max(max(r - uROuter, uRInner - r), abs(p.z) - uZPad);
+
+    if (bound > 0.3) { return bound; }
+
+    float ang = atan(xy.y, xy.x);
+    float a0 = mod(ang, uSectorAngle);
+    float am = uMirror > 0.5 ? min(a0, uSectorAngle - a0) : a0;
+    float rep0 = uMirror > 0.5 ? -am : a0 + uSectorAngle;
+    float rep1 = uMirror > 0.5 ? uSectorAngle - am : a0 - uSectorAngle;
+
+    float d = mapDragonSingle(vec3(r * cos(am), r * sin(am), p.z));
+
+    // Neighbour across the first border (angle 0): its distance is at least
+    // the distance to that border plane, so skip it when it cannot win.
+    float g0 = r * sin(am);
+
+    if (g0 < d) {
+      d = min(d, mapDragonSingle(vec3(r * cos(rep0), r * sin(rep0), p.z)));
+    }
+
+    float g1 = r * sin(uCellAngle - am);
+
+    if (g1 < d) {
+      d = min(d, mapDragonSingle(vec3(r * cos(rep1), r * sin(rep1), p.z)));
+    }
+
+    return d;
+  }
+
+  // Winning folded point at the hit, for the shading walk (body coordinate,
+  // stripe frame). Same gating as mapScene.
+  vec3 foldWinner(vec3 p) {
+    float c = cos(uMandalaSpin);
+    float s = sin(uMandalaSpin);
+    vec2 xy = vec2(c * p.x + s * p.y, -s * p.x + c * p.y);
+    float r = length(xy);
+    float ang = atan(xy.y, xy.x);
+    float a0 = mod(ang, uSectorAngle);
+    float am = uMirror > 0.5 ? min(a0, uSectorAngle - a0) : a0;
+    float rep0 = uMirror > 0.5 ? -am : a0 + uSectorAngle;
+    float rep1 = uMirror > 0.5 ? uSectorAngle - am : a0 - uSectorAngle;
+
+    vec3 q = vec3(r * cos(am), r * sin(am), p.z);
+    float d = mapDragonSingle(q);
+
+    vec3 q0 = vec3(r * cos(rep0), r * sin(rep0), p.z);
+    float d0 = r * sin(am) < d ? mapDragonSingle(q0) : 1e9;
+
+    if (d0 < d) {
+      d = d0;
+      q = q0;
+    }
+
+    vec3 q1 = vec3(r * cos(rep1), r * sin(rep1), p.z);
+    float d1 = r * sin(uCellAngle - am) < d ? mapDragonSingle(q1) : 1e9;
+
+    if (d1 < d) {
+      q = q1;
+    }
+
+    return q;
+  }
+
+  // Body coordinate of the closest point on the capsule chain (cell space).
+  float dragonS(vec3 p) {
+    float sTail = uHead - uBodyLen;
+    float kStart = floor(sTail);
+    float kLast = floor(uHead) + 0.5;
+    float best = 1e9;
+    float sBest = uHead;
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (float(i) >= uSeqLen) { break; }
+
+      float k = float(i) + uSeqLen * ceil((kStart - float(i)) / uSeqLen);
+
+      if (k > kLast) { continue; }
+
+      float u0 = max(sTail - k, 0.0);
+      float u1 = min(uHead - k, 1.0);
+
+      if (u1 - u0 < 1e-4) { continue; }
+
+      vec4 P = uArcP[i];
+      vec4 M = uArcM[i];
+      vec4 Z = uArcZ[i];
+
+      float bound = segDist3(
+        p,
+        vec3(P.xy, Z.x),
+        vec3(P.zw, Z.y)
+      ) - uBoundPad;
+
+      if (bound > best) { continue; }
+
+      float uPrev = u0;
+      vec3 prev = arcPoint(k, u0, P, M, Z);
+      float rPrev = bodyRadiusAt(uHead - (k + u0));
+
+      for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
+        float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
+        vec3 cur = arcPoint(k, un, P, M, Z);
+        float rCur = bodyRadiusAt(uHead - (k + un));
+
+        vec3 pa = p - prev;
+        vec3 ba = cur - prev;
+        float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+        float d = length(pa - ba * h) - mix(rPrev, rCur, h);
+
+        if (d < best) {
+          best = d;
+          sBest = k + mix(uPrev, un, h);
+        }
+
+        uPrev = un;
+        prev = cur;
+        rPrev = rCur;
+      }
+    }
+
+    return sBest;
+  }
+
+  // Exact centreline point at an arbitrary body coordinate — used only at the
+  // hit for smooth stripe shading.
+  vec3 pathPointAt(float s) {
+    float k = floor(s);
+    float ki = mod(k, uSeqLen);
+    vec4 P = vec4(0.0);
+    vec4 M = vec4(0.0);
+    vec4 Z = vec4(0.0);
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (abs(float(i) - ki) < 0.5) {
+        P = uArcP[i];
+        M = uArcM[i];
+        Z = uArcZ[i];
+      }
+    }
+
+    return arcPoint(k, s - k, P, M, Z);
+  }
+
+  // 4-tap tetrahedron normal on the folded scene.
+  vec3 calcNormal(vec3 p) {
+    vec2 k = vec2(1.0, -1.0);
+    float e = SURF_EPS;
+
+    return normalize(
+      k.xyy * mapScene(p + k.xyy * e) +
+      k.yyx * mapScene(p + k.yyx * e) +
+      k.yxy * mapScene(p + k.yxy * e) +
+      k.xxx * mapScene(p + k.xxx * e)
+    );
+  }
+
+  float calcAO(vec3 p, vec3 n) {
+    float occ = 0.0;
+    float sca = 1.0;
+
+    for (int i = 0; i < 3; i++) {
+      float h = 0.03 + 0.11 * float(i);
+      float d = mapScene(p + n * h);
+
+      occ += (h - d) * sca;
+      sca *= 0.6;
+    }
+
+    return clamp(1.0 - 2.5 * occ, 0.0, 1.0);
+  }
+
+  // Iridescent wet-scale shading; the braid is painted on as stripes around a
+  // smooth tangent frame, evaluated in the winning folded cell so every copy
+  // shows the same living pattern. Lighting stays in world space, so each
+  // copy of the rosette catches the light from its own angle.
+  vec3 shadeDragon(vec3 pos, vec3 n, vec3 rd) {
+    vec3 q = foldWinner(pos);
+    float sB = dragonS(q);
+    vec3 core = pathPointAt(sB);
+    vec3 axis = normalize(
+      pathPointAt(sB + 0.03) - pathPointAt(sB - 0.03) + vec3(1e-6)
+    );
+
+    float behind = max(uHead - sB, 0.0);
+
+    vec3 refUp = normalize(mix(
+      vec3(0.0, 1.0, 0.0),
+      vec3(1.0, 0.0, 0.0),
+      smoothstep(0.8, 0.98, abs(axis.y))
+    ));
+    vec3 fN = normalize(cross(refUp, axis));
+    vec3 fB = cross(axis, fN);
+    vec3 rad = q - core;
+    float phi = atan(dot(rad, fB), dot(rad, fN) + 1e-5);
+
+    float band = 0.0;
+    float groove = 0.0;
+
+    if (uStripes > 0.5) {
+      band = cos(phi * uStripes - behind * uTwist + uSpin);
+      groove = 0.5 - 0.5 * band;
+    }
+
+    // Optional per-sector hue: which copy of the rosette is this?
+    float wAng = atan(pos.y, pos.x) - uMandalaSpin;
+    float sectorId = floor(mod(wAng, TAU) / uSectorAngle);
+
+    float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), uFresnelPower);
+    float phase = behind * uLengthHueShift + uHueSpeed
+      + band * uStripeHueShift
+      + sectorId * uSectorHueShift;
+    vec3 base = iridescent(phase + uShimmer * fres);
+
+    base *= 1.0 - uStripeDepth * groove;
+
+    float diff = max(dot(n, uLightDir), 0.0);
+    vec3 hlf = normalize(uLightDir - rd);
+    float spec = pow(max(dot(n, hlf), 0.0), uSpecPower) * uSpecular;
+    float ao = calcAO(pos, n);
+
+    vec3 col = base * (uAmbient + uDiffuse * diff * ao);
+
+    col += base * fres * uRimStrength;
+    col += vec3(spec) * ao;
+
+    return col;
+  }
+
+  // Sphere-trace the folded rosette. The annulus bound inside mapScene does
+  // the empty-space skipping, so no extra bounding volume is needed.
+  vec4 traceScene(vec3 ro, vec3 rd) {
+    float t = 0.0;
+    bool hit = false;
+
+    for (int i = 0; i < ${ MAX_STEPS }; i++) {
+      vec3 pos = ro + rd * t;
+      float d = mapScene(pos);
+
+      if (d < SURF_EPS) { hit = true; break; }
+
+      t += d;
+
+      if (t > MAX_DIST) { break; }
+    }
+
+    if (!hit) { return vec4(uBgColor, MAX_DIST); }
+
+    vec3 pos = ro + rd * t;
+    vec3 n = calcNormal(pos);
+    vec3 col = shadeDragon(pos, n, rd);
+    float fog = exp(-uFogDensity * t);
+
+    return vec4(mix(uBgColor, col, fog), t);
+  }
+
+  // ── The rose window ───────────────────────────────────────────────────────
+  // One analytic stained-glass disc behind the dragons: iridescent cells by
+  // ring and folded angle, frost, lead lines on every seam, a bright hub, and
+  // the dragons' own light pooling on the glass beneath them.
+  vec4 windowLayer(vec3 ro, vec3 rd, float tHit) {
+    if (uBackAlpha < 0.003) { return vec4(vec3(0.0), 1.0); }
+
+    float rz = abs(rd.z) < 1e-5 ? (rd.z < 0.0 ? -1e-5 : 1e-5) : rd.z;
+    float t = (-uBackDepth - ro.z) / rz;
+
+    if (t <= 0.0 || t >= tHit) { return vec4(vec3(0.0), 1.0); }
+
+    vec3 hp = ro + rd * t;
+    float r = length(hp.xy);
+    float disc = 1.0 - smoothstep(uBackRadius - 0.2, uBackRadius, r);
+
+    if (disc <= 0.002) { return vec4(vec3(0.0), 1.0); }
+
+    float c = cos(uMandalaSpin);
+    float s = sin(uMandalaSpin);
+    vec2 xy = vec2(c * hp.x + s * hp.y, -s * hp.x + c * hp.y);
+    float ang = atan(xy.y, xy.x);
+    float a0 = mod(ang, uSectorAngle);
+    float am = uMirror > 0.5 ? min(a0, uSectorAngle - a0) : a0;
+
+    // Stained-glass cells: hue steps ring by ring, drifts with the folded
+    // angle, and breathes with the frost.
+    float ring = r * uRings / max(uBackRadius, 0.3);
+    float ringId = floor(ring);
+    vec3 glass = iridescent(ringId * uBackHueShift + am * 0.4 + uBackHuePhase);
+
+    float bright = uBackBrightness + uCenterGlow * exp(-r * r * 0.35);
+
+    if (uGlassFrost > 0.001) {
+      float frost = perlinNoise(vec3(xy * uFrostScale, 5.1));
+
+      bright *= mix(1.0, clamp(0.45 + 1.2 * frost, 0.0, 1.3), uGlassFrost);
+    }
+
+    // Lead lines: ring seams + the two folded sector seams (constant width).
+    float fr = fract(ring);
+    float leadR = exp(-min(fr, 1.0 - fr) * 14.0);
+    float leadA = exp(-min(am, uCellAngle - am) * r * 26.0);
+    float lead = min(leadR + leadA, 1.0);
+
+    vec3 col = glass * bright;
+
+    col *= 1.0 - uLeadDark * lead;
+    col += iridescent(ringId * uBackHueShift + 0.31 + uBackHuePhase)
+      * lead * uLeadGlow * 0.6;
+
+    // The dragons' light pooling on the glass beneath them (lateral proximity
+    // in the folded cell, depth ignored so the glow tracks the dance).
+    if (uDragonGlow > 0.001) {
+      float dd = max(
+        mapDragonSingle(vec3(r * cos(am), r * sin(am), 0.0)) * uLip,
+        0.0
+      );
+
+      col += iridescent(uHueSpeed + ringId * 0.1)
+        * uDragonGlow * exp(-dd / 0.45);
+    }
+
+    float fog = exp(-uFogDensity * t);
+
+    col = mix(uBgColor, col, fog);
+
+    float a = clamp(uBackAlpha * disc * fog, 0.0, 0.97);
+
+    return vec4(a * col, 1.0 - a);
+  }
+
+  void main() {
+    vec2 frag = vec2(vUv.x * uResolution.x, vUv.y * uResolution.y);
+    vec2 uv = (frag - 0.5 * uResolution) / uResolution.y;
+
+    vec3 ro = uCamPos;
+    vec3 rd = normalize(uCamFwd * uFocal + uCamRight * uv.x + uCamUp * uv.y);
+
+    vec4 opaque = traceScene(ro, rd);
+    vec4 glass = windowLayer(ro, rd, opaque.a);
+
+    vec3 col = glass.rgb + glass.a * opaque.rgb;
+
+    // Alpha: dragons are solid; escaped rays with no glass in front stay
+    // transparent so the p5 background shows through around the rosette.
+    float opaqueSolid = opaque.a < MAX_DIST ? 1.0 : 0.0;
+    float alpha = (1.0 - glass.a) + glass.a * opaqueSolid;
+
+    gl_FragColor = vec4(col, alpha);
+  }
+`;
+
+const scene = createNoiseFieldRenderer( FRAGMENT );
+
+// ── CPU side ─────────────────────────────────────────────────────────────────
+
+// Deterministic xorshift32 — identical sequences on every platform, so the
+// recorded video always matches the preview.
+function makeRng( seed ) {
+  let s = ( Math.imul(
+    seed + 1,
+    2654435761
+  ) ^ 0x9e3779b9 ) >>> 0;
+
+  if ( s === 0 ) {
+    s = 1;
+  }
+
+  return () => {
+    s ^= s << 13;
+    s >>>= 0;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    s >>>= 0;
+
+    return s / 4294967296;
+  };
+}
+
+// Seeded waypoint chain inside the canonical cell: angles across the wedge,
+// radii alternating inner/outer for a petalled rhythm (optional), and a
+// little depth relief. Joined by a cyclic 3D Hermite (tangents × flow).
+function buildArcs( {
+  waypoints,
+  seed,
+  cellAngle,
+  rMin,
+  rMax,
+  depthAmp,
+  petalWeave,
+  flow
+} ) {
+  const rng = makeRng( seed );
+  const points = [];
+
+  for ( let k = 0; k < waypoints; k++ ) {
+    const theta = 0.04 + rng() * Math.max(
+      cellAngle - 0.08,
+      0.02
+    );
+    const span = rMax - rMin;
+
+    let radius;
+
+    if ( petalWeave ) {
+      radius = k % 2 === 0
+        ? rMin + rng() * span * 0.35
+        : rMax - rng() * span * 0.35;
+    } else {
+      radius = rMin + rng() * span;
+    }
+
+    points.push( {
+      x: radius * Math.cos( theta ),
+      y: radius * Math.sin( theta ),
+      z: ( rng() * 2 - 1 ) * depthAmp,
+      radius
+    } );
+  }
+
+  const arcs = [];
+
+  for ( let k = 0; k < waypoints; k++ ) {
+    const prev = points[ ( k - 1 + waypoints ) % waypoints ];
+    const a = points[ k ];
+    const b = points[ ( k + 1 ) % waypoints ];
+    const next = points[ ( k + 2 ) % waypoints ];
+
+    arcs.push( {
+      p0: [
+        a.x,
+        a.y
+      ],
+      p1: [
+        b.x,
+        b.y
+      ],
+      m0: [
+        0.5 * flow * ( b.x - prev.x ),
+        0.5 * flow * ( b.y - prev.y )
+      ],
+      m1: [
+        0.5 * flow * ( next.x - a.x ),
+        0.5 * flow * ( next.y - a.y )
+      ],
+      z0: a.z,
+      z1: b.z,
+      mz0: 0.5 * flow * ( b.z - prev.z ),
+      mz1: 0.5 * flow * ( next.z - a.z ),
+      point: a
+    } );
+  }
+
+  return arcs;
+}
+
+// Waypoint-crossing bookkeeping for the chime (wrap-aware, as in v3).
+let lastCrossU = null;
+
+// Index of the last fired hum grain (the v2/v3 seamless drone bed).
+let lastGrainIndex = null;
+
+sketch.setup(
+  () => {},
+  {}
+);
+
+sketch.draw( () => {
+  const p = getP5();
+  const o = options.sketch ?? {};
+  const mandala = o.mandala ?? {};
+  const path = o.path ?? {};
+  const dragon = o.dragon ?? {};
+  const rose = o.window ?? {};
+  const camera = o.camera ?? {};
+  const colors = o.colors ?? {};
+  const light = o.light ?? {};
+  const sound = o.sound ?? {};
+
+  p.clear();
+  p.background( ...( o.backgroundColor ?? [
+    5,
+    6,
+    14
+  ] ) );
+
+  const timeScale = o.timeScale ?? 1;
+  const t = animation.angle;
+
+  // ── Fold geometry ──────────────────────────────────────────────────────────
+  const sectors = Math.min(
+    12,
+    Math.max(
+      3,
+      Math.round( mandala.sectors ?? 8 )
+    )
+  );
+  const mirror = mandala.mirror ?? true;
+  const sectorAngle = p.TAU / sectors;
+  const cellAngle = mirror ? sectorAngle / 2 : sectorAngle;
+  const spinTurnsMandala = Math.round( ( mandala.spin ?? 0 ) * timeScale );
+  const mandalaSpin = t * spinTurnsMandala;
+
+  // ── Loop-exact clock ───────────────────────────────────────────────────────
+  const waypoints = Math.min(
+    MAX_SEQ,
+    Math.max(
+      3,
+      Math.round( path.waypointsPerLoop ?? 6 )
+    )
+  );
+  const f = animation.progression * waypoints;
+
+  // ── The dance ──────────────────────────────────────────────────────────────
+  const flow = Math.min(
+    Math.max(
+      path.flow ?? 0.65,
+      0
+    ),
+    1
+  );
+  const pose = Math.min(
+    Math.max(
+      path.pose ?? 0.5,
+      0
+    ),
+    1
+  );
+  const rMin = Math.max(
+    mandala.innerRadius ?? 0.9,
+    0.3
+  );
+  const rMax = Math.max(
+    mandala.outerRadius ?? 2.6,
+    rMin + 0.4
+  );
+  const depthAmp = mandala.depthRelief ?? 0.35;
+  const seed = Math.round( path.seed ?? 11 );
+
+  const arcs = buildArcs( {
+    waypoints,
+    seed,
+    cellAngle,
+    rMin,
+    rMax,
+    depthAmp,
+    petalWeave: path.petalWeave ?? true,
+    flow
+  } );
+
+  // ── Body ───────────────────────────────────────────────────────────────────
+  const bodyLen = Math.min(
+    Math.max(
+      dragon.bodyLength ?? 3,
+      0.5
+    ),
+    waypoints - 0.55
+  );
+  const bodyRadius = Math.max(
+    dragon.bodyRadius ?? 0.14,
+    0.03
+  );
+  const headBulge = dragon.headBulge ?? 0.35;
+  const headLen = dragon.headLength ?? 0.6;
+  const tailLen = Math.min(
+    dragon.tailLength ?? 1.4,
+    bodyLen
+  );
+  const radiusPulse = dragon.radiusPulse ?? 0.18;
+
+  const pulseWavesInt = Math.max(
+    1,
+    Math.round( dragon.pulseWaves ?? 4 )
+  );
+  const pulseFreq = ( p.TAU * pulseWavesInt ) / bodyLen;
+  const pulseTravelInt = Math.round( ( dragon.pulseTravel ?? -3 ) * timeScale );
+
+  const swimWavesInt = Math.max(
+    1,
+    Math.round( path.swimWaves ?? 3 )
+  );
+  const swimFreq = ( p.TAU * swimWavesInt ) / bodyLen;
+  const swimCycles = Math.round( ( path.swimSpeed ?? 2 ) * timeScale );
+  const swimT = t * swimCycles;
+  const swimAmpX = path.swimX ?? 0.05;
+  const swimAmpY = path.swimY ?? 0.05;
+  const swimPhase = path.swimPhase ?? 1.6;
+
+  const stripes = Math.round( dragon.stripes ?? 5 );
+  const stripeDepth = dragon.stripeDepth ?? 0.35;
+  const twist = ( p.TAU * ( dragon.twist ?? 3 ) ) / bodyLen;
+  const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
+
+  // ── March safety ───────────────────────────────────────────────────────────
+  let maxTangent = 0;
+  let minRk = Infinity;
+  let maxRk = 0;
+  let maxZk = 0;
+
+  for ( const arc of arcs ) {
+    maxTangent = Math.max(
+      maxTangent,
+      Math.hypot(
+        arc.m0[ 0 ],
+        arc.m0[ 1 ],
+        arc.mz0
+      ),
+      Math.hypot(
+        arc.m1[ 0 ],
+        arc.m1[ 1 ],
+        arc.mz1
+      )
+    );
+    minRk = Math.min(
+      minRk,
+      arc.point.radius
+    );
+    maxRk = Math.max(
+      maxRk,
+      arc.point.radius
+    );
+    maxZk = Math.max(
+      maxZk,
+      Math.abs( arc.point.z )
+    );
+  }
+
+  const swimLen = Math.hypot(
+    swimAmpX,
+    swimAmpY
+  );
+  const maxR = bodyRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
+  const overshoot = ( 8 / 27 ) * maxTangent;
+  const reach = overshoot + swimLen + maxR + 0.05;
+  const boundPad = reach;
+
+  const lipschitz = 1.3 + bodyRadius * (
+    radiusPulse * pulseFreq
+    + headBulge / Math.max(
+      headLen,
+      0.1
+    )
+    + 1 / Math.max(
+      tailLen,
+      0.3
+    )
+  );
+
+  // ── Camera (static by default) ─────────────────────────────────────────────
+  // The renderer's ray convention spans ±0.5 vertically, so a plane at
+  // distance D shows a half-height of D / (2·focal): the distance is derived
+  // from that so distance = 1 frames the whole rosette whatever the fov.
+  const view = camera.view ?? "facade";
+  const backRadius = rose.radius ?? 3.3;
+  const frameRadius = Math.max(
+    maxRk + 0.6,
+    backRadius
+  );
+  const fov = camera.fov ?? 45;
+  const focal = 1 / Math.tan( ( fov * Math.PI ) / 180 / 2 );
+  const dist = ( camera.distance ?? 1 ) * 2.15 * focal * frameRadius;
+
+  let elevation = 0;
+  let azimuth = 0;
+
+  if ( view === "oblique" || view === "drift" ) {
+    elevation = Math.min(
+      Math.max(
+        camera.elevation ?? 0.55,
+        -1.35
+      ),
+      1.35
+    );
+    azimuth = camera.azimuth ?? 0.45;
+  }
+
+  if ( view === "drift" ) {
+    const driftTurnsInt = Math.round( camera.driftTurns ?? 1 );
+
+    azimuth += p.TAU * driftTurnsInt * animation.progression;
+  }
+
+  const camPos = [
+    Math.cos( elevation ) * Math.sin( azimuth ) * dist,
+    Math.sin( elevation ) * dist,
+    Math.cos( elevation ) * Math.cos( azimuth ) * dist
+  ];
+
+  const norm3 = (
+    v, fallback
+  ) => {
+    const len = Math.hypot(
+      v[ 0 ],
+      v[ 1 ],
+      v[ 2 ]
+    );
+
+    if ( len < 1e-5 ) {
+      return fallback;
+    }
+
+    return [
+      v[ 0 ] / len,
+      v[ 1 ] / len,
+      v[ 2 ] / len
+    ];
+  };
+
+  const fwd = norm3(
+    [
+      -camPos[ 0 ],
+      -camPos[ 1 ],
+      -camPos[ 2 ]
+    ],
+    [
+      0,
+      0,
+      -1
+    ]
+  );
+  const right = norm3(
+    [
+      fwd[ 2 ],
+      0,
+      -fwd[ 0 ]
+    ],
+    [
+      1,
+      0,
+      0
+    ]
+  );
+  const up = [
+    right[ 1 ] * fwd[ 2 ] - right[ 2 ] * fwd[ 1 ],
+    right[ 2 ] * fwd[ 0 ] - right[ 0 ] * fwd[ 2 ],
+    right[ 0 ] * fwd[ 1 ] - right[ 1 ] * fwd[ 0 ]
+  ];
+
+  // ── Chime on every waypoint pass ───────────────────────────────────────────
+  // Each time the head settles on a waypoint (f crosses an integer), a soft
+  // airy chime rings: pitch rises with the waypoint's radius (outer petals
+  // ring higher), stereo pan follows the home copy's x. Wrap-aware, silent on
+  // big scrubs.
+  if ( lastCrossU === null ) {
+    lastCrossU = f;
+  } else if ( f !== lastCrossU ) {
+    let delta = f - lastCrossU;
+
+    if ( delta > waypoints / 2 ) {
+      delta -= waypoints;
+    } else if ( delta < -waypoints / 2 ) {
+      delta += waypoints;
+    }
+
+    const crossed = Math.floor( f ) - Math.floor( f - delta );
+
+    if ( ( sound.chimeEnabled ?? true )
+      && crossed !== 0
+      && Math.abs( crossed ) <= 2 ) {
+      const c = delta > 0 ? Math.floor( f ) : Math.ceil( f );
+      const ci = ( ( c % waypoints ) + waypoints ) % waypoints;
+      const wp = arcs[ ci ].point;
+      const rNorm = ( wp.radius - rMin ) / Math.max(
+        rMax - rMin,
+        0.01
+      );
+
+      audio.trigger(
+        "whoosh",
+        {
+          duration: sound.chimeLength ?? 0.6,
+          freq: 480 * ( sound.chimePitch ?? 1 ) * ( 0.75 + 0.5 * rNorm ),
+          gain: 0.5 * ( sound.chimeVolume ?? 0.6 ),
+          pan: Math.min(
+            Math.max(
+              ( wp.x / rMax ) * ( sound.chimePan ?? 0.7 ),
+              -1
+            ),
+            1
+          )
+        }
+      );
+    }
+
+    lastCrossU = f;
+  }
+
+  // ── Constant dragon hum (same seamless grain bed as v2/v3) ─────────────────
+  if ( sound.humEnabled ?? true ) {
+    const loopDuration = sketch.sketchOptions?.animation?.duration ?? 12;
+    const grainsPerLoop = Math.max(
+      4,
+      Math.round( loopDuration / 0.35 )
+    );
+    const grainIndex = Math.floor( animation.progression * grainsPerLoop ) % grainsPerLoop;
+
+    if ( grainIndex !== lastGrainIndex ) {
+      lastGrainIndex = grainIndex;
+
+      const grainSpacing = loopDuration / grainsPerLoop;
+      const humPitch = sound.humPitch ?? 1;
+      const wobble = 1 + 0.1 * Math.sin( swimT );
+
+      audio.trigger(
+        "drone",
+        {
+          duration: grainSpacing * 2.2,
+          freq: 165 * humPitch * wobble,
+          gain: 0.4 * ( sound.humVolume ?? 0.45 ),
+          sub: 0.4,
+          pan: 0
+        }
+      );
+    }
+  } else {
+    lastGrainIndex = null;
+  }
+
+  const az = light.azimuth ?? 2.6;
+  const el = light.elevation ?? 0.6;
+  const lightDir = [
+    Math.cos( el ) * Math.sin( az ),
+    Math.sin( el ),
+    -Math.cos( el ) * Math.cos( az )
+  ];
+
+  // ── Seamless hues (v2/v3 bookkeeping) ──────────────────────────────────────
+  const hueSpread = colors.hueSpread ?? 1.55;
+  const hueCycles = Math.round( ( colors.hueSpeed ?? 1 ) * timeScale * p.TAU * hueSpread );
+  const hueSpeedPhase = hueSpread ? ( t * hueCycles ) / ( p.TAU * hueSpread ) : 0;
+  const lengthHueShift = hueSpread
+    ? ( colors.bodyHueWaves ?? 1.5 ) / ( bodyLen * hueSpread )
+    : 0;
+
+  const flatten = ( key ) => {
+    const out = [];
+
+    for ( let i = 0; i < MAX_SEQ; i++ ) {
+      out.push( ...key( arcs[ i % waypoints ] ) );
+    }
+
+    return out;
+  };
+
+  scene.render( {
+    columns: 1,
+    rows: 1,
+    resolutionScale: camera.quality ?? 0.75,
+    uniforms: {
+      uSeqLen: waypoints,
+      uHead: f,
+      uBodyLen: bodyLen,
+      uArcP: {
+        vec4v: flatten( ( arc ) => [
+          arc.p0[ 0 ],
+          arc.p0[ 1 ],
+          arc.p1[ 0 ],
+          arc.p1[ 1 ]
+        ] )
+      },
+      uArcM: {
+        vec4v: flatten( ( arc ) => [
+          arc.m0[ 0 ],
+          arc.m0[ 1 ],
+          arc.m1[ 0 ],
+          arc.m1[ 1 ]
+        ] )
+      },
+      uArcZ: {
+        vec4v: flatten( ( arc ) => [
+          arc.z0,
+          arc.z1,
+          arc.mz0,
+          arc.mz1
+        ] )
+      },
+      uPose: pose,
+      uSwimAmp: [
+        swimAmpX,
+        swimAmpY
+      ],
+      uSwimFreq: swimFreq,
+      uSwimT: swimT,
+      uSwimPhase: swimPhase,
+      uBodyRadius: bodyRadius,
+      uTailLen: tailLen,
+      uHeadBulge: headBulge,
+      uHeadLen: headLen,
+      uRadiusPulse: radiusPulse,
+      uPulseFreq: pulseFreq,
+      uPulseT: t * pulseTravelInt,
+      uBoundPad: boundPad,
+      uLip: lipschitz,
+      uStripes: stripes,
+      uStripeDepth: stripeDepth,
+      uTwist: twist,
+      uSpin: t * spinTurns,
+      uStripeHueShift: colors.stripeHueShift ?? 0.35,
+      uSectorAngle: sectorAngle,
+      uCellAngle: cellAngle,
+      uMirror: mirror ? 1 : 0,
+      uMandalaSpin: mandalaSpin,
+      uSectorHueShift: mandala.sectorHueShift ?? 0,
+      uRInner: Math.max(
+        minRk - reach - 0.05,
+        0
+      ),
+      uROuter: maxRk + reach + 0.05,
+      uZPad: maxZk + reach + 0.05,
+      uBackAlpha: rose.alpha ?? 0.8,
+      uBackDepth: rose.depth ?? 1.5,
+      uBackRadius: backRadius,
+      uRings: Math.max(
+        1,
+        Math.round( rose.rings ?? 5 )
+      ),
+      uBackHueShift: rose.hueShift ?? 0.14,
+      uBackHuePhase: rose.huePhase ?? 0.35,
+      uBackBrightness: rose.brightness ?? 0.35,
+      uCenterGlow: rose.centerGlow ?? 0.8,
+      uLeadDark: rose.leadDarkness ?? 0.55,
+      uLeadGlow: rose.leadGlow ?? 0.5,
+      uGlassFrost: rose.frost ?? 0.5,
+      uFrostScale: rose.frostScale ?? 3,
+      uDragonGlow: rose.dragonGlow ?? 0.7,
+      uCamPos: camPos,
+      uCamFwd: fwd,
+      uCamRight: right,
+      uCamUp: up,
+      uFocal: focal,
+      uHueSpeed: hueSpeedPhase,
+      uHueSpread: hueSpread,
+      uHuePhase: colors.huePhase ?? 1.17,
+      uLengthHueShift: lengthHueShift,
+      uShimmer: colors.shimmer ?? 1.1,
+      uSaturation: colors.saturation ?? 0.9,
+      uBrightness: colors.brightness ?? 1.05,
+      uLightDir: lightDir,
+      uAmbient: light.ambient ?? 0.32,
+      uDiffuse: light.diffuse ?? 1,
+      uSpecular: light.specular ?? 0.6,
+      uSpecPower: light.specPower ?? 24,
+      uFresnelPower: light.fresnelPower ?? 2.5,
+      uRimStrength: light.rimStrength ?? 0.55,
+      uFogDensity: o.fogDensity ?? 0.015,
+      uBgColor: ( o.backgroundColor ?? [
+        5,
+        6,
+        14
+      ] ).map( ( v ) => v / 255 )
+    }
+  } );
+} );

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/index.js
@@ -45,7 +45,7 @@ import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 // ── Looping ──────────────────────────────────────────────────────────────────
 // The head advances by exactly K waypoints per loop over a cyclic path, and
 // every pattern on the body (pulse, swim, hue) is anchored to the head, so
-// loop closure is automatic. Time-driven rates (stripe spin, pulse travel,
+// loop closure is automatic. Time-driven rates (braid spin, pulse travel,
 // swim travel, hue scroll, mandala spin, camera drift) are snapped to whole
 // cycles per loop, so the last frame reproduces the first.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -76,7 +76,7 @@ const FRAGMENT = `
   uniform float uSwimPhase;   // second-axis sway phase offset
 
   // ── Body radii ──
-  uniform float uBodyRadius;
+  uniform float uPipeRadius;
   uniform float uTailLen;     // waypoints over which the tail tapers away
   uniform float uHeadBulge;   // head swell amount
   uniform float uHeadLen;     // head swell falloff (waypoints behind the head)
@@ -86,12 +86,13 @@ const FRAGMENT = `
   uniform float uBoundPad;    // CPU-computed inflation for the per-arc bound
   uniform float uLip;         // CPU-computed safety divisor for the march
 
-  // ── Braid stripes (shading-only pipes) ──
-  uniform float uStripes;     // stripe count around the body (0 = plain skin)
-  uniform float uStripeDepth; // groove darkening between stripes
-  uniform float uTwist;       // stripe winding (rad per waypoint along the body)
-  uniform float uSpin;        // stripe rotation over time (whole turns per loop)
-  uniform float uStripeHueShift;
+  // ── Pipe braid (the v1/v2 bundle, wound around the free centreline) ──
+  uniform float uPipeCount;   // pipes in the bundle (1 = plain snake)
+  uniform float uBraidRadius; // bundle orbit radius (0 = pipes merged)
+  uniform float uBraidMerge;  // body length over which the braid unwinds into the head
+  uniform float uTwist;       // braid winding (rad per waypoint along the body)
+  uniform float uSpin;        // braid rotation over time (whole turns per loop)
+  uniform float uPipeHueShift;
 
   // ── Kaleidoscope fold ──
   uniform float uSectorAngle; // TAU / sectors
@@ -189,12 +190,12 @@ const FRAGMENT = `
     return vec3(xy, z);
   }
 
-  // Body radius at a distance behind the head — tail taper, head swell,
+  // Pipe radius at a distance behind the head — tail taper, head swell,
   // travelling pulse. Body-anchored, so the loop closes by construction.
-  float bodyRadiusAt(float behind) {
+  float pipeRadiusAt(float behind) {
     float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
     float hb = behind / max(uHeadLen, 0.05);
-    float r = uBodyRadius * mix(0.08, 1.0, taper);
+    float r = uPipeRadius * mix(0.08, 1.0, taper);
 
     r *= 1.0 + uHeadBulge * exp(-hb * hb);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
@@ -202,13 +203,51 @@ const FRAGMENT = `
     return r;
   }
 
-  // Tapered capsule (radius lerped along the axis); uLip covers the shortfall.
-  float coneCap(vec3 p, vec3 a, vec3 b, float r1, float r2) {
+  // Braid orbit radius: the bundle unwinds into a single rounded head over
+  // uBraidMerge (exactly v2's head merge) and collapses again at the tail tip.
+  float braidRadiusAt(float behind) {
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+    float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
+
+    return uBraidRadius * merge * taper;
+  }
+
+  // One braided capsule segment. Instead of one tube per pipe, the angle
+  // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
+  // per capsule): a single circle distance then covers every pipe of the
+  // bundle, so the cost is independent of how many pipes there are. Slightly
+  // non-metric (taper, twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
-    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+    float bb = max(dot(ba, ba), 1e-8);
+    float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+    vec3 q = pa - ba * h;
+    float behind = mix(bA, bB, h);
+    float pr = pipeRadiusAt(behind);
+    float br = braidRadiusAt(behind);
 
-    return length(pa - ba * h) - mix(r1, r2, h);
+    if (uPipeCount < 1.5 || br < 0.004) {
+      return length(q) - (pr + br);
+    }
+
+    vec3 T = ba * inversesqrt(bb);
+    vec3 refUp = normalize(mix(
+      vec3(0.0, 1.0, 0.0),
+      vec3(1.0, 0.0, 0.0),
+      smoothstep(0.8, 0.98, abs(T.y))
+    ));
+    vec3 fN = normalize(cross(refUp, T));
+    vec3 fB = cross(T, fN);
+    vec3 perp = q - T * dot(q, T);
+    float rho = length(perp);
+    float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+    float psi = phi + uTwist * behind + uSpin;
+    float sector = TAU / uPipeCount;
+    float pm = mod(psi + 0.5 * sector, sector) - 0.5 * sector;
+    float d2 = dot(q, q) + br * br - 2.0 * rho * br * cos(pm);
+
+    return sqrt(max(d2, 0.0)) - pr;
   }
 
   // ── Dragon SDF (one copy, evaluated in cell space) ────────────────────────
@@ -246,16 +285,16 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, Z);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
-        float rCur = bodyRadiusAt(uHead - (k + un));
+        float bCur = uHead - (k + un);
 
-        best = min(best, coneCap(p, prev, cur, rPrev, rCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
@@ -305,7 +344,7 @@ const FRAGMENT = `
   }
 
   // Winning folded point at the hit, for the shading walk (body coordinate,
-  // stripe frame). Same gating as mapScene.
+  // pipe id). Same gating as mapScene.
   vec3 foldWinner(vec3 p) {
     float c = cos(uMandalaSpin);
     float s = sin(uMandalaSpin);
@@ -338,13 +377,15 @@ const FRAGMENT = `
     return q;
   }
 
-  // Body coordinate of the closest point on the capsule chain (cell space).
-  float dragonS(vec3 p) {
+  // Body coordinate of the closest point on the chain (cell space) and which
+  // pipe of the bundle owns the hit (for its hue band).
+  vec2 dragonInfo(vec3 p) {
     float sTail = uHead - uBodyLen;
     float kStart = floor(sTail);
     float kLast = floor(uHead) + 0.5;
     float best = 1e9;
     float sBest = uHead;
+    float pipeBest = 0.0;
 
     for (int i = 0; i < ${ MAX_SEQ }; i++) {
       if (float(i) >= uSeqLen) { break; }
@@ -372,50 +413,48 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, Z);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
-        float rCur = bodyRadiusAt(uHead - (k + un));
-
-        vec3 pa = p - prev;
-        vec3 ba = cur - prev;
-        float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
-        float d = length(pa - ba * h) - mix(rPrev, rCur, h);
+        float bCur = uHead - (k + un);
+        float d = braidCap(p, prev, cur, bPrev, bCur);
 
         if (d < best) {
           best = d;
+
+          // Recover the owning pipe from the winning capsule's fold.
+          vec3 pa = p - prev;
+          vec3 ba = cur - prev;
+          float bb = max(dot(ba, ba), 1e-8);
+          float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+          vec3 qq = pa - ba * h;
+          vec3 T = ba * inversesqrt(bb);
+          vec3 refUp = normalize(mix(
+            vec3(0.0, 1.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            smoothstep(0.8, 0.98, abs(T.y))
+          ));
+          vec3 fN = normalize(cross(refUp, T));
+          vec3 fB = cross(T, fN);
+          vec3 perp = qq - T * dot(qq, T);
+          float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+          float behind = mix(bPrev, bCur, h);
+          float psi = phi + uTwist * behind + uSpin;
+          float sector = TAU / max(uPipeCount, 1.0);
+
           sBest = k + mix(uPrev, un, h);
+          pipeBest = mod(floor(psi / sector + 0.5), max(uPipeCount, 1.0));
         }
 
         uPrev = un;
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
-    return sBest;
-  }
-
-  // Exact centreline point at an arbitrary body coordinate — used only at the
-  // hit for smooth stripe shading.
-  vec3 pathPointAt(float s) {
-    float k = floor(s);
-    float ki = mod(k, uSeqLen);
-    vec4 P = vec4(0.0);
-    vec4 M = vec4(0.0);
-    vec4 Z = vec4(0.0);
-
-    for (int i = 0; i < ${ MAX_SEQ }; i++) {
-      if (abs(float(i) - ki) < 0.5) {
-        P = uArcP[i];
-        M = uArcM[i];
-        Z = uArcZ[i];
-      }
-    }
-
-    return arcPoint(k, s - k, P, M, Z);
+    return vec2(sBest, pipeBest);
   }
 
   // 4-tap tetrahedron normal on the folded scene.
@@ -446,37 +485,16 @@ const FRAGMENT = `
     return clamp(1.0 - 2.5 * occ, 0.0, 1.0);
   }
 
-  // Iridescent wet-scale shading; the braid is painted on as stripes around a
-  // smooth tangent frame, evaluated in the winning folded cell so every copy
-  // shows the same living pattern. Lighting stays in world space, so each
-  // copy of the rosette catches the light from its own angle.
+  // Iridescent wet-tube shading, v2 style: each pipe of the braid carries its
+  // own hue band (fading into the merged head), evaluated in the winning
+  // folded cell so every copy shows the same living bundle. Lighting stays in
+  // world space, so each copy of the rosette catches the light from its own
+  // angle.
   vec3 shadeDragon(vec3 pos, vec3 n, vec3 rd) {
     vec3 q = foldWinner(pos);
-    float sB = dragonS(q);
-    vec3 core = pathPointAt(sB);
-    vec3 axis = normalize(
-      pathPointAt(sB + 0.03) - pathPointAt(sB - 0.03) + vec3(1e-6)
-    );
-
-    float behind = max(uHead - sB, 0.0);
-
-    vec3 refUp = normalize(mix(
-      vec3(0.0, 1.0, 0.0),
-      vec3(1.0, 0.0, 0.0),
-      smoothstep(0.8, 0.98, abs(axis.y))
-    ));
-    vec3 fN = normalize(cross(refUp, axis));
-    vec3 fB = cross(axis, fN);
-    vec3 rad = q - core;
-    float phi = atan(dot(rad, fB), dot(rad, fN) + 1e-5);
-
-    float band = 0.0;
-    float groove = 0.0;
-
-    if (uStripes > 0.5) {
-      band = cos(phi * uStripes - behind * uTwist + uSpin);
-      groove = 0.5 - 0.5 * band;
-    }
+    vec2 info = dragonInfo(q);
+    float behind = max(uHead - info.x, 0.0);
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
 
     // Optional per-sector hue: which copy of the rosette is this?
     float wAng = atan(pos.y, pos.x) - uMandalaSpin;
@@ -484,11 +502,9 @@ const FRAGMENT = `
 
     float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), uFresnelPower);
     float phase = behind * uLengthHueShift + uHueSpeed
-      + band * uStripeHueShift
+      + info.y * uPipeHueShift * merge
       + sectorId * uSectorHueShift;
     vec3 base = iridescent(phase + uShimmer * fres);
-
-    base *= 1.0 - uStripeDepth * groove;
 
     float diff = max(dot(n, uLightDir), 0.0);
     vec3 hlf = normalize(uLightDir - rd);
@@ -829,21 +845,33 @@ sketch.draw( () => {
     ),
     waypoints - 0.55
   );
-  const bodyRadius = Math.max(
-    dragon.bodyRadius ?? 0.14,
-    0.03
+  const pipeCount = Math.min(
+    Math.max(
+      Math.round( dragon.pipes ?? 5 ),
+      1
+    ),
+    8
   );
+  const pipeRadius = Math.max(
+    dragon.pipeRadius ?? 0.05,
+    0.02
+  );
+  const braidRadius = Math.max(
+    dragon.braidRadius ?? 0.12,
+    0
+  );
+  const braidMerge = dragon.braidMerge ?? 0.5;
   const headBulge = dragon.headBulge ?? 0.35;
   const headLen = dragon.headLength ?? 0.6;
   const tailLen = Math.min(
     dragon.tailLength ?? 1.4,
     bodyLen
   );
-  const radiusPulse = dragon.radiusPulse ?? 0.18;
+  const radiusPulse = dragon.radiusPulse ?? 0.08;
 
   const pulseWavesInt = Math.max(
     1,
-    Math.round( dragon.pulseWaves ?? 4 )
+    Math.round( dragon.pulseWaves ?? 3 )
   );
   const pulseFreq = ( p.TAU * pulseWavesInt ) / bodyLen;
   const pulseTravelInt = Math.round( ( dragon.pulseTravel ?? -3 ) * timeScale );
@@ -859,9 +887,7 @@ sketch.draw( () => {
   const swimAmpY = path.swimY ?? 0.05;
   const swimPhase = path.swimPhase ?? 1.6;
 
-  const stripes = Math.round( dragon.stripes ?? 5 );
-  const stripeDepth = dragon.stripeDepth ?? 0.35;
-  const twist = ( p.TAU * ( dragon.twist ?? 3 ) ) / bodyLen;
+  const twist = ( p.TAU * ( dragon.twist ?? 1.5 ) ) / bodyLen;
   const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
 
   // ── March safety ───────────────────────────────────────────────────────────
@@ -902,12 +928,28 @@ sketch.draw( () => {
     swimAmpX,
     swimAmpY
   );
-  const maxR = bodyRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
+  const maxR = braidRadius
+    + pipeRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
   const overshoot = ( 8 / 27 ) * maxTangent;
   const reach = overshoot + swimLen + maxR + 0.05;
   const boundPad = reach;
 
-  const lipschitz = 1.3 + bodyRadius * (
+  // Lipschitz divisor: taper/pulse slopes plus the braid's own twist gradient
+  // (pipe positions rotate along the body, steepening the field between pipes).
+  let minChord = Infinity;
+
+  for ( const arc of arcs ) {
+    minChord = Math.min(
+      minChord,
+      Math.hypot(
+        arc.p1[ 0 ] - arc.p0[ 0 ],
+        arc.p1[ 1 ] - arc.p0[ 1 ],
+        arc.z1 - arc.z0
+      )
+    );
+  }
+
+  const lipschitz = 1.3 + pipeRadius * (
     radiusPulse * pulseFreq
     + headBulge / Math.max(
       headLen,
@@ -916,6 +958,15 @@ sketch.draw( () => {
     + 1 / Math.max(
       tailLen,
       0.3
+    )
+  ) + braidRadius * (
+    twist / Math.max(
+      minChord,
+      0.4
+    )
+    + 1 / Math.max(
+      braidMerge,
+      0.25
     )
   );
 
@@ -1155,7 +1206,7 @@ sketch.draw( () => {
       uSwimFreq: swimFreq,
       uSwimT: swimT,
       uSwimPhase: swimPhase,
-      uBodyRadius: bodyRadius,
+      uPipeRadius: pipeRadius,
       uTailLen: tailLen,
       uHeadBulge: headBulge,
       uHeadLen: headLen,
@@ -1164,11 +1215,12 @@ sketch.draw( () => {
       uPulseT: t * pulseTravelInt,
       uBoundPad: boundPad,
       uLip: lipschitz,
-      uStripes: stripes,
-      uStripeDepth: stripeDepth,
+      uPipeCount: pipeCount,
+      uBraidRadius: braidRadius,
+      uBraidMerge: braidMerge,
       uTwist: twist,
       uSpin: t * spinTurns,
-      uStripeHueShift: colors.stripeHueShift ?? 0.35,
+      uPipeHueShift: colors.pipeHueShift ?? 0.33,
       uSectorAngle: sectorAngle,
       uCellAngle: cellAngle,
       uMirror: mirror ? 1 : 0,

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
@@ -13,8 +13,8 @@ export const formValues = {
   path: {
     waypointsPerLoop: 6,
     seed: 11,
-    pose: 0.5,
-    flow: 0.65,
+    pose: 0.4,
+    flow: 0.78,
     petalWeave: true,
     swimX: 0.05,
     swimY: 0.05,
@@ -25,8 +25,8 @@ export const formValues = {
   dragon: {
     bodyLength: 3,
     pipes: 5,
-    pipeRadius: 0.05,
-    braidRadius: 0.12,
+    pipeRadius: 0.04,
+    braidRadius: 0.09,
     braidMerge: 0.5,
     headBulge: 0.35,
     headLength: 0.6,
@@ -34,7 +34,7 @@ export const formValues = {
     radiusPulse: 0.08,
     pulseWaves: 3,
     pulseTravel: -3,
-    twist: 1.5,
+    twist: 0.8,
     spin: -2
   },
   window: {

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
@@ -24,16 +24,17 @@ export const formValues = {
   },
   dragon: {
     bodyLength: 3,
-    bodyRadius: 0.14,
+    pipes: 5,
+    pipeRadius: 0.05,
+    braidRadius: 0.12,
+    braidMerge: 0.5,
     headBulge: 0.35,
     headLength: 0.6,
     tailLength: 1.4,
-    radiusPulse: 0.18,
-    pulseWaves: 4,
+    radiusPulse: 0.08,
+    pulseWaves: 3,
     pulseTravel: -3,
-    stripes: 5,
-    stripeDepth: 0.35,
-    twist: 3,
+    twist: 1.5,
     spin: -2
   },
   window: {
@@ -65,7 +66,7 @@ export const formValues = {
     hueSpread: 1.55,
     huePhase: 1.17,
     bodyHueWaves: 1.5,
-    stripeHueShift: 0.35,
+    pipeHueShift: 0.33,
     shimmer: 1.1,
     saturation: 0.9,
     brightness: 1.05
@@ -242,12 +243,33 @@ export const formConfiguration: Record<string, any> = {
         max: 14,
         step: 0.5
       },
-      bodyRadius: {
-        label: "Body radius",
+      pipes: {
+        label: "Pipes (braid bundle size)",
         component: "slider",
-        min: 0.05,
-        max: 0.35,
-        step: 0.01
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      pipeRadius: {
+        label: "Pipe radius",
+        component: "slider",
+        min: 0.02,
+        max: 0.2,
+        step: 0.005
+      },
+      braidRadius: {
+        label: "Braid radius (pipe orbit)",
+        component: "slider",
+        min: 0,
+        max: 0.3,
+        step: 0.005
+      },
+      braidMerge: {
+        label: "Head merge (braid → head)",
+        component: "slider",
+        min: 0.1,
+        max: 2,
+        step: 0.05
       },
       headBulge: {
         label: "Head swell",
@@ -291,29 +313,15 @@ export const formConfiguration: Record<string, any> = {
         max: 6,
         step: 0.01
       },
-      stripes: {
-        label: "Braid stripes (0 = plain skin)",
-        component: "slider",
-        min: 0,
-        max: 8,
-        step: 1
-      },
-      stripeDepth: {
-        label: "Stripe groove depth",
-        component: "slider",
-        min: 0,
-        max: 0.8,
-        step: 0.01
-      },
       twist: {
-        label: "Stripe twist (turns along the body)",
+        label: "Braid twist (turns along the body)",
         component: "slider",
         min: 0,
         max: 8,
         step: 0.05
       },
       spin: {
-        label: "Stripe spin (snaps to whole turns/loop)",
+        label: "Braid spin (snaps to whole turns/loop)",
         component: "slider",
         min: -4,
         max: 4,
@@ -516,8 +524,8 @@ export const formConfiguration: Record<string, any> = {
         max: 4,
         step: 0.05
       },
-      stripeHueShift: {
-        label: "Stripe hue shift",
+      pipeHueShift: {
+        label: "Pipe hue shift",
         component: "slider",
         min: -2,
         max: 2,

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/options.ts
@@ -1,0 +1,678 @@
+
+export const formValues = {
+  timeScale: 1,
+  mandala: {
+    sectors: 8,
+    mirror: true,
+    spin: 0,
+    sectorHueShift: 0,
+    innerRadius: 0.9,
+    outerRadius: 2.6,
+    depthRelief: 0.35
+  },
+  path: {
+    waypointsPerLoop: 6,
+    seed: 11,
+    pose: 0.5,
+    flow: 0.65,
+    petalWeave: true,
+    swimX: 0.05,
+    swimY: 0.05,
+    swimWaves: 3,
+    swimSpeed: 2,
+    swimPhase: 1.6
+  },
+  dragon: {
+    bodyLength: 3,
+    bodyRadius: 0.14,
+    headBulge: 0.35,
+    headLength: 0.6,
+    tailLength: 1.4,
+    radiusPulse: 0.18,
+    pulseWaves: 4,
+    pulseTravel: -3,
+    stripes: 5,
+    stripeDepth: 0.35,
+    twist: 3,
+    spin: -2
+  },
+  window: {
+    alpha: 0.8,
+    depth: 1.5,
+    radius: 3.3,
+    rings: 5,
+    hueShift: 0.14,
+    huePhase: 0.35,
+    brightness: 0.35,
+    centerGlow: 0.8,
+    leadDarkness: 0.55,
+    leadGlow: 0.5,
+    frost: 0.5,
+    frostScale: 3,
+    dragonGlow: 0.7
+  },
+  camera: {
+    view: "facade" as "facade" | "oblique" | "drift",
+    distance: 1,
+    elevation: 0.55,
+    azimuth: 0.45,
+    driftTurns: 1,
+    fov: 45,
+    quality: 0.75
+  },
+  colors: {
+    hueSpeed: 1,
+    hueSpread: 1.55,
+    huePhase: 1.17,
+    bodyHueWaves: 1.5,
+    stripeHueShift: 0.35,
+    shimmer: 1.1,
+    saturation: 0.9,
+    brightness: 1.05
+  },
+  light: {
+    azimuth: 2.6,
+    elevation: 0.6,
+    ambient: 0.32,
+    diffuse: 1,
+    specular: 0.6,
+    specPower: 24,
+    fresnelPower: 2.5,
+    rimStrength: 0.55
+  },
+  sound: {
+    chimeEnabled: false,
+    chimeVolume: 0.6,
+    chimePitch: 1,
+    chimeLength: 0.6,
+    chimePan: 0.7,
+    humEnabled: false,
+    humVolume: 0.45,
+    humPitch: 1
+  },
+  fogDensity: 0.015,
+  backgroundColor: [
+    5,
+    6,
+    14
+  ]
+};
+
+export const formConfiguration: Record<string, any> = {
+  timeScale: {
+    label: "Time scale",
+    component: "slider",
+    min: 0,
+    max: 5,
+    step: 0.01
+  },
+  mandala: {
+    component: "nested-object",
+    label: "Kaleidoscope",
+    fields: {
+      sectors: {
+        label: "Sectors (dragon copies)",
+        component: "slider",
+        min: 3,
+        max: 12,
+        step: 1
+      },
+      mirror: {
+        label: "Mirror symmetry (twins kiss at the seams)",
+        component: "checkbox"
+      },
+      spin: {
+        label: "Rosette spin / loop (0 = still, snaps whole)",
+        component: "slider",
+        min: -2,
+        max: 2,
+        step: 1
+      },
+      sectorHueShift: {
+        label: "Per-sector hue shift (0 = identical copies)",
+        component: "slider",
+        min: -1,
+        max: 1,
+        step: 0.01
+      },
+      innerRadius: {
+        label: "Inner radius (hub the dance keeps clear)",
+        component: "slider",
+        min: 0.3,
+        max: 2,
+        step: 0.01
+      },
+      outerRadius: {
+        label: "Outer radius (dance reach)",
+        component: "slider",
+        min: 1.2,
+        max: 4,
+        step: 0.01
+      },
+      depthRelief: {
+        label: "Depth relief (petals lean out of the plane)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      }
+    }
+  },
+  path: {
+    component: "nested-object",
+    label: "The dance (path)",
+    fields: {
+      waypointsPerLoop: {
+        label: "Poses per loop (speed)",
+        component: "slider",
+        min: 3,
+        max: 16,
+        step: 1
+      },
+      seed: {
+        label: "Choreography seed",
+        component: "slider",
+        min: 0,
+        max: 200,
+        step: 1
+      },
+      pose: {
+        label: "Pose (settle on each figure)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      flow: {
+        label: "Flow (0 = darts, 1 = calligraphy)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      petalWeave: {
+        label: "Petal weave (alternate inner/outer poses)",
+        component: "checkbox"
+      },
+      swimX: {
+        label: "Swim sway X",
+        component: "slider",
+        min: 0,
+        max: 0.25,
+        step: 0.005
+      },
+      swimY: {
+        label: "Swim sway Y",
+        component: "slider",
+        min: 0,
+        max: 0.25,
+        step: 0.005
+      },
+      swimWaves: {
+        label: "Swim waves along the body",
+        component: "slider",
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      swimSpeed: {
+        label: "Swim speed (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.01
+      },
+      swimPhase: {
+        label: "Swim axis phase",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      }
+    }
+  },
+  dragon: {
+    component: "nested-object",
+    label: "Dragon (finite snake)",
+    fields: {
+      bodyLength: {
+        label: "Body length (in poses, < poses/loop)",
+        component: "slider",
+        min: 1,
+        max: 14,
+        step: 0.5
+      },
+      bodyRadius: {
+        label: "Body radius",
+        component: "slider",
+        min: 0.05,
+        max: 0.35,
+        step: 0.01
+      },
+      headBulge: {
+        label: "Head swell",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      headLength: {
+        label: "Head length",
+        component: "slider",
+        min: 0.1,
+        max: 1.5,
+        step: 0.05
+      },
+      tailLength: {
+        label: "Tail taper length",
+        component: "slider",
+        min: 0.3,
+        max: 4,
+        step: 0.05
+      },
+      radiusPulse: {
+        label: "Body pulse (morph)",
+        component: "slider",
+        min: 0,
+        max: 0.6,
+        step: 0.01
+      },
+      pulseWaves: {
+        label: "Pulse waves along the body",
+        component: "slider",
+        min: 1,
+        max: 12,
+        step: 1
+      },
+      pulseTravel: {
+        label: "Pulse travel (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -6,
+        max: 6,
+        step: 0.01
+      },
+      stripes: {
+        label: "Braid stripes (0 = plain skin)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 1
+      },
+      stripeDepth: {
+        label: "Stripe groove depth",
+        component: "slider",
+        min: 0,
+        max: 0.8,
+        step: 0.01
+      },
+      twist: {
+        label: "Stripe twist (turns along the body)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 0.05
+      },
+      spin: {
+        label: "Stripe spin (snaps to whole turns/loop)",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.01
+      }
+    }
+  },
+  window: {
+    component: "nested-object",
+    label: "Rose window (stained glass)",
+    fields: {
+      alpha: {
+        label: "Window opacity (0 = void behind)",
+        component: "slider",
+        min: 0,
+        max: 0.97,
+        step: 0.01
+      },
+      depth: {
+        label: "Window distance behind the dance",
+        component: "slider",
+        min: 0.6,
+        max: 4,
+        step: 0.05
+      },
+      radius: {
+        label: "Window radius",
+        component: "slider",
+        min: 1.5,
+        max: 6,
+        step: 0.05
+      },
+      rings: {
+        label: "Stained-glass rings",
+        component: "slider",
+        min: 1,
+        max: 12,
+        step: 1
+      },
+      hueShift: {
+        label: "Hue shift per ring",
+        component: "slider",
+        min: -0.5,
+        max: 0.5,
+        step: 0.01
+      },
+      huePhase: {
+        label: "Window hue phase",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      },
+      brightness: {
+        label: "Glass brightness",
+        component: "slider",
+        min: 0,
+        max: 1.5,
+        step: 0.01
+      },
+      centerGlow: {
+        label: "Hub glow (light through the centre)",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      leadDarkness: {
+        label: "Lead lines darkness",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      leadGlow: {
+        label: "Lead lines glow",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      frost: {
+        label: "Frost mottling",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      frostScale: {
+        label: "Frost grain scale",
+        component: "slider",
+        min: 0.5,
+        max: 12,
+        step: 0.25
+      },
+      dragonGlow: {
+        label: "Dragon light on the glass",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  camera: {
+    component: "nested-object",
+    label: "Camera",
+    fields: {
+      view: {
+        label: "View",
+        component: "select",
+        options: [
+          {
+            label: "Facade (rose window, static)",
+            value: "facade"
+          },
+          {
+            label: "Oblique (three-quarter, static)",
+            value: "oblique"
+          },
+          {
+            label: "Drift (slow orbit / loop)",
+            value: "drift"
+          }
+        ]
+      },
+      distance: {
+        label: "Distance (1 = rosette fills the frame)",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      },
+      elevation: {
+        label: "Elevation (oblique/drift)",
+        component: "slider",
+        min: -1.35,
+        max: 1.35,
+        step: 0.01
+      },
+      azimuth: {
+        label: "Azimuth (oblique/drift)",
+        component: "slider",
+        min: -3.1416,
+        max: 3.1416,
+        step: 0.01
+      },
+      driftTurns: {
+        label: "Drift orbits / loop (snaps whole)",
+        component: "slider",
+        min: -2,
+        max: 2,
+        step: 1
+      },
+      fov: {
+        label: "Field of view °",
+        component: "slider",
+        min: 25,
+        max: 100,
+        step: 1
+      },
+      quality: {
+        label: "Render quality",
+        component: "slider",
+        min: 0.4,
+        max: 1,
+        step: 0.05
+      }
+    }
+  },
+  colors: {
+    component: "nested-object",
+    label: "Iridescent (dragon)",
+    fields: {
+      hueSpeed: {
+        label: "Hue speed (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -5,
+        max: 5,
+        step: 0.01
+      },
+      hueSpread: {
+        label: "Hue spread",
+        component: "slider",
+        min: 0.1,
+        max: 6,
+        step: 0.01
+      },
+      huePhase: {
+        label: "Hue phase",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      },
+      bodyHueWaves: {
+        label: "Hue waves along the body",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.05
+      },
+      stripeHueShift: {
+        label: "Stripe hue shift",
+        component: "slider",
+        min: -2,
+        max: 2,
+        step: 0.01
+      },
+      shimmer: {
+        label: "Shimmer (oil-slick)",
+        component: "slider",
+        min: 0,
+        max: 3,
+        step: 0.01
+      },
+      saturation: {
+        label: "Saturation",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      brightness: {
+        label: "Brightness",
+        component: "slider",
+        min: 0,
+        max: 3,
+        step: 0.01
+      }
+    }
+  },
+  light: {
+    component: "nested-object",
+    label: "Lighting",
+    fields: {
+      azimuth: {
+        label: "Light azimuth",
+        component: "slider",
+        min: -3.1416,
+        max: 3.1416,
+        step: 0.01
+      },
+      elevation: {
+        label: "Light elevation",
+        component: "slider",
+        min: -1.5708,
+        max: 1.5708,
+        step: 0.01
+      },
+      ambient: {
+        label: "Ambient",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      diffuse: {
+        label: "Diffuse",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      specular: {
+        label: "Specular",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      specPower: {
+        label: "Specular sharpness",
+        component: "slider",
+        min: 1,
+        max: 128,
+        step: 1
+      },
+      fresnelPower: {
+        label: "Fresnel power",
+        component: "slider",
+        min: 0.5,
+        max: 6,
+        step: 0.01
+      },
+      rimStrength: {
+        label: "Rim glow",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  sound: {
+    component: "nested-object",
+    label: "Sound",
+    fields: {
+      chimeEnabled: {
+        label: "Chime on every pose",
+        component: "checkbox"
+      },
+      chimeVolume: {
+        label: "Chime volume",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      chimePitch: {
+        label: "Chime pitch",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      },
+      chimeLength: {
+        label: "Chime length (s)",
+        component: "slider",
+        min: 0.1,
+        max: 1.5,
+        step: 0.01
+      },
+      chimePan: {
+        label: "Chime stereo pan",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      humEnabled: {
+        label: "Dragon hum (constant)",
+        component: "checkbox"
+      },
+      humVolume: {
+        label: "Hum volume",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      humPitch: {
+        label: "Hum pitch",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      }
+    }
+  },
+  fogDensity: {
+    label: "Fog density",
+    component: "slider",
+    min: 0,
+    max: 0.4,
+    step: 0.005
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  }
+};

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
@@ -74,7 +74,7 @@ const FRAGMENT = `
   uniform float uSwimPhase;   // second-axis sway phase offset
 
   // ── Body radii ──
-  uniform float uBodyRadius;
+  uniform float uPipeRadius;
   uniform float uTailLen;
   uniform float uHeadBulge;
   uniform float uHeadLen;
@@ -84,12 +84,13 @@ const FRAGMENT = `
   uniform float uBoundPad;    // CPU-computed inflation for the per-arc bound
   uniform float uLip;         // CPU-computed safety divisor for the march
 
-  // ── Braid stripes (shading-only pipes) ──
-  uniform float uStripes;
-  uniform float uStripeDepth;
-  uniform float uTwist;
-  uniform float uSpin;
-  uniform float uStripeHueShift;
+  // ── Pipe braid (the v1/v2 bundle, wound around the free centreline) ──
+  uniform float uPipeCount;   // pipes in the bundle (1 = plain snake)
+  uniform float uBraidRadius; // bundle orbit radius (0 = pipes merged)
+  uniform float uBraidMerge;  // body length over which the braid unwinds into the head
+  uniform float uTwist;       // braid winding (rad per waypoint along the body)
+  uniform float uSpin;        // braid rotation over time (whole turns per loop)
+  uniform float uPipeHueShift;
 
   // ── The screw (self-similar vortex) ──
   uniform float uLogShrink;   // log σ (< 0): scale per depth octave
@@ -190,10 +191,10 @@ const FRAGMENT = `
     return vec3(xz.x, y, xz.y);
   }
 
-  float bodyRadiusAt(float behind) {
+  float pipeRadiusAt(float behind) {
     float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
     float hb = behind / max(uHeadLen, 0.05);
-    float r = uBodyRadius * mix(0.08, 1.0, taper);
+    float r = uPipeRadius * mix(0.08, 1.0, taper);
 
     r *= 1.0 + uHeadBulge * exp(-hb * hb);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
@@ -201,12 +202,51 @@ const FRAGMENT = `
     return r;
   }
 
-  float coneCap(vec3 p, vec3 a, vec3 b, float r1, float r2) {
+  // Braid orbit radius: the bundle unwinds into a single rounded head over
+  // uBraidMerge (exactly v2's head merge) and collapses again at the tail tip.
+  float braidRadiusAt(float behind) {
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+    float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
+
+    return uBraidRadius * merge * taper;
+  }
+
+  // One braided capsule segment. Instead of one tube per pipe, the angle
+  // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
+  // per capsule): a single circle distance then covers every pipe of the
+  // bundle, so the cost is independent of how many pipes there are. Slightly
+  // non-metric (taper, twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
-    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+    float bb = max(dot(ba, ba), 1e-8);
+    float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+    vec3 q = pa - ba * h;
+    float behind = mix(bA, bB, h);
+    float pr = pipeRadiusAt(behind);
+    float br = braidRadiusAt(behind);
 
-    return length(pa - ba * h) - mix(r1, r2, h);
+    if (uPipeCount < 1.5 || br < 0.004) {
+      return length(q) - (pr + br);
+    }
+
+    vec3 T = ba * inversesqrt(bb);
+    vec3 refUp = normalize(mix(
+      vec3(0.0, 1.0, 0.0),
+      vec3(1.0, 0.0, 0.0),
+      smoothstep(0.8, 0.98, abs(T.y))
+    ));
+    vec3 fN = normalize(cross(refUp, T));
+    vec3 fB = cross(T, fN);
+    vec3 perp = q - T * dot(q, T);
+    float rho = length(perp);
+    float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+    float psi = phi + uTwist * behind + uSpin;
+    float sector = TAU / uPipeCount;
+    float pm = mod(psi + 0.5 * sector, sector) - 0.5 * sector;
+    float d2 = dot(q, q) + br * br - 2.0 * rho * br * cos(pm);
+
+    return sqrt(max(d2, 0.0)) - pr;
   }
 
   // ── Dragon SDF (one copy, cell space) — v3/v4 slot walk ───────────────────
@@ -241,16 +281,16 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, Z);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
-        float rCur = bodyRadiusAt(uHead - (k + un));
+        float bCur = uHead - (k + un);
 
-        best = min(best, coneCap(p, prev, cur, rPrev, rCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
@@ -331,13 +371,15 @@ const FRAGMENT = `
     return win;
   }
 
-  // Body coordinate of the closest point on the chain (cell space).
-  float dragonS(vec3 p) {
+  // Body coordinate of the closest point on the chain (cell space) and which
+  // pipe of the bundle owns the hit (for its hue band).
+  vec2 dragonInfo(vec3 p) {
     float sTail = uHead - uBodyLen;
     float kStart = floor(sTail);
     float kLast = floor(uHead) + 0.5;
     float best = 1e9;
     float sBest = uHead;
+    float pipeBest = 0.0;
 
     for (int i = 0; i < ${ MAX_SEQ }; i++) {
       if (float(i) >= uSeqLen) { break; }
@@ -365,48 +407,48 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, Z);
-      float rPrev = bodyRadiusAt(uHead - (k + u0));
+      float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
-        float rCur = bodyRadiusAt(uHead - (k + un));
-
-        vec3 pa = p - prev;
-        vec3 ba = cur - prev;
-        float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
-        float d = length(pa - ba * h) - mix(rPrev, rCur, h);
+        float bCur = uHead - (k + un);
+        float d = braidCap(p, prev, cur, bPrev, bCur);
 
         if (d < best) {
           best = d;
+
+          // Recover the owning pipe from the winning capsule's fold.
+          vec3 pa = p - prev;
+          vec3 ba = cur - prev;
+          float bb = max(dot(ba, ba), 1e-8);
+          float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
+          vec3 qq = pa - ba * h;
+          vec3 T = ba * inversesqrt(bb);
+          vec3 refUp = normalize(mix(
+            vec3(0.0, 1.0, 0.0),
+            vec3(1.0, 0.0, 0.0),
+            smoothstep(0.8, 0.98, abs(T.y))
+          ));
+          vec3 fN = normalize(cross(refUp, T));
+          vec3 fB = cross(T, fN);
+          vec3 perp = qq - T * dot(qq, T);
+          float phi = atan(dot(perp, fB), dot(perp, fN) + 1e-6);
+          float behind = mix(bPrev, bCur, h);
+          float psi = phi + uTwist * behind + uSpin;
+          float sector = TAU / max(uPipeCount, 1.0);
+
           sBest = k + mix(uPrev, un, h);
+          pipeBest = mod(floor(psi / sector + 0.5), max(uPipeCount, 1.0));
         }
 
         uPrev = un;
         prev = cur;
-        rPrev = rCur;
+        bPrev = bCur;
       }
     }
 
-    return sBest;
-  }
-
-  vec3 pathPointAt(float s) {
-    float k = floor(s);
-    float ki = mod(k, uSeqLen);
-    vec4 P = vec4(0.0);
-    vec4 M = vec4(0.0);
-    vec4 Z = vec4(0.0);
-
-    for (int i = 0; i < ${ MAX_SEQ }; i++) {
-      if (abs(float(i) - ki) < 0.5) {
-        P = uArcP[i];
-        M = uArcM[i];
-        Z = uArcZ[i];
-      }
-    }
-
-    return arcPoint(k, s - k, P, M, Z);
+    return vec2(sBest, pipeBest);
   }
 
   // ── Funnel wall: a cone bowl with a rim and an open throat ────────────────
@@ -452,46 +494,23 @@ const FRAGMENT = `
     return clamp(1.0 - 2.5 * occ, 0.0, 1.0);
   }
 
-  // Dragon shading — v4's stripe-painted braid, with the copy's depth octave
+  // Dragon shading — the v1/v2 pipe braid, each pipe carrying its own hue
+  // band (fading into the merged head), with the copy's depth octave
   // darkening and hue-drifting it toward the drain. Depth effects depend only
   // on the continuous octave coordinate, so the loop seam just relabels them.
   vec3 shadeDragon(vec3 pos, vec3 n, vec3 rd) {
     vec4 win = dragonWinner(pos);
     vec3 q = win.xyz;
     float ll = win.w;
-    float sB = dragonS(q);
-    vec3 core = pathPointAt(sB);
-    vec3 axis = normalize(
-      pathPointAt(sB + 0.03) - pathPointAt(sB - 0.03) + vec3(1e-6)
-    );
-
-    float behind = max(uHead - sB, 0.0);
-
-    vec3 refUp = normalize(mix(
-      vec3(0.0, 1.0, 0.0),
-      vec3(1.0, 0.0, 0.0),
-      smoothstep(0.8, 0.98, abs(axis.y))
-    ));
-    vec3 fN = normalize(cross(refUp, axis));
-    vec3 fB = cross(axis, fN);
-    vec3 rad = q - core;
-    float phi = atan(dot(rad, fB), dot(rad, fN) + 1e-5);
-
-    float band = 0.0;
-    float groove = 0.0;
-
-    if (uStripes > 0.5) {
-      band = cos(phi * uStripes - behind * uTwist + uSpin);
-      groove = 0.5 - 0.5 * band;
-    }
+    vec2 info = dragonInfo(q);
+    float behind = max(uHead - info.x, 0.0);
+    float merge = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
 
     float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), uFresnelPower);
     float phase = behind * uLengthHueShift + uHueSpeed
-      + band * uStripeHueShift
+      + info.y * uPipeHueShift * merge
       + ll * uOctaveHueShift;
     vec3 base = iridescent(phase + uShimmer * fres);
-
-    base *= 1.0 - uStripeDepth * groove;
 
     float diff = max(dot(n, uLightDir), 0.0);
     vec3 hlf = normalize(uLightDir - rd);
@@ -797,10 +816,22 @@ sketch.draw( () => {
     ),
     waypoints - 0.55
   );
-  const bodyRadius = Math.max(
-    dragon.bodyRadius ?? 0.15,
-    0.03
+  const pipeCount = Math.min(
+    Math.max(
+      Math.round( dragon.pipes ?? 5 ),
+      1
+    ),
+    8
   );
+  const pipeRadius = Math.max(
+    dragon.pipeRadius ?? 0.065,
+    0.02
+  );
+  const braidRadius = Math.max(
+    dragon.braidRadius ?? 0.1,
+    0
+  );
+  const braidMerge = dragon.braidMerge ?? 0.5;
   const headBulge = dragon.headBulge ?? 0.35;
   const headLen = dragon.headLength ?? 0.6;
   const tailLen = Math.min(
@@ -827,9 +858,7 @@ sketch.draw( () => {
   const swimAmpY = path.swimY ?? 0.06;
   const swimPhase = path.swimPhase ?? 1.6;
 
-  const stripes = Math.round( dragon.stripes ?? 5 );
-  const stripeDepth = dragon.stripeDepth ?? 0.35;
-  const twist = ( p.TAU * ( dragon.twist ?? 3 ) ) / bodyLen;
+  const twist = ( p.TAU * ( dragon.twist ?? 2 ) ) / bodyLen;
   const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
 
   // ── March safety & cell bounds ─────────────────────────────────────────────
@@ -875,11 +904,27 @@ sketch.draw( () => {
     swimAmpX,
     swimAmpY
   );
-  const maxR = bodyRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
+  const maxR = braidRadius
+    + pipeRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
   const overshoot = ( 8 / 27 ) * maxTangent;
   const reach = overshoot + swimLen + maxR + 0.05;
 
-  const lipschitz = 1.3 + bodyRadius * (
+  // Lipschitz divisor: taper/pulse slopes plus the braid's own twist gradient
+  // (pipe positions rotate along the body, steepening the field between pipes).
+  let minChord = Infinity;
+
+  for ( const arc of arcs ) {
+    minChord = Math.min(
+      minChord,
+      Math.hypot(
+        arc.p1[ 0 ] - arc.p0[ 0 ],
+        arc.p1[ 1 ] - arc.p0[ 1 ],
+        arc.z1 - arc.z0
+      )
+    );
+  }
+
+  const lipschitz = 1.3 + pipeRadius * (
     radiusPulse * pulseFreq
     + headBulge / Math.max(
       headLen,
@@ -888,6 +933,15 @@ sketch.draw( () => {
     + 1 / Math.max(
       tailLen,
       0.3
+    )
+  ) + braidRadius * (
+    twist / Math.max(
+      minChord,
+      0.4
+    )
+    + 1 / Math.max(
+      braidMerge,
+      0.25
     )
   );
 
@@ -1143,7 +1197,7 @@ sketch.draw( () => {
       uSwimFreq: swimFreq,
       uSwimT: swimT,
       uSwimPhase: swimPhase,
-      uBodyRadius: bodyRadius,
+      uPipeRadius: pipeRadius,
       uTailLen: tailLen,
       uHeadBulge: headBulge,
       uHeadLen: headLen,
@@ -1152,11 +1206,12 @@ sketch.draw( () => {
       uPulseT: t * pulseTravelInt,
       uBoundPad: reach,
       uLip: lipschitz,
-      uStripes: stripes,
-      uStripeDepth: stripeDepth,
+      uPipeCount: pipeCount,
+      uBraidRadius: braidRadius,
+      uBraidMerge: braidMerge,
       uTwist: twist,
       uSpin: t * spinTurns,
-      uStripeHueShift: colors.stripeHueShift ?? 0.35,
+      uPipeHueShift: colors.pipeHueShift ?? 0.33,
       uLogShrink: logShrink,
       uLogInvShrink: 1 / logShrink,
       uAlpha: alpha,

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
@@ -47,7 +47,7 @@ import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MAX_SEQ = 16; // max waypoints per loop (uniform array size)
-const ARC_SAMPLES = 8; // tapered capsules sampled per arc
+const ARC_SAMPLES = 10; // tapered capsules sampled per arc
 const MAX_STEPS = 90; // sphere-trace iterations per ray
 const SURF_EPS = 0.0012; // hit threshold (world units)
 const MAX_DIST = 40.0; // ray cutoff / far plane
@@ -191,12 +191,35 @@ const FRAGMENT = `
     return vec3(xz.x, y, xz.y);
   }
 
+  // Analytic (unnormalised) centreline tangent at the same parameter — the
+  // Hermite derivative in the ring plane and in height. Adjacent capsules
+  // share their sample tangents, so the braid frame built on them is
+  // CONTINUOUS along the whole body (chord-based frames would jump at every
+  // joint and chop the pipes into segments).
+  vec3 arcTangent(float k, float u, vec4 P, vec4 M, vec4 Z) {
+    float w = mix(u, u * u * (3.0 - 2.0 * u), uPose);
+    float w2 = w * w;
+    float g00 = 6.0 * w2 - 6.0 * w;
+    float g10 = 3.0 * w2 - 4.0 * w + 1.0;
+    float g01 = -6.0 * w2 + 6.0 * w;
+    float g11 = 3.0 * w2 - 2.0 * w;
+
+    vec2 xz = P.xy * g00 + M.xy * g10 + P.zw * g01 + M.zw * g11;
+    float y = Z.x * g00 + Z.z * g10 + Z.y * g01 + Z.w * g11;
+
+    return vec3(xz.x, y, xz.y);
+  }
+
   float pipeRadiusAt(float behind) {
     float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
     float hb = behind / max(uHeadLen, 0.05);
     float r = uPipeRadius * mix(0.08, 1.0, taper);
 
-    r *= 1.0 + uHeadBulge * exp(-hb * hb);
+    // The swell only appears where the braid has already merged into one
+    // head — swelling separate pipes would bead them into a grape cluster.
+    float mg = smoothstep(0.0, max(uBraidMerge, 0.02), behind);
+
+    r *= 1.0 + uHeadBulge * exp(-hb * hb) * (1.0 - mg);
     r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
 
     return r;
@@ -214,9 +237,11 @@ const FRAGMENT = `
   // One braided capsule segment. Instead of one tube per pipe, the angle
   // around the local axis is FOLDED by the pipe count (v1/v2's untwist trick,
   // per capsule): a single circle distance then covers every pipe of the
-  // bundle, so the cost is independent of how many pipes there are. Slightly
-  // non-metric (taper, twist) — uLip covers the shortfall.
-  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB) {
+  // bundle, so the cost is independent of how many pipes there are. The frame
+  // rides the SMOOTH end tangents (shared between neighbouring capsules), so
+  // the pipes flow seamlessly across the joints. Slightly non-metric (taper,
+  // twist) — uLip covers the shortfall.
+  float braidCap(vec3 p, vec3 a, vec3 b, float bA, float bB, vec3 tA, vec3 tB) {
     vec3 pa = p - a;
     vec3 ba = b - a;
     float bb = max(dot(ba, ba), 1e-8);
@@ -230,7 +255,9 @@ const FRAGMENT = `
       return length(q) - (pr + br);
     }
 
-    vec3 T = ba * inversesqrt(bb);
+    vec3 Tm = mix(tA, tB, h);
+    float tl = dot(Tm, Tm);
+    vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
     vec3 refUp = normalize(mix(
       vec3(0.0, 1.0, 0.0),
       vec3(1.0, 0.0, 0.0),
@@ -281,15 +308,18 @@ const FRAGMENT = `
       if (bound > best) { continue; }
 
       vec3 prev = arcPoint(k, u0, P, M, Z);
+      vec3 tPrev = arcTangent(k, u0, P, M, Z);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
+        vec3 tCur = arcTangent(k, un, P, M, Z);
         float bCur = uHead - (k + un);
 
-        best = min(best, braidCap(p, prev, cur, bPrev, bCur));
+        best = min(best, braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur));
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }
@@ -407,24 +437,29 @@ const FRAGMENT = `
 
       float uPrev = u0;
       vec3 prev = arcPoint(k, u0, P, M, Z);
+      vec3 tPrev = arcTangent(k, u0, P, M, Z);
       float bPrev = uHead - (k + u0);
 
       for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
         float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
         vec3 cur = arcPoint(k, un, P, M, Z);
+        vec3 tCur = arcTangent(k, un, P, M, Z);
         float bCur = uHead - (k + un);
-        float d = braidCap(p, prev, cur, bPrev, bCur);
+        float d = braidCap(p, prev, cur, bPrev, bCur, tPrev, tCur);
 
         if (d < best) {
           best = d;
 
-          // Recover the owning pipe from the winning capsule's fold.
+          // Recover the owning pipe from the winning capsule's fold, in the
+          // same smooth-tangent frame braidCap used.
           vec3 pa = p - prev;
           vec3 ba = cur - prev;
           float bb = max(dot(ba, ba), 1e-8);
           float h = clamp(dot(pa, ba) / bb, 0.0, 1.0);
           vec3 qq = pa - ba * h;
-          vec3 T = ba * inversesqrt(bb);
+          vec3 Tm = mix(tPrev, tCur, h);
+          float tl = dot(Tm, Tm);
+          vec3 T = tl > 1e-6 ? Tm * inversesqrt(tl) : ba * inversesqrt(bb);
           vec3 refUp = normalize(mix(
             vec3(0.0, 1.0, 0.0),
             vec3(1.0, 0.0, 0.0),
@@ -444,6 +479,7 @@ const FRAGMENT = `
 
         uPrev = un;
         prev = cur;
+        tPrev = tCur;
         bPrev = bCur;
       }
     }

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/index.js
@@ -1,0 +1,1227 @@
+import options from "@/p5/utils/options.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
+import animation from "@/p5/utils/animation.js";
+import audio from "@/p5/utils/audio.js";
+import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dragon-corridor v5 — "maelström". A funnel of light, and dragons caught in
+// it: the ONE dragon circling inside a reference cell is replicated into an
+// infinite procession of self-similar copies — each one rotated by a swirl
+// offset and shrunk by a fixed factor per depth octave — spiralling forever
+// down the throat of the vortex. Deeper copies are smaller, darker, hue-
+// shifted, until the drain swallows them.
+//
+//   • Perpetual fall, perfect loop — the whole ensemble is advanced by
+//     exactly ONE whole screw step (rotate α, shrink σ) per loop (the
+//     infinite-zoom trick): at the seam every copy lands exactly where the
+//     next one started, so the fall never ends and never jumps. The wall is
+//     a cone through the apex — the one surface invariant under that screw —
+//     and its glowing spiral arms are phase-locked to the same screw, so
+//     they stream into the drain seamlessly too.
+//
+//   • The dance — the v4 waypoint machinery bent into a ring: K seeded
+//     waypoints circle the axis once per loop (radius and height wobbling,
+//     swim sway on top), joined by a cyclic 3D Hermite. The dragon chases
+//     its own tail around the drain while the screw drags it down.
+//
+//   • The march — one copy's SDF is the v3/v4 capsule chain; the ensemble is
+//     evaluated by finding the point's depth octave from its radius and
+//     testing the three nearest copies, each behind a cheap ring-band bound,
+//     so the infinite procession costs about one evaluation. Octaves are
+//     cut off in the dark of the drain, where the copies fade out anyway.
+//
+//   • Cameras — STATIC by default: "brink" leans over the rim (default),
+//     "abyss" stares straight down the throat, "drift" is the only moving
+//     one (whole orbits per loop). The vertigo comes from the scene itself.
+//
+// ── Looping ──────────────────────────────────────────────────────────────────
+// The head advances by exactly K waypoints per loop over a cyclic ring path;
+// the screw advances by a whole number of octaves per loop; per-copy depth
+// effects (fade, hue drift) depend only on the continuous octave coordinate,
+// which relabels onto itself at the seam; wall-arm phases shift by whole
+// periods. Time-driven rates (stripe spin, pulse travel, swim travel, hue
+// scroll, camera drift) are snapped to whole cycles per loop.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_SEQ = 16; // max waypoints per loop (uniform array size)
+const ARC_SAMPLES = 8; // tapered capsules sampled per arc
+const MAX_STEPS = 90; // sphere-trace iterations per ray
+const SURF_EPS = 0.0012; // hit threshold (world units)
+const MAX_DIST = 40.0; // ray cutoff / far plane
+const OCT_MIN = -2.0; // largest copy rendered (octaves above the cell)
+const OCT_MAX = 14.0; // deepest copy rendered (the drain swallows the rest)
+
+const FRAGMENT = `
+  const float SURF_EPS = ${ SURF_EPS.toFixed( 4 ) };
+  const float MAX_DIST = ${ MAX_DIST.toFixed( 4 ) };
+
+  // ── Path / sequence (one copy, in cell space) ──
+  uniform float uSeqLen;      // K = waypoints per loop
+  uniform float uHead;        // head parameter, in waypoints
+  uniform float uBodyLen;     // body length, in waypoints (< K)
+  uniform vec4  uArcP[${ MAX_SEQ }]; // xy = start waypoint, zw = end (horizontal)
+  uniform vec4  uArcM[${ MAX_SEQ }]; // xy / zw = Hermite tangents (pre-scaled by flow)
+  uniform vec4  uArcZ[${ MAX_SEQ }]; // x/y = start/end height, z/w = height tangents
+
+  // ── Path shaping ──
+  uniform float uPose;        // settle on each waypoint (0 = uniform glide)
+  uniform vec2  uSwimAmp;     // swim sway amplitude (horizontal axes)
+  uniform float uSwimFreq;    // sway spatial freq (rad per waypoint, body-anchored)
+  uniform float uSwimT;       // sway travel phase (whole cycles per loop)
+  uniform float uSwimPhase;   // second-axis sway phase offset
+
+  // ── Body radii ──
+  uniform float uBodyRadius;
+  uniform float uTailLen;
+  uniform float uHeadBulge;
+  uniform float uHeadLen;
+  uniform float uRadiusPulse;
+  uniform float uPulseFreq;
+  uniform float uPulseT;
+  uniform float uBoundPad;    // CPU-computed inflation for the per-arc bound
+  uniform float uLip;         // CPU-computed safety divisor for the march
+
+  // ── Braid stripes (shading-only pipes) ──
+  uniform float uStripes;
+  uniform float uStripeDepth;
+  uniform float uTwist;
+  uniform float uSpin;
+  uniform float uStripeHueShift;
+
+  // ── The screw (self-similar vortex) ──
+  uniform float uLogShrink;   // log σ (< 0): scale per depth octave
+  uniform float uLogInvShrink; // 1 / log σ
+  uniform float uAlpha;       // swirl offset per octave (radians)
+  uniform float uFallPhase;   // whole-octaves-per-loop × progression
+  uniform float uCellRMid;    // cell mid radius (octave estimate origin)
+  uniform vec2  uCellRBand;   // cell radius band, body reach included
+  uniform vec2  uCellYBand;   // cell height band, body reach included
+  uniform float uDragonRMax;  // global airspace bound for all copies
+  uniform float uDragonYMax;
+  uniform float uDrainFade;   // per-octave brightness fade into the drain
+  uniform float uOctaveHueShift; // per-octave hue drift of the copies
+
+  // ── Funnel wall ──
+  uniform float uSlope;       // wall: y = slope · radius (apex at the origin)
+  uniform float uWallNorm;    // 1 / √(1 + slope²)
+  uniform float uWallRim;     // bowl radius (the brink)
+  uniform float uDrainHole;   // open throat radius (0 = closed)
+  uniform vec3  uWallColor;
+  uniform float uArms;        // spiral arm count
+  uniform float uArmB;        // CPU: TAU·armPitch − arms·α (screw invariance)
+  uniform float uWallAnim;    // CPU: TAU·armPitch·fallPhase (whole periods/loop)
+  uniform float uArmSharp;    // arm sharpness
+  uniform float uStreakGlow;  // arm brightness
+  uniform float uWallHueStep; // static iridescent banding per octave
+  uniform float uDrainDark;   // octave where the drain darkness takes over
+  uniform float uRimGlow;     // bright lip at the brink
+
+  // ── Camera (full basis computed on the CPU) ──
+  uniform vec3  uCamPos;
+  uniform vec3  uCamFwd;
+  uniform vec3  uCamRight;
+  uniform vec3  uCamUp;
+  uniform float uFocal;
+
+  // ── Iridescent palette (shared vocabulary with v1…v4) ──
+  uniform float uHueSpeed;
+  uniform float uHueSpread;
+  uniform float uHuePhase;
+  uniform float uLengthHueShift;
+  uniform float uShimmer;
+  uniform float uSaturation;
+  uniform float uBrightness;
+
+  // ── Lighting ──
+  uniform vec3  uLightDir;
+  uniform float uAmbient;
+  uniform float uDiffuse;
+  uniform float uSpecular;
+  uniform float uSpecPower;
+  uniform float uFresnelPower;
+  uniform float uRimStrength;
+
+  uniform float uFogDensity;
+  uniform vec3  uBgColor;
+
+  // Oil-slick / thin-film iridescence — identical palette to v1…v4.
+  vec3 iridescent(float t) {
+    vec3 spectrum = 0.5 + 0.5 * cos(
+      TAU * (uHueSpread * t + vec3(0.0, 0.33, 0.67)) + uHuePhase
+    );
+
+    float luma = dot(spectrum, vec3(0.299, 0.587, 0.114));
+
+    return clamp(mix(vec3(luma), spectrum, uSaturation) * uBrightness, 0.0, 1.0);
+  }
+
+  float segDist3(vec3 p, vec3 a, vec3 b) {
+    vec3 pa = p - a;
+    vec3 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+
+    return length(pa - ba * h);
+  }
+
+  // Centreline point of arc k at local parameter u — cyclic 3D Hermite ring
+  // around the axis (y up), pose warp and swim sway on top.
+  vec3 arcPoint(float k, float u, vec4 P, vec4 M, vec4 Z) {
+    float w = mix(u, u * u * (3.0 - 2.0 * u), uPose);
+    float w2 = w * w;
+    float w3 = w2 * w;
+    float h00 = 2.0 * w3 - 3.0 * w2 + 1.0;
+    float h10 = w3 - 2.0 * w2 + w;
+    float h01 = -2.0 * w3 + 3.0 * w2;
+    float h11 = w3 - w2;
+
+    vec2 xz = P.xy * h00 + M.xy * h10 + P.zw * h01 + M.zw * h11;
+    float y = Z.x * h00 + Z.z * h10 + Z.y * h01 + Z.w * h11;
+
+    float behind = uHead - (k + u);
+
+    xz += uSwimAmp * vec2(
+      sin(behind * uSwimFreq - uSwimT),
+      sin(behind * uSwimFreq - uSwimT + uSwimPhase)
+    );
+
+    return vec3(xz.x, y, xz.y);
+  }
+
+  float bodyRadiusAt(float behind) {
+    float taper = smoothstep(uBodyLen, uBodyLen - uTailLen, behind);
+    float hb = behind / max(uHeadLen, 0.05);
+    float r = uBodyRadius * mix(0.08, 1.0, taper);
+
+    r *= 1.0 + uHeadBulge * exp(-hb * hb);
+    r *= 1.0 + uRadiusPulse * sin(behind * uPulseFreq - uPulseT);
+
+    return r;
+  }
+
+  float coneCap(vec3 p, vec3 a, vec3 b, float r1, float r2) {
+    vec3 pa = p - a;
+    vec3 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+
+    return length(pa - ba * h) - mix(r1, r2, h);
+  }
+
+  // ── Dragon SDF (one copy, cell space) — v3/v4 slot walk ───────────────────
+  float mapDragonSingle(vec3 p) {
+    float sTail = uHead - uBodyLen;
+    float kStart = floor(sTail);
+    float kLast = floor(uHead) + 0.5;
+    float best = 1e9;
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (float(i) >= uSeqLen) { break; }
+
+      float k = float(i) + uSeqLen * ceil((kStart - float(i)) / uSeqLen);
+
+      if (k > kLast) { continue; }
+
+      float u0 = max(sTail - k, 0.0);
+      float u1 = min(uHead - k, 1.0);
+
+      if (u1 - u0 < 1e-4) { continue; }
+
+      vec4 P = uArcP[i];
+      vec4 M = uArcM[i];
+      vec4 Z = uArcZ[i];
+
+      float bound = segDist3(
+        p,
+        vec3(P.x, Z.x, P.y),
+        vec3(P.z, Z.y, P.w)
+      ) - uBoundPad;
+
+      if (bound > best) { continue; }
+
+      vec3 prev = arcPoint(k, u0, P, M, Z);
+      float rPrev = bodyRadiusAt(uHead - (k + u0));
+
+      for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
+        float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
+        vec3 cur = arcPoint(k, un, P, M, Z);
+        float rCur = bodyRadiusAt(uHead - (k + un));
+
+        best = min(best, coneCap(p, prev, cur, rPrev, rCur));
+        prev = cur;
+        rPrev = rCur;
+      }
+    }
+
+    return best / uLip;
+  }
+
+  // ── The procession: min over the self-similar copies ──────────────────────
+  // A point's depth octave follows from its radius, so only the three nearest
+  // copies can matter; each is gated by its ring-band bound before the full
+  // capsule walk. Scaled evaluation stays an exact SDF (uniform scale).
+  float mapDragons(vec3 p) {
+    float rp = length(p.xz);
+    float dB = max(rp - uDragonRMax, p.y - uDragonYMax);
+
+    if (dB > 0.35) { return dB; }
+
+    float k0 = floor(
+      log(max(rp, 1e-4) / uCellRMid) * uLogInvShrink - uFallPhase + 0.5
+    );
+    float best = 1e9;
+
+    for (int j = -1; j <= 1; j++) {
+      float k = clamp(k0 + float(j), ${ OCT_MIN.toFixed( 1 ) }, ${ OCT_MAX.toFixed( 1 ) });
+      float ll = k + uFallPhase;
+      float e = exp(uLogShrink * ll);
+
+      float bnd = max(
+        max(e * uCellRBand.x - rp, rp - e * uCellRBand.y),
+        max(e * uCellYBand.x - p.y, p.y - e * uCellYBand.y)
+      );
+
+      if (bnd > best) { continue; }
+
+      float a = -uAlpha * ll;
+      float ca = cos(a);
+      float sa = sin(a);
+      vec3 q = vec3(
+        (ca * p.x - sa * p.z) / e,
+        p.y / e,
+        (sa * p.x + ca * p.z) / e
+      );
+
+      best = min(best, e * mapDragonSingle(q));
+    }
+
+    return best;
+  }
+
+  // Winning copy at the hit: cell-space point + its depth coordinate.
+  vec4 dragonWinner(vec3 p) {
+    float rp = length(p.xz);
+    float k0 = floor(
+      log(max(rp, 1e-4) / uCellRMid) * uLogInvShrink - uFallPhase + 0.5
+    );
+    float best = 1e9;
+    vec4 win = vec4(p, 0.0);
+
+    for (int j = -1; j <= 1; j++) {
+      float k = clamp(k0 + float(j), ${ OCT_MIN.toFixed( 1 ) }, ${ OCT_MAX.toFixed( 1 ) });
+      float ll = k + uFallPhase;
+      float e = exp(uLogShrink * ll);
+      float a = -uAlpha * ll;
+      float ca = cos(a);
+      float sa = sin(a);
+      vec3 q = vec3(
+        (ca * p.x - sa * p.z) / e,
+        p.y / e,
+        (sa * p.x + ca * p.z) / e
+      );
+      float d = e * mapDragonSingle(q);
+
+      if (d < best) {
+        best = d;
+        win = vec4(q, ll);
+      }
+    }
+
+    return win;
+  }
+
+  // Body coordinate of the closest point on the chain (cell space).
+  float dragonS(vec3 p) {
+    float sTail = uHead - uBodyLen;
+    float kStart = floor(sTail);
+    float kLast = floor(uHead) + 0.5;
+    float best = 1e9;
+    float sBest = uHead;
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (float(i) >= uSeqLen) { break; }
+
+      float k = float(i) + uSeqLen * ceil((kStart - float(i)) / uSeqLen);
+
+      if (k > kLast) { continue; }
+
+      float u0 = max(sTail - k, 0.0);
+      float u1 = min(uHead - k, 1.0);
+
+      if (u1 - u0 < 1e-4) { continue; }
+
+      vec4 P = uArcP[i];
+      vec4 M = uArcM[i];
+      vec4 Z = uArcZ[i];
+
+      float bound = segDist3(
+        p,
+        vec3(P.x, Z.x, P.y),
+        vec3(P.z, Z.y, P.w)
+      ) - uBoundPad;
+
+      if (bound > best) { continue; }
+
+      float uPrev = u0;
+      vec3 prev = arcPoint(k, u0, P, M, Z);
+      float rPrev = bodyRadiusAt(uHead - (k + u0));
+
+      for (int m = 1; m <= ${ ARC_SAMPLES }; m++) {
+        float un = mix(u0, u1, float(m) / ${ ARC_SAMPLES.toFixed( 1 ) });
+        vec3 cur = arcPoint(k, un, P, M, Z);
+        float rCur = bodyRadiusAt(uHead - (k + un));
+
+        vec3 pa = p - prev;
+        vec3 ba = cur - prev;
+        float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1e-8), 0.0, 1.0);
+        float d = length(pa - ba * h) - mix(rPrev, rCur, h);
+
+        if (d < best) {
+          best = d;
+          sBest = k + mix(uPrev, un, h);
+        }
+
+        uPrev = un;
+        prev = cur;
+        rPrev = rCur;
+      }
+    }
+
+    return sBest;
+  }
+
+  vec3 pathPointAt(float s) {
+    float k = floor(s);
+    float ki = mod(k, uSeqLen);
+    vec4 P = vec4(0.0);
+    vec4 M = vec4(0.0);
+    vec4 Z = vec4(0.0);
+
+    for (int i = 0; i < ${ MAX_SEQ }; i++) {
+      if (abs(float(i) - ki) < 0.5) {
+        P = uArcP[i];
+        M = uArcM[i];
+        Z = uArcZ[i];
+      }
+    }
+
+    return arcPoint(k, s - k, P, M, Z);
+  }
+
+  // ── Funnel wall: a cone bowl with a rim and an open throat ────────────────
+  float mapWall(vec3 p) {
+    float rp = length(p.xz);
+    float d = (p.y - uSlope * rp) * uWallNorm;
+
+    d = max(d, rp - uWallRim);
+
+    if (uDrainHole > 0.001) { d = max(d, uDrainHole - rp); }
+
+    return d;
+  }
+
+  float mapScene(vec3 p) {
+    return min(mapDragons(p), mapWall(p));
+  }
+
+  vec3 calcNormal(vec3 p) {
+    vec2 k = vec2(1.0, -1.0);
+    float e = SURF_EPS;
+
+    return normalize(
+      k.xyy * mapScene(p + k.xyy * e) +
+      k.yyx * mapScene(p + k.yyx * e) +
+      k.yxy * mapScene(p + k.yxy * e) +
+      k.xxx * mapScene(p + k.xxx * e)
+    );
+  }
+
+  float calcAO(vec3 p, vec3 n) {
+    float occ = 0.0;
+    float sca = 1.0;
+
+    for (int i = 0; i < 3; i++) {
+      float h = 0.03 + 0.11 * float(i);
+      float d = mapScene(p + n * h);
+
+      occ += (h - d) * sca;
+      sca *= 0.6;
+    }
+
+    return clamp(1.0 - 2.5 * occ, 0.0, 1.0);
+  }
+
+  // Dragon shading — v4's stripe-painted braid, with the copy's depth octave
+  // darkening and hue-drifting it toward the drain. Depth effects depend only
+  // on the continuous octave coordinate, so the loop seam just relabels them.
+  vec3 shadeDragon(vec3 pos, vec3 n, vec3 rd) {
+    vec4 win = dragonWinner(pos);
+    vec3 q = win.xyz;
+    float ll = win.w;
+    float sB = dragonS(q);
+    vec3 core = pathPointAt(sB);
+    vec3 axis = normalize(
+      pathPointAt(sB + 0.03) - pathPointAt(sB - 0.03) + vec3(1e-6)
+    );
+
+    float behind = max(uHead - sB, 0.0);
+
+    vec3 refUp = normalize(mix(
+      vec3(0.0, 1.0, 0.0),
+      vec3(1.0, 0.0, 0.0),
+      smoothstep(0.8, 0.98, abs(axis.y))
+    ));
+    vec3 fN = normalize(cross(refUp, axis));
+    vec3 fB = cross(axis, fN);
+    vec3 rad = q - core;
+    float phi = atan(dot(rad, fB), dot(rad, fN) + 1e-5);
+
+    float band = 0.0;
+    float groove = 0.0;
+
+    if (uStripes > 0.5) {
+      band = cos(phi * uStripes - behind * uTwist + uSpin);
+      groove = 0.5 - 0.5 * band;
+    }
+
+    float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), uFresnelPower);
+    float phase = behind * uLengthHueShift + uHueSpeed
+      + band * uStripeHueShift
+      + ll * uOctaveHueShift;
+    vec3 base = iridescent(phase + uShimmer * fres);
+
+    base *= 1.0 - uStripeDepth * groove;
+
+    float diff = max(dot(n, uLightDir), 0.0);
+    vec3 hlf = normalize(uLightDir - rd);
+    float spec = pow(max(dot(n, hlf), 0.0), uSpecPower) * uSpecular;
+    float ao = calcAO(pos, n);
+
+    vec3 col = base * (uAmbient + uDiffuse * diff * ao);
+
+    col += base * fres * uRimStrength;
+    col += vec3(spec) * ao;
+
+    // Swallowed by the drain: deeper octaves fade to black.
+    col *= exp(-max(ll, 0.0) * uDrainFade);
+
+    return col;
+  }
+
+  // Wall shading — glowing spiral arms streaming into the throat. The arm
+  // phase is built to be invariant under the screw (uArmB) and its animation
+  // shifts by whole periods per loop (uWallAnim), so the streaming loops.
+  vec3 shadeWall(vec3 pos, vec3 n, vec3 rd) {
+    float rp = max(length(pos.xz), 1e-4);
+    float theta = atan(pos.z, pos.x);
+    float oct = log(rp / uCellRMid) * uLogInvShrink;
+
+    float phase = uArms * theta + uArmB * oct + uWallAnim;
+    float streak = pow(0.5 + 0.5 * cos(phase), uArmSharp);
+
+    // Static iridescent banding by depth octave, tempered toward the wall
+    // colour so the bowl stays deep; darkness eats the throat.
+    vec3 glass = mix(uWallColor * 1.6, iridescent(oct * uWallHueStep + 0.2), 0.55);
+    float drain = 1.0 - smoothstep(uDrainDark, uDrainDark + 2.5, oct);
+    float lip = exp(-abs(rp - uWallRim) * 3.0) * uRimGlow;
+
+    float diff = max(dot(n, uLightDir), 0.0);
+    vec3 col = uWallColor * (0.25 + 0.75 * diff) * drain;
+
+    col += glass * streak * uStreakGlow * drain;
+    col += glass * lip;
+
+    float fres = pow(1.0 - clamp(dot(n, -rd), 0.0, 1.0), 3.0);
+
+    col += uWallColor * fres * 0.35;
+
+    return col;
+  }
+
+  vec4 traceScene(vec3 ro, vec3 rd) {
+    float t = 0.0;
+    bool hit = false;
+
+    for (int i = 0; i < ${ MAX_STEPS }; i++) {
+      vec3 pos = ro + rd * t;
+      float d = mapScene(pos);
+
+      if (d < SURF_EPS) { hit = true; break; }
+
+      t += d;
+
+      if (t > MAX_DIST) { break; }
+    }
+
+    if (!hit) { return vec4(uBgColor, MAX_DIST); }
+
+    vec3 pos = ro + rd * t;
+    vec3 n = calcNormal(pos);
+
+    vec3 col = mapDragons(pos) < mapWall(pos)
+      ? shadeDragon(pos, n, rd)
+      : shadeWall(pos, n, rd);
+
+    float fog = exp(-uFogDensity * t);
+
+    return vec4(mix(uBgColor, col, fog), t);
+  }
+
+  void main() {
+    vec2 frag = vec2(vUv.x * uResolution.x, vUv.y * uResolution.y);
+    vec2 uv = (frag - 0.5 * uResolution) / uResolution.y;
+
+    vec3 ro = uCamPos;
+    vec3 rd = normalize(uCamFwd * uFocal + uCamRight * uv.x + uCamUp * uv.y);
+
+    vec4 opaque = traceScene(ro, rd);
+
+    // Escaped rays (sky above the rim, the void through the open throat) stay
+    // transparent so the p5 background shows through.
+    float alpha = opaque.a < MAX_DIST ? 1.0 : 0.0;
+
+    gl_FragColor = vec4(opaque.rgb, alpha);
+  }
+`;
+
+const scene = createNoiseFieldRenderer( FRAGMENT );
+
+// ── CPU side ─────────────────────────────────────────────────────────────────
+
+// Deterministic xorshift32 — identical sequences on every platform.
+function makeRng( seed ) {
+  let s = ( Math.imul(
+    seed + 1,
+    2654435761
+  ) ^ 0x9e3779b9 ) >>> 0;
+
+  if ( s === 0 ) {
+    s = 1;
+  }
+
+  return () => {
+    s ^= s << 13;
+    s >>>= 0;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    s >>>= 0;
+
+    return s / 4294967296;
+  };
+}
+
+// Seeded ring of waypoints circling the axis once: angles sweep the full
+// turn, radii wobble around the cell (alternating in/out when weave is on),
+// heights ride the funnel wall with a hover gap. Cyclic 3D Hermite.
+function buildArcs( {
+  waypoints,
+  seed,
+  rMid,
+  rSpread,
+  slope,
+  hover,
+  heightJitter,
+  weave,
+  flow
+} ) {
+  const rng = makeRng( seed );
+  const points = [];
+
+  for ( let k = 0; k < waypoints; k++ ) {
+    const theta = ( ( k + ( rng() - 0.5 ) * 0.55 ) / waypoints ) * Math.PI * 2;
+
+    let radius;
+
+    if ( weave ) {
+      radius = k % 2 === 0
+        ? rMid - rSpread * ( 0.35 + 0.65 * rng() )
+        : rMid + rSpread * ( 0.35 + 0.65 * rng() );
+    } else {
+      radius = rMid + rSpread * ( rng() * 2 - 1 );
+    }
+
+    points.push( {
+      x: radius * Math.cos( theta ),
+      z: radius * Math.sin( theta ),
+      y: slope * radius + hover + heightJitter * ( rng() * 2 - 1 ),
+      radius
+    } );
+  }
+
+  const arcs = [];
+
+  for ( let k = 0; k < waypoints; k++ ) {
+    const prev = points[ ( k - 1 + waypoints ) % waypoints ];
+    const a = points[ k ];
+    const b = points[ ( k + 1 ) % waypoints ];
+    const next = points[ ( k + 2 ) % waypoints ];
+
+    arcs.push( {
+      p0: [
+        a.x,
+        a.z
+      ],
+      p1: [
+        b.x,
+        b.z
+      ],
+      m0: [
+        0.5 * flow * ( b.x - prev.x ),
+        0.5 * flow * ( b.z - prev.z )
+      ],
+      m1: [
+        0.5 * flow * ( next.x - a.x ),
+        0.5 * flow * ( next.z - a.z )
+      ],
+      z0: a.y,
+      z1: b.y,
+      mz0: 0.5 * flow * ( b.y - prev.y ),
+      mz1: 0.5 * flow * ( next.y - a.y ),
+      point: a
+    } );
+  }
+
+  return arcs;
+}
+
+// Waypoint-crossing bookkeeping for the eddy whoosh (wrap-aware, as in v3/v4).
+let lastCrossU = null;
+
+// Index of the last fired hum grain (the family's seamless drone bed).
+let lastGrainIndex = null;
+
+sketch.setup(
+  () => {},
+  {}
+);
+
+sketch.draw( () => {
+  const p = getP5();
+  const o = options.sketch ?? {};
+  const vortex = o.vortex ?? {};
+  const path = o.path ?? {};
+  const dragon = o.dragon ?? {};
+  const wall = o.wall ?? {};
+  const camera = o.camera ?? {};
+  const colors = o.colors ?? {};
+  const light = o.light ?? {};
+  const sound = o.sound ?? {};
+
+  p.clear();
+  p.background( ...( o.backgroundColor ?? [
+    4,
+    5,
+    12
+  ] ) );
+
+  const timeScale = o.timeScale ?? 1;
+  const t = animation.angle;
+
+  // ── The screw ──────────────────────────────────────────────────────────────
+  const shrink = Math.min(
+    Math.max(
+      vortex.shrink ?? 0.78,
+      0.5
+    ),
+    0.94
+  );
+  const alpha = vortex.swirlOffset ?? 2.4;
+  const plungeInt = Math.max(
+    1,
+    Math.round( vortex.fallSpeed ?? 1 )
+  );
+  const fallPhase = animation.progression * plungeInt;
+  const logShrink = Math.log( shrink );
+
+  // ── Loop-exact clock ───────────────────────────────────────────────────────
+  const waypoints = Math.min(
+    MAX_SEQ,
+    Math.max(
+      4,
+      Math.round( path.waypointsPerLoop ?? 10 )
+    )
+  );
+  const f = animation.progression * waypoints;
+
+  // ── The dance (cell ring) ──────────────────────────────────────────────────
+  const flow = Math.min(
+    Math.max(
+      path.flow ?? 0.85,
+      0
+    ),
+    1
+  );
+  const pose = Math.min(
+    Math.max(
+      path.pose ?? 0.3,
+      0
+    ),
+    1
+  );
+  const rMid = 2.0;
+  const rSpread = Math.min(
+    Math.max(
+      vortex.ringSpread ?? 0.3,
+      0.05
+    ),
+    0.8
+  );
+  const slope = Math.min(
+    Math.max(
+      vortex.steepness ?? 0.75,
+      0.2
+    ),
+    2
+  );
+  const hover = vortex.hover ?? 0.3;
+  const seed = Math.round( path.seed ?? 17 );
+
+  const arcs = buildArcs( {
+    waypoints,
+    seed,
+    rMid,
+    rSpread,
+    slope,
+    hover,
+    heightJitter: path.heightJitter ?? 0.15,
+    weave: path.weave ?? true,
+    flow
+  } );
+
+  // ── Body ───────────────────────────────────────────────────────────────────
+  const bodyLen = Math.min(
+    Math.max(
+      dragon.bodyLength ?? 4.5,
+      0.5
+    ),
+    waypoints - 0.55
+  );
+  const bodyRadius = Math.max(
+    dragon.bodyRadius ?? 0.15,
+    0.03
+  );
+  const headBulge = dragon.headBulge ?? 0.35;
+  const headLen = dragon.headLength ?? 0.6;
+  const tailLen = Math.min(
+    dragon.tailLength ?? 1.6,
+    bodyLen
+  );
+  const radiusPulse = dragon.radiusPulse ?? 0.18;
+
+  const pulseWavesInt = Math.max(
+    1,
+    Math.round( dragon.pulseWaves ?? 5 )
+  );
+  const pulseFreq = ( p.TAU * pulseWavesInt ) / bodyLen;
+  const pulseTravelInt = Math.round( ( dragon.pulseTravel ?? -3 ) * timeScale );
+
+  const swimWavesInt = Math.max(
+    1,
+    Math.round( path.swimWaves ?? 3 )
+  );
+  const swimFreq = ( p.TAU * swimWavesInt ) / bodyLen;
+  const swimCycles = Math.round( ( path.swimSpeed ?? 2 ) * timeScale );
+  const swimT = t * swimCycles;
+  const swimAmpX = path.swimX ?? 0.06;
+  const swimAmpY = path.swimY ?? 0.06;
+  const swimPhase = path.swimPhase ?? 1.6;
+
+  const stripes = Math.round( dragon.stripes ?? 5 );
+  const stripeDepth = dragon.stripeDepth ?? 0.35;
+  const twist = ( p.TAU * ( dragon.twist ?? 3 ) ) / bodyLen;
+  const spinTurns = Math.round( ( dragon.spin ?? -2 ) * timeScale );
+
+  // ── March safety & cell bounds ─────────────────────────────────────────────
+  let maxTangent = 0;
+  let minRk = Infinity;
+  let maxRk = 0;
+  let minYk = Infinity;
+  let maxYk = 0;
+
+  for ( const arc of arcs ) {
+    maxTangent = Math.max(
+      maxTangent,
+      Math.hypot(
+        arc.m0[ 0 ],
+        arc.m0[ 1 ],
+        arc.mz0
+      ),
+      Math.hypot(
+        arc.m1[ 0 ],
+        arc.m1[ 1 ],
+        arc.mz1
+      )
+    );
+    minRk = Math.min(
+      minRk,
+      arc.point.radius
+    );
+    maxRk = Math.max(
+      maxRk,
+      arc.point.radius
+    );
+    minYk = Math.min(
+      minYk,
+      arc.point.y
+    );
+    maxYk = Math.max(
+      maxYk,
+      arc.point.y
+    );
+  }
+
+  const swimLen = Math.hypot(
+    swimAmpX,
+    swimAmpY
+  );
+  const maxR = bodyRadius * ( 1 + headBulge ) * ( 1 + radiusPulse );
+  const overshoot = ( 8 / 27 ) * maxTangent;
+  const reach = overshoot + swimLen + maxR + 0.05;
+
+  const lipschitz = 1.3 + bodyRadius * (
+    radiusPulse * pulseFreq
+    + headBulge / Math.max(
+      headLen,
+      0.1
+    )
+    + 1 / Math.max(
+      tailLen,
+      0.3
+    )
+  );
+
+  // Biggest rendered copy (OCT_MIN octaves above the cell) sets the airspace.
+  const biggest = Math.pow(
+    shrink,
+    -2
+  );
+  const dragonRMax = ( maxRk + reach ) * biggest + 0.1;
+  const dragonYMax = ( maxYk + reach ) * biggest + 0.1;
+
+  // ── Funnel wall ────────────────────────────────────────────────────────────
+  const wallRim = wall.rim ?? 4.2;
+  const armsInt = Math.max(
+    1,
+    Math.round( wall.arms ?? 3 )
+  );
+  const armPitchInt = Math.round( wall.armPitch ?? 2 );
+  const armB = p.TAU * armPitchInt - armsInt * alpha;
+  const wallAnim = p.TAU * armPitchInt * fallPhase;
+
+  // ── Camera (static by default) ─────────────────────────────────────────────
+  // Same fit convention as v4: distance = 1 frames the whole bowl.
+  const view = camera.view ?? "brink";
+  const fov = camera.fov ?? 50;
+  const focal = 1 / Math.tan( ( fov * Math.PI ) / 180 / 2 );
+  const dist = ( camera.distance ?? 1 ) * 1.7 * focal * wallRim;
+
+  let elevation;
+  let azimuth = camera.azimuth ?? 0.6;
+
+  if ( view === "abyss" ) {
+    elevation = 1.5;
+  } else {
+    elevation = Math.min(
+      Math.max(
+        camera.elevation ?? 0.95,
+        0.25
+      ),
+      1.5
+    );
+  }
+
+  if ( view === "drift" ) {
+    const driftTurnsInt = Math.round( camera.driftTurns ?? 1 );
+
+    azimuth += p.TAU * driftTurnsInt * animation.progression;
+  }
+
+  const target = [
+    0,
+    slope * wallRim * 0.3,
+    0
+  ];
+  const camPos = [
+    target[ 0 ] + Math.cos( elevation ) * Math.sin( azimuth ) * dist,
+    target[ 1 ] + Math.sin( elevation ) * dist,
+    target[ 2 ] + Math.cos( elevation ) * Math.cos( azimuth ) * dist
+  ];
+
+  const norm3 = (
+    v, fallback
+  ) => {
+    const len = Math.hypot(
+      v[ 0 ],
+      v[ 1 ],
+      v[ 2 ]
+    );
+
+    if ( len < 1e-5 ) {
+      return fallback;
+    }
+
+    return [
+      v[ 0 ] / len,
+      v[ 1 ] / len,
+      v[ 2 ] / len
+    ];
+  };
+
+  const fwd = norm3(
+    [
+      target[ 0 ] - camPos[ 0 ],
+      target[ 1 ] - camPos[ 1 ],
+      target[ 2 ] - camPos[ 2 ]
+    ],
+    [
+      0,
+      -1,
+      0
+    ]
+  );
+  const right = norm3(
+    [
+      fwd[ 2 ],
+      0,
+      -fwd[ 0 ]
+    ],
+    [
+      1,
+      0,
+      0
+    ]
+  );
+  const up = [
+    right[ 1 ] * fwd[ 2 ] - right[ 2 ] * fwd[ 1 ],
+    right[ 2 ] * fwd[ 0 ] - right[ 0 ] * fwd[ 2 ],
+    right[ 0 ] * fwd[ 1 ] - right[ 1 ] * fwd[ 0 ]
+  ];
+
+  // ── Eddy whoosh on every waypoint pass ─────────────────────────────────────
+  // The head sweeping past each ring waypoint stirs a soft airy eddy: pitch
+  // rises for the inner poses (closer to the drain), pan follows the home
+  // copy. Wrap-aware, silent on big scrubs.
+  if ( lastCrossU === null ) {
+    lastCrossU = f;
+  } else if ( f !== lastCrossU ) {
+    let delta = f - lastCrossU;
+
+    if ( delta > waypoints / 2 ) {
+      delta -= waypoints;
+    } else if ( delta < -waypoints / 2 ) {
+      delta += waypoints;
+    }
+
+    const crossed = Math.floor( f ) - Math.floor( f - delta );
+
+    if ( ( sound.eddyEnabled ?? true )
+      && crossed !== 0
+      && Math.abs( crossed ) <= 2 ) {
+      const c = delta > 0 ? Math.floor( f ) : Math.ceil( f );
+      const ci = ( ( c % waypoints ) + waypoints ) % waypoints;
+      const wp = arcs[ ci ].point;
+      const inward = 1 - ( wp.radius - ( rMid - rSpread ) ) / Math.max(
+        2 * rSpread,
+        0.01
+      );
+
+      audio.trigger(
+        "whoosh",
+        {
+          duration: sound.eddyLength ?? 0.7,
+          freq: 420 * ( sound.eddyPitch ?? 1 ) * ( 0.8 + 0.5 * inward ),
+          gain: 0.5 * ( sound.eddyVolume ?? 0.6 ),
+          pan: Math.min(
+            Math.max(
+              ( wp.x / rMid ) * ( sound.eddyPan ?? 0.7 ),
+              -1
+            ),
+            1
+          )
+        }
+      );
+    }
+
+    lastCrossU = f;
+  }
+
+  // ── Constant maelström roar (the family hum bed, pitched low) ──────────────
+  if ( sound.humEnabled ?? true ) {
+    const loopDuration = sketch.sketchOptions?.animation?.duration ?? 12;
+    const grainsPerLoop = Math.max(
+      4,
+      Math.round( loopDuration / 0.35 )
+    );
+    const grainIndex = Math.floor( animation.progression * grainsPerLoop ) % grainsPerLoop;
+
+    if ( grainIndex !== lastGrainIndex ) {
+      lastGrainIndex = grainIndex;
+
+      const grainSpacing = loopDuration / grainsPerLoop;
+      const humPitch = sound.humPitch ?? 0.7;
+      const wobble = 1 + 0.1 * Math.sin( swimT );
+
+      audio.trigger(
+        "drone",
+        {
+          duration: grainSpacing * 2.2,
+          freq: 150 * humPitch * wobble,
+          gain: 0.4 * ( sound.humVolume ?? 0.5 ),
+          sub: 0.55,
+          pan: 0
+        }
+      );
+    }
+  } else {
+    lastGrainIndex = null;
+  }
+
+  const az = light.azimuth ?? 2.4;
+  const el = light.elevation ?? 0.9;
+  const lightDir = [
+    Math.cos( el ) * Math.sin( az ),
+    Math.sin( el ),
+    -Math.cos( el ) * Math.cos( az )
+  ];
+
+  // ── Seamless hues (family bookkeeping) ─────────────────────────────────────
+  const hueSpread = colors.hueSpread ?? 1.55;
+  const hueCycles = Math.round( ( colors.hueSpeed ?? 1 ) * timeScale * p.TAU * hueSpread );
+  const hueSpeedPhase = hueSpread ? ( t * hueCycles ) / ( p.TAU * hueSpread ) : 0;
+  const lengthHueShift = hueSpread
+    ? ( colors.bodyHueWaves ?? 1.5 ) / ( bodyLen * hueSpread )
+    : 0;
+
+  const flatten = ( key ) => {
+    const out = [];
+
+    for ( let i = 0; i < MAX_SEQ; i++ ) {
+      out.push( ...key( arcs[ i % waypoints ] ) );
+    }
+
+    return out;
+  };
+
+  scene.render( {
+    columns: 1,
+    rows: 1,
+    resolutionScale: camera.quality ?? 0.75,
+    uniforms: {
+      uSeqLen: waypoints,
+      uHead: f,
+      uBodyLen: bodyLen,
+      uArcP: {
+        vec4v: flatten( ( arc ) => [
+          arc.p0[ 0 ],
+          arc.p0[ 1 ],
+          arc.p1[ 0 ],
+          arc.p1[ 1 ]
+        ] )
+      },
+      uArcM: {
+        vec4v: flatten( ( arc ) => [
+          arc.m0[ 0 ],
+          arc.m0[ 1 ],
+          arc.m1[ 0 ],
+          arc.m1[ 1 ]
+        ] )
+      },
+      uArcZ: {
+        vec4v: flatten( ( arc ) => [
+          arc.z0,
+          arc.z1,
+          arc.mz0,
+          arc.mz1
+        ] )
+      },
+      uPose: pose,
+      uSwimAmp: [
+        swimAmpX,
+        swimAmpY
+      ],
+      uSwimFreq: swimFreq,
+      uSwimT: swimT,
+      uSwimPhase: swimPhase,
+      uBodyRadius: bodyRadius,
+      uTailLen: tailLen,
+      uHeadBulge: headBulge,
+      uHeadLen: headLen,
+      uRadiusPulse: radiusPulse,
+      uPulseFreq: pulseFreq,
+      uPulseT: t * pulseTravelInt,
+      uBoundPad: reach,
+      uLip: lipschitz,
+      uStripes: stripes,
+      uStripeDepth: stripeDepth,
+      uTwist: twist,
+      uSpin: t * spinTurns,
+      uStripeHueShift: colors.stripeHueShift ?? 0.35,
+      uLogShrink: logShrink,
+      uLogInvShrink: 1 / logShrink,
+      uAlpha: alpha,
+      uFallPhase: fallPhase,
+      uCellRMid: rMid,
+      uCellRBand: [
+        Math.max(
+          minRk - reach,
+          0.05
+        ),
+        maxRk + reach
+      ],
+      uCellYBand: [
+        Math.max(
+          minYk - reach,
+          0
+        ),
+        maxYk + reach
+      ],
+      uDragonRMax: dragonRMax,
+      uDragonYMax: dragonYMax,
+      uDrainFade: vortex.drainFade ?? 0.28,
+      uOctaveHueShift: vortex.octaveHueShift ?? 0.12,
+      uSlope: slope,
+      uWallNorm: 1 / Math.sqrt( 1 + slope * slope ),
+      uWallRim: wallRim,
+      uDrainHole: wall.drainHole ?? 0.3,
+      uWallColor: ( wall.color ?? [
+        30,
+        42,
+        70
+      ] ).map( ( v ) => v / 255 ),
+      uArms: armsInt,
+      uArmB: armB,
+      uWallAnim: wallAnim,
+      uArmSharp: wall.armSharpness ?? 5,
+      uStreakGlow: wall.streakGlow ?? 0.8,
+      uWallHueStep: wall.hueStep ?? 0.09,
+      uDrainDark: wall.drainDarkness ?? 3,
+      uRimGlow: wall.rimGlow ?? 0.5,
+      uCamPos: camPos,
+      uCamFwd: fwd,
+      uCamRight: right,
+      uCamUp: up,
+      uFocal: focal,
+      uHueSpeed: hueSpeedPhase,
+      uHueSpread: hueSpread,
+      uHuePhase: colors.huePhase ?? 1.17,
+      uLengthHueShift: lengthHueShift,
+      uShimmer: colors.shimmer ?? 1.1,
+      uSaturation: colors.saturation ?? 0.9,
+      uBrightness: colors.brightness ?? 1.05,
+      uLightDir: lightDir,
+      uAmbient: light.ambient ?? 0.3,
+      uDiffuse: light.diffuse ?? 1,
+      uSpecular: light.specular ?? 0.6,
+      uSpecPower: light.specPower ?? 24,
+      uFresnelPower: light.fresnelPower ?? 2.5,
+      uRimStrength: light.rimStrength ?? 0.5,
+      uFogDensity: o.fogDensity ?? 0.02,
+      uBgColor: ( o.backgroundColor ?? [
+        4,
+        5,
+        12
+      ] ).map( ( v ) => v / 255 )
+    }
+  } );
+} );

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/options.ts
@@ -1,0 +1,674 @@
+
+export const formValues = {
+  timeScale: 1,
+  vortex: {
+    shrink: 0.78,
+    swirlOffset: 2.4,
+    fallSpeed: 1,
+    steepness: 0.75,
+    ringSpread: 0.3,
+    hover: 0.3,
+    drainFade: 0.28,
+    octaveHueShift: 0.12
+  },
+  path: {
+    waypointsPerLoop: 10,
+    seed: 17,
+    pose: 0.3,
+    flow: 0.85,
+    weave: true,
+    heightJitter: 0.15,
+    swimX: 0.06,
+    swimY: 0.06,
+    swimWaves: 3,
+    swimSpeed: 2,
+    swimPhase: 1.6
+  },
+  dragon: {
+    bodyLength: 4.5,
+    bodyRadius: 0.15,
+    headBulge: 0.35,
+    headLength: 0.6,
+    tailLength: 1.6,
+    radiusPulse: 0.18,
+    pulseWaves: 5,
+    pulseTravel: -3,
+    stripes: 5,
+    stripeDepth: 0.35,
+    twist: 3,
+    spin: -2
+  },
+  wall: {
+    color: [
+      30,
+      42,
+      70
+    ],
+    rim: 4.2,
+    drainHole: 0.3,
+    arms: 3,
+    armPitch: 2,
+    armSharpness: 5,
+    streakGlow: 0.8,
+    hueStep: 0.05,
+    drainDarkness: 3,
+    rimGlow: 0.25
+  },
+  camera: {
+    view: "brink" as "brink" | "abyss" | "drift",
+    distance: 1,
+    elevation: 0.95,
+    azimuth: 0.6,
+    driftTurns: 1,
+    fov: 50,
+    quality: 0.75
+  },
+  colors: {
+    hueSpeed: 1,
+    hueSpread: 1.55,
+    huePhase: 1.17,
+    bodyHueWaves: 1.5,
+    stripeHueShift: 0.35,
+    shimmer: 1.1,
+    saturation: 0.9,
+    brightness: 1.05
+  },
+  light: {
+    azimuth: 2.4,
+    elevation: 0.9,
+    ambient: 0.3,
+    diffuse: 1,
+    specular: 0.6,
+    specPower: 24,
+    fresnelPower: 2.5,
+    rimStrength: 0.5
+  },
+  sound: {
+    eddyEnabled: false,
+    eddyVolume: 0.6,
+    eddyPitch: 1,
+    eddyLength: 0.7,
+    eddyPan: 0.7,
+    humEnabled: false,
+    humVolume: 0.5,
+    humPitch: 0.7
+  },
+  fogDensity: 0.02,
+  backgroundColor: [
+    4,
+    5,
+    12
+  ]
+};
+
+export const formConfiguration: Record<string, any> = {
+  timeScale: {
+    label: "Time scale",
+    component: "slider",
+    min: 0,
+    max: 5,
+    step: 0.01
+  },
+  vortex: {
+    component: "nested-object",
+    label: "Vortex (the screw)",
+    fields: {
+      shrink: {
+        label: "Shrink per octave (deeper = smaller)",
+        component: "slider",
+        min: 0.5,
+        max: 0.94,
+        step: 0.01
+      },
+      swirlOffset: {
+        label: "Swirl offset per octave (rad)",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      },
+      fallSpeed: {
+        label: "Fall speed (octaves / loop, snaps whole)",
+        component: "slider",
+        min: 1,
+        max: 3,
+        step: 1
+      },
+      steepness: {
+        label: "Funnel steepness",
+        component: "slider",
+        min: 0.2,
+        max: 2,
+        step: 0.01
+      },
+      ringSpread: {
+        label: "Ring spread (radial wobble of the dance)",
+        component: "slider",
+        min: 0.05,
+        max: 0.8,
+        step: 0.01
+      },
+      hover: {
+        label: "Hover above the wall",
+        component: "slider",
+        min: 0.05,
+        max: 1,
+        step: 0.01
+      },
+      drainFade: {
+        label: "Drain fade (deep copies go dark)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      octaveHueShift: {
+        label: "Hue drift per octave of depth",
+        component: "slider",
+        min: -0.5,
+        max: 0.5,
+        step: 0.01
+      }
+    }
+  },
+  path: {
+    component: "nested-object",
+    label: "The dance (ring path)",
+    fields: {
+      waypointsPerLoop: {
+        label: "Poses per loop (circling speed)",
+        component: "slider",
+        min: 4,
+        max: 16,
+        step: 1
+      },
+      seed: {
+        label: "Choreography seed",
+        component: "slider",
+        min: 0,
+        max: 200,
+        step: 1
+      },
+      pose: {
+        label: "Pose (settle on each figure)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      flow: {
+        label: "Flow (0 = darts, 1 = calligraphy)",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      weave: {
+        label: "Weave (alternate inner/outer poses)",
+        component: "checkbox"
+      },
+      heightJitter: {
+        label: "Height wobble of the poses",
+        component: "slider",
+        min: 0,
+        max: 0.6,
+        step: 0.01
+      },
+      swimX: {
+        label: "Swim sway X",
+        component: "slider",
+        min: 0,
+        max: 0.25,
+        step: 0.005
+      },
+      swimY: {
+        label: "Swim sway Y",
+        component: "slider",
+        min: 0,
+        max: 0.25,
+        step: 0.005
+      },
+      swimWaves: {
+        label: "Swim waves along the body",
+        component: "slider",
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      swimSpeed: {
+        label: "Swim speed (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.01
+      },
+      swimPhase: {
+        label: "Swim axis phase",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      }
+    }
+  },
+  dragon: {
+    component: "nested-object",
+    label: "Dragon (finite snake)",
+    fields: {
+      bodyLength: {
+        label: "Body length (in poses, < poses/loop)",
+        component: "slider",
+        min: 1,
+        max: 14,
+        step: 0.5
+      },
+      bodyRadius: {
+        label: "Body radius",
+        component: "slider",
+        min: 0.05,
+        max: 0.35,
+        step: 0.01
+      },
+      headBulge: {
+        label: "Head swell",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      headLength: {
+        label: "Head length",
+        component: "slider",
+        min: 0.1,
+        max: 1.5,
+        step: 0.05
+      },
+      tailLength: {
+        label: "Tail taper length",
+        component: "slider",
+        min: 0.3,
+        max: 4,
+        step: 0.05
+      },
+      radiusPulse: {
+        label: "Body pulse (morph)",
+        component: "slider",
+        min: 0,
+        max: 0.6,
+        step: 0.01
+      },
+      pulseWaves: {
+        label: "Pulse waves along the body",
+        component: "slider",
+        min: 1,
+        max: 12,
+        step: 1
+      },
+      pulseTravel: {
+        label: "Pulse travel (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -6,
+        max: 6,
+        step: 0.01
+      },
+      stripes: {
+        label: "Braid stripes (0 = plain skin)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 1
+      },
+      stripeDepth: {
+        label: "Stripe groove depth",
+        component: "slider",
+        min: 0,
+        max: 0.8,
+        step: 0.01
+      },
+      twist: {
+        label: "Stripe twist (turns along the body)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 0.05
+      },
+      spin: {
+        label: "Stripe spin (snaps to whole turns/loop)",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.01
+      }
+    }
+  },
+  wall: {
+    component: "nested-object",
+    label: "Funnel wall",
+    fields: {
+      color: {
+        label: "Wall color",
+        component: "color"
+      },
+      rim: {
+        label: "Bowl radius (the brink)",
+        component: "slider",
+        min: 2.5,
+        max: 7,
+        step: 0.05
+      },
+      drainHole: {
+        label: "Open throat radius (0 = closed)",
+        component: "slider",
+        min: 0,
+        max: 1.2,
+        step: 0.01
+      },
+      arms: {
+        label: "Spiral arms",
+        component: "slider",
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      armPitch: {
+        label: "Arm pitch (turns per octave, snaps whole)",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 1
+      },
+      armSharpness: {
+        label: "Arm sharpness",
+        component: "slider",
+        min: 1,
+        max: 16,
+        step: 0.5
+      },
+      streakGlow: {
+        label: "Arm glow",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      hueStep: {
+        label: "Iridescent banding per octave",
+        component: "slider",
+        min: -0.4,
+        max: 0.4,
+        step: 0.01
+      },
+      drainDarkness: {
+        label: "Drain darkness onset (octaves down)",
+        component: "slider",
+        min: 0.5,
+        max: 8,
+        step: 0.1
+      },
+      rimGlow: {
+        label: "Brink lip glow",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  camera: {
+    component: "nested-object",
+    label: "Camera",
+    fields: {
+      view: {
+        label: "View",
+        component: "select",
+        options: [
+          {
+            label: "Brink (over the rim, static)",
+            value: "brink"
+          },
+          {
+            label: "Abyss (straight down the throat, static)",
+            value: "abyss"
+          },
+          {
+            label: "Drift (slow orbit / loop)",
+            value: "drift"
+          }
+        ]
+      },
+      distance: {
+        label: "Distance (1 = the bowl fills the frame)",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      },
+      elevation: {
+        label: "Elevation (brink/drift)",
+        component: "slider",
+        min: 0.25,
+        max: 1.5,
+        step: 0.01
+      },
+      azimuth: {
+        label: "Azimuth",
+        component: "slider",
+        min: -3.1416,
+        max: 3.1416,
+        step: 0.01
+      },
+      driftTurns: {
+        label: "Drift orbits / loop (snaps whole)",
+        component: "slider",
+        min: -2,
+        max: 2,
+        step: 1
+      },
+      fov: {
+        label: "Field of view °",
+        component: "slider",
+        min: 25,
+        max: 100,
+        step: 1
+      },
+      quality: {
+        label: "Render quality",
+        component: "slider",
+        min: 0.4,
+        max: 1,
+        step: 0.05
+      }
+    }
+  },
+  colors: {
+    component: "nested-object",
+    label: "Iridescent (dragon)",
+    fields: {
+      hueSpeed: {
+        label: "Hue speed (snaps to whole cycles/loop)",
+        component: "slider",
+        min: -5,
+        max: 5,
+        step: 0.01
+      },
+      hueSpread: {
+        label: "Hue spread",
+        component: "slider",
+        min: 0.1,
+        max: 6,
+        step: 0.01
+      },
+      huePhase: {
+        label: "Hue phase",
+        component: "slider",
+        min: 0,
+        max: 6.2832,
+        step: 0.01
+      },
+      bodyHueWaves: {
+        label: "Hue waves along the body",
+        component: "slider",
+        min: -4,
+        max: 4,
+        step: 0.05
+      },
+      stripeHueShift: {
+        label: "Stripe hue shift",
+        component: "slider",
+        min: -2,
+        max: 2,
+        step: 0.01
+      },
+      shimmer: {
+        label: "Shimmer (oil-slick)",
+        component: "slider",
+        min: 0,
+        max: 3,
+        step: 0.01
+      },
+      saturation: {
+        label: "Saturation",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      brightness: {
+        label: "Brightness",
+        component: "slider",
+        min: 0,
+        max: 3,
+        step: 0.01
+      }
+    }
+  },
+  light: {
+    component: "nested-object",
+    label: "Lighting",
+    fields: {
+      azimuth: {
+        label: "Light azimuth",
+        component: "slider",
+        min: -3.1416,
+        max: 3.1416,
+        step: 0.01
+      },
+      elevation: {
+        label: "Light elevation",
+        component: "slider",
+        min: -1.5708,
+        max: 1.5708,
+        step: 0.01
+      },
+      ambient: {
+        label: "Ambient",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      diffuse: {
+        label: "Diffuse",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      specular: {
+        label: "Specular",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      },
+      specPower: {
+        label: "Specular sharpness",
+        component: "slider",
+        min: 1,
+        max: 128,
+        step: 1
+      },
+      fresnelPower: {
+        label: "Fresnel power",
+        component: "slider",
+        min: 0.5,
+        max: 6,
+        step: 0.01
+      },
+      rimStrength: {
+        label: "Rim glow",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.01
+      }
+    }
+  },
+  sound: {
+    component: "nested-object",
+    label: "Sound",
+    fields: {
+      eddyEnabled: {
+        label: "Eddy whoosh on every pose",
+        component: "checkbox"
+      },
+      eddyVolume: {
+        label: "Eddy volume",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      eddyPitch: {
+        label: "Eddy pitch",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      },
+      eddyLength: {
+        label: "Eddy length (s)",
+        component: "slider",
+        min: 0.1,
+        max: 1.5,
+        step: 0.01
+      },
+      eddyPan: {
+        label: "Eddy stereo pan",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      humEnabled: {
+        label: "Maelström roar (constant)",
+        component: "checkbox"
+      },
+      humVolume: {
+        label: "Roar volume",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      humPitch: {
+        label: "Roar pitch",
+        component: "slider",
+        min: 0.4,
+        max: 2.5,
+        step: 0.01
+      }
+    }
+  },
+  fogDensity: {
+    label: "Fog density",
+    component: "slider",
+    min: 0,
+    max: 0.4,
+    step: 0.005
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  }
+};

--- a/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/options.ts
+++ b/src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/options.ts
@@ -26,16 +26,17 @@ export const formValues = {
   },
   dragon: {
     bodyLength: 4.5,
-    bodyRadius: 0.15,
+    pipes: 5,
+    pipeRadius: 0.065,
+    braidRadius: 0.1,
+    braidMerge: 0.5,
     headBulge: 0.35,
     headLength: 0.6,
     tailLength: 1.6,
     radiusPulse: 0.18,
     pulseWaves: 5,
     pulseTravel: -3,
-    stripes: 5,
-    stripeDepth: 0.35,
-    twist: 3,
+    twist: 2,
     spin: -2
   },
   wall: {
@@ -68,7 +69,7 @@ export const formValues = {
     hueSpread: 1.55,
     huePhase: 1.17,
     bodyHueWaves: 1.5,
-    stripeHueShift: 0.35,
+    pipeHueShift: 0.33,
     shimmer: 1.1,
     saturation: 0.9,
     brightness: 1.05
@@ -262,12 +263,33 @@ export const formConfiguration: Record<string, any> = {
         max: 14,
         step: 0.5
       },
-      bodyRadius: {
-        label: "Body radius",
+      pipes: {
+        label: "Pipes (braid bundle size)",
         component: "slider",
-        min: 0.05,
-        max: 0.35,
-        step: 0.01
+        min: 1,
+        max: 8,
+        step: 1
+      },
+      pipeRadius: {
+        label: "Pipe radius",
+        component: "slider",
+        min: 0.02,
+        max: 0.2,
+        step: 0.005
+      },
+      braidRadius: {
+        label: "Braid radius (pipe orbit)",
+        component: "slider",
+        min: 0,
+        max: 0.3,
+        step: 0.005
+      },
+      braidMerge: {
+        label: "Head merge (braid → head)",
+        component: "slider",
+        min: 0.1,
+        max: 2,
+        step: 0.05
       },
       headBulge: {
         label: "Head swell",
@@ -311,29 +333,15 @@ export const formConfiguration: Record<string, any> = {
         max: 6,
         step: 0.01
       },
-      stripes: {
-        label: "Braid stripes (0 = plain skin)",
-        component: "slider",
-        min: 0,
-        max: 8,
-        step: 1
-      },
-      stripeDepth: {
-        label: "Stripe groove depth",
-        component: "slider",
-        min: 0,
-        max: 0.8,
-        step: 0.01
-      },
       twist: {
-        label: "Stripe twist (turns along the body)",
+        label: "Braid twist (turns along the body)",
         component: "slider",
         min: 0,
         max: 8,
         step: 0.05
       },
       spin: {
-        label: "Stripe spin (snaps to whole turns/loop)",
+        label: "Braid spin (snaps to whole turns/loop)",
         component: "slider",
         min: -4,
         max: 4,
@@ -512,8 +520,8 @@ export const formConfiguration: Record<string, any> = {
         max: 4,
         step: 0.05
       },
-      stripeHueShift: {
-        label: "Stripe hue shift",
+      pipeHueShift: {
+        label: "Pipe hue shift",
         component: "slider",
         min: -2,
         max: 2,


### PR DESCRIPTION
## What

Two new takes on the dragon-corridor family (follow-ups to #265), where the dragon becomes the entire scene — **plus the return of the real v1/v2 pipe braid across v3/v4/v5**:

- **v4 — mandala**: `src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v4-mandala/`
- **v5 — maelström**: `src/sketches/p5/sketches/dragon-corridor/dragon-corridor-v5-maelstrom/`
- **braid refactor** touching v3 (merged in #265), v4 and v5

(+ regenerated metadata/registries.)

## The pipe braid is back (v3/v4/v5)

The single stripe-painted tube read flat next to the original dragons. The three free-centreline sketches now march a **real braid**: on each capsule segment the angle around the local axis is folded by the pipe count (v1/v2's untwist trick applied per capsule), so one circle distance covers the whole bundle — the cost is independent of the pipe count. The braid twists along the body, unwinds into the rounded head over a `braidMerge` length exactly like v2, collapses at the tail tip, and each pipe carries its own hue band (`pipeHueShift`) fading into the merged head. New dragon options everywhere: `pipes`, `pipeRadius`, `braidRadius`, `braidMerge`; `twist`/`spin` now drive geometry; v3 clamps the whole bundle to fit through its holes; the Lipschitz divisor accounts for the twist gradient.

## v4 — mandala kaleidoscope

A kaleidoscope chamber folds space around the z axis: the ONE dragon dancing inside a single angular cell is replicated into a **living rosette of iridescent dragons** in perfect N-fold (optionally mirrored) symmetry, over an analytic stained-glass rose window.

- **The fold** — polar domain folding; near the two cell borders the neighbouring copies are also evaluated, gated by the exact distance-to-border plane, so twins kiss at the seams crack-free at ~one evaluation cost.
- **The dance** — seeded waypoints inside the cell (petalled inner/outer rhythm, depth relief), cyclic 3D Hermite; `pose` locks figures, `flow` rounds the dance into calligraphy.
- **The rose window** — iridescent cells by ring and folded angle, frost, glowing lead lines, a bright hub, and the dragons casting their own light onto the glass.
- **Static cameras by default**: `facade` (distance = 1 always frames the whole window), `oblique`; `drift` is the only moving view. The rosette's own spin snaps to whole turns, 0 by default.

## v5 — maelström vortex

A funnel of light and dragons caught in it: the dragon circling a reference ring is replicated into an **infinite self-similar procession** (rotate + shrink per depth octave) spiralling forever down the throat of the vortex, over a cone wall with glowing spiral arms streaming into an open drain.

- **Perpetual fall, perfect loop** — the ensemble advances by exactly one whole screw step per loop (the infinite-zoom trick); the wall arms are phase-locked to the same screw; per-copy depth effects (fade, hue drift) relabel onto themselves at the seam.
- **Procession march** — a point's depth octave follows from its radius, so only the three nearest copies are tested, each behind a cheap ring-band bound: the infinite procession costs ~one evaluation.
- **Static cameras by default**: `brink` (over the rim), `abyss` (straight down the throat), `drift` as the only moving view.

## Shared

Both reuse the family engine: braided capsule-chain dragon, body-anchored patterns (automatic loop closure), whole-cycle time rates, full iridescent/light option groups, and sounds off by default.

## Verification

- `npm run check` — lint + typecheck clean, 1725 tests pass
- `npm run build` — compiles all sketch routes
- Verified headlessly (Playwright + SwiftShader) after the braid refactor: v3 shows the bundle threading the ice holes and merging into the head; v4's rosette petals are sheaves of distinct hue-shifted pipes; v5's procession spirals into the drain with clearly separated pipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNGz7DMZHZY3PDWGzGxkR5