### PR TITLE
rings v8: multi-line text blocks and exact point deposits

### DIFF
--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/index.js
@@ -47,7 +47,8 @@ import {
 // rings v8 — morph hyper interactive.
 //
 // v7 let a troupe of virtual pointers sculpt ONE letter at random. v8 gives
-// the troupe a SCRIPT: a list of texts (single letters or whole words), and
+// the troupe a SCRIPT: a list of texts (single letters, whole words or
+// multi-line blocks — each line centred and stacked by the line spacing), and
 // the cursors physically convert each one into the next — the loop is cut
 // into one beat per text, each beat holding the finished word legible for a
 // configurable fraction and spending the rest as the conversion window.
@@ -87,7 +88,10 @@ import {
 
 const MAX_POINTS = 128; // pool slots = capsules (uniform array size)
 const MAX_WORD_POINTS = 64; // handle budget cap per text
-const MAX_CONTOURS = 12; // outlines kept per text (longest first)
+// Outlines kept per text (longest first). Multi-line texts carry one outline
+// per letter (plus counters), and no more than budget/3 rings can ever earn
+// their ≥ 3 points anyway — so this is the natural ceiling, not 12.
+const MAX_CONTOURS = 21;
 const MAX_STEPS = 96; // sphere-trace iterations per ray
 const BUILD_SIZE = 100; // glyph sampling size; geometry normalised by it
 
@@ -212,7 +216,8 @@ function buildWord( {
   fontName,
   sampleFactor,
   simplifyThreshold,
-  handles
+  handles,
+  lineSpacing
 } ) {
   const p = getP5();
   const font = string.fonts[ fontName ] ?? string.fonts.sans;
@@ -225,16 +230,61 @@ function buildWord( {
   p.textFont( font );
   p.textSize( BUILD_SIZE );
 
-  const raw = font.textToPoints(
-    word,
-    0,
-    0,
-    BUILD_SIZE,
-    {
-      sampleFactor,
-      simplifyThreshold
-    }
+  // Multi-line texts: each line is sampled on its own baseline and centred
+  // horizontally, so a cycle entry can be a whole stacked block (vertical
+  // reels-style layouts). Blank lines keep their slot as breathing room.
+  const lines = word.split( "\n" ).map( ( line ) => line.trim() );
+  const lineHeight = BUILD_SIZE * Math.max(
+    lineSpacing ?? 1.15,
+    0.5
   );
+  const raw = [];
+
+  lines.forEach( (
+    line, lineIndex
+  ) => {
+    if ( !line ) {
+      return;
+    }
+
+    const linePoints = font.textToPoints(
+      line,
+      0,
+      lineIndex * lineHeight,
+      BUILD_SIZE,
+      {
+        sampleFactor,
+        simplifyThreshold
+      }
+    );
+
+    if ( !linePoints.length ) {
+      return;
+    }
+
+    let lineMinX = Infinity;
+    let lineMaxX = -Infinity;
+
+    for ( const pt of linePoints ) {
+      lineMinX = Math.min(
+        lineMinX,
+        pt.x
+      );
+      lineMaxX = Math.max(
+        lineMaxX,
+        pt.x
+      );
+    }
+
+    const lineCtrX = ( lineMinX + lineMaxX ) / 2;
+
+    for ( const pt of linePoints ) {
+      raw.push( {
+        x: pt.x - lineCtrX,
+        y: pt.y
+      } );
+    }
+  } );
 
   p.pop();
 
@@ -392,7 +442,8 @@ function getWord( cfg ) {
     fontFamily,
     cfg.sampleFactor,
     cfg.simplifyThreshold,
-    cfg.handles
+    cfg.handles,
+    cfg.lineSpacing
   ].join( "|" );
 
   const cached = geometryMemo.get( key );
@@ -1070,9 +1121,14 @@ sketch.draw( () => {
     0
   ] ) );
 
-  // ── The text cycle: one geometry per entry (letters or words) ──────────────
+  // ── The text cycle: one geometry per entry (letters, words or multi-line
+  // blocks — real newlines from the textarea, or a literal "\n") ─────────────
   const wordList = ( Array.isArray( textCfg.words ) ? textCfg.words : [] )
-    .map( ( word ) => ( word ?? "" ).toString().trim() )
+    .map( ( word ) => ( word ?? "" ).toString().replace(
+      /\\n/g,
+      "\n"
+    )
+      .trim() )
     .filter( Boolean );
 
   if ( !wordList.length ) {
@@ -1084,7 +1140,8 @@ sketch.draw( () => {
     fontName: textCfg.font ?? "agiro",
     sampleFactor: textCfg.detail ?? 1,
     simplifyThreshold: textCfg.simplify ?? 0,
-    handles: textCfg.handles ?? 48
+    handles: textCfg.handles ?? 48,
+    lineSpacing: textCfg.lineSpacing ?? 1.15
   } ) );
 
   // Font still loading (or an entry produced no outline) — wait it out.

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/options.ts
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/options.ts
@@ -29,7 +29,10 @@ export const formValues = {
     simplify: 0,
     // Points sampled along each text's outlines (split proportionally to
     // contour perimeter, ≥ 3 per ring).
-    handles: 28
+    handles: 28,
+    // Baseline-to-baseline distance between the lines of a multi-line entry,
+    // in font-size units (vertical reels layouts).
+    lineSpacing: 1.15
   },
 
   material: {
@@ -233,13 +236,13 @@ export const formConfiguration: Record<string, any> = {
     label: "Texts",
     fields: {
       words: {
-        label: "Cycle (letters or words, one beat each)",
+        label: "Cycle (one beat each — line breaks make stacked blocks)",
         component: "item-list",
         minItems: 1,
         maxItems: 8,
         itemConfig: {
           label: "Text",
-          component: "text"
+          component: "textarea"
         }
       },
       font: {
@@ -270,6 +273,13 @@ export const formConfiguration: Record<string, any> = {
         min: 12,
         max: 64,
         step: 1
+      },
+      lineSpacing: {
+        label: "Line spacing (× font size)",
+        component: "slider",
+        min: 0.6,
+        max: 2,
+        step: 0.05
       }
     }
   },

--- a/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
+++ b/src/sketches/p5/sketches/rings/rings-v8-morph-hyper-interactive/virtualPointers.js
@@ -916,6 +916,11 @@ export function createMorphTroupe() {
         };
       }
 
+      // Release pause: keep the grip pinned on the exact destination. The
+      // drag's last in-flight frame always lands short of the target by one
+      // frame's travel (badly so when a slice is compressed or the canvas is
+      // tall), and a released point would sit visibly off until the beat snap
+      // "repaired" it — pinning here deposits it precisely instead.
       return {
         pos: anchorEnd(
           active,
@@ -923,7 +928,8 @@ export function createMorphTroupe() {
         ),
         icon: OPEN,
         alpha,
-        pressed: false
+        pressed: true,
+        targetIndex: active.poolIndex
       };
     }
 
@@ -989,11 +995,14 @@ export function createMorphTroupe() {
       };
     }
 
+    // Same pinned deposit as the move release: the carried bead settles on
+    // the exact destination before the cursor lets go.
     return {
       pos: dstPos,
       icon: ADD,
       alpha,
-      pressed: false
+      pressed: true,
+      targetIndex: active.poolIndex
     };
   }
 
@@ -1073,6 +1082,27 @@ export function createMorphTroupe() {
         }
 
         return resolved;
+      } );
+
+      // Safety sweep: a remove whose carry window fell between two frames
+      // must still retire its point — otherwise it lingers mid-canvas until
+      // the beat snap teleports it away.
+      const sweepStep = Math.min(
+        Math.floor( ctx.now / ctx.stepDur ),
+        ctx.steps.length - 1
+      );
+      const bounds = subBounds( timing );
+
+      state.cursors.forEach( ( cursor ) => {
+        cursor.events.forEach( ( event ) => {
+          if ( event.type !== "remove" || event.step !== sweepStep ) {
+            return;
+          }
+
+          if ( ctx.now >= event.t0 + bounds[ 2 ] * ( event.t1 - event.t0 ) ) {
+            ctx.deactivatePoint( event.poolIndex );
+          }
+        } );
       } );
 
       return pointers;


### PR DESCRIPTION
Follow-up to #293, aimed at vertical (reels) use of the v8 morph sketch.

## 1. Multi-line text blocks

Cycle entries are now **textareas**: a text can span several lines, each line sampled on its own baseline, centred horizontally, and stacked by a new `text.lineSpacing` option (baseline-to-baseline distance in font-size units, default 1.15). A multi-line block fills the vertical space of a tall canvas, and the existing auto-fit camera frames it out of the box (it already fits both axes from the shape's bbox). A literal `\n` typed in a single-line string is also translated to a real newline. Blank lines inside a block are kept as breathing room.

`MAX_CONTOURS` rises from 12 to 21 — the natural ceiling, since no more than `budget/3` rings can ever earn their minimum 3 points — so multi-line blocks don't silently drop letters.

## 2. Points are now deposited exactly where the next word needs them

The reported bug: cursors sometimes released points at positions that didn't match the finished letter (noticeably in vertical formats), and the beat-boundary snap "auto-corrected" them. Root cause: the drag's **last in-flight frame always lands short of the destination** by one frame's travel — a few percent of the path, which on a tall canvas with long travels is tens of pixels — and the release phase let go immediately, so nothing ever finished the gesture.

- The **release pause** of move and add tasks now keeps the grip pinned on the *exact* destination: the point converges onto its target over the release window before the cursor lets go, so the snap has nothing left to repair.
- A **safety sweep** retires the points of remove tasks whose carry window fell entirely between two frames — they otherwise lingered mid-canvas until the snap teleported them away.

Both fixes stay pure functions of the loop clock, so scrubbing and deterministic capture replay identically.

## Validation

- `npm run check` — lint (0 errors), typecheck, 1772 tests pass
- `npm run build` — all sketch routes compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZGedcYmC3ehVmgoKDeWyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZGedcYmC3ehVmgoKDeWyk)_