### PR TITLE
Multi-mask segmentation with click-to-unpick (v1-mask + photo-trail-effect-v1)

### DIFF
--- a/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/index.js
+++ b/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/index.js
@@ -7,12 +7,16 @@ import string from "@/p5/utils/string.js";
 import imageUtils from "@/p5/utils/imageUtils.js";
 import * as common from "@/p5/utils/common.js";
 import mediapipe, {
-  init as mediapipeInit,
-  interact
+  init as mediapipeInit
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   drawSegmentationMask
 } from "@/p5/utils/segmentation.js";
+import {
+  createMultiMaskSegmenter,
+  drawFocusMarkers,
+  hitFocusMarker
+} from "@/p5/utils/multiSegmentation.js";
 import {
   setSketchOptions,
   subscribeSketchOptions
@@ -27,29 +31,25 @@ const state = {
   // even when the option is stored as a single-element array by the picker).
   imagePath: null,
 
-  // Last focus point sent to the segmenter, in normalized (0-1) image space.
-  roi: {
-    x: 0.5,
-    y: 0.5
-  },
+  // Working copy of the focus points, normalized (0-1) image space. One
+  // segmentation mask is kept per point; the subject is their union.
+  points: [],
+  // JSON of the points we last took from / wrote to the store, so we can
+  // tell an external edit (form, reload) apart from our own click write.
+  pointsSyncHash: null,
 
-  // Raw category mask from MediaPipe: { data, width, height } at image
-  // resolution. Kept around so edge tweaks rebuild the cut-out without a new
-  // inference.
-  rawMask: null,
-  lastResultAt: null,
-
-  // Finished cut-out (photo with the feathered mask applied).
+  // Finished cut-out (photo with the feathered union mask applied).
   subject: null,
-  // Edge settings the cached subject was built with, so we only rebuild when
+  // Settings the cached subject was built with, so we only rebuild when
   // they actually change.
   builtWith: {
     inverse: null,
     softness: null,
     expand: null
   },
+  // Segmenter mask-set version the cached subject was built from.
+  builtVersion: -1,
   maskDirty: false,
-  pendingSegment: false,
 
   // Where the (unscaled) photo sits on the canvas — the reference rectangle
   // used to translate a click into a point on the image.
@@ -63,9 +63,12 @@ const state = {
   // Reused graphics buffers.
   photoG: null, // full photo, drawn to measure photoRect / "original" backdrop
   bgG: null, // full-bleed backdrop for the blur / dim modes
-  binaryMaskG: null, // hard 1-bit mask straight from the model
+  binaryMaskG: null, // hard 1-bit union mask
   softMaskG: null // feathered + grown/shrunk mask actually used to cut out
 };
+
+// One inference per focus point, run sequentially; masks cached per point.
+const segmenter = createMultiMaskSegmenter();
 
 /* ------------------------------------------------------------------ */
 /*  Small helpers                                                       */
@@ -87,28 +90,50 @@ function resolveImagePath( value ) {
   return value || null;
 }
 
-function currentRoi() {
-  const roi = options.sketch?.segmentation?.roi;
+function isPoint( value ) {
+  return !!value && typeof value.x === "number" && typeof value.y === "number";
+}
 
-  if ( roi && typeof roi.x === "number" && typeof roi.y === "number" ) {
+function sanitizePoint( value ) {
+  if ( !isPoint( value ) ) {
+    // A fresh, not-yet-edited form item — park it in the middle.
     return {
-      x: clamp(
-        roi.x,
-        0,
-        1
-      ),
-      y: clamp(
-        roi.y,
-        0,
-        1
-      )
+      x: 0.5,
+      y: 0.5
     };
   }
 
   return {
-    x: 0.5,
-    y: 0.5
+    x: clamp(
+      value.x,
+      0,
+      1
+    ),
+    y: clamp(
+      value.y,
+      0,
+      1
+    )
   };
+}
+
+// The stored focus points. Templates saved before multi-mask kept a single
+// `roi` point — adopt it as the first (and only) point. An explicit empty
+// `points` array means "no subject picked" and is respected.
+function storedPoints() {
+  const seg = options.sketch?.segmentation ?? {};
+
+  if ( Array.isArray( seg.points ) ) {
+    return seg.points.map( sanitizePoint );
+  }
+
+  if ( isPoint( seg.roi ) ) {
+    return [
+      sanitizePoint( seg.roi )
+    ];
+  }
+
+  return [];
 }
 
 function photoSettings() {
@@ -171,6 +196,49 @@ function ensureMaskGraphics(
 }
 
 /* ------------------------------------------------------------------ */
+/*  Point list sync                                                     */
+/* ------------------------------------------------------------------ */
+
+// Reconcile the working copy with the stored options (form edit, reload,
+// preset): adopt whenever the stored list differs from what we last synced.
+function syncPoints() {
+  const seg = options.sketch?.segmentation ?? {};
+  const raw = Array.isArray( seg.points ) ? seg.points : null;
+  const rawHash = JSON.stringify( raw );
+
+  if ( rawHash === state.pointsSyncHash ) {
+    return;
+  }
+
+  state.pointsSyncHash = rawHash;
+  state.points = storedPoints();
+  segmenter.setPoints( state.points );
+}
+
+// Persist the working copy so the picked zones survive reloads and are
+// exported with the template. Origin "p5" so the options module skips its
+// own change handler while React still picks the new values up.
+function persistPoints() {
+  const points = state.points.map( ( pt ) => ( {
+    x: pt.x,
+    y: pt.y
+  } ) );
+
+  state.pointsSyncHash = JSON.stringify( points );
+
+  setSketchOptions(
+    {
+      sketch: {
+        segmentation: {
+          points
+        }
+      }
+    },
+    "p5"
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Click → image-point mapping (robust to CSS scaling / margins / zoom) */
 /* ------------------------------------------------------------------ */
 
@@ -209,11 +277,34 @@ function getInternalCanvasPoint( event ) {
   };
 }
 
-// Map a canvas point onto the photo and, if it lands on the image, store the
-// focus point and re-run the segmenter exactly where the user clicked.
+// A click on a focus marker (the circle with the minus) unpicks that zone;
+// a click anywhere else on the photo picks a new one.
 function handlePointerSelect( point ) {
   if ( !point ) {
     return;
+  }
+
+  const marker = options.sketch?.marker ?? {};
+
+  if ( marker.show ) {
+    const hit = hitFocusMarker(
+      state.points,
+      state.photoRect,
+      point,
+      marker.radius ?? 16
+    );
+
+    if ( hit !== -1 ) {
+      state.points.splice(
+        hit,
+        1
+      );
+      segmenter.setPoints( state.points );
+      persistPoints();
+      state.maskDirty = true;
+
+      return;
+    }
   }
 
   const {
@@ -228,7 +319,7 @@ function handlePointerSelect( point ) {
     return;
   }
 
-  const roi = {
+  state.points.push( {
     x: clamp(
       ( point.x - x ) / w,
       0,
@@ -239,49 +330,14 @@ function handlePointerSelect( point ) {
       0,
       1
     )
-  };
-
-  state.roi = roi;
-
-  // Persist as a sketch-origin change so the 2D pad reflects it without the
-  // subscribe handler bouncing it back through the segmenter again.
-  setSketchOptions(
-    {
-      sketch: {
-        segmentation: {
-          roi
-        }
-      }
-    },
-    "p5"
-  );
-
-  triggerSegmentation();
+  } );
+  segmenter.setPoints( state.points );
+  persistPoints();
 }
 
 /* ------------------------------------------------------------------ */
-/*  Segmentation                                                        */
+/*  Subject rebuild                                                     */
 /* ------------------------------------------------------------------ */
-
-function triggerSegmentation() {
-  const photo = common.getAsset( state.imagePath );
-
-  if ( !photo?.img?.width || !mediapipe.processor.ready ) {
-    // Try again from the draw loop once the photo / processor are ready.
-    state.pendingSegment = true;
-
-    return;
-  }
-
-  const roi = currentRoi();
-  const imageElement = photo.img.canvas || photo.img.elt || photo.img;
-
-  interact(
-    roi.x * photo.img.width,
-    roi.y * photo.img.height,
-    imageElement
-  );
-}
 
 function smoothstep( t ) {
   const c = clamp(
@@ -293,23 +349,26 @@ function smoothstep( t ) {
   return c * c * ( 3 - 2 * c );
 }
 
-// Build the cut-out from the latest raw mask using the current edge settings.
-// Feathering and grow/shrink are done in one pass: the binary mask is blurred,
-// then its alpha is remapped through a smoothstep whose centre shifts the edge
-// (expand) and whose width controls the softness.
+// Build the cut-out from the union of every picked mask using the current
+// edge settings. Feathering and grow/shrink are done in one pass: the
+// binary union is blurred, then its alpha is remapped through a smoothstep
+// whose centre shifts the edge (expand) and whose width controls the
+// softness.
 function rebuildSubject() {
   const photo = common.getAsset( state.imagePath );
-  const raw = state.rawMask;
+  const seg = options.sketch?.segmentation ?? {};
+  const inverse = seg.inverse ?? true;
+  const combined = segmenter.combined( inverse );
 
-  if ( !photo?.img?.width || !raw?.data ) {
+  if ( !photo?.img?.width || !combined ) {
+    state.subject = null;
+
     return;
   }
 
   const {
     data, width, height
-  } = raw;
-  const seg = options.sketch?.segmentation ?? {};
-  const inverse = seg.inverse ?? true;
+  } = combined;
   const softness = clamp(
     seg.edgeSoftness ?? 0,
     0,
@@ -328,7 +387,8 @@ function rebuildSubject() {
   );
 
   // White where kept, fully transparent elsewhere — p5's mask() keys off the
-  // alpha channel (destination-in), so only the alpha matters here.
+  // alpha channel (destination-in), so only the alpha matters here. The
+  // union already applied `inverse` per raw mask, so it is passed as false.
   drawSegmentationMask(
     binary,
     data,
@@ -338,7 +398,7 @@ function rebuildSubject() {
       255,
       255
     ],
-    inverse
+    false
   );
 
   let mask = binary;
@@ -591,36 +651,6 @@ function drawSubject( p ) {
   p.pop();
 }
 
-function drawMarker( p ) {
-  const marker = options.sketch?.marker ?? {};
-
-  if ( !marker.show ) {
-    return;
-  }
-
-  const roi = currentRoi();
-  const {
-    x, y, w, h
-  } = state.photoRect;
-
-  if ( w <= 0 || h <= 0 ) {
-    return;
-  }
-
-  p.push();
-  p.noFill();
-  p.stroke( ...( marker.color ?? [
-    255
-  ] ) );
-  p.strokeWeight( marker.weight ?? 3 );
-  p.circle(
-    x + roi.x * w,
-    y + roi.y * h,
-    ( marker.radius ?? 16 ) * 2
-  );
-  p.pop();
-}
-
 /* ------------------------------------------------------------------ */
 /*  Lifecycle                                                           */
 /* ------------------------------------------------------------------ */
@@ -631,7 +661,15 @@ sketch.setup( () => {
   p.background( ...options.sketch.backgroundColor );
 
   state.imagePath = resolveImagePath( options.sketch?.photo?.image );
-  state.roi = currentRoi();
+  state.points = [];
+  state.pointsSyncHash = null;
+  state.subject = null;
+  state.builtVersion = -1;
+  state.maskDirty = false;
+
+  segmenter.reset();
+  segmenter.setImage( state.imagePath );
+  syncPoints();
 
   subscribeSketchOptions( (
     newOptions, origin
@@ -647,26 +685,13 @@ sketch.setup( () => {
 
     if ( nextImage !== state.imagePath ) {
       state.imagePath = nextImage;
-      state.rawMask = null;
       state.subject = null;
-      state.lastResultAt = null;
-      state.pendingSegment = true;
+      segmenter.setImage( nextImage );
 
       return;
     }
 
-    const roi = sk.segmentation?.roi;
-
-    if (
-      roi &&
-      ( roi.x !== state.roi.x || roi.y !== state.roi.y )
-    ) {
-      state.roi = {
-        x: roi.x,
-        y: roi.y
-      };
-      triggerSegmentation();
-    }
+    // Point-list edits are adopted from the draw loop via syncPoints().
 
     const seg = sk.segmentation ?? {};
 
@@ -679,12 +704,10 @@ sketch.setup( () => {
     }
   } );
 
-  // Segment the default focus point as soon as the photo + processor are ready.
-  state.pendingSegment = true;
-
   // Fire-and-forget: awaiting init would block setup (and therefore the first
   // draw) on the ~4s model-load + prewarm. Instead the photo renders right away
-  // and the draw loop kicks off segmentation the moment the processor is ready.
+  // and the draw loop segments each focus point as soon as the processor is
+  // ready.
   mediapipeInit( {
     enableIdle: false,
     worker: false,
@@ -739,27 +762,14 @@ sketch.draw( () => {
   p.frameRate( options.animation.framerate );
   ensureCanvasGraphics( p );
 
-  // Kick off a deferred segmentation once everything it needs is available.
-  if (
-    state.pendingSegment &&
-    mediapipe.processor.ready &&
-    !mediapipe.processor.busy
-  ) {
-    state.pendingSegment = false;
-    triggerSegmentation();
-  }
+  // Adopt external point edits, then let the segmenter pump one inference
+  // per point that is still missing its mask.
+  syncPoints();
+  segmenter.update( photo );
 
-  // A fresh inference landed → cache it and flag a rebuild.
-  const result = mediapipe.tasks.interactive;
-
-  if ( result?.result && result.updatedAt !== state.lastResultAt ) {
-    state.lastResultAt = result.updatedAt;
-    state.rawMask = result.result;
-    state.maskDirty = true;
-  }
-
-  if ( state.maskDirty && state.rawMask ) {
+  if ( state.maskDirty || state.builtVersion !== segmenter.version ) {
     state.maskDirty = false;
+    state.builtVersion = segmenter.version;
     rebuildSubject();
   }
 
@@ -769,8 +779,18 @@ sketch.draw( () => {
     photo
   );
 
-  // Title sits behind the cut-out subject: backdrop → title → subject.
+  // Backdrop → subject → markers: the union cut-out sits on top.
 
   drawSubject( p );
-  drawMarker( p );
+
+  const marker = options.sketch?.marker ?? {};
+
+  if ( marker.show ) {
+    drawFocusMarkers(
+      p,
+      state.points,
+      state.photoRect,
+      marker
+    );
+  }
 } );

--- a/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/options.ts
+++ b/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/options.ts
@@ -13,12 +13,15 @@ export const formValues = {
     fill: false
   },
   segmentation: {
-    // Normalized (0-1) focus point fed to the interactive segmenter. Click the
-    // canvas to move it; it is also editable from the 2D pad below.
-    roi: {
-      x: 0.44326979424839197,
-      y: 0.5386447230522758
-    },
+    // Normalized (0-1) focus points fed to the interactive segmenter — one
+    // mask per point, the subject is their union. Click the photo to add a
+    // point, click a marker (the circle with the minus) to unpick its zone.
+    points: [
+      {
+        x: 0.44326979424839197,
+        y: 0.5386447230522758
+      }
+    ],
     inverse: true,
     // Feather the cut-out border so the mask blends instead of showing the hard,
     // aliased model edge. 0 = crisp, 1 = very soft.
@@ -114,14 +117,18 @@ export const formConfiguration: Record<string, any> = {
     component: "nested-object",
     initialExpanded: true,
     fields: {
-      roi: {
-        component: "vector2d",
-        label: "Focus point",
-        allowNegative: false,
-        min: 0,
-        max: 1,
-        step: 0.01,
-        yDown: true
+      points: {
+        label: "Focus points (click photo to add, click a marker to remove)",
+        component: "item-list",
+        itemConfig: {
+          component: "vector2d",
+          label: "Focus point",
+          allowNegative: false,
+          min: 0,
+          max: 1,
+          step: 0.01,
+          yDown: true
+        }
       },
       inverse: {
         label: "Inverse mask",
@@ -242,11 +249,11 @@ export const formConfiguration: Record<string, any> = {
     }
   },
   marker: {
-    label: "Focus marker",
+    label: "Focus markers",
     component: "nested-object",
     fields: {
       show: {
-        label: "Show marker",
+        label: "Show markers (click one to unpick its zone)",
         component: "checkbox"
       },
       color: {

--- a/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v2-noise-reveal/index.js
+++ b/src/sketches/p5/sketches/photo-segmentation/photo-segmentation-v2-noise-reveal/index.js
@@ -8,12 +8,14 @@ import imageUtils from "@/p5/utils/imageUtils.js";
 import * as common from "@/p5/utils/common.js";
 import animation from "@/p5/utils/animation.js";
 import mediapipe, {
-  init as mediapipeInit,
-  interact
+  init as mediapipeInit
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   drawSegmentationMask
 } from "@/p5/utils/segmentation.js";
+import {
+  createMultiMaskSegmenter
+} from "@/p5/utils/multiSegmentation.js";
 import {
   setSketchOptions,
   subscribeSketchOptions
@@ -40,12 +42,6 @@ const state = {
   // Seed the noise generator was last configured with, to re-seed on edits.
   seededWith: null,
 
-  // Raw category mask from MediaPipe: { data, width, height } at image
-  // resolution. Kept around so edge tweaks rebuild the cut-out without a new
-  // inference.
-  rawMask: null,
-  lastResultAt: null,
-
   // Finished cut-out (photo with the feathered mask applied).
   subject: null,
   // Edge settings the cached subject was built with, so we only rebuild when
@@ -55,8 +51,9 @@ const state = {
     softness: null,
     expand: null
   },
+  // Segmenter mask-set version the cached subject was built from.
+  builtVersion: -1,
   maskDirty: false,
-  pendingSegment: false,
 
   // Where the (unscaled) photo sits on the canvas — the reference rectangle
   // used to translate a click into a point on the image.
@@ -73,6 +70,28 @@ const state = {
   binaryMaskG: null, // hard 1-bit mask straight from the model
   softMaskG: null // feathered + grown/shrunk mask actually used to cut out
 };
+
+// Shared inference plumbing (pump, retry, mask cache). The reveal shows one
+// mask at a time, so the walk keeps exactly one focus point in the set —
+// each pick replaces it. adoptLatest keeps the pre-manager racing
+// semantics: when the walk re-picks before an inference lands, the landed
+// result is still shown (attributed to the current point) instead of being
+// discarded — otherwise a fast pick cadence could outrun the segmenter and
+// never reveal anything.
+const segmenter = createMultiMaskSegmenter( {
+  adoptLatest: true
+} );
+
+// Point the segmenter at a new focus point. The previous mask is pruned
+// immediately, but the on-screen subject is kept until the new inference
+// lands (see the rebuild guard in draw), so the reveal reads exactly as
+// before: one mask replacing the other.
+function applyRoi( roi ) {
+  state.roi = roi;
+  segmenter.setPoints( [
+    roi
+  ] );
+}
 
 /* ------------------------------------------------------------------ */
 /*  Small helpers                                                       */
@@ -290,11 +309,11 @@ function runAutoFocus( p ) {
   }
 
   state.autoPickIndex = segment;
-  state.roi = autoRoiForSegment(
+  applyRoi( autoRoiForSegment(
     p,
     segment,
     auto
-  );
+  ) );
 
   // Persist as a sketch-origin change so the 2D pad tracks the walk without
   // the subscribe handler bouncing it back through the segmenter again.
@@ -308,8 +327,6 @@ function runAutoFocus( p ) {
     },
     "p5"
   );
-
-  triggerSegmentation();
 }
 
 /* ------------------------------------------------------------------ */
@@ -384,7 +401,7 @@ function handlePointerSelect( point ) {
     )
   };
 
-  state.roi = roi;
+  applyRoi( roi );
 
   setSketchOptions(
     {
@@ -396,33 +413,11 @@ function handlePointerSelect( point ) {
     },
     "p5"
   );
-
-  triggerSegmentation();
 }
 
 /* ------------------------------------------------------------------ */
 /*  Segmentation                                                        */
 /* ------------------------------------------------------------------ */
-
-function triggerSegmentation() {
-  const photo = common.getAsset( state.imagePath );
-
-  if ( !photo?.img?.width || !mediapipe.processor.ready ) {
-    // Try again from the draw loop once the photo / processor are ready.
-    state.pendingSegment = true;
-
-    return;
-  }
-
-  const roi = state.roi ?? currentRoi();
-  const imageElement = photo.img.canvas || photo.img.elt || photo.img;
-
-  interact(
-    roi.x * photo.img.width,
-    roi.y * photo.img.height,
-    imageElement
-  );
-}
 
 function smoothstep( t ) {
   const c = clamp(
@@ -434,23 +429,26 @@ function smoothstep( t ) {
   return c * c * ( 3 - 2 * c );
 }
 
-// Build the cut-out from the latest raw mask using the current edge settings.
-// Feathering and grow/shrink are done in one pass: the binary mask is blurred,
-// then its alpha is remapped through a smoothstep whose centre shifts the edge
-// (expand) and whose width controls the softness.
+// Build the cut-out from the current pick's mask using the current edge
+// settings. Feathering and grow/shrink are done in one pass: the binary mask
+// is blurred, then its alpha is remapped through a smoothstep whose centre
+// shifts the edge (expand) and whose width controls the softness. When no
+// mask is available yet (the walk just moved and its inference is still
+// running) the previous subject is kept, so masks replace each other with no
+// blank frame in between.
 function rebuildSubject() {
   const photo = common.getAsset( state.imagePath );
-  const raw = state.rawMask;
+  const seg = options.sketch?.segmentation ?? {};
+  const inverse = seg.inverse ?? true;
+  const combined = segmenter.combined( inverse );
 
-  if ( !photo?.img?.width || !raw?.data ) {
+  if ( !photo?.img?.width || !combined ) {
     return;
   }
 
   const {
     data, width, height
-  } = raw;
-  const seg = options.sketch?.segmentation ?? {};
-  const inverse = seg.inverse ?? true;
+  } = combined;
   const softness = clamp(
     seg.edgeSoftness ?? 0,
     0,
@@ -469,7 +467,9 @@ function rebuildSubject() {
   );
 
   // White where kept, fully transparent elsewhere — p5's mask() keys off the
-  // alpha channel (destination-in), so only the alpha matters here.
+  // alpha channel (destination-in), so only the alpha matters here. The
+  // combined mask already applied `inverse` per raw mask, so it is passed as
+  // false.
   drawSegmentationMask(
     binary,
     data,
@@ -479,7 +479,7 @@ function rebuildSubject() {
       255,
       255
     ],
-    inverse
+    false
   );
 
   let mask = binary;
@@ -772,9 +772,17 @@ sketch.setup( () => {
   p.background( ...options.sketch.backgroundColor );
 
   state.imagePath = resolveImagePath( options.sketch?.photo?.image );
-  state.roi = currentRoi();
   state.autoPickIndex = -1;
   state.seededWith = null;
+  state.subject = null;
+  state.builtVersion = -1;
+  state.maskDirty = false;
+
+  segmenter.reset();
+  segmenter.setImage( state.imagePath );
+  // Segments the default focus point as soon as the photo + processor are
+  // ready (covers the auto-walk-disabled case).
+  applyRoi( currentRoi() );
 
   subscribeSketchOptions( (
     newOptions, origin
@@ -790,10 +798,8 @@ sketch.setup( () => {
 
     if ( nextImage !== state.imagePath ) {
       state.imagePath = nextImage;
-      state.rawMask = null;
       state.subject = null;
-      state.lastResultAt = null;
-      state.pendingSegment = true;
+      segmenter.setImage( nextImage );
 
       return;
     }
@@ -804,11 +810,10 @@ sketch.setup( () => {
       roi &&
       ( roi.x !== state.roi.x || roi.y !== state.roi.y )
     ) {
-      state.roi = {
+      applyRoi( {
         x: roi.x,
         y: roi.y
-      };
-      triggerSegmentation();
+      } );
     }
 
     const seg = sk.segmentation ?? {};
@@ -821,10 +826,6 @@ sketch.setup( () => {
       state.maskDirty = true;
     }
   } );
-
-  // Segment the default focus point as soon as the photo + processor are ready
-  // (covers the auto-walk-disabled case).
-  state.pendingSegment = true;
 
   // Fire-and-forget: awaiting init would block setup (and therefore the first
   // draw) on the ~4s model-load + prewarm. Instead the photo renders right away
@@ -883,31 +884,21 @@ sketch.draw( () => {
   p.frameRate( options.animation.framerate );
   ensureCanvasGraphics( p );
 
-  // Kick off a deferred segmentation once everything it needs is available.
-  if (
-    state.pendingSegment &&
-    mediapipe.processor.ready &&
-    !mediapipe.processor.busy
-  ) {
-    state.pendingSegment = false;
-    triggerSegmentation();
-  }
-
   // The noise walk clicks around the photo on its own, one pick per loop
   // segment.
   runAutoFocus( p );
 
-  // A fresh inference landed → cache it and flag a rebuild.
-  const result = mediapipe.tasks.interactive;
+  // Pump the pending inference (one at a time) and rebuild once its mask is
+  // in — until then the previous subject stays up, so the reveal never shows
+  // a blank frame between picks.
+  segmenter.update( photo );
 
-  if ( result?.result && result.updatedAt !== state.lastResultAt ) {
-    state.lastResultAt = result.updatedAt;
-    state.rawMask = result.result;
-    state.maskDirty = true;
-  }
-
-  if ( state.maskDirty && state.rawMask ) {
+  if (
+    ( state.maskDirty || state.builtVersion !== segmenter.version ) &&
+    segmenter.maskCount > 0
+  ) {
     state.maskDirty = false;
+    state.builtVersion = segmenter.version;
     rebuildSubject();
   }
 

--- a/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/index.js
+++ b/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/index.js
@@ -8,13 +8,17 @@ import imageUtils from "@/p5/utils/imageUtils.js";
 import * as common from "@/p5/utils/common.js";
 import animation from "@/p5/utils/animation.js";
 import easing from "@/p5/utils/easing.js";
-import mediapipe, {
-  init as mediapipeInit,
-  interact
+import {
+  init as mediapipeInit
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
   drawSegmentationMask
 } from "@/p5/utils/segmentation.js";
+import {
+  createMultiMaskSegmenter,
+  drawFocusMarkers,
+  hitFocusMarker
+} from "@/p5/utils/multiSegmentation.js";
 import {
   setSketchOptions,
   subscribeSketchOptions
@@ -34,8 +38,11 @@ import {
 /*                                                                     */
 /*    1. the full photo (original / blur / dim / color backdrop),      */
 /*    2. the trails,                                                   */
-/*    3. the subject cut out with MediaPipe's interactive segmenter    */
-/*       (click the canvas to pick the subject — an animal, a person). */
+/*    3. the subject cut out with MediaPipe's interactive segmenter.   */
+/*       Click the photo to pick a subject (an animal, a person, …) —  */
+/*       every click adds a focus point with its own mask, the cut-out */
+/*       is their union, and clicking a focus marker (the circle with  */
+/*       the minus) unpicks that zone again.                           */
 /*                                                                     */
 /*  Every trail is defined by draggable, persisted handles             */
 /*  (normalized 0..1 so they survive resizes and exports):             */
@@ -63,26 +70,21 @@ const state = {
   // Path of the photo currently driving the segmenter.
   imagePath: null,
 
-  // Last focus point sent to the segmenter, normalized (0-1) image space.
-  roi: {
-    x: 0.5,
-    y: 0.5
-  },
+  // Working copy of the focus points, normalized (0-1) image space. One
+  // mask per point; the subject is their union.
+  focusPoints: [],
+  focusSyncHash: null,
 
-  // Raw category mask from MediaPipe: { data, width, height } at image
-  // resolution.
-  rawMask: null,
-  lastResultAt: null,
-
-  // Finished cut-out (photo with the feathered mask applied).
+  // Finished cut-out (photo with the feathered union mask applied).
   subject: null,
   builtWith: {
     inverse: null,
     softness: null,
     expand: null
   },
+  // Segmenter mask-set version the cached subject was built from.
+  builtVersion: -1,
   maskDirty: false,
-  pendingSegment: false,
 
   // Where the photo sits on the canvas — used both to map clicks onto the
   // image and to detect layout changes that invalidate the pixel samples.
@@ -128,6 +130,9 @@ const state = {
 
 const draggable = createDraggable();
 
+// One inference per focus point, run sequentially; masks cached per point.
+const segmenter = createMultiMaskSegmenter();
+
 /* ------------------------------------------------------------------ */
 /*  Small helpers                                                      */
 /* ------------------------------------------------------------------ */
@@ -167,20 +172,77 @@ function resolveImagePath( value ) {
   return value || null;
 }
 
-function currentRoi() {
-  const roi = options.sketch?.segmentation?.roi;
-
-  if ( roi && typeof roi.x === "number" && typeof roi.y === "number" ) {
+function sanitizeFocusPoint( value ) {
+  if ( !isPoint( value ) ) {
+    // A fresh, not-yet-edited form item — park it in the middle.
     return {
-      x: clamp01( roi.x ),
-      y: clamp01( roi.y )
+      x: 0.5,
+      y: 0.5
     };
   }
 
   return {
-    x: 0.5,
-    y: 0.5
+    x: clamp01( value.x ),
+    y: clamp01( value.y )
   };
+}
+
+// The stored focus points. Templates saved before multi-mask kept a single
+// `roi` point — adopt it as the first (and only) point. An explicit empty
+// `points` array means "no subject picked" and is respected.
+function storedFocusPoints() {
+  const seg = options.sketch?.segmentation ?? {};
+
+  if ( Array.isArray( seg.points ) ) {
+    return seg.points.map( sanitizeFocusPoint );
+  }
+
+  if ( isPoint( seg.roi ) ) {
+    return [
+      sanitizeFocusPoint( seg.roi )
+    ];
+  }
+
+  return [];
+}
+
+// Reconcile the working copy with the stored options (form edit, reload,
+// preset): adopt whenever the stored list differs from what we last synced.
+function syncFocusPoints() {
+  const seg = options.sketch?.segmentation ?? {};
+  const raw = Array.isArray( seg.points ) ? seg.points : null;
+  const rawHash = JSON.stringify( raw );
+
+  if ( rawHash === state.focusSyncHash ) {
+    return;
+  }
+
+  state.focusSyncHash = rawHash;
+  state.focusPoints = storedFocusPoints();
+  segmenter.setPoints( state.focusPoints );
+}
+
+// Persist the picked zones so they survive reloads and are exported with
+// the template. Origin "p5" so the options module skips its own change
+// handler while React still picks the new values up.
+function persistFocusPoints() {
+  const points = state.focusPoints.map( ( pt ) => ( {
+    x: pt.x,
+    y: pt.y
+  } ) );
+
+  state.focusSyncHash = JSON.stringify( points );
+
+  setSketchOptions(
+    {
+      sketch: {
+        segmentation: {
+          points
+        }
+      }
+    },
+    "p5"
+  );
 }
 
 function photoSettings() {
@@ -305,8 +367,9 @@ function getInternalCanvasPoint( event ) {
   };
 }
 
-// Map a canvas click onto the photo and re-run the segmenter there — unless
-// the click landed on (or just released) a trail handle.
+// Route a canvas click: a trail handle wins (the drag layer owns it), then
+// a focus marker (the circle with the minus) unpicks its zone, and anywhere
+// else on the photo picks a new one.
 function handleCanvasClick( event ) {
   const point = getInternalCanvasPoint( event );
 
@@ -326,6 +389,29 @@ function handleCanvasClick( event ) {
     return;
   }
 
+  const marker = options.sketch?.marker ?? {};
+
+  if ( marker.show ) {
+    const hit = hitFocusMarker(
+      state.focusPoints,
+      state.photoRect,
+      point,
+      marker.radius ?? 16
+    );
+
+    if ( hit !== -1 ) {
+      state.focusPoints.splice(
+        hit,
+        1
+      );
+      segmenter.setPoints( state.focusPoints );
+      persistFocusPoints();
+      state.maskDirty = true;
+
+      return;
+    }
+  }
+
   const {
     x, y, w, h
   } = state.photoRect;
@@ -338,68 +424,37 @@ function handleCanvasClick( event ) {
     return;
   }
 
-  const roi = {
+  state.focusPoints.push( {
     x: clamp01( ( point.x - x ) / w ),
     y: clamp01( ( point.y - y ) / h )
-  };
-
-  state.roi = roi;
-
-  // Persist as a sketch-origin change so the 2D pad reflects it without the
-  // subscribe handler bouncing it back through the segmenter again.
-  setSketchOptions(
-    {
-      sketch: {
-        segmentation: {
-          roi
-        }
-      }
-    },
-    "p5"
-  );
-
-  triggerSegmentation();
+  } );
+  segmenter.setPoints( state.focusPoints );
+  persistFocusPoints();
 }
 
 /* ------------------------------------------------------------------ */
-/*  Segmentation (same pipeline as photo-segmentation)                 */
+/*  Segmentation (same pipeline as photo-segmentation-v1-mask)         */
 /* ------------------------------------------------------------------ */
 
-function triggerSegmentation() {
-  const photo = common.getAsset( state.imagePath );
-
-  if ( !photo?.img?.width || !mediapipe.processor.ready ) {
-    state.pendingSegment = true;
-
-    return;
-  }
-
-  const roi = currentRoi();
-  const imageElement = photo.img.canvas || photo.img.elt || photo.img;
-
-  interact(
-    roi.x * photo.img.width,
-    roi.y * photo.img.height,
-    imageElement
-  );
-}
-
-// Build the cut-out from the latest raw mask using the current edge
-// settings: blur the binary mask, then remap its alpha through a smoothstep
-// whose centre shifts the edge (expand) and whose width sets the softness.
+// Build the cut-out from the union of every picked mask using the current
+// edge settings: blur the binary union, then remap its alpha through a
+// smoothstep whose centre shifts the edge (expand) and whose width sets the
+// softness.
 function rebuildSubject() {
   const photo = common.getAsset( state.imagePath );
-  const raw = state.rawMask;
+  const seg = options.sketch?.segmentation ?? {};
+  const inverse = seg.inverse ?? true;
+  const combined = segmenter.combined( inverse );
 
-  if ( !photo?.img?.width || !raw?.data ) {
+  if ( !photo?.img?.width || !combined ) {
+    state.subject = null;
+
     return;
   }
 
   const {
     data, width, height
-  } = raw;
-  const seg = options.sketch?.segmentation ?? {};
-  const inverse = seg.inverse ?? true;
+  } = combined;
   const softness = clamp01( seg.edgeSoftness ?? 0 );
   const expand = clamp(
     seg.edgeExpand ?? 0,
@@ -413,6 +468,8 @@ function rebuildSubject() {
     height
   );
 
+  // The union already applied `inverse` per raw mask, so it is passed as
+  // false here.
   drawSegmentationMask(
     binary,
     data,
@@ -422,7 +479,7 @@ function rebuildSubject() {
       255,
       255
     ],
-    inverse
+    false
   );
 
   let mask = binary;
@@ -676,34 +733,19 @@ function drawSubject( p ) {
   p.pop();
 }
 
-function drawMarker( p ) {
+function drawMarkers( p ) {
   const marker = options.sketch?.marker ?? {};
 
   if ( !marker.show ) {
     return;
   }
 
-  const roi = currentRoi();
-  const {
-    x, y, w, h
-  } = state.photoRect;
-
-  if ( w <= 0 || h <= 0 ) {
-    return;
-  }
-
-  p.push();
-  p.noFill();
-  p.stroke( ...( marker.color ?? [
-    255
-  ] ) );
-  p.strokeWeight( marker.weight ?? 3 );
-  p.circle(
-    x + roi.x * w,
-    y + roi.y * h,
-    ( marker.radius ?? 16 ) * 2
+  drawFocusMarkers(
+    p,
+    state.focusPoints,
+    state.photoRect,
+    marker
   );
-  p.pop();
 }
 
 /* ------------------------------------------------------------------ */
@@ -1733,7 +1775,6 @@ sketch.setup( () => {
   p.background( ...options.sketch.backgroundColor );
 
   state.imagePath = resolveImagePath( options.sketch?.photo?.image );
-  state.roi = currentRoi();
 
   // Every buffer belongs to the previous p5 instance after a sketch reset —
   // drop them so they are recreated lazily against the fresh one.
@@ -1753,9 +1794,15 @@ sketch.setup( () => {
   state.samplePixelsReady = false;
   state.handleTargets = [];
   state.handleMeta = [];
-  state.rawMask = null;
   state.subject = null;
-  state.lastResultAt = null;
+  state.focusPoints = [];
+  state.focusSyncHash = null;
+  state.builtVersion = -1;
+  state.maskDirty = false;
+
+  segmenter.reset();
+  segmenter.setImage( state.imagePath );
+  syncFocusPoints();
 
   // Re-arm the listeners (the engine's registries are cleared on reset).
   draggable.attach();
@@ -1784,24 +1831,14 @@ sketch.setup( () => {
 
     if ( nextImage !== state.imagePath ) {
       state.imagePath = nextImage;
-      state.rawMask = null;
       state.subject = null;
-      state.lastResultAt = null;
-      state.pendingSegment = true;
       state.sampleDirty = true;
+      segmenter.setImage( nextImage );
 
       return;
     }
 
-    const roi = sk.segmentation?.roi;
-
-    if ( roi && ( roi.x !== state.roi.x || roi.y !== state.roi.y ) ) {
-      state.roi = {
-        x: roi.x,
-        y: roi.y
-      };
-      triggerSegmentation();
-    }
+    // Point-list edits are adopted from the draw loop via syncFocusPoints().
 
     const seg = sk.segmentation ?? {};
 
@@ -1814,11 +1851,9 @@ sketch.setup( () => {
     }
   } );
 
-  // Segment the default focus point as soon as the photo + processor are
-  // ready. Fire-and-forget: awaiting init would block the first draw on the
-  // ~4s model load, so the photo and trails render right away instead.
-  state.pendingSegment = true;
-
+  // Fire-and-forget: awaiting init would block the first draw on the ~4s
+  // model load, so the photo and trails render right away and the draw loop
+  // segments each focus point as soon as the processor is ready.
   mediapipeInit( {
     enableIdle: false,
     worker: false,
@@ -1869,27 +1904,14 @@ sketch.draw( () => {
   p.frameRate( options.animation.framerate );
   ensureCanvasGraphics( p );
 
-  // Kick off a deferred segmentation once everything it needs is available.
-  if (
-    state.pendingSegment &&
-    mediapipe.processor.ready &&
-    !mediapipe.processor.busy
-  ) {
-    state.pendingSegment = false;
-    triggerSegmentation();
-  }
+  // Adopt external point edits, then let the segmenter pump one inference
+  // per focus point that is still missing its mask.
+  syncFocusPoints();
+  segmenter.update( photo );
 
-  // A fresh inference landed → cache it and flag a rebuild.
-  const result = mediapipe.tasks.interactive;
-
-  if ( result?.result && result.updatedAt !== state.lastResultAt ) {
-    state.lastResultAt = result.updatedAt;
-    state.rawMask = result.result;
-    state.maskDirty = true;
-  }
-
-  if ( state.maskDirty && state.rawMask ) {
+  if ( state.maskDirty || state.builtVersion !== segmenter.version ) {
     state.maskDirty = false;
+    state.builtVersion = segmenter.version;
     rebuildSubject();
   }
 
@@ -1989,5 +2011,5 @@ sketch.draw( () => {
     );
   }
 
-  drawMarker( p );
+  drawMarkers( p );
 } );

--- a/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/options.ts
+++ b/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/options.ts
@@ -33,12 +33,15 @@ export const formValues = {
     fill: false
   },
   segmentation: {
-    // Normalized (0-1) focus point fed to the interactive segmenter. Click
-    // the canvas to move it — that is how the subject is chosen dynamically.
-    roi: {
-      x: 0.4720334741274328,
-      y: 0.2927933578609266
-    },
+    // Normalized (0-1) focus points fed to the interactive segmenter — one
+    // mask per point, the subject is their union. Click the photo to add a
+    // point, click a marker (the circle with the minus) to unpick its zone.
+    points: [
+      {
+        x: 0.4720334741274328,
+        y: 0.2927933578609266
+      }
+    ],
     inverse: true,
     edgeSoftness: 0.25,
     edgeExpand: 0
@@ -151,7 +154,9 @@ export const formValues = {
     size: 16
   },
   marker: {
-    show: false,
+    // Focus markers double as the unpick control (click the circle with
+    // the minus to remove that zone), so they show by default.
+    show: true,
     color: [
       255,
       255,
@@ -209,14 +214,18 @@ export const formConfiguration: Record<string, any> = {
     label: "Segmentation",
     component: "nested-object",
     fields: {
-      roi: {
-        component: "vector2d",
-        label: "Focus point (click the canvas)",
-        allowNegative: false,
-        min: 0,
-        max: 1,
-        step: 0.01,
-        yDown: true
+      points: {
+        label: "Focus points (click photo to add, click a marker to remove)",
+        component: "item-list",
+        itemConfig: {
+          component: "vector2d",
+          label: "Focus point",
+          allowNegative: false,
+          min: 0,
+          max: 1,
+          step: 0.01,
+          yDown: true
+        }
       },
       inverse: {
         label: "Inverse mask",
@@ -581,11 +590,11 @@ export const formConfiguration: Record<string, any> = {
     }
   },
   marker: {
-    label: "Focus marker",
+    label: "Focus markers",
     component: "nested-object",
     fields: {
       show: {
-        label: "Show marker",
+        label: "Show markers (click one to unpick its zone)",
         component: "checkbox"
       },
       color: {

--- a/src/sketches/p5/utils/multiSegmentation.js
+++ b/src/sketches/p5/utils/multiSegmentation.js
@@ -1,0 +1,300 @@
+import mediapipe, {
+  interact
+} from "./mediapipe/mediapipe.js";
+
+// ── Multi-point interactive segmentation ────────────────────────────────────
+// Manages several focus points on one photo for MediaPipe's interactive
+// segmenter. The segmenter answers one point at a time (a single result
+// slot), so the manager runs one inference per point sequentially, caches
+// each point's raw category mask, and exposes the union of every mask as
+// the combined subject. Used by photo-segmentation-v1-mask and
+// photo-trail-effect-v1, which share the click-to-pick /
+// click-a-marker-to-unpick interaction.
+
+// An in-flight request that never lands (dropped message, worker restart)
+// is retried after this long.
+const IN_FLIGHT_TIMEOUT_MS = 4000;
+
+function pointKey( pt ) {
+  return `${ pt.x.toFixed( 5 ) },${ pt.y.toFixed( 5 ) }`;
+}
+
+export function createMultiMaskSegmenter() {
+  const state = {
+    // Focus points, normalized (0-1) image space.
+    points: [],
+    // pointKey → raw mask {data, width, height} from the segmenter.
+    masks: new Map(),
+    imagePath: null,
+    inFlightKey: null,
+    inFlightAt: 0,
+    lastResultAt: null,
+    // Bumped whenever the mask set changes, so callers can cheaply detect
+    // that the combined subject needs a rebuild.
+    version: 0,
+    combinedCache: null
+  };
+
+  return {
+    get points() {
+      return state.points;
+    },
+
+    get version() {
+      return state.version;
+    },
+
+    get maskCount() {
+      return state.masks.size;
+    },
+
+    reset() {
+      state.points = [];
+      state.masks.clear();
+      state.imagePath = null;
+      state.inFlightKey = null;
+      state.inFlightAt = 0;
+      state.lastResultAt = null;
+      state.version++;
+      state.combinedCache = null;
+    },
+
+    // A new photo invalidates every cached mask (they belong to the old
+    // pixels).
+    setImage( path ) {
+      if ( path === state.imagePath ) {
+        return;
+      }
+
+      state.imagePath = path;
+      state.masks.clear();
+      state.inFlightKey = null;
+      state.version++;
+    },
+
+    // Adopt the working point list. Masks of removed points are pruned;
+    // points without a mask get segmented by the next update() calls.
+    setPoints( points ) {
+      state.points = points.map( ( pt ) => ( {
+        x: pt.x,
+        y: pt.y
+      } ) );
+
+      const keys = new Set( state.points.map( pointKey ) );
+      let changed = false;
+
+      for ( const key of [
+        ...state.masks.keys()
+      ] ) {
+        if ( !keys.has( key ) ) {
+          state.masks.delete( key );
+          changed = true;
+        }
+      }
+
+      if ( state.inFlightKey && !keys.has( state.inFlightKey ) ) {
+        state.inFlightKey = null;
+      }
+
+      if ( changed ) {
+        state.version++;
+      }
+    },
+
+    // Per-frame pump: adopt a landed inference, then fire the next missing
+    // one. Strictly one at a time — the interactive task has a single
+    // result slot, so a second request would clobber the first.
+    update( photo ) {
+      const result = mediapipe.tasks.interactive;
+
+      if ( result?.result && result.updatedAt !== state.lastResultAt ) {
+        state.lastResultAt = result.updatedAt;
+
+        if ( state.inFlightKey ) {
+          // The point may have been unpicked while its inference ran.
+          const stillWanted = state.points.some( ( pt ) => pointKey( pt ) === state.inFlightKey );
+
+          if ( stillWanted ) {
+            state.masks.set(
+              state.inFlightKey,
+              result.result
+            );
+            state.version++;
+          }
+
+          state.inFlightKey = null;
+        }
+      }
+
+      if (
+        state.inFlightKey &&
+        performance.now() - state.inFlightAt > IN_FLIGHT_TIMEOUT_MS
+      ) {
+        state.inFlightKey = null;
+      }
+
+      if (
+        state.inFlightKey ||
+        !photo?.img?.width ||
+        !mediapipe.processor.ready ||
+        mediapipe.processor.busy
+      ) {
+        return;
+      }
+
+      const next = state.points.find( ( pt ) => !state.masks.has( pointKey( pt ) ) );
+
+      if ( !next ) {
+        return;
+      }
+
+      state.inFlightKey = pointKey( next );
+      state.inFlightAt = performance.now();
+
+      const imageElement = photo.img.canvas || photo.img.elt || photo.img;
+
+      interact(
+        next.x * photo.img.width,
+        next.y * photo.img.height,
+        imageElement
+      );
+    },
+
+    // Union of every cached mask: data[i] = 1 where any mask marks the
+    // pixel as subject. `inverse` mirrors the sketches' checkbox (with it
+    // on, the model's category mask marks the clicked object with 0).
+    // Cached until the mask set or the flag changes.
+    combined( inverse ) {
+      if ( state.masks.size === 0 ) {
+        return null;
+      }
+
+      const cache = state.combinedCache;
+
+      if ( cache && cache.version === state.version && cache.inverse === inverse ) {
+        return cache;
+      }
+
+      let width = 0;
+      let height = 0;
+      let out = null;
+
+      state.masks.forEach( ( raw ) => {
+        if ( !raw?.data ) {
+          return;
+        }
+
+        if ( !out ) {
+          width = raw.width;
+          height = raw.height;
+          out = new Uint8Array( width * height );
+        }
+
+        // A mask with other dimensions is stale (previous photo) — skip it.
+        if ( raw.width !== width || raw.height !== height ) {
+          return;
+        }
+
+        const data = raw.data;
+        const length = Math.min(
+          data.length,
+          out.length
+        );
+
+        for ( let i = 0; i < length; i++ ) {
+          if ( inverse ? data[ i ] === 0 : data[ i ] > 0 ) {
+            out[ i ] = 1;
+          }
+        }
+      } );
+
+      if ( !out ) {
+        return null;
+      }
+
+      state.combinedCache = {
+        version: state.version,
+        inverse,
+        data: out,
+        width,
+        height
+      };
+
+      return state.combinedCache;
+    }
+  };
+}
+
+// ── Focus-marker UI ─────────────────────────────────────────────────────────
+// The circles drawn on every picked point carry a small "minus" line: the
+// affordance that clicking the circle unpicks that zone.
+
+/**
+ * Index of the focus point whose marker contains the canvas-space `point`,
+ * or -1. `rect` is the photo rectangle on the canvas ({x, y, w, h}).
+ */
+export function hitFocusMarker(
+  points, rect, point, radius
+) {
+  if ( !rect || rect.w <= 0 || rect.h <= 0 ) {
+    return -1;
+  }
+
+  for ( let i = 0; i < points.length; i++ ) {
+    const cx = rect.x + points[ i ].x * rect.w;
+    const cy = rect.y + points[ i ].y * rect.h;
+
+    if ( Math.hypot(
+      point.x - cx,
+      point.y - cy
+    ) <= radius ) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Draw one circle + minus per focus point. `cfg` mirrors the sketches'
+ * marker option block ({ color, radius, weight }).
+ */
+export function drawFocusMarkers(
+  p, points, rect, cfg
+) {
+  if ( !rect || rect.w <= 0 || rect.h <= 0 || points.length === 0 ) {
+    return;
+  }
+
+  const radius = cfg.radius ?? 16;
+  const weight = cfg.weight ?? 3;
+  const color = cfg.color ?? [
+    255
+  ];
+
+  p.push();
+  p.noFill();
+  p.stroke( ...color );
+  p.strokeWeight( weight );
+
+  points.forEach( ( pt ) => {
+    const cx = rect.x + pt.x * rect.w;
+    const cy = rect.y + pt.y * rect.h;
+
+    p.circle(
+      cx,
+      cy,
+      radius * 2
+    );
+
+    // The "minus" inside the circle: click here to unpick this zone.
+    p.line(
+      cx - radius * 0.45,
+      cy,
+      cx + radius * 0.45,
+      cy
+    );
+  } );
+
+  p.pop();
+}

--- a/src/sketches/p5/utils/multiSegmentation.js
+++ b/src/sketches/p5/utils/multiSegmentation.js
@@ -19,7 +19,19 @@ function pointKey( pt ) {
   return `${ pt.x.toFixed( 5 ) },${ pt.y.toFixed( 5 ) }`;
 }
 
-export function createMultiMaskSegmenter() {
+/**
+ * @param {object} [config]
+ * @param {boolean} [config.adoptLatest=false] - Attribute a result whose
+ *   focus point was replaced while its inference ran to the next point still
+ *   missing a mask, instead of discarding it. Single-point sketches that
+ *   re-pick faster than the segmenter answers (the v2 noise walk) want this:
+ *   it reproduces the pre-manager racing semantics where the latest landed
+ *   result was always shown. Multi-point sketches must keep it off — an
+ *   unpicked zone's mask must never be attributed to another point.
+ */
+export function createMultiMaskSegmenter( {
+  adoptLatest = false
+} = {} ) {
   const state = {
     // Focus points, normalized (0-1) image space.
     points: [],
@@ -110,13 +122,25 @@ export function createMultiMaskSegmenter() {
       if ( result?.result && result.updatedAt !== state.lastResultAt ) {
         state.lastResultAt = result.updatedAt;
 
-        if ( state.inFlightKey ) {
-          // The point may have been unpicked while its inference ran.
-          const stillWanted = state.points.some( ( pt ) => pointKey( pt ) === state.inFlightKey );
+        // The point may have been unpicked while its inference ran; with
+        // adoptLatest the orphaned result goes to the next maskless point
+        // (old racing semantics), otherwise it is discarded.
+        let targetKey =
+          state.inFlightKey &&
+          state.points.some( ( pt ) => pointKey( pt ) === state.inFlightKey )
+            ? state.inFlightKey
+            : null;
 
-          if ( stillWanted ) {
+        if ( !targetKey && adoptLatest ) {
+          const orphanTarget = state.points.find( ( pt ) => !state.masks.has( pointKey( pt ) ) );
+
+          targetKey = orphanTarget ? pointKey( orphanTarget ) : null;
+        }
+
+        if ( state.inFlightKey || adoptLatest ) {
+          if ( targetKey ) {
             state.masks.set(
-              state.inFlightKey,
+              targetKey,
               result.result
             );
             state.version++;


### PR DESCRIPTION
## What

The interactive segmenter now supports **several focus points at once** in both `photo-segmentation-v1-mask` and `photo-trail-effect-v1`:

- **Click the photo → add a focus point.** Every point gets its own MediaPipe inference and its own cached mask; the subject cut-out is the **union** of all masks (so you can pick two animals, or a subject plus a prop).
- **Click a focus marker → unpick that zone.** Each marker circle now carries a small **"minus"** line as the affordance; clicking inside the circle removes that point and its mask, and the cut-out rebuilds without it.

`photo-segmentation-v2-noise-reveal` is also **ported to the shared manager** — a pure refactor, its render and noise-walk animation are unchanged.

## How

- New shared manager **`utils/multiSegmentation.js`** used by all three sketches:
  - per-point raw-mask cache keyed by the point,
  - a one-at-a-time inference pump (the interactive task has a single result slot, so requests run sequentially, with a retry timeout for dropped ones); results landing while their point was unpicked are discarded,
  - a cached union that applies the `inverse` flag per raw mask,
  - `drawFocusMarkers` (circle + minus) and `hitFocusMarker` (the unpick hit-test),
  - an opt-in **`adoptLatest`** mode for the v2 single-point walk: when a pick replaces the point before its inference lands, the landed result is attributed to the current point (the pre-manager racing semantics) instead of being discarded — without it a pick cadence faster than the segmenter would never reveal anything. Multi-point sketches keep the strict default.
- The feather/expand edge pipeline is unchanged — it now runs on the binary union instead of a single raw mask. In v2 the previous subject stays on screen until the new pick's mask lands, so masks keep replacing each other with no blank frame, exactly as before.
- In the trail sketch, click routing is: trail drag-handle → focus marker (unpick) → photo (pick). Markers show by default there now, since they double as the unpick control.

## Options / compatibility

- v1-mask + trail: `segmentation.roi` (single point) becomes **`segmentation.points`** (item-list of `vector2d`, editable per point from the form). Templates saved with the old `roi` shape still load: the single point is adopted as the first focus point. An explicitly empty `points` array means "no subject picked" and is respected.
- v2 keeps its `segmentation.roi` option shape untouched (single walking point).

## Verification

- `npm run check` (lint + typecheck + 1799 tests) and `npm run build` pass.
- Verified headlessly against the production build:
  - v1-mask + trail: initial point segments on load; a click adds a second zone (options go 1 → 2 points, the cut-out becomes the union of both masks); clicking the marker at that spot unpicks it (back to 1 point) — zero page errors.
  - v2-noise-reveal: the walk keeps picking on its own (distinct roi values over time), each pick's zone revealed sharp over the blurred backdrop with no blank frame between masks — zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVMDcUJoeuxo9JvPYkmD8d