### PR TITLE
rings v7/v8: seamless colour loop and reliable point carries

### DIFF
--- a/src/sketches/p5/sketches/rings/rings-v7-hyper-interactive/index.js
+++ b/src/sketches/p5/sketches/rings/rings-v7-hyper-interactive/index.js
@@ -1230,6 +1230,33 @@ sketch.draw( () => {
     targets[ index ].depth = projected.depth;
   };
 
+  // A troupe grab must never miss its handle: on a frame that lands mid-drag
+  // the cursor can already be outside the pick-up radius, and a proximity
+  // pick would leave the handle behind. The troupe knows which handle each
+  // dragging cursor holds, so bind the drag explicitly; a handle already held
+  // by another pointer (mouse, touch, pinch) is left alone.
+  const heldHandles = new Set( draggable.drags.values() );
+
+  virtualPointers.forEach( ( pointer ) => {
+    if ( !pointer.pressed || pointer.targetIndex === undefined ) {
+      return;
+    }
+
+    if (
+      draggable.drags.get( pointer.key ) === pointer.targetIndex
+        || heldHandles.has( pointer.targetIndex )
+        || pointer.targetIndex >= targets.length
+    ) {
+      return;
+    }
+
+    draggable.drags.set(
+      pointer.key,
+      pointer.targetIndex
+    );
+    heldHandles.add( pointer.targetIndex );
+  } );
+
   // Who is holding what before this frame's update — the released-key diff
   // below tells human releases (persist) apart from virtual ones (ephemeral).
   const heldBefore = [

--- a/src/sketches/p5/sketches/rings/rings-v7-hyper-interactive/virtualPointers.js
+++ b/src/sketches/p5/sketches/rings/rings-v7-hyper-interactive/virtualPointers.js
@@ -685,11 +685,15 @@ export function createPointerTroupe() {
           return;
         }
 
+        // targetIndex names the handle a dragging cursor is holding, so the
+        // sketch can bind the drag explicitly instead of relying on the
+        // proximity pick (which can miss when a frame lands mid-drag).
         pointers.push( {
           key: `${ VIRTUAL_POINTER_PREFIX }${ cursor.index }`,
           x: cursor.pos.x,
           y: cursor.pos.y,
           pressed: cursor.phase === "drag",
+          targetIndex: cursor.phase === "drag" ? cursor.queue[ cursor.qi ] : undefined,
           kind: "virtual"
         } );
       } );

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
@@ -3,6 +3,7 @@ import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
 import animation from "@/p5/utils/animation.js";
+import easing from "@/p5/utils/easing.js";
 import createNoiseFieldRenderer from "@/p5/utils/noiseFieldGpu.js";
 import string from "@/p5/utils/string.js";
 import {
@@ -1175,7 +1176,15 @@ sketch.draw( () => {
       margin
     );
 
-    distanceOverride = fitSrc + ( fitDst - fitSrc ) * morphU;
+    // The zoom rides an easing curve instead of the raw morph progress, so it
+    // coasts into each word's framing with a decelerating tail (pick a Back
+    // ease for a touch of overshoot) rather than stopping dead at the beat
+    // boundary. Every curve lands on exactly 0/1 at the ends, so the hold
+    // windows and the loop wrap stay seamless.
+    const fitEaseKey = autoFit.easing ?? "easeInOutCubic";
+    const fitEase = typeof easing[ fitEaseKey ] === "function" ? easing[ fitEaseKey ] : ( x ) => x;
+
+    distanceOverride = fitSrc + ( fitDst - fitSrc ) * fitEase( morphU );
   }
 
   const progress = t / T;

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
@@ -77,7 +77,11 @@ import {
 // ── Loop safety ──────────────────────────────────────────────────────────────
 // The schedule lives on the loop clock: frame 0 is word[0] fully formed with
 // every cursor gone, and the final beat reserves time for the exodus — so
-// uT = TAU meets uT = 0 exactly, live and in deterministic capture.
+// uT = TAU meets uT = 0 exactly, live and in deterministic capture. Colours
+// close too: each capsule's hue identity eases from its current word's arc id
+// to the id it will carry after the beat snap (rings-v4's continuous uPipeId,
+// per point), so no boundary — including the wrap back to word[0] — recolours
+// the word abruptly.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const MAX_POINTS = 128; // pool slots = capsules (uniform array size)
@@ -458,7 +462,11 @@ function getTransition(
 // beat's word — every time the step or the cycle signature changes.
 const state = {
   poolKey: null,
-  slots: []
+  slots: [],
+  // Per-slot hue identity AFTER the snap to the next word (null = the point
+  // does not survive the conversion). Uploaded ids ease toward these over the
+  // morph window so the snap never recolours a capsule — see "Loop safety".
+  dstIds: []
 };
 
 const draggable = createDraggable();
@@ -466,7 +474,7 @@ const pinch = createPinchTracker();
 const troupe = createMorphTroupe();
 
 function rebuildPool(
-  src, transition
+  src, dst, transition
 ) {
   const slots = src.points.map( (
     pt, i
@@ -478,22 +486,31 @@ function rebuildPool(
     next: src.next[ i ],
     id: src.ids[ i ]
   } ) );
+  const dstIds = slots.map( () => null );
+
+  transition.moves.forEach( ( move ) => {
+    dstIds[ move.from ] = dst.ids[ move.to ];
+  } );
 
   transition.adds.slice(
     0,
     MAX_POINTS - slots.length
   ).forEach( ( dstIndex ) => {
+    // A carried-in bead wears its destination arc id from the start, so the
+    // splice at the beat boundary keeps its colour.
     slots.push( {
       x: 0,
       y: 0,
       z: 0,
       active: false,
       next: -1,
-      id: dstIndex / MAX_WORD_POINTS
+      id: dst.ids[ dstIndex ]
     } );
+    dstIds.push( dst.ids[ dstIndex ] );
   } );
 
   state.slots = slots;
+  state.dstIds = dstIds;
 }
 
 // SHIFT state for the mouse depth gesture, tracked at module scope: p5's own
@@ -1018,6 +1035,7 @@ const segB = new Float32Array( MAX_POINTS * 4 );
 sketch.setup( async() => {
   state.poolKey = null;
   state.slots = [];
+  state.dstIds = [];
   dragCursor.clear();
   depthActive.clear();
 
@@ -1104,6 +1122,7 @@ sketch.draw( () => {
     state.poolKey = poolKey;
     rebuildPool(
       src,
+      dst,
       transition
     );
   }
@@ -1115,6 +1134,18 @@ sketch.draw( () => {
   const tubeR = Math.max(
     material.thickness ?? 0.05,
     0.005
+  );
+
+  // Progress through this beat's conversion window (0 through the hold, then
+  // 0 → 1 across the morph) — drives the camera auto-fit ease and the hue
+  // identity blend toward the next word.
+  const morphU = clamp(
+    ( t - stepIndex * stepDur - holdDur ) / Math.max(
+      stepDur - holdDur,
+      1e-4
+    ),
+    0,
+    1
   );
 
   // ── Camera: auto-fit distance eases from this word to the next ─────────────
@@ -1142,14 +1173,6 @@ sketch.draw( () => {
       tubeR,
       aspect,
       margin
-    );
-    const morphU = clamp(
-      ( t - stepIndex * stepDur - holdDur ) / Math.max(
-        stepDur - holdDur,
-        1e-4
-      ),
-      0,
-      1
     );
 
     distanceOverride = fitSrc + ( fitDst - fitSrc ) * morphU;
@@ -1306,6 +1329,36 @@ sketch.draw( () => {
     ].join( "|" )
   } );
 
+  // A troupe grab must never miss its point. When a task slice is compressed
+  // (long words, many tasks, the exodus-shortened final beat) the cursor's
+  // first pressed frame can already sit outside the pick-up radius, and a
+  // proximity pick would leave the point behind — it would then pop into
+  // place at the beat snap instead of being carried in like the others. The
+  // schedule knows exactly which slot each cursor holds, so bind the drag
+  // explicitly; a slot already held by another pointer (mouse, touch, pinch)
+  // is left alone.
+  const heldSlots = new Set( draggable.drags.values() );
+
+  virtualPointers.forEach( ( pointer ) => {
+    if ( !pointer.pressed || pointer.targetIndex === undefined ) {
+      return;
+    }
+
+    if (
+      draggable.drags.get( pointer.key ) === pointer.targetIndex
+        || heldSlots.has( pointer.targetIndex )
+        || !state.slots[ pointer.targetIndex ]?.active
+    ) {
+      return;
+    }
+
+    draggable.drags.set(
+      pointer.key,
+      pointer.targetIndex
+    );
+    heldSlots.add( pointer.targetIndex );
+  } );
+
   const {
     hovers,
     grabbed
@@ -1406,7 +1459,9 @@ sketch.draw( () => {
   let written = 0;
   let radius = 0;
 
-  state.slots.forEach( ( slot ) => {
+  state.slots.forEach( (
+    slot, index
+  ) => {
     if ( !slot.active || written >= MAX_POINTS ) {
       return;
     }
@@ -1423,12 +1478,19 @@ sketch.draw( () => {
       )
     );
 
+    // Ease the hue identity toward what the snap will assign, so the beat
+    // boundary (and the loop wrap) never recolours the finished word.
+    const dstId = state.dstIds[ index ] ?? null;
+    const hueId = dstId === null
+      ? slot.id
+      : slot.id + ( dstId - slot.id ) * morphU;
+
     const w = written * 4;
 
     segA[ w ] = slot.x;
     segA[ w + 1 ] = slot.y;
     segA[ w + 2 ] = slot.z;
-    segA[ w + 3 ] = slot.id;
+    segA[ w + 3 ] = hueId;
     segB[ w ] = other.x;
     segB[ w + 1 ] = other.y;
     segB[ w + 2 ] = other.z;

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/options.ts
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/options.ts
@@ -121,8 +121,13 @@ export const formValues = {
         fade: 0.35
       },
       // Cursors caught between jobs (a hold beat, or waiting for their next
-      // window) show the spinning beach ball instead of the plain pointer.
+      // window): where they wait is the mode — "stay" on the finished point,
+      // "aside" at a random spot along the canvas border (still visible, the
+      // finished text breathes), or "exit" off-canvas entirely (they fade out
+      // and re-enter like the entrance/exodus). The beach ball spins wherever
+      // they wait visibly.
       idle: {
+        mode: "aside",
         beachball: true,
         spinSpeed: 1.95
       }
@@ -144,10 +149,13 @@ export const formValues = {
     fov: 30,
     distance: 11.8,
     // Auto-fit eases the distance from each text's fitted framing to the
-    // next's during the conversion — words and letters mix freely.
+    // next's during the conversion — words and letters mix freely. The zoom
+    // rides the easing curve, so it coasts into each framing instead of
+    // stopping dead (a Back ease adds a touch of overshoot).
     autoFit: {
       enabled: true,
-      margin: 0.15
+      margin: 0.15,
+      easing: "easeInOutCubic"
     },
     phase: 0.3,
     elevation: 0.2,
@@ -486,6 +494,24 @@ export const formConfiguration: Record<string, any> = {
             component: "nested-object",
             label: "Waiting",
             fields: {
+              mode: {
+                label: "Between jobs",
+                component: "select",
+                options: [
+                  {
+                    value: "stay",
+                    label: "Stay on the finished point"
+                  },
+                  {
+                    value: "aside",
+                    label: "Step aside to the canvas edge"
+                  },
+                  {
+                    value: "exit",
+                    label: "Leave the canvas, re-enter for the next job"
+                  }
+                ]
+              },
               beachball: {
                 label: "Spin the waiting icon between jobs",
                 component: "checkbox"
@@ -582,6 +608,10 @@ export const formConfiguration: Record<string, any> = {
             min: 0,
             max: 1.5,
             step: 0.05
+          },
+          easing: {
+            label: "Zoom easing (how the framing settles)",
+            component: "easing"
           }
         }
       },

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
@@ -701,7 +701,8 @@ export function createMorphTroupe() {
             ),
             icon: GRABBING,
             alpha,
-            pressed: true
+            pressed: true,
+            targetIndex: active.poolIndex
           };
         }
 
@@ -727,7 +728,8 @@ export function createMorphTroupe() {
           ),
           icon: v < 0.35 ? GRABBING : REMOVE,
           alpha,
-          pressed: true
+          pressed: true,
+          targetIndex: active.poolIndex
         };
       }
 
@@ -814,7 +816,8 @@ export function createMorphTroupe() {
         ),
         icon: ADD,
         alpha,
-        pressed: true
+        pressed: true,
+        targetIndex: active.poolIndex
       };
     }
 
@@ -888,11 +891,15 @@ export function createMorphTroupe() {
         );
 
         if ( resolved ) {
+          // targetIndex names the pool slot a pressed cursor is carrying, so
+          // the sketch can bind the drag explicitly instead of relying on the
+          // proximity pick (which can miss when a task slice is compressed).
           pointers.push( {
             key: `${ VIRTUAL_POINTER_PREFIX }${ cursor.index }`,
             x: resolved.pos.x,
             y: resolved.pos.y,
             pressed: resolved.pressed,
+            targetIndex: resolved.targetIndex,
             kind: "virtual"
           } );
         }

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
@@ -1,5 +1,8 @@
 import cache from "@/p5/utils/cache.js";
 import easing from "@/p5/utils/easing.js";
+import {
+  hashedRandom
+} from "@/p5/utils/letterPaths.js";
 
 // ── Virtual pointers v8: the word-morphing troupe ───────────────────────────
 // v7's crowd sculpted one letter at random. Here the cursors are the STAGE
@@ -9,8 +12,12 @@ import easing from "@/p5/utils/easing.js";
 // from outside the canvas when the next word needs more (add-pointer icon),
 // and CARRYING OFF points the next word doesn't need (the cursor grabs one,
 // retreats, and its icon flips to the remove-pointer as it leaves). Between
-// two conversions the finished word holds legible, and any cursor still on
-// stage waits — optionally as a spinning beach ball.
+// two conversions the finished word holds legible, and where a cursor waits
+// out the gap is the `idle.mode` option: "stay" parks it on the point it just
+// finished (optionally spinning as a beach ball), "aside" walks it to a
+// hashed spot along the canvas border so the word breathes with the troupe
+// still on stage, and "exit" sends it off-canvas entirely — it fades out like
+// the exodus and re-enters for its next task.
 //
 // ── Scheduling (why every loop is the same show) ──
 // The whole cycle is laid out ON the loop clock: with W words the loop is cut
@@ -82,6 +89,10 @@ const DEFAULTS = {
     fade: 0.35
   },
   idle: {
+    // Where a cursor waits between jobs: "stay" (on the point it finished),
+    // "aside" (a hashed spot along the canvas border), or "exit" (off-canvas,
+    // fading out and re-entering like the entrance/exodus).
+    mode: "stay",
     beachball: true,
     spinSpeed: 1
   }
@@ -496,6 +507,87 @@ export function createMorphTroupe() {
     return null;
   }
 
+  // Where a cursor waits out the gap after `prev`, per the idle mode: the
+  // finished point itself ("stay"), a hashed spot along the canvas border
+  // ("aside" — deterministic in cursor index and beat, so scrubbing replays
+  // it), or an off-canvas point beyond the finished point ("exit").
+  function parkSpot(
+    prev, ctx, cfg, cursorIndex, mode
+  ) {
+    const anchor = anchorEnd(
+      prev,
+      ctx
+    );
+
+    if ( !anchor || mode === "stay" ) {
+      return anchor;
+    }
+
+    if ( mode === "exit" ) {
+      return offCanvasPoint(
+        anchor,
+        outwardDir(
+          anchor,
+          ctx.width,
+          ctx.height
+        ),
+        ctx.width,
+        ctx.height,
+        80
+      );
+    }
+
+    // "aside": a point on the border rectangle inset a little from the canvas
+    // edge, picked by perimeter position — visible, but clear of the word.
+    const seed = Math.round( cfg.seed ?? DEFAULTS.seed ) * 1009;
+    const u = hashedRandom( seed + cursorIndex * 13 + prev.step * 29 + 3 );
+    const inset = 0.07 * Math.min(
+      ctx.width,
+      ctx.height
+    );
+    const rw = Math.max(
+      ctx.width - 2 * inset,
+      1
+    );
+    const rh = Math.max(
+      ctx.height - 2 * inset,
+      1
+    );
+    let d = u * 2 * ( rw + rh );
+
+    if ( d < rw ) {
+      return {
+        x: inset + d,
+        y: inset
+      };
+    }
+
+    d -= rw;
+
+    if ( d < rh ) {
+      return {
+        x: ctx.width - inset,
+        y: inset + d
+      };
+    }
+
+    d -= rh;
+
+    if ( d < rw ) {
+      return {
+        x: ctx.width - inset - d,
+        y: ctx.height - inset
+      };
+    }
+
+    d -= rw;
+
+    return {
+      x: inset,
+      y: ctx.height - inset - d
+    };
+  }
+
   // Resolve one cursor at loop time `now`: { pos, icon, alpha, pressed } or
   // null while off-stage. Everything derives from the schedule + the live
   // projections — nothing accumulates frame to frame.
@@ -508,6 +600,8 @@ export function createMorphTroupe() {
       return null;
     }
 
+    const cfg = ctx.config ?? {};
+    const idleMode = cfg.idle?.mode ?? DEFAULTS.idle.mode;
     const first = events[ 0 ];
     const exit = events[ events.length - 1 ];
 
@@ -519,7 +613,7 @@ export function createMorphTroupe() {
       timing.fade,
       0.01
     );
-    const alpha = Math.min(
+    let alpha = Math.min(
       clamp(
         ( now - first.t0 ) / fade,
         0,
@@ -556,24 +650,87 @@ export function createMorphTroupe() {
 
     const bounds = subBounds( timing );
     const margin = 80;
+    // Did an idle gap precede the active event? (Consecutive tasks touch, so
+    // a real gap only opens across a hold beat or an empty morph window.)
+    const gapBefore = !!prev && ( active ? active.t0 - prev.t1 : now - prev.t1 ) > 1e-3;
 
-    // Idling between tasks (a hold beat): stay where the last task ended,
-    // showing the waiting artwork.
+    // A cursor coming back from an off-canvas park fades back in like its
+    // first entrance.
+    if ( active && gapBefore && idleMode === "exit" ) {
+      alpha = Math.min(
+        alpha,
+        clamp(
+          ( now - active.t0 ) / fade,
+          0,
+          1
+        )
+      );
+    }
+
+    // Idling between tasks (a hold beat): travel to the parking spot of the
+    // configured idle mode and wait there.
     if ( !active ) {
-      const pos = prev
+      const anchor = prev
         ? anchorEnd(
           prev,
           ctx
         )
         : null;
 
-      if ( !pos ) {
+      if ( !anchor ) {
         return null;
+      }
+
+      if ( idleMode === "stay" ) {
+        return {
+          pos: anchor,
+          icon: WAITING,
+          alpha,
+          pressed: false
+        };
+      }
+
+      const spot = parkSpot(
+        prev,
+        ctx,
+        cfg,
+        cursor.index,
+        idleMode
+      ) ?? anchor;
+      const travelDur = Math.max(
+        timing.travel,
+        0.01
+      );
+      const u = clamp(
+        ( now - prev.t1 ) / travelDur,
+        0,
+        1
+      );
+      const pos = lerpPoint(
+        anchor,
+        spot,
+        ease( u )
+      );
+
+      if ( idleMode === "exit" ) {
+        return {
+          pos,
+          icon: POINTING,
+          alpha: Math.min(
+            alpha,
+            1 - clamp(
+              ( now - prev.t1 ) / fade,
+              0,
+              1
+            )
+          ),
+          pressed: false
+        };
       }
 
       return {
         pos,
-        icon: WAITING,
+        icon: u < 1 ? POINTING : WAITING,
         alpha,
         pressed: false
       };
@@ -588,14 +745,25 @@ export function createMorphTroupe() {
       1
     );
 
-    // Where this event STARTS: the previous event's end, or (first
-    // appearance) off-canvas beyond the first approach target.
+    // Where this event STARTS: the previous event's end (or, after an idle
+    // gap, the parking spot the cursor waited on), or (first appearance)
+    // off-canvas beyond the first approach target.
     const startAnchor = () => {
       if ( prev ) {
-        return anchorEnd(
-          prev,
-          ctx
-        ) ?? {
+        const from = gapBefore
+          ? parkSpot(
+            prev,
+            ctx,
+            cfg,
+            cursor.index,
+            idleMode
+          )
+          : anchorEnd(
+            prev,
+            ctx
+          );
+
+        return from ?? {
           x: ctx.width / 2,
           y: -margin
         };


### PR DESCRIPTION
Fixes two loop artifacts in the virtual-pointer rings sketches, then adds two v8 refinements: an eased auto-fit zoom and configurable cursor idle placement.

## 1. Colours jumped abruptly when the loop restarted (v8)

Each capsule's hue comes from its arc identity (`uSegA.w`). During a conversion the troupe drags points to the next word's **positions**, but they kept the source word's **ids** — so at every beat snap (including the wrap back to `word[0]`, where the shape already matches frame 0 exactly) the hue identities changed all at once and the finished word visibly recoloured.

- Uploaded ids now **ease toward the id each point will carry after the snap**, driven by the same morph progress as the camera auto-fit. At the boundary the blended id equals the post-snap id, so no capsule changes colour — the loop closes seamlessly. This is rings-v4's continuous `uPipeId` idea, applied per point.
- Carried-in beads now wear their destination arc id from the start. They were normalised by `MAX_WORD_POINTS` (64) instead of the target word's real point count, which also recoloured them at the splice.

## 2. The last points of a morph sometimes popped in instantly (v8, hardened in v7 too)

The troupe grabbed points through the drag layer's **proximity pick** (radius ~44–49 px). When a task slice is compressed — long words, many tasks, the exodus-shortened final beat — the cursor's first *pressed* frame can already be outside the pick-up radius: the grab misses, the point is never carried, and it teleports into place at the beat snap.

- Troupe pointers now name the pool slot they hold (`targetIndex`) and the sketch **binds the drag explicitly** before the drag layer runs, so a scripted grab can never miss regardless of frame rate or slice length.
- A slot already held by a real pointer (mouse, touch, pinch) is left alone — manual sculpting mid-show keeps priority.
- v7 uses the same pick mechanism for its handle drags, so it gets the same explicit binding.

## 3. Auto-fit zoom settles with inertia instead of stopping dead (v8)

The zoom between two words' fitted framings rode the raw morph progress (constant speed → hard stop at the beat boundary). The distance blend now rides an easing curve — new `camera.autoFit.easing` option (default `easeInOutCubic`), so the zoom coasts into each framing with a decelerating tail; picking a Back ease adds a touch of terminal overshoot. Every curve lands on exactly 0/1 at the ends, so holds and the loop wrap stay seamless.

## 4. Cursor idle placement modes (v8)

New `interaction.virtualPointers.idle.mode` controls where a cursor waits between jobs:

- **`stay`** — on the point it just finished (previous behaviour; still the code-level default for saved templates).
- **`aside`** — walks to a hashed spot along the canvas border, still visible (beach ball spins there), letting the finished text breathe. New template default.
- **`exit`** — leaves the canvas entirely, fading out like the exodus, and re-enters for its next task.

Parking spots are deterministic (hashed per cursor and beat, seeded by the existing `seed` option) and the approach to the next task starts from the parking spot, so scrubbing and deterministic capture replay the identical show.

## Validation

- `npm run check` — lint (0 errors), typecheck, 1772 tests pass
- `npm run build` — all sketch routes compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZGedcYmC3ehVmgoKDeWyk