### PR TITLE
photo-swap-collage: Instagram swap trend template with configurable swap zone

### DIFF
--- a/src/sketches/p5/sketches/photo/photo-swap-collage/index.js
+++ b/src/sketches/p5/sketches/photo/photo-swap-collage/index.js
@@ -1,11 +1,31 @@
 import options from "@/p5/utils/options.js";
+import {
+  setSketchOptions
+} from "@/p5/shared/syncSketchOptions.js";
 
 import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
+import events from "@/p5/utils/events.js";
 import mappers from "@/p5/utils/mappers.js";
 import animation from "@/p5/utils/animation.js";
 import imageUtils from "@/p5/utils/imageUtils.js";
+
+// seam-hugging default swap-zone position per collage direction
+const SEAM_DEFAULTS = {
+  horizontal: {
+    x: 1,
+    y: 0.5
+  },
+  vertical: {
+    x: 0.5,
+    y: 1
+  }
+};
+
+const sketchState = {
+  lastDirection: null
+};
 
 // object-fit: cover via the 9-arg p5 image() — the crop happens at the
 // source rect, so a zoomed background never bleeds outside its half
@@ -41,10 +61,203 @@ function drawImageCover( {
   );
 }
 
+function getDirection() {
+  return options.sketch.layout?.direction === "vertical" ? "vertical" : "horizontal";
+}
+
+function getHalves( direction ) {
+  const p = getP5();
+
+  if ( direction === "vertical" ) {
+    const halfHeight = p.height / 2;
+
+    return [
+      {
+        x: 0,
+        y: 0,
+        width: p.width,
+        height: halfHeight
+      },
+      {
+        x: 0,
+        y: halfHeight,
+        width: p.width,
+        height: halfHeight
+      }
+    ];
+  }
+
+  const halfWidth = p.width / 2;
+
+  return [
+    {
+      x: 0,
+      y: 0,
+      width: halfWidth,
+      height: p.height
+    },
+    {
+      x: halfWidth,
+      y: 0,
+      width: halfWidth,
+      height: p.height
+    }
+  ];
+}
+
+// axis-wise involution: applying it twice gives the identity, so the same
+// function maps first-half -> second-half positions and back
+function mirrorPosition( position ) {
+  const {
+    horizontalMirror = true,
+    verticalMirror = true
+  } = options.sketch.swapZone ?? {};
+
+  return {
+    x: horizontalMirror ? 1 - position.x : position.x,
+    y: verticalMirror ? 1 - position.y : position.y
+  };
+}
+
+function clampCenter(
+  value, min, max
+) {
+  if ( min > max ) {
+    return ( min + max ) / 2;
+  }
+
+  return Math.min(
+    Math.max(
+      value,
+      min
+    ),
+    max
+  );
+}
+
+// resolve the swap rect (top-left based) for one half, keeping it fully inside
+function placeSwapRect(
+  half, position, rectWidth, rectHeight
+) {
+  const centerX = clampCenter(
+    half.x + position.x * half.width,
+    half.x + rectWidth / 2,
+    half.x + half.width - rectWidth / 2
+  );
+  const centerY = clampCenter(
+    half.y + position.y * half.height,
+    half.y + rectHeight / 2,
+    half.y + half.height - rectHeight / 2
+  );
+
+  return {
+    x: centerX - rectWidth / 2,
+    y: centerY - rectHeight / 2,
+    width: rectWidth,
+    height: rectHeight
+  };
+}
+
+function getInternalCanvasPoint( event ) {
+  const p = getP5();
+  const canvasElement = sketch.engine?.getCanvasElement?.();
+
+  if ( !canvasElement ) {
+    return null;
+  }
+
+  // getBoundingClientRect accounts for the editor's CSS scaling/transforms
+  const rect = canvasElement.getBoundingClientRect();
+
+  const clientX = event.touches?.[ 0 ]?.clientX ?? event.changedTouches?.[ 0 ]?.clientX ?? event.clientX;
+  const clientY = event.touches?.[ 0 ]?.clientY ?? event.changedTouches?.[ 0 ]?.clientY ?? event.clientY;
+
+  if ( typeof clientX !== "number" || typeof clientY !== "number" ) {
+    return null;
+  }
+
+  return {
+    x: ( clientX - rect.left ) / rect.width * p.width,
+    y: ( clientY - rect.top ) / rect.height * p.height
+  };
+}
+
+function handleCanvasClick( event ) {
+  const p = getP5();
+  const point = getInternalCanvasPoint( event );
+
+  if ( !point || point.x < 0 || point.x > p.width || point.y < 0 || point.y > p.height ) {
+    return;
+  }
+
+  const direction = getDirection();
+  const [
+    halfA,
+    halfB
+  ] = getHalves( direction );
+  const clickedSecondHalf = direction === "vertical" ? point.y >= halfB.y : point.x >= halfB.x;
+  const half = clickedSecondHalf ? halfB : halfA;
+
+  let position = {
+    x: ( point.x - half.x ) / half.width,
+    y: ( point.y - half.y ) / half.height
+  };
+
+  if ( clickedSecondHalf ) {
+    // inverse-mirror back onto the first half, so the zone lands where you click
+    position = mirrorPosition( position );
+  }
+
+  setSketchOptions(
+    {
+      sketch: {
+        swapZone: {
+          position
+        }
+      }
+    },
+    "p5"
+  );
+}
+
+// when the direction flips and the position is still the previous direction's
+// untouched seam default, follow the new seam; custom positions are kept
+function syncSeamDefaultOnDirectionChange( direction ) {
+  if ( sketchState.lastDirection === null || sketchState.lastDirection === direction ) {
+    sketchState.lastDirection = direction;
+    return;
+  }
+
+  const previousDefault = SEAM_DEFAULTS[ sketchState.lastDirection ];
+  const position = options.sketch.swapZone?.position;
+
+  if ( position?.x === previousDefault.x && position?.y === previousDefault.y ) {
+    setSketchOptions(
+      {
+        sketch: {
+          swapZone: {
+            position: {
+              ...SEAM_DEFAULTS[ direction ]
+            }
+          }
+        }
+      },
+      "p5"
+    );
+  }
+
+  sketchState.lastDirection = direction;
+}
+
 sketch.setup( () => {
   const p = getP5();
 
   p.background( ...options.sketch.backgroundColor );
+
+  events.register(
+    "engine-canvas-mouse-clicked",
+    handleCanvasClick
+  );
 } );
 
 sketch.draw( () => {
@@ -53,6 +266,10 @@ sketch.draw( () => {
 
   p.clear();
   p.background( ...o.backgroundColor );
+
+  const direction = getDirection();
+
+  syncSeamDefaultOnDirectionChange( direction );
 
   const images = imageUtils.getImages();
 
@@ -64,61 +281,61 @@ sketch.draw( () => {
   const pairIndex = Math.floor( pairPosition );
   const pairProgression = pairPosition - pairIndex;
 
-  const leftImage = mappers.circularIndex(
+  const firstImage = mappers.circularIndex(
     pairIndex,
     images
   )?.img;
-  const rightImage = mappers.circularIndex(
+  const secondImage = mappers.circularIndex(
     pairIndex + 1,
     images
   )?.img;
 
-  if ( !leftImage || !rightImage ) {
+  if ( !firstImage || !secondImage ) {
     return;
   }
 
-  const halfWidth = p.width / 2;
+  const [
+    halfA,
+    halfB
+  ] = getHalves( direction );
   const backgroundZoom = o.background.zoom * ( 1 + o.background.zoomAmplitude * pairProgression );
 
   // swapped backgrounds: each half shows the *opposite* photo, zoomed in
   drawImageCover( {
-    img: rightImage,
-    x: 0,
-    y: 0,
-    width: halfWidth,
-    height: p.height,
+    img: secondImage,
+    ...halfA,
     zoom: backgroundZoom
   } );
 
   drawImageCover( {
-    img: leftImage,
-    x: halfWidth,
-    y: 0,
-    width: halfWidth,
-    height: p.height,
+    img: firstImage,
+    ...halfB,
     zoom: backgroundZoom
   } );
 
-  // centered collage window, straddling the seam, showing the photos unswapped
-  const innerWidth = o.inner.width * p.width;
-  const innerHalfWidth = innerWidth / 2;
-  const innerHeight = innerHalfWidth * o.inner.aspect;
-  const innerX = ( p.width - innerWidth ) / 2;
-  const innerY = ( p.height - innerHeight ) / 2 + o.inner.verticalOffset * p.height;
+  // swap zone: one rect per half, showing that half's own photo unswapped
+  const rectWidth = o.swapZone.width * p.width;
+  const rectHeight = o.swapZone.height * p.height;
+  const positionA = o.swapZone.position ?? SEAM_DEFAULTS[ direction ];
+  const positionB = mirrorPosition( positionA );
 
   drawImageCover( {
-    img: leftImage,
-    x: innerX,
-    y: innerY,
-    width: innerHalfWidth,
-    height: innerHeight
+    img: firstImage,
+    ...placeSwapRect(
+      halfA,
+      positionA,
+      rectWidth,
+      rectHeight
+    )
   } );
 
   drawImageCover( {
-    img: rightImage,
-    x: innerX + innerHalfWidth,
-    y: innerY,
-    width: innerHalfWidth,
-    height: innerHeight
+    img: secondImage,
+    ...placeSwapRect(
+      halfB,
+      positionB,
+      rectWidth,
+      rectHeight
+    )
   } );
 } );

--- a/src/sketches/p5/sketches/photo/photo-swap-collage/options.ts
+++ b/src/sketches/p5/sketches/photo/photo-swap-collage/options.ts
@@ -5,15 +5,24 @@ export const formValues = {
   // Assets
   images: await getTestImagePaths(),
 
+  layout: {
+    direction: "horizontal"
+  },
+
   background: {
     zoom: 1.8,
     zoomAmplitude: 0.08
   },
 
-  inner: {
-    width: 0.68,
-    aspect: 1.3,
-    verticalOffset: 0
+  swapZone: {
+    width: 0.34,
+    height: 0.35,
+    position: {
+      x: 1,
+      y: 0.5
+    },
+    horizontalMirror: true,
+    verticalMirror: true
   },
 
   // Colors
@@ -30,6 +39,27 @@ export const formConfiguration: Record<string, any> = {
   images: {
     component: "images-stack",
     label: "Images"
+  },
+
+  layout: {
+    component: "nested-object",
+    label: "Layout",
+    fields: {
+      direction: {
+        component: "select",
+        label: "Collage direction",
+        options: [
+          {
+            label: "Horizontal (side by side)",
+            value: "horizontal"
+          },
+          {
+            label: "Vertical (stacked)",
+            value: "vertical"
+          }
+        ]
+      }
+    }
   },
 
   background: {
@@ -53,30 +83,40 @@ export const formConfiguration: Record<string, any> = {
     }
   },
 
-  inner: {
+  swapZone: {
     component: "nested-object",
-    label: "Inner collage",
+    label: "Swap zone",
     fields: {
       width: {
         label: "Width",
         component: "slider",
-        min: 0.2,
+        min: 0.05,
         max: 0.95,
         step: 0.01
       },
-      aspect: {
-        label: "Aspect ratio",
+      height: {
+        label: "Height",
         component: "slider",
-        min: 0.5,
-        max: 2,
-        step: 0.05
-      },
-      verticalOffset: {
-        label: "Vertical offset",
-        component: "slider",
-        min: -0.4,
-        max: 0.4,
+        min: 0.05,
+        max: 0.95,
         step: 0.01
+      },
+      position: {
+        component: "vector2d",
+        label: "Position (click the canvas)",
+        allowNegative: false,
+        min: 0,
+        max: 1,
+        step: 0.01,
+        yDown: true
+      },
+      horizontalMirror: {
+        label: "Horizontal mirror",
+        component: "checkbox"
+      },
+      verticalMirror: {
+        label: "Vertical mirror",
+        component: "checkbox"
       }
     }
   },


### PR DESCRIPTION
Adds the `photo/photo-swap-collage` p5 template reproducing the Instagram "swap collage" trend: two photos shown as zoomed backgrounds on opposite halves, with a swap window straddling the seam showing each photo unswapped.

(Replaces closed PR #289 — same branch, now with the configurable swap-zone options on top.)

## Features

- **Collage direction**: horizontal (side by side) or vertical (stacked) via `layout.direction`.
- **Swap-zone size**: `swapZone.width` / `swapZone.height` sliders (fractions of the canvas), one rectangle per half.
- **Click-to-position**: clicking the canvas moves the swap zone. The position is stored in options (`vector2d` field) through `setSketchOptions(..., "p5")` — same pattern as `photo-zoom-point` — so the form stays in sync and recordings reproduce it. Clicking the second half inverse-mirrors the point so the zone lands where you click on either half.
- **Mirror strategy**: `horizontalMirror` / `verticalMirror` booleans (both on by default) derive the second half's rectangle from the first half's position (e.g. click top-right → other side bottom-left).
- **Seam-hugging defaults**: right-middle of the first image in horizontal, bottom-middle in vertical; switching direction updates an untouched default automatically, custom positions are preserved.
- Pair cycling over the loop with a subtle Ken Burns zoom on the backgrounds; cover-cropping done with the 9-arg `p.image()` source rect so zoomed halves never bleed across the seam.

## Verification

- `npm run check` (lint, typecheck, 1770 Jest tests) and `npm run build` pass.
- Headless Playwright verification of the rendered canvas: default horizontal look, vertical layout, canvas clicks on both halves (with mirror inversion) and option writes into the store.
- `metadata.json` / generated registries regenerated via `npm run sketch:meta:write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p4FH9JSmb6xoV9mbi74Nw

---
_Generated by [Claude Code](https://claude.ai/code/session_014p4FH9JSmb6xoV9mbi74Nw)_