### PR TITLE
Add photo-swap-collage sketch (Instagram side-by-side swap trend)

### DIFF
--- a/src/generated/sketchModuleRegistry.ts
+++ b/src/generated/sketchModuleRegistry.ts
@@ -176,6 +176,7 @@ export const sketchModuleLoaders: Record<string, SketchModuleLoader> = {
   "p5:photo/photo-segmentation": () => import( "@/p5/sketches/photo/photo-segmentation/index.js" ),
   "p5:photo/photo-stack": () => import( "@/p5/sketches/photo/photo-stack/index.js" ),
   "p5:photo/photo-stack-top-bottom": () => import( "@/p5/sketches/photo/photo-stack-top-bottom/index.js" ),
+  "p5:photo/photo-swap-collage": () => import( "@/p5/sketches/photo/photo-swap-collage/index.js" ),
   "p5:photo/photo-switch": () => import( "@/p5/sketches/photo/photo-switch/index.js" ),
   "p5:photo/photo-switch-blurry-background": () => import( "@/p5/sketches/photo/photo-switch-blurry-background/index.js" ),
   "p5:photo/photo-switch-letter-mask": () => import( "@/p5/sketches/photo/photo-switch-letter-mask/index.js" ),

--- a/src/generated/sketchOptionsRegistry.ts
+++ b/src/generated/sketchOptionsRegistry.ts
@@ -195,6 +195,7 @@ export const sketchFormLoaders: Record<string, SketchModuleLoader> = {
   "p5:photo/photo-segmentation": () => import( "@/p5/sketches/photo/photo-segmentation/options" ),
   "p5:photo/photo-stack": () => import( "@/p5/sketches/photo/photo-stack/options" ),
   "p5:photo/photo-stack-top-bottom": () => import( "@/p5/sketches/photo/photo-stack-top-bottom/options" ),
+  "p5:photo/photo-swap-collage": () => import( "@/p5/sketches/photo/photo-swap-collage/options" ),
   "p5:photo/photo-switch": () => import( "@/p5/sketches/photo/photo-switch/options" ),
   "p5:photo/photo-switch-blurry-background": () => import( "@/p5/sketches/photo/photo-switch-blurry-background/options" ),
   "p5:photo/photo-switch-letter-mask": () => import( "@/p5/sketches/photo/photo-switch-letter-mask/options" ),

--- a/src/sketches/metadata.json
+++ b/src/sketches/metadata.json
@@ -3694,5 +3694,17 @@
     "hiddenFromGallery": false,
     "mtime": "2026-07-31T20:43:21.901Z",
     "ctime": "2026-07-31T12:57:43.303Z"
+  },
+  {
+    "name": "photo-swap-collage",
+    "engine": "p5",
+    "category": "photo",
+    "hasSketchForm": true,
+    "hasThumbnail": false,
+    "hasPreview": false,
+    "hiddenFromHome": false,
+    "hiddenFromGallery": false,
+    "mtime": "2026-08-01T17:21:48.453Z",
+    "ctime": "2026-08-01T17:21:43.133Z"
   }
 ]

--- a/src/sketches/p5/sketches/photo/photo-swap-collage/index.js
+++ b/src/sketches/p5/sketches/photo/photo-swap-collage/index.js
@@ -1,0 +1,124 @@
+import options from "@/p5/utils/options.js";
+
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
+import mappers from "@/p5/utils/mappers.js";
+import animation from "@/p5/utils/animation.js";
+import imageUtils from "@/p5/utils/imageUtils.js";
+
+// object-fit: cover via the 9-arg p5 image() — the crop happens at the
+// source rect, so a zoomed background never bleeds outside its half
+function drawImageCover( {
+  img,
+  x,
+  y,
+  width,
+  height,
+  zoom = 1
+} ) {
+  const p = getP5();
+
+  const coverScale = Math.max(
+    width / img.width,
+    height / img.height
+  ) * zoom;
+  const sourceWidth = width / coverScale;
+  const sourceHeight = height / coverScale;
+  const sourceX = ( img.width - sourceWidth ) / 2;
+  const sourceY = ( img.height - sourceHeight ) / 2;
+
+  p.image(
+    img,
+    x,
+    y,
+    width,
+    height,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight
+  );
+}
+
+sketch.setup( () => {
+  const p = getP5();
+
+  p.background( ...options.sketch.backgroundColor );
+} );
+
+sketch.draw( () => {
+  const p = getP5();
+  const o = options.sketch;
+
+  p.clear();
+  p.background( ...o.backgroundColor );
+
+  const images = imageUtils.getImages();
+
+  if ( images.length < 2 ) {
+    return;
+  }
+
+  const pairPosition = animation.progression * images.length;
+  const pairIndex = Math.floor( pairPosition );
+  const pairProgression = pairPosition - pairIndex;
+
+  const leftImage = mappers.circularIndex(
+    pairIndex,
+    images
+  )?.img;
+  const rightImage = mappers.circularIndex(
+    pairIndex + 1,
+    images
+  )?.img;
+
+  if ( !leftImage || !rightImage ) {
+    return;
+  }
+
+  const halfWidth = p.width / 2;
+  const backgroundZoom = o.background.zoom * ( 1 + o.background.zoomAmplitude * pairProgression );
+
+  // swapped backgrounds: each half shows the *opposite* photo, zoomed in
+  drawImageCover( {
+    img: rightImage,
+    x: 0,
+    y: 0,
+    width: halfWidth,
+    height: p.height,
+    zoom: backgroundZoom
+  } );
+
+  drawImageCover( {
+    img: leftImage,
+    x: halfWidth,
+    y: 0,
+    width: halfWidth,
+    height: p.height,
+    zoom: backgroundZoom
+  } );
+
+  // centered collage window, straddling the seam, showing the photos unswapped
+  const innerWidth = o.inner.width * p.width;
+  const innerHalfWidth = innerWidth / 2;
+  const innerHeight = innerHalfWidth * o.inner.aspect;
+  const innerX = ( p.width - innerWidth ) / 2;
+  const innerY = ( p.height - innerHeight ) / 2 + o.inner.verticalOffset * p.height;
+
+  drawImageCover( {
+    img: leftImage,
+    x: innerX,
+    y: innerY,
+    width: innerHalfWidth,
+    height: innerHeight
+  } );
+
+  drawImageCover( {
+    img: rightImage,
+    x: innerX + innerHalfWidth,
+    y: innerY,
+    width: innerHalfWidth,
+    height: innerHeight
+  } );
+} );

--- a/src/sketches/p5/sketches/photo/photo-swap-collage/options.ts
+++ b/src/sketches/p5/sketches/photo/photo-swap-collage/options.ts
@@ -1,0 +1,89 @@
+import getTestImagePaths from "@/utils/getTestImagePaths";
+
+// Default values only
+export const formValues = {
+  // Assets
+  images: await getTestImagePaths(),
+
+  background: {
+    zoom: 1.8,
+    zoomAmplitude: 0.08
+  },
+
+  inner: {
+    width: 0.68,
+    aspect: 1.3,
+    verticalOffset: 0
+  },
+
+  // Colors
+  backgroundColor: [
+    246,
+    235,
+    225
+  ]
+};
+
+// UI configuration only
+export const formConfiguration: Record<string, any> = {
+  // Assets
+  images: {
+    component: "images-stack",
+    label: "Images"
+  },
+
+  background: {
+    component: "nested-object",
+    label: "Background halves",
+    fields: {
+      zoom: {
+        label: "Zoom",
+        component: "slider",
+        min: 1,
+        max: 4,
+        step: 0.05
+      },
+      zoomAmplitude: {
+        label: "Zoom animation amplitude",
+        component: "slider",
+        min: 0,
+        max: 0.5,
+        step: 0.01
+      }
+    }
+  },
+
+  inner: {
+    component: "nested-object",
+    label: "Inner collage",
+    fields: {
+      width: {
+        label: "Width",
+        component: "slider",
+        min: 0.2,
+        max: 0.95,
+        step: 0.01
+      },
+      aspect: {
+        label: "Aspect ratio",
+        component: "slider",
+        min: 0.5,
+        max: 2,
+        step: 0.05
+      },
+      verticalOffset: {
+        label: "Vertical offset",
+        component: "slider",
+        min: -0.4,
+        max: 0.4,
+        step: 0.01
+      }
+    }
+  },
+
+  // Colors
+  backgroundColor: {
+    component: "color",
+    label: "Background color"
+  }
+};


### PR DESCRIPTION
## Summary

New p5 template `photo/photo-swap-collage` reproducing the Instagram photo trend where two photos sit side by side with a centered "swap zone":

- The canvas is split vertically in two halves; each half's **background** shows the *opposite* photo, cover-cropped and zoomed in.
- A centered collage window straddles the seam and shows both photos **unswapped** (left photo on the left, right photo on the right), producing the swapped-square effect.
- The sketch cycles through consecutive image pairs over the loop, with a subtle Ken Burns-style zoom on the backgrounds.

## Details

- `index.js` uses a small `drawImageCover` helper built on the 9-arg `p.image()` (source-rect crop), so zoomed backgrounds are cropped at the source and never bleed across the seam — no clip layers needed.
- `options.ts` exposes: images (`images-stack`), background zoom + zoom animation amplitude, inner window width / aspect ratio / vertical offset, and background color.
- Metadata + registries regenerated via `npm run sketch:meta:write`.

## Testing

- `npm run check` — lint (0 errors), typecheck, 1770 tests pass.
- `npm run build` + headless Playwright canvas capture of `/sketches/p5/photo/photo-swap-collage` to verify the rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p4FH9JSmb6xoV9mbi74Nw

---
_Generated by [Claude Code](https://claude.ai/code/session_014p4FH9JSmb6xoV9mbi74Nw)_