### PR TITLE
Coalesce useDragSlider updates to one per frame

### DIFF
--- a/src/hooks/__tests__/useDragSlider.test.ts
+++ b/src/hooks/__tests__/useDragSlider.test.ts
@@ -1,0 +1,405 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  act, renderHook
+} from "@testing-library/react";
+import type {
+  PointerEvent as ReactPointerEvent
+} from "react";
+
+import useDragSlider from "../useDragSlider";
+
+// The bar spans x = 0…100, so a clientX maps 1:1 to a percentage of the range.
+const BAR_WIDTH = 100;
+
+type PointerInit = {
+  type?: string;
+  pointerId?: number;
+  pointerType?: string;
+  clientX?: number;
+  clientY?: number;
+};
+
+const pointerEvent = ( init: PointerInit = {} ) =>
+  ( {
+    type: "pointermove",
+    pointerId: 1,
+    pointerType: "mouse",
+    clientX: 0,
+    clientY: 0,
+    ...init
+  } as unknown as ReactPointerEvent<HTMLDivElement> );
+
+const keyEvent = ( key: string ) =>
+  ( {
+    key,
+    preventDefault: jest.fn()
+  } as unknown as React.KeyboardEvent<HTMLDivElement> );
+
+function createBar(): HTMLDivElement {
+  const element = document.createElement( "div" );
+
+  element.getBoundingClientRect = () =>
+    ( {
+      left: 0,
+      top: 0,
+      width: BAR_WIDTH,
+      height: 20
+    } as DOMRect );
+  element.setPointerCapture = jest.fn();
+  element.releasePointerCapture = jest.fn();
+  element.hasPointerCapture = jest.fn( () => true );
+
+  return element;
+}
+
+describe(
+  "useDragSlider",
+  () => {
+    let scheduled: Map<number, FrameRequestCallback>;
+    let nextFrameId: number;
+
+    // Deterministic frames: the hook batches drag updates through rAF, so the
+    // tests decide when a frame runs.
+    const runFrames = () => {
+      const callbacks = [
+        ...scheduled.values()
+      ];
+
+      scheduled.clear();
+
+      act( () => {
+        callbacks.forEach( ( callback ) => callback( 0 ) );
+      } );
+    };
+
+    const setup = ( value = 0 ) => {
+      const onChange = jest.fn();
+      const bar = createBar();
+      const view = renderHook(
+        ( props: { value: number } ) =>
+          useDragSlider( {
+            min: 0,
+            max: 100,
+            step: 1,
+            value: props.value,
+            onChange
+          } ),
+        {
+          initialProps: {
+            value
+          }
+        }
+      );
+
+      view.result.current.ref.current = bar;
+
+      const fire = (
+        handler: "onPointerDown" | "onPointerMove" | "onPointerUp" | "onPointerCancel",
+        init: PointerInit = {}
+      ) => {
+        act( () => {
+          view.result.current.handlers[ handler ]( pointerEvent( {
+            type:
+              handler === "onPointerUp"
+                ? "pointerup"
+                : handler === "onPointerCancel"
+                  ? "pointercancel"
+                  : "pointermove",
+            ...init
+          } ) );
+        } );
+      };
+
+      return {
+        onChange,
+        bar,
+        view,
+        fire
+      };
+    };
+
+    beforeEach( () => {
+      scheduled = new Map();
+      nextFrameId = 1;
+
+      jest
+        .spyOn(
+          window,
+          "requestAnimationFrame"
+        )
+        .mockImplementation( ( callback: FrameRequestCallback ) => {
+          const id = nextFrameId++;
+
+          scheduled.set(
+            id,
+            callback
+          );
+
+          return id;
+        } );
+
+      jest
+        .spyOn(
+          window,
+          "cancelAnimationFrame"
+        )
+        .mockImplementation( ( id: number ) => {
+          scheduled.delete( id );
+        } );
+    } );
+
+    afterEach( () => {
+      jest.restoreAllMocks();
+    } );
+
+    it(
+      "commits the press point immediately for mouse input",
+      () => {
+        const {
+          onChange, fire
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            clientX: 30
+          }
+        );
+
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+        expect( onChange ).toHaveBeenCalledWith( 30 );
+      }
+    );
+
+    it(
+      "coalesces a burst of moves into one change per frame",
+      () => {
+        const {
+          onChange, fire
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            clientX: 10
+          }
+        );
+        onChange.mockClear();
+
+        [
+          20,
+          30,
+          40,
+          50
+        ].forEach( ( clientX ) => fire(
+          "onPointerMove",
+          {
+            clientX
+          }
+        ) );
+
+        // Nothing is emitted from the event handlers themselves.
+        expect( onChange ).not.toHaveBeenCalled();
+
+        runFrames();
+
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+        expect( onChange ).toHaveBeenCalledWith( 50 );
+      }
+    );
+
+    it(
+      "skips moves that land on the value the bar already holds",
+      () => {
+        const {
+          onChange, fire
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            clientX: 30
+          }
+        );
+        onChange.mockClear();
+
+        // Both round to 30 with step 1 — sub-step jitter must not emit.
+        fire(
+          "onPointerMove",
+          {
+            clientX: 30.2
+          }
+        );
+        runFrames();
+        fire(
+          "onPointerMove",
+          {
+            clientX: 29.8
+          }
+        );
+        runFrames();
+
+        expect( onChange ).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      "flushes the trailing move on pointer up when its frame hasn't run",
+      () => {
+        const {
+          onChange, fire
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            clientX: 10
+          }
+        );
+        onChange.mockClear();
+
+        fire(
+          "onPointerMove",
+          {
+            clientX: 80
+          }
+        );
+        fire(
+          "onPointerUp",
+          {
+            clientX: 80
+          }
+        );
+
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+        expect( onChange ).toHaveBeenCalledWith( 80 );
+
+        // The cancelled frame must not replay the same value.
+        runFrames();
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+      }
+    );
+
+    it(
+      "leaves a vertical touch gesture to the scrolling panel",
+      () => {
+        const {
+          onChange, fire, bar
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            pointerType: "touch",
+            clientX: 50,
+            clientY: 50
+          }
+        );
+
+        expect( onChange ).not.toHaveBeenCalled();
+
+        fire(
+          "onPointerMove",
+          {
+            pointerType: "touch",
+            clientX: 51,
+            clientY: 70
+          }
+        );
+        fire(
+          "onPointerMove",
+          {
+            pointerType: "touch",
+            clientX: 52,
+            clientY: 90
+          }
+        );
+        runFrames();
+
+        expect( onChange ).not.toHaveBeenCalled();
+        expect( bar.setPointerCapture ).not.toHaveBeenCalled();
+      }
+    );
+
+    it(
+      "adjusts the value once a touch gesture locks horizontally",
+      () => {
+        const {
+          onChange, fire, bar
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            pointerType: "touch",
+            clientX: 50,
+            clientY: 50
+          }
+        );
+        fire(
+          "onPointerMove",
+          {
+            pointerType: "touch",
+            clientX: 70,
+            clientY: 52
+          }
+        );
+
+        expect( bar.setPointerCapture ).toHaveBeenCalledWith( 1 );
+        expect( onChange ).not.toHaveBeenCalled();
+
+        runFrames();
+
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+        expect( onChange ).toHaveBeenCalledWith( 70 );
+      }
+    );
+
+    it(
+      "sets the value on a touch tap that never picked a direction",
+      () => {
+        const {
+          onChange, fire
+        } = setup();
+
+        fire(
+          "onPointerDown",
+          {
+            pointerType: "touch",
+            clientX: 42,
+            clientY: 50
+          }
+        );
+        fire(
+          "onPointerUp",
+          {
+            pointerType: "touch",
+            clientX: 42,
+            clientY: 50
+          }
+        );
+
+        expect( onChange ).toHaveBeenCalledTimes( 1 );
+        expect( onChange ).toHaveBeenCalledWith( 42 );
+      }
+    );
+
+    it(
+      "keeps keyboard stepping immediate",
+      () => {
+        const {
+          onChange, view
+        } = setup( 10 );
+
+        act( () => {
+          view.result.current.handlers.onKeyDown( keyEvent( "ArrowRight" ) );
+        } );
+
+        expect( onChange ).toHaveBeenCalledWith( 11 );
+      }
+    );
+  }
+);

--- a/src/hooks/useDragSlider.ts
+++ b/src/hooks/useDragSlider.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  useRef, type KeyboardEvent, type PointerEvent
+  useEffect, useRef, type KeyboardEvent, type PointerEvent
 } from "react";
 
 import clamp from "@/utils/clamp";
@@ -28,6 +28,16 @@ const DIRECTION_LOCK_THRESHOLD = 6;
  * scroll with a finger that happens to land on the bar doesn't jump it. The
  * element must carry `touch-action: pan-y` so the browser keeps owning vertical
  * pans. Mouse / pen keep the classic click-anywhere-then-drag behaviour.
+ *
+ * A drag emits at most one `onChange` per animation frame, and never re-emits a
+ * value the bar already holds. Pointer moves arrive far faster than the options
+ * form can consume them — a single change fans out through react-hook-form,
+ * every field watching it, and the sketch bridge — so calling `onChange` from
+ * each move buries the main thread in redundant renders and lets React's
+ * nested-update guard ("Maximum update depth exceeded") trip on a chain of
+ * updates scheduled straight from the event handler. Coalescing keeps the drag
+ * to one update per painted frame; the trailing value is flushed on pointer-up
+ * so the gesture always lands where the finger left it.
  */
 export default function useDragSlider( {
   min,
@@ -43,6 +53,26 @@ export default function useDragSlider( {
     startX: number;
     startY: number;
   } | null>( null );
+
+  // Latest value the gesture produced but hasn't handed to `onChange` yet, and
+  // the frame scheduled to do so.
+  const pending = useRef<number | null>( null );
+  const frame = useRef<number | null>( null );
+  // Last value this gesture emitted — the baseline for skipping no-op changes.
+  // Null between gestures, where the `value` prop is the baseline instead.
+  const emitted = useRef<number | null>( null );
+
+  // A drag can outlive the slider (collapsing the panel mid-gesture), so drop
+  // any frame still owed on unmount.
+  useEffect(
+    () => () => {
+      if ( frame.current !== null ) {
+        cancelAnimationFrame( frame.current );
+        frame.current = null;
+      }
+    },
+    []
+  );
 
   const stepDecimals = ( () => {
     const text = String( step );
@@ -74,7 +104,48 @@ export default function useDragSlider( {
     );
   };
 
+  const commit = ( next: number ) => {
+    if ( next === ( emitted.current ?? value ) ) {
+      return;
+    }
+
+    emitted.current = next;
+    onChange( next );
+  };
+
+  const flushPending = () => {
+    if ( frame.current !== null ) {
+      cancelAnimationFrame( frame.current );
+      frame.current = null;
+    }
+
+    const next = pending.current;
+
+    pending.current = null;
+
+    if ( next !== null ) {
+      commit( next );
+    }
+  };
+
+  // Hold the value until the next frame, so a burst of moves costs one update.
+  const scheduleCommit = ( clientX: number ) => {
+    pending.current = valueFromClientX( clientX );
+
+    if ( frame.current !== null ) {
+      return;
+    }
+
+    frame.current = requestAnimationFrame( () => {
+      frame.current = null;
+      flushPending();
+    } );
+  };
+
   const onPointerDown = ( event: PointerEvent<HTMLDivElement> ) => {
+    emitted.current = null;
+    pending.current = null;
+
     if ( event.pointerType === "touch" ) {
       // Wait for the first move to tell a scroll from an adjust.
       gesture.current = {
@@ -95,7 +166,7 @@ export default function useDragSlider( {
       startY: event.clientY
     };
     ref.current?.setPointerCapture( event.pointerId );
-    onChange( valueFromClientX( event.clientX ) );
+    commit( valueFromClientX( event.clientX ) );
   };
 
   const onPointerMove = ( event: PointerEvent<HTMLDivElement> ) => {
@@ -116,7 +187,7 @@ export default function useDragSlider( {
       if ( dx >= dy ) {
         state.mode = "dragging";
         ref.current?.setPointerCapture( event.pointerId );
-        onChange( valueFromClientX( event.clientX ) );
+        scheduleCommit( event.clientX );
       } else {
         // Vertical intent: hand the gesture back to the page for scrolling.
         state.mode = "scrolling";
@@ -126,7 +197,7 @@ export default function useDragSlider( {
     }
 
     if ( state.mode === "dragging" ) {
-      onChange( valueFromClientX( event.clientX ) );
+      scheduleCommit( event.clientX );
     }
   };
 
@@ -140,8 +211,13 @@ export default function useDragSlider( {
     // A tap (no committed direction) sets the value at the touch point, keeping
     // the familiar tap-to-set affordance — but only on a real pointerup, never
     // on the pointercancel the browser fires when it takes over for scrolling.
-    if ( state.mode === "pending" && event.type === "pointerup" ) {
-      onChange( valueFromClientX( event.clientX ) );
+    if ( state.mode === "pending" ) {
+      if ( event.type === "pointerup" ) {
+        commit( valueFromClientX( event.clientX ) );
+      }
+    } else {
+      // Land the value the last move produced, whether or not its frame ran.
+      flushPending();
     }
 
     if ( ref.current?.hasPointerCapture( event.pointerId ) ) {
@@ -149,6 +225,7 @@ export default function useDragSlider( {
     }
 
     gesture.current = null;
+    emitted.current = null;
   };
 
   const onKeyDown = ( event: KeyboardEvent<HTMLDivElement> ) => {


### PR DESCRIPTION
## What

`useDragSlider` called `onChange` from **every** `pointermove` while dragging, including the many moves that land on the value the bar already holds (a 300 px bar with `step: 1` over a small range maps dozens of pixels to the same value).

Each of those calls fans out: `field.onChange` → react-hook-form update + zod resolver → every `useWatch`/`useController` subscriber in the options tree → the `watch()` subscription in `useFormState` → the sketch options bridge. A drag therefore scheduled update cascades at pointer-event rate, straight from the event handler — which is what React's nested-update guard reports as:

```
Maximum update depth exceeded …
src/hooks/useDragSlider.ts (129:7) @ onPointerMove
```

## Changes (`src/hooks/useDragSlider.ts`)

- **Coalesce**: a drag stores the latest value and hands it to `onChange` on the next animation frame, so a burst of moves costs one update per painted frame instead of one per event. The update is also no longer scheduled from inside the pointer-event dispatch.
- **Dedupe**: a value equal to the one the gesture last emitted is skipped, so sub-step jitter emits nothing at all.
- **Flush on release**: `pointerup`/`pointercancel` cancels the owed frame and commits the trailing value, so the gesture still lands exactly where the pointer left it.
- **Unmount safety**: a frame still owed when the slider unmounts mid-drag (e.g. collapsing the panel) is cancelled.
- Mouse press, touch tap-to-set, the touch direction lock and keyboard stepping still commit immediately — they are one-shot, not a stream.

Public API, the touch/scroll direction lock and the pointer-capture behaviour are unchanged, so both consumers (`SliderInput`, `ControlledColorInput`'s alpha bar) are untouched.

## Tests

New `src/hooks/__tests__/useDragSlider.test.ts` (8 cases) covers: immediate mouse press commit, burst coalescing into a single change per frame, sub-step moves emitting nothing, trailing flush on pointer-up without a replay from the cancelled frame, vertical touch left to the scrolling panel, horizontal touch lock, touch tap-to-set, and keyboard stepping.

## Verification

- `npm run check` (lint + typecheck + 1737 tests) and `npm run build` pass.
- Driven headlessly against the running dev app (`/sketches/p5/noise-grid/noise-grid-v1-basic`): dragging a slider end-to-end still tracks the pointer (`189 → 493` of max `500`; a half-way drag lands on `251`), with no console errors.

## Note on reproduction

I could not reproduce the overlay error itself here: flooding sliders with hundreds of synthetic `pointermove`s across seven sketches (p5 + gsap, desktop and mobile viewports, with `INTERACTION_BINDINGS`/`LIVE_THUMBNAIL`/`PREVIEW_ON_HOVER` on) never tripped the guard, so I could not confirm a specific downstream oscillation. What is measurable is the update storm this removes — each pointer move previously re-rendered the whole options tree — and after the change a drag schedules no state update from inside the event dispatch at all. If the error resurfaces, the stack should now point at the frame callback rather than `onPointerMove`, which would place the loop downstream of this hook (the `watch()` → `SET_OPTIONS` → `setSketchOptions` → `syncLeafValues` round-trip is the path I'd look at next).

---
_Generated by [Claude Code](https://claude.ai/code/session_012ULxPj4okhBf7qG5S7KGMK)_