### PR TITLE
Interaction bindings: inert seed, on-demand lifecycle, and relocation out of sketch.*

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
@@ -26,6 +26,14 @@ import {
 import {
   interactionBindingsEnabled
 } from "@/lib/interactionBindings";
+// bindings.js is already a small, pure module statically imported by the
+// engine runtime for every sketch (see options.js) — importing it here too is
+// no added weight. defaults.js (the ~1000-line panel/values data) is dynamic
+// -imported lazily inside enableSourceInputs below, so an editor session that
+// never binds a live input source never pulls it into the client bundle.
+import {
+  needsInteractionBlock
+} from "@/p5/utils/interaction/bindings.js";
 import {
   type Binding,
   type BindingKind,
@@ -98,7 +106,7 @@ export default function BindingAffordance( {
   config
 }: Props ) {
   const {
-    setValue, register
+    setValue, register, getValues
   } = useFormContext();
 
   const scope = getSketchScope( fieldPath );
@@ -162,6 +170,28 @@ export default function BindingAffordance( {
   // control.
   const bindingPath = `${ bindingsPath }.${ index }`;
 
+  // Strip the scope's `interaction` block once no binding needs it any more —
+  // the inverse of enableSourceInputs' on-demand seed below. Checked after
+  // every bindings-array write (add / remove / reset) and every source-
+  // category switch, so a sketch never carries the block, or shows its
+  // settings panel (gated the same way in GenericObjectForm), once its last
+  // interactive binding is gone.
+  const pruneInteractionIfUnused = ( nextList: Binding[] ) => {
+    if ( needsInteractionBlock( nextList ) ) {
+      return;
+    }
+
+    if ( getValues( `${ scope }.interaction` ) !== undefined ) {
+      setValue(
+        `${ scope }.interaction`,
+        undefined,
+        {
+          shouldDirty: true
+        }
+      );
+    }
+  };
+
   const writeBindings = ( next: Binding[] ) => {
     setValue(
       bindingsPath,
@@ -170,6 +200,7 @@ export default function BindingAffordance( {
         shouldDirty: true
       }
     );
+    pruneInteractionIfUnused( next );
   };
 
   const setField = (
@@ -186,10 +217,26 @@ export default function BindingAffordance( {
 
   // Picking an interaction input source should make it actually produce a
   // channel — flip the matching `interaction.*` enable flags on so the camera /
-  // mic / sensor for that source boots immediately. `sketch.interaction` exists
-  // on every sketch (seeded in getSketchMeta), so these writes land and the
-  // Interaction panel's own toggles reflect them.
-  const enableSourceInputs = ( source: string ) => {
+  // mic / sensor for that source boots immediately. The scope's `interaction`
+  // block only exists once something needs it (seeded server-side for sketches
+  // that already ship input-sourced bindings, pruned client-side otherwise —
+  // see getSketchMeta / pruneInteractionIfUnused), so the first pick seeds an
+  // inert clone of the shared defaults before flipping its flags on.
+  const enableSourceInputs = async( source: string ) => {
+    if ( getValues( `${ scope }.interaction` ) === undefined ) {
+      const {
+        inertInteractionFormValues
+      } = await import( "@/p5/utils/interaction/defaults.js" );
+
+      setValue(
+        `${ scope }.interaction`,
+        inertInteractionFormValues(),
+        {
+          shouldDirty: true
+        }
+      );
+    }
+
     for ( const path of interactionEnablePaths( source ) ) {
       setValue(
         `${ scope }.interaction.${ path }`,
@@ -201,18 +248,24 @@ export default function BindingAffordance( {
     }
   };
 
-  // Append a new layer (binding) for this parameter and select it.
+  // Append a new layer (binding) for this parameter and select it. The default
+  // source is the baseline input (mouse) — an interactive binding as soon as
+  // it exists, so it seeds/enables the interaction block like any explicit
+  // source pick.
   const addLayer = () => {
+    const first = sourceOptions[ 0 ];
+
     writeBindings( [
       ...list,
       makeDefaultBinding(
         target,
         kind,
-        sourceOptions[ 0 ],
+        first,
         config
       )
     ] );
     setSelLayer( layers.length );
+    void enableSourceInputs( first.source );
   };
 
   // Remove the selected layer, then select a remaining one.
@@ -382,7 +435,20 @@ export default function BindingAffordance( {
         "project",
         first.project ?? null
       );
-      enableSourceInputs( first.source );
+      void enableSourceInputs( first.source );
+    }
+
+    // Switching THIS binding away from an input source may have removed the
+    // scope's last reason to carry the interaction block — check with the
+    // projected next source (the write above hasn't round-tripped through
+    // form state yet within this same tick).
+    if ( next !== "input" ) {
+      pruneInteractionIfUnused( list.map( (
+        b, i
+      ) => ( i === index ? {
+        ...b,
+        source: next
+      } : b ) ) );
     }
   };
 
@@ -590,7 +656,7 @@ export default function BindingAffordance( {
                         "project",
                         project ?? null
                       );
-                      enableSourceInputs( source );
+                      void enableSourceInputs( source );
                     } }
                     aria-label="Source"
                     className="absolute inset-0 h-full w-full cursor-pointer opacity-0"

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
@@ -52,6 +52,7 @@ import {
   DEFAULT_RANDOM,
   encodeSource,
   getSketchScope,
+  interactiveScopeFor,
   interactionEnablePaths,
   makeDefaultBinding,
   SEQUENCE_MODE_OPTIONS,
@@ -94,8 +95,10 @@ function fieldDomain( config: FieldConfig ) {
  * the channel's activity; clicking it opens a popover to pick the source,
  * range, curve and smoothing — or to remove the binding.
  *
- * Bindings are stored as data at `<scope>.bindings` (an array on the sketch
- * settings), resolved at read time by the options proxy. The mapping-range and
+ * Bindings are stored as data at the sketch scope's paired `interactive`
+ * namespace (`interactive.bindings` / `slides.N.interactive.bindings` — see
+ * interactiveScopeFor), resolved at read time by the options proxy so binding
+ * data never pollutes the sketch's own parameters. The mapping-range and
  * smoothing controls are real `ControlledSliderInput`s and the enable/invert
  * toggles are the shared `ToggleSwitch`, both bound to the binding's path in
  * the form so they behave exactly like every other control in the panel.
@@ -111,7 +114,10 @@ export default function BindingAffordance( {
 
   const scope = getSketchScope( fieldPath );
   const target = toSketchRelativePath( fieldPath );
-  const bindingsPath = scope ? `${ scope }.bindings` : "";
+  // Binding data lives in the `interactive` namespace paired with the field's
+  // sketch scope — never inside the sketch parameters themselves.
+  const interactiveScope = scope ? interactiveScopeFor( scope ) : "";
+  const bindingsPath = interactiveScope ? `${ interactiveScope }.bindings` : "";
 
   const bindings = useWatch( {
     name: bindingsPath || "__no_bindings__"
@@ -170,20 +176,22 @@ export default function BindingAffordance( {
   // control.
   const bindingPath = `${ bindingsPath }.${ index }`;
 
-  // Strip the scope's `interaction` block once no binding needs it any more —
-  // the inverse of enableSourceInputs' on-demand seed below. Checked after
-  // every bindings-array write (add / remove / reset) and every source-
+  // Strip the plugin-managed `interaction` block once no binding needs it any
+  // more — the inverse of enableSourceInputs' on-demand seed below. Checked
+  // after every bindings-array write (add / remove / reset) and every source-
   // category switch, so a sketch never carries the block, or shows its
   // settings panel (gated the same way in GenericObjectForm), once its last
-  // interactive binding is gone.
+  // interactive binding is gone. Only the `interactive` namespace is pruned —
+  // a sketch-DECLARED block at `${scope}.interaction` is a real sketch
+  // parameter (hand-tracking, audio, …) and is never touched.
   const pruneInteractionIfUnused = ( nextList: Binding[] ) => {
     if ( needsInteractionBlock( nextList ) ) {
       return;
     }
 
-    if ( getValues( `${ scope }.interaction` ) !== undefined ) {
+    if ( getValues( `${ interactiveScope }.interaction` ) !== undefined ) {
       setValue(
-        `${ scope }.interaction`,
+        `${ interactiveScope }.interaction`,
         undefined,
         {
           shouldDirty: true
@@ -217,29 +225,38 @@ export default function BindingAffordance( {
 
   // Picking an interaction input source should make it actually produce a
   // channel — flip the matching `interaction.*` enable flags on so the camera /
-  // mic / sensor for that source boots immediately. The scope's `interaction`
-  // block only exists once something needs it (seeded server-side for sketches
-  // that already ship input-sourced bindings, pruned client-side otherwise —
-  // see getSketchMeta / pruneInteractionIfUnused), so the first pick seeds an
-  // inert clone of the shared defaults before flipping its flags on.
+  // mic / sensor for that source boots immediately. The flags land wherever
+  // the interaction block actually lives: a sketch-DECLARED block at the
+  // sketch scope (hand-tracking, audio, … — their own panel and sketch code
+  // read it, and the engine gives it precedence) is written in place;
+  // otherwise the plugin-managed block in the `interactive` namespace is
+  // seeded from an inert clone of the shared defaults on first use, then
+  // flipped. The seed never touches sketch parameters, and is pruned again by
+  // pruneInteractionIfUnused once no binding needs it.
   const enableSourceInputs = async( source: string ) => {
-    if ( getValues( `${ scope }.interaction` ) === undefined ) {
-      const {
-        inertInteractionFormValues
-      } = await import( "@/p5/utils/interaction/defaults.js" );
+    let interactionScope = scope;
 
-      setValue(
-        `${ scope }.interaction`,
-        inertInteractionFormValues(),
-        {
-          shouldDirty: true
-        }
-      );
+    if ( getValues( `${ scope }.interaction` ) === undefined ) {
+      interactionScope = interactiveScope;
+
+      if ( getValues( `${ interactiveScope }.interaction` ) === undefined ) {
+        const {
+          inertInteractionFormValues
+        } = await import( "@/p5/utils/interaction/defaults.js" );
+
+        setValue(
+          `${ interactiveScope }.interaction`,
+          inertInteractionFormValues(),
+          {
+            shouldDirty: true
+          }
+        );
+      }
     }
 
     for ( const path of interactionEnablePaths( source ) ) {
       setValue(
-        `${ scope }.interaction.${ path }`,
+        `${ interactionScope }.interaction.${ path }`,
         true,
         {
           shouldDirty: true

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/BindingAffordance.tsx
@@ -92,8 +92,13 @@ function fieldDomain( config: FieldConfig ) {
 /**
  * The per-field modulation control. A small pastille sits beside a bindable
  * field (slider / number / vector2d). Bound, it is a live VU meter glowing with
- * the channel's activity; clicking it opens a popover to pick the source,
+ * the source's activity; clicking it opens a popover to pick the source,
  * range, curve and smoothing — or to remove the binding.
+ *
+ * A first click starts the parameter oscillating (see makeDefaultBinding):
+ * generators need no device, no permission and no interaction block, so
+ * modulating a parameter is a zero-consequence action until the user
+ * deliberately switches the source to a live input.
  *
  * Bindings are stored as data at the sketch scope's paired `interactive`
  * namespace (`interactive.bindings` / `slides.N.interactive.bindings` — see
@@ -234,6 +239,14 @@ export default function BindingAffordance( {
   // flipped. The seed never touches sketch parameters, and is pruned again by
   // pruneInteractionIfUnused once no binding needs it.
   const enableSourceInputs = async( source: string ) => {
+    const paths = interactionEnablePaths( source );
+
+    // Generators (and unknown ids) have no source to enable — and must not
+    // seed an interaction block they'd never read.
+    if ( paths.length === 0 ) {
+      return;
+    }
+
     let interactionScope = scope;
 
     if ( getValues( `${ scope }.interaction` ) === undefined ) {
@@ -254,7 +267,7 @@ export default function BindingAffordance( {
       }
     }
 
-    for ( const path of interactionEnablePaths( source ) ) {
+    for ( const path of paths ) {
       setValue(
         `${ interactionScope }.interaction.${ path }`,
         true,
@@ -265,24 +278,23 @@ export default function BindingAffordance( {
     }
   };
 
-  // Append a new layer (binding) for this parameter and select it. The default
-  // source is the baseline input (mouse) — an interactive binding as soon as
-  // it exists, so it seeds/enables the interaction block like any explicit
-  // source pick.
+  // Append a new layer (binding) for this parameter and select it. A continuous
+  // target starts on the oscillator (see makeDefaultBinding) — a generator, so
+  // nothing is enabled and no interaction block is seeded; a vector2d target
+  // starts on an input source, which is enabled like any explicit source pick.
   const addLayer = () => {
-    const first = sourceOptions[ 0 ];
+    const binding = makeDefaultBinding(
+      target,
+      kind,
+      config
+    );
 
     writeBindings( [
       ...list,
-      makeDefaultBinding(
-        target,
-        kind,
-        first,
-        config
-      )
+      binding
     ] );
     setSelLayer( layers.length );
-    void enableSourceInputs( first.source );
+    void enableSourceInputs( binding.source );
   };
 
   // Remove the selected layer, then select a remaining one.
@@ -522,7 +534,7 @@ export default function BindingAffordance( {
   return (
     <Popover className="relative shrink-0">
       <PopoverButton
-        title={ bound ? "Edit modulation" : "Bind to an interactive input" }
+        title={ bound ? "Edit modulation" : "Modulate this parameter" }
         onClick={ () => {
           // First click on an unbound field creates the first layer AND opens
           // the popover (no preventDefault) so it can be configured immediately.

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
@@ -307,6 +307,22 @@ export function toSketchRelativePath( registeredName: string ): string | null {
   return String( registeredName ).slice( scope.length + 1 );
 }
 
+/**
+ * The `interactive` namespace scope paired with a sketch-settings scope —
+ * where the binding system stores its data (`bindings`, and the plugin-managed
+ * `interaction` block), OUTSIDE the sketch's own parameters:
+ *   "sketch"          → "interactive"
+ *   "slides.2.sketch" → "slides.2.interactive"
+ */
+export function interactiveScopeFor( sketchScope: string ): string {
+  return sketchScope === "sketch"
+    ? "interactive"
+    : sketchScope.replace(
+      /\.sketch$/,
+      ".interactive"
+    );
+}
+
 // ── Default binding factory ─────────────────────────────────────────────────
 
 function makeId(): string {

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils.ts
@@ -340,11 +340,20 @@ function makeId(): string {
  * Build a sensible default binding for a field, pre-filling the mapping range
  * from the field's configured min/max so the modulation lands in a useful
  * range out of the box.
+ *
+ * A continuous target starts on the OSCILLATOR, not an input channel: a
+ * generator computes from the sketch's own progression, so creating a binding
+ * needs no interaction block, asks for no camera/mic, and stays deterministic
+ * under recording — the parameter simply starts animating. Reaching for a live
+ * input is then an explicit choice in the source selector (which seeds the
+ * interaction block at that point — see enableSourceInputs).
+ *
+ * A vector2d target has no generator family (mapVector reads a channel), so it
+ * starts on the first input source instead.
  */
 export function makeDefaultBinding(
   target: string,
   kind: BindingKind,
-  source: SourceOption,
   config: FieldConfig
 ): Binding {
   const anyConfig = config as any;
@@ -352,6 +361,7 @@ export function makeDefaultBinding(
   if ( kind === "vector2d" ) {
     const min = anyConfig.min ?? 0;
     const max = anyConfig.max ?? 1;
+    const source = channelSourceOptions( kind )[ 0 ];
 
     return {
       id: makeId(),
@@ -377,10 +387,12 @@ export function makeDefaultBinding(
 
   return {
     id: makeId(),
-    source: source.source,
-    project: source.project,
+    source: "oscillator",
     target,
     kind: "continuous",
+    oscillator: {
+      ...DEFAULT_OSCILLATOR
+    },
     mapping: {
       min: anyConfig.min ?? 0,
       max: anyConfig.max ?? 1,

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config.ts
@@ -26,6 +26,15 @@ interface BaseConfig {
    * falls back to a sensible zero value.
    */
   default?: unknown;
+  /**
+   * Marks a field injected by the platform rather than declared by the
+   * sketch's own options.ts. Today only the interaction-bindings plugin's
+   * shared Interaction panel sets it: the form renders a managed interaction
+   * field against the top-level `interactive` namespace (and only while a
+   * binding needs it), where a sketch-declared one edits the sketch scope
+   * unconditionally.
+   */
+  managed?: boolean;
 }
 
 // Step 2: Define the config shape for each component type

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/InteractivePanel/InteractivePanel.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/InteractivePanel/InteractivePanel.tsx
@@ -25,7 +25,8 @@ import {
 import {
   type Binding,
   bindingSourceLabel,
-  humanizeTarget
+  humanizeTarget,
+  interactiveScopeFor
 } from "../ContentItems/components/BindingAffordance/bindingUtils";
 
 type Props = {
@@ -56,7 +57,11 @@ export default function InteractivePanel( {
     expanded,
     setExpanded
   ] = useState( false );
-  const bindingsPath = `${ basePath }.bindings`;
+  // Binding data lives in the `interactive` namespace paired with the scope's
+  // sketch settings ("sketch" → "interactive", "slides.N.sketch" →
+  // "slides.N.interactive") — never inside the sketch parameters.
+  const interactiveScope = interactiveScopeFor( basePath );
+  const bindingsPath = `${ interactiveScope }.bindings`;
   const bindings = useWatch( {
     name: bindingsPath
   } ) as Binding[] | undefined;
@@ -139,13 +144,15 @@ export default function InteractivePanel( {
     );
 
     // Mirrors BindingAffordance.pruneInteractionIfUnused: the mixer can also
-    // remove the scope's last binding that needed the interaction block.
+    // remove the scope's last binding that needed the interaction block. Only
+    // the plugin-managed block in the `interactive` namespace is pruned — a
+    // sketch-declared `sketch.interaction` is a real parameter and stays.
     if (
       !needsInteractionBlock( next ) &&
-      getValues( `${ basePath }.interaction` ) !== undefined
+      getValues( `${ interactiveScope }.interaction` ) !== undefined
     ) {
       setValue(
-        `${ basePath }.interaction`,
+        `${ interactiveScope }.interaction`,
         undefined,
         {
           shouldDirty: true

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/InteractivePanel/InteractivePanel.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/InteractivePanel/InteractivePanel.tsx
@@ -20,6 +20,9 @@ import {
 import ControlledSliderInput
   from "../ContentItems/components/ControlledSliderInput/ControlledSliderInput";
 import {
+  needsInteractionBlock
+} from "@/p5/utils/interaction/bindings.js";
+import {
   type Binding,
   bindingSourceLabel,
   humanizeTarget
@@ -47,7 +50,7 @@ export default function InteractivePanel( {
   basePath
 }: Props ) {
   const {
-    setValue
+    setValue, getValues
   } = useFormContext();
   const [
     expanded,
@@ -123,15 +126,32 @@ export default function InteractivePanel( {
   };
 
   const removeAt = ( index: number ) => {
+    const next = list.filter( (
+      _, j
+    ) => j !== index );
+
     setValue(
       bindingsPath,
-      list.filter( (
-        _, j
-      ) => j !== index ),
+      next,
       {
         shouldDirty: true
       }
     );
+
+    // Mirrors BindingAffordance.pruneInteractionIfUnused: the mixer can also
+    // remove the scope's last binding that needed the interaction block.
+    if (
+      !needsInteractionBlock( next ) &&
+      getValues( `${ basePath }.interaction` ) !== undefined
+    ) {
+      setValue(
+        `${ basePath }.interaction`,
+        undefined,
+        {
+          shouldDirty: true
+        }
+      );
+    }
   };
 
   const clearSolos = () => {

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
@@ -1,7 +1,13 @@
 import dynamic from "next/dynamic";
 import {
+  useWatch
+} from "react-hook-form";
+import {
   FieldConfig
 } from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config";
+import {
+  needsInteractionBlock
+} from "@/p5/utils/interaction/bindings.js";
 
 // FieldRenderer is the heavy hub of the option form: it statically pulls in all
 // nine Controlled* inputs and recurses through ItemListRenderer (a large
@@ -20,6 +26,38 @@ type GenericObjectFormProps = {
   config: Record<string, FieldConfig>;
 };
 
+// The shared Interaction block's field descriptor is present in `config`
+// unconditionally (it's a static, cheap schema — see getSketchMeta), but the
+// block itself — and this panel — should only show up once a live binding
+// actually reads from it. Otherwise every sketch with the plugin on would
+// show a giant "Interaction" settings group despite having zero bindings.
+// Watching `bindings` (rather than `interaction` itself) means the panel
+// disappears the instant the last qualifying binding is removed, matching
+// BindingAffordance/InteractivePanel's pruning of the value block.
+function InteractionField( {
+  fieldBasePath, fieldName, config
+}: {
+  fieldBasePath: string;
+  fieldName: string;
+  config: FieldConfig;
+} ) {
+  const bindings = useWatch( {
+    name: `${ fieldBasePath }.bindings`
+  } );
+
+  if ( !needsInteractionBlock( bindings ) ) {
+    return null;
+  }
+
+  return (
+    <FieldRenderer
+      fieldBasePath={ fieldBasePath }
+      fieldName={ fieldName }
+      config={ config }
+    />
+  );
+}
+
 export default function GenericObjectForm( {
   basePath = "",
   config
@@ -34,6 +72,17 @@ export default function GenericObjectForm( {
         if ( !fieldConfig ) {
           console.warn( `No form config found for field "${ fieldName }".` );
           return null;
+        }
+
+        if ( fieldName === "interaction" ) {
+          return (
+            <InteractionField
+              key={ fieldName }
+              fieldBasePath={ basePath }
+              fieldName={ fieldName }
+              config={ fieldConfig }
+            />
+          );
         }
 
         return (

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/RootSettings/components/GenericObjectForm/GenericObjectForm.tsx
@@ -6,8 +6,8 @@ import {
   FieldConfig
 } from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/constants/field-config";
 import {
-  needsInteractionBlock
-} from "@/p5/utils/interaction/bindings.js";
+  interactiveScopeFor
+} from "@/components/ClientProcessingSketch/components/SketchOptions/components/ContentItems/components/BindingAffordance/bindingUtils";
 
 // FieldRenderer is the heavy hub of the option form: it statically pulls in all
 // nine Controlled* inputs and recurses through ItemListRenderer (a large
@@ -26,32 +26,38 @@ type GenericObjectFormProps = {
   config: Record<string, FieldConfig>;
 };
 
-// The shared Interaction block's field descriptor is present in `config`
-// unconditionally (it's a static, cheap schema — see getSketchMeta), but the
-// block itself — and this panel — should only show up once a live binding
-// actually reads from it. Otherwise every sketch with the plugin on would
-// show a giant "Interaction" settings group despite having zero bindings.
-// Watching `bindings` (rather than `interaction` itself) means the panel
-// disappears the instant the last qualifying binding is removed, matching
-// BindingAffordance/InteractivePanel's pruning of the value block.
-function InteractionField( {
-  fieldBasePath, fieldName, config
+// The plugin-INJECTED Interaction panel (config.managed — see getSketchMeta).
+// Its field descriptor is present in `config` unconditionally (a static,
+// cheap schema), but the panel only shows while the plugin-managed block
+// actually exists in the scope's `interactive` namespace — seeded the first
+// time a binding picks a live input source, pruned when the last such binding
+// goes (see BindingAffordance) — so its lifecycle exactly tracks the value
+// block it edits, and a sketch with zero bindings never shows a giant
+// "Interaction" settings group. It edits the `interactive` namespace, never
+// the sketch parameters.
+//
+// A sketch-DECLARED interaction config (no `managed` flag — hand-tracking,
+// audio, …) never routes through here: it is a real sketch parameter, edited
+// at the sketch scope and rendered unconditionally like any other field.
+function ManagedInteractionField( {
+  sketchBasePath, fieldName, config
 }: {
-  fieldBasePath: string;
+  sketchBasePath: string;
   fieldName: string;
   config: FieldConfig;
 } ) {
-  const bindings = useWatch( {
-    name: `${ fieldBasePath }.bindings`
+  const interactiveScope = interactiveScopeFor( sketchBasePath );
+  const interaction = useWatch( {
+    name: `${ interactiveScope }.interaction`
   } );
 
-  if ( !needsInteractionBlock( bindings ) ) {
+  if ( interaction === undefined ) {
     return null;
   }
 
   return (
     <FieldRenderer
-      fieldBasePath={ fieldBasePath }
+      fieldBasePath={ interactiveScope }
       fieldName={ fieldName }
       config={ config }
     />
@@ -74,11 +80,11 @@ export default function GenericObjectForm( {
           return null;
         }
 
-        if ( fieldName === "interaction" ) {
+        if ( fieldName === "interaction" && fieldConfig.managed ) {
           return (
-            <InteractionField
+            <ManagedInteractionField
               key={ fieldName }
-              fieldBasePath={ basePath }
+              sketchBasePath={ basePath }
               fieldName={ fieldName }
               config={ fieldConfig }
             />

--- a/src/components/SketchPage/SketchPage.tsx
+++ b/src/components/SketchPage/SketchPage.tsx
@@ -283,15 +283,22 @@ export default function SketchPage() {
   // When the sketch consumes touch input (interaction.touch source), hand the
   // touchscreen over to it: the viewport must not pan/zoom — nor pause the
   // loop — on finger gestures. The options store is the only bridge needed;
-  // the sketch itself stays unaware of the UI. Mirrors the runtime merge in
-  // slides.getSketchSettings(): a slide-level `sketch` shallowly overrides
-  // the global one, so its `interaction` block wins when present.
+  // the sketch itself stays unaware of the UI. Mirrors the engine's
+  // effectiveInteractive precedence: a sketch-declared `interaction` block
+  // (slide sketch over global, like slides.getSketchSettings()) wins; the
+  // binding plugin's `interactive.interaction` namespace (slide over root)
+  // fills in when the sketch declares none.
   const disableTouchGestures = useMemo(
     () => {
-      const slideSketch = activeSlideIndex !== undefined
-        ? options?.slides?.[ activeSlideIndex ]?.sketch
+      const slide = activeSlideIndex !== undefined
+        ? options?.slides?.[ activeSlideIndex ]
         : undefined;
-      const interaction = ( slideSketch?.interaction ?? options?.sketch?.interaction ) as
+      const interaction = (
+        slide?.sketch?.interaction ??
+        options?.sketch?.interaction ??
+        slide?.interactive?.interaction ??
+        options?.interactive?.interaction
+      ) as
         | { enabled?: boolean;
           touch?: { enabled?: boolean } }
         | undefined;

--- a/src/sketches/p5/utils/interaction/bindings.js
+++ b/src/sketches/p5/utils/interaction/bindings.js
@@ -133,6 +133,20 @@ export function isGenerator( source ) {
   return GENERATOR_SOURCES.has( source );
 }
 
+// Whether any binding in the list is bound to a live "input" channel — as
+// opposed to a generator, which computes standalone from the sketch's own
+// progression and needs no `interaction` block at all. Shared by the
+// server-side seed (getSketchOptions.getSketchMeta, for sketches that ship
+// default input-sourced bindings) and the client binding UI
+// (BindingAffordance / GenericObjectForm), so a sketch only carries — and
+// only shows the settings panel for — the shared Interaction block while it
+// actually has a binding that needs it.
+export function needsInteractionBlock( bindings ) {
+  const list = Array.isArray( bindings ) ? bindings : [];
+
+  return list.some( ( binding ) => binding && binding.source && !isGenerator( binding.source ) );
+}
+
 function frac( x ) {
   return x - Math.floor( x );
 }

--- a/src/sketches/p5/utils/interaction/defaults.js
+++ b/src/sketches/p5/utils/interaction/defaults.js
@@ -179,6 +179,24 @@ export const interactionFormValues = {
   }
 };
 
+// A clone of `interactionFormValues` with the top-level and orbit `enabled`
+// flags forced off — the shape every panel control expects, but with nothing
+// live: no interaction handler boot, no orbit virtual pointer. Seeding a
+// sketch's `interaction` block with the raw defaults (enabled: true,
+// orbit.enabled: true) would make it look and behave interactive before any
+// binding actually needs it. Shared by the server-side seed (getSketchOptions
+// .getSketchMeta, for sketches that ship default bindings) and the client
+// seed (BindingAffordance, the first time a binding picks a live input
+// source) so both start from the identical inert shape.
+export function inertInteractionFormValues() {
+  const values = structuredClone( interactionFormValues );
+
+  values.enabled = false;
+  values.orbit.enabled = false;
+
+  return values;
+}
+
 // ── Form configuration fragment ────────────────────────────────────────────
 // Use as:  formConfiguration = { interaction: interactionFormConfiguration, ... }
 

--- a/src/sketches/p5/utils/interaction/index.js
+++ b/src/sketches/p5/utils/interaction/index.js
@@ -982,6 +982,11 @@ function _collectMouse(
     return;
   }
 
+  // Lazily wire the raw pointer listeners, like _initGyro: the engine only
+  // boots initInteraction() at setup when a source is already enabled, so a
+  // mouse source toggled on at runtime must arm tracking itself (idempotent).
+  ensurePointerTracking();
+
   // `offset` is the vector2d pad value; offsetX/offsetY are kept as a fallback
   // for options saved before the two sliders were merged into one pad.
   const ox = mouse.offset?.x ?? mouse.offsetX ?? 0;
@@ -1047,6 +1052,10 @@ function _collectTouch(
   if ( !touch?.enabled ) {
     return;
   }
+
+  // Same runtime-toggle story as _collectMouse: without the setup boot, the
+  // touch listeners must be armed from the collector (idempotent).
+  ensurePointerTracking();
 
   const rawTouches = getRawTouches();
   const maxTouches = touch.maxTouches ?? 5;

--- a/src/sketches/p5/utils/options.js
+++ b/src/sketches/p5/utils/options.js
@@ -517,6 +517,26 @@ export function registerEvents() {
 // dispose-on-reset only loads the (lazy) module when there's something to free.
 let _interactionInited = false;
 
+// The handler-managed source groups, each gated by its own `enabled` flag
+// (`vision` covers all camera trackers). Mirrors the per-source guards the
+// collectors in interaction/index.js check, like interactionEnablePaths in
+// the BindingAffordance does on the form side.
+const INTERACTION_SOURCE_GROUPS = [
+  "mouse",
+  "touch",
+  "vision",
+  "orbit",
+  "perlinNoise",
+  "gyroscope",
+  "midi",
+  "audio",
+  "joypad"
+];
+
+function hasEnabledInteractionSource( interaction ) {
+  return INTERACTION_SOURCE_GROUPS.some( ( source ) => interaction[ source ]?.enabled === true );
+}
+
 // Engine-managed interaction init: when a sketch's options carry an enabled
 // `interaction` block, boot the handler once at setup so its sources (webcam,
 // audio, gyro, touch, …) are available as binding channels with no per-sketch
@@ -524,11 +544,21 @@ let _interactionInited = false;
 // of the core module-eval chain. `initInteraction` is idempotent (re-arms
 // listeners), so it's safe alongside sketches that still call it themselves;
 // fire-and-forget so vision warm-up doesn't block setup.
+//
+// A block with NO enabled source (e.g. the inert one seeded on every sketch
+// when the bindings plugin is on) must not boot: there is nothing to sample,
+// and the baseline mouse binding works without the handler (channels.js keeps
+// its own listener). Sources enabled later at runtime lazy-init from their
+// collectors instead.
 function initInteractionForOptions() {
   try {
     const interaction = liveSketchBase( getSketchOptions() )?.interaction;
 
-    if ( interaction && interaction.enabled !== false ) {
+    if (
+      interaction &&
+      interaction.enabled !== false &&
+      hasEnabledInteractionSource( interaction )
+    ) {
       _interactionInited = true;
       import( "./interaction/index.js" )
         .then( ( mod ) => mod.initInteraction( interaction ) )

--- a/src/sketches/p5/utils/options.js
+++ b/src/sketches/p5/utils/options.js
@@ -552,7 +552,13 @@ function hasEnabledInteractionSource( interaction ) {
 // collectors instead.
 function initInteractionForOptions() {
   try {
-    const interaction = liveSketchBase( getSketchOptions() )?.interaction;
+    const live = getSketchOptions();
+    const {
+      interaction
+    } = effectiveInteractive(
+      live,
+      liveSketchBase( live )
+    );
 
     if (
       interaction &&
@@ -584,7 +590,7 @@ export function disposeInteractionOnReset() {
     .catch( () => {} );
 }
 
-// The per-slide-merged sketch settings object the bindings live on.
+// The per-slide-merged sketch settings object binding targets resolve against.
 function liveSketchBase( live ) {
   if ( typeof window !== "undefined" && window.getSketchSettings ) {
     try {
@@ -595,6 +601,42 @@ function liveSketchBase( live ) {
   }
 
   return live.sketch ?? {};
+}
+
+// The active slide (when the slides module is loaded), for resolving the
+// per-slide `interactive` override without re-deriving slide state here.
+function liveCurrentSlide() {
+  if ( typeof window !== "undefined" && window.getCurrentSlide ) {
+    try {
+      return window.getCurrentSlide()?.slide ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+// The effective interaction-bindings state for the current frame. Bindings and
+// the plugin-managed interaction block live in the top-level `interactive`
+// namespace (root, overridden key-by-key by the active slide's own), NOT
+// inside the sketch parameters. Two deliberate fallbacks:
+//   - bindings: a legacy `bindings` array still sitting on the merged sketch
+//     (pre-migration capture snapshots load without passing through
+//     initOptions) keeps working;
+//   - interaction: a block on the merged sketch WINS — that's a sketch-declared
+//     parameter (hand-tracking, audio, … read it from their own code), and the
+//     binding UI writes source-enable flags into it when it exists.
+function effectiveInteractive(
+  live, base
+) {
+  const root = live?.interactive;
+  const slide = liveCurrentSlide()?.interactive;
+
+  return {
+    bindings: slide?.bindings ?? root?.bindings ?? base?.bindings,
+    interaction: base?.interaction ?? slide?.interaction ?? root?.interaction
+  };
 }
 
 // The generator context: the loop-normalized progression (deterministic during
@@ -624,14 +666,24 @@ function publishChannelsFrame() {
   }
 
   try {
-    const base = liveSketchBase( getSketchOptions() );
-    const channels = sampleChannels( base?.interaction );
+    const live = getSketchOptions();
+    const base = liveSketchBase( live );
+    const {
+      bindings, interaction
+    } = effectiveInteractive(
+      live,
+      base
+    );
+    const channels = sampleChannels( interaction );
 
     publishChannels( channels );
 
-    if ( base && Array.isArray( base.bindings ) && base.bindings.length > 0 ) {
+    if ( Array.isArray( bindings ) && bindings.length > 0 ) {
       publishBindingSignals( computeBindingSignals(
-        base,
+        {
+          ...base,
+          bindings
+        },
         channels,
         bindingContext()
       ) );
@@ -676,26 +728,44 @@ export function syncEffectivePrevious(
 /* ------------------------------------------------------------------ */
 
 // Resolve the per-slide-merged sketch object, then layer interactive bindings
-// over it. `resolveBindings` returns the same object untouched when the sketch
-// declares no bindings, so non-interactive sketches pay nothing.
+// over it. Bindings come from the top-level `interactive` namespace (see
+// effectiveInteractive); with none active the base object is returned
+// untouched, so non-interactive sketches pay nothing — no per-access
+// allocation on this hot path (the proxy runs it on every `.sketch` read).
 function resolveSketch( live ) {
   const base = liveSketchBase( live );
 
-  if (
-    !BINDINGS_ENABLED ||
-    !base ||
-    !Array.isArray( base.bindings ) ||
-    base.bindings.length === 0
-  ) {
+  if ( !BINDINGS_ENABLED || !base ) {
+    return base;
+  }
+
+  const {
+    bindings, interaction
+  } = effectiveInteractive(
+    live,
+    base
+  );
+
+  if ( !Array.isArray( bindings ) || bindings.length === 0 ) {
     return base;
   }
 
   try {
     const context = bindingContext();
 
+    // The shim also grafts the effective interaction onto the resolved clone,
+    // so sketch code reading `options.sketch.interaction` sees the block the
+    // engine actually sampled, wherever it is stored. (resolveBindings
+    // memoizes the clone per frame, so this stays off the per-access path.)
     return resolveBindings(
-      base,
-      sampleChannels( base.interaction ),
+      {
+        ...base,
+        bindings,
+        ...( interaction !== undefined && {
+          interaction
+        } )
+      },
+      sampleChannels( interaction ),
       context.frame,
       context
     );

--- a/src/types/sketch.types.ts
+++ b/src/types/sketch.types.ts
@@ -1494,6 +1494,9 @@ export const SlideSchema = z.object( {
   content: z.array( ContentItemSchema ).default( [] ),
   assets: Assets,
   sketch: z.any().optional(),
+  // Per-slide interaction-bindings namespace (`{ bindings, interaction }`),
+  // overriding the root `interactive` key-by-key — see migrateInteractiveOptions.
+  interactive: z.any().optional(),
   transition: SlideTransitionSchema.optional()
 } );
 
@@ -1519,7 +1522,12 @@ export const OptionsSchema = z.object( {
   // the key to be present unless it says so. Spelled out to match SlideSchema
   // above and keep `OptionsSchema.parse( {} )` working — per-sketch params are
   // supplied by each sketch's own options.ts, not by this root schema.
-  sketch: z.any().optional()
+  sketch: z.any().optional(),
+  // The interaction-bindings plugin's namespace (`{ bindings, interaction }`),
+  // kept OUTSIDE `sketch` so binding data never pollutes the sketch's own
+  // parameters (exports, save-defaults, randomize, sketch code). Untyped like
+  // `sketch` — its shape belongs to the plugin, not this root schema.
+  interactive: z.any().optional()
 } );
 
 export type ContentItem = z.infer<typeof ContentItemSchema>;

--- a/src/utils/__tests__/migrateInteractiveOptions.test.ts
+++ b/src/utils/__tests__/migrateInteractiveOptions.test.ts
@@ -1,0 +1,251 @@
+import migrateInteractiveOptions from "@/utils/migrateInteractiveOptions";
+import initOptions from "@/utils/initOptions";
+
+describe(
+  "migrateInteractiveOptions",
+  () => {
+    it(
+      "moves legacy sketch.bindings to interactive.bindings",
+      () => {
+        const bindings = [
+          {
+            source: "mouse",
+            target: "radius",
+            kind: "continuous"
+          }
+        ];
+        const options: Record<string, any> = migrateInteractiveOptions( {
+          sketch: {
+            radius: 10,
+            bindings
+          }
+        } );
+
+        expect( options.interactive.bindings ).toBe( bindings );
+        expect( options.sketch.bindings ).toBeUndefined();
+        expect( options.sketch.radius ).toBe( 10 );
+      }
+    );
+
+    it(
+      "does NOT mutate the input — the parsed tree shares `sketch` by reference with page props / the live store",
+      () => {
+        const input = {
+          sketch: {
+            radius: 10,
+            bindings: [
+              {
+                source: "mouse",
+                target: "radius",
+                kind: "continuous"
+              }
+            ]
+          },
+          slides: [
+            {
+              sketch: {
+                bindings: [
+                  {
+                    source: "orbit",
+                    target: "spin",
+                    kind: "continuous"
+                  }
+                ]
+              }
+            }
+          ]
+        };
+        const migrated: Record<string, any> = migrateInteractiveOptions( input );
+
+        // The input keeps its legacy shape untouched…
+        expect( input.sketch.bindings ).toHaveLength( 1 );
+        expect( input.slides[ 0 ].sketch.bindings ).toHaveLength( 1 );
+        expect( ( input as Record<string, any> ).interactive ).toBeUndefined();
+
+        // …and a second migration of the same input still finds the bindings
+        // (the original in-place version stripped them on first call, so
+        // re-parses of shared props produced no `interactive` namespace).
+        const again: Record<string, any> = migrateInteractiveOptions( input );
+
+        expect( migrated.interactive.bindings ).toHaveLength( 1 );
+        expect( again.interactive.bindings ).toHaveLength( 1 );
+        expect( again.slides[ 0 ].interactive.bindings ).toHaveLength( 1 );
+      }
+    );
+
+    it(
+      "keeps an existing interactive.bindings over a legacy copy, dropping the legacy one",
+      () => {
+        const kept = [
+          {
+            source: "orbit",
+            target: "count",
+            kind: "continuous"
+          }
+        ];
+        const options: Record<string, any> = migrateInteractiveOptions( {
+          sketch: {
+            bindings: [
+              {
+                source: "mouse",
+                target: "count",
+                kind: "continuous"
+              }
+            ]
+          },
+          interactive: {
+            bindings: kept
+          }
+        } );
+
+        expect( options.interactive.bindings ).toBe( kept );
+        expect( options.sketch.bindings ).toBeUndefined();
+      }
+    );
+
+    it(
+      "leaves sketch.interaction where it is (sketch-declared blocks are real parameters)",
+      () => {
+        const interaction = {
+          enabled: true,
+          vision: {
+            enabled: true
+          }
+        };
+        const options: Record<string, any> = migrateInteractiveOptions( {
+          sketch: {
+            interaction
+          }
+        } );
+
+        expect( options.sketch.interaction ).toBe( interaction );
+        expect( options.interactive ).toBeUndefined();
+      }
+    );
+
+    it(
+      "migrates per-slide sketch.bindings to the slide's interactive namespace",
+      () => {
+        const slideBindings = [
+          {
+            source: "mouse",
+            target: "spin",
+            kind: "continuous"
+          }
+        ];
+        const options: Record<string, any> = migrateInteractiveOptions( {
+          sketch: {},
+          slides: [
+            {
+              sketch: {
+                spin: 1,
+                bindings: slideBindings
+              }
+            },
+            {
+              sketch: {
+                spin: 2
+              }
+            }
+          ]
+        } );
+
+        expect( options.slides[ 0 ].interactive.bindings ).toBe( slideBindings );
+        expect( options.slides[ 0 ].sketch.bindings ).toBeUndefined();
+        expect( options.slides[ 1 ].interactive ).toBeUndefined();
+      }
+    );
+
+    it(
+      "returns the input object unchanged when nothing needs migrating",
+      () => {
+        const input = {
+          sketch: {
+            radius: 4
+          }
+        };
+        const options: Record<string, any> = migrateInteractiveOptions( input );
+
+        expect( options ).toBe( input );
+        expect( options.interactive ).toBeUndefined();
+      }
+    );
+  }
+);
+
+describe(
+  "initOptions (interactive migration wired in)",
+  () => {
+    it(
+      "parses legacy options and relocates bindings, preserving interactive through the schema",
+      () => {
+        const parsed = initOptions( {
+          sketch: {
+            radius: 12,
+            bindings: [
+              {
+                source: "oscillator",
+                target: "radius",
+                kind: "continuous"
+              }
+            ]
+          }
+        } ) as Record<string, any>;
+
+        expect( parsed.interactive.bindings ).toHaveLength( 1 );
+        expect( parsed.sketch.bindings ).toBeUndefined();
+      }
+    );
+
+    it(
+      "leaves the caller's options object intact across repeated initOptions calls",
+      () => {
+        const raw = {
+          sketch: {
+            radius: 12,
+            bindings: [
+              {
+                source: "mouse",
+                target: "radius",
+                kind: "continuous"
+              }
+            ]
+          }
+        };
+
+        const first = initOptions( raw ) as Record<string, any>;
+        const second = initOptions( raw ) as Record<string, any>;
+
+        expect( raw.sketch.bindings ).toHaveLength( 1 );
+        expect( first.interactive.bindings ).toHaveLength( 1 );
+        expect( second.interactive.bindings ).toHaveLength( 1 );
+      }
+    );
+
+    it(
+      "keeps an already-migrated interactive namespace intact through parse",
+      () => {
+        const parsed = initOptions( {
+          interactive: {
+            bindings: [
+              {
+                source: "mouse",
+                target: "spin",
+                kind: "continuous"
+              }
+            ],
+            interaction: {
+              enabled: true,
+              mouse: {
+                enabled: true
+              }
+            }
+          }
+        } ) as Record<string, any>;
+
+        expect( parsed.interactive.bindings ).toHaveLength( 1 );
+        expect( parsed.interactive.interaction.mouse.enabled ).toBe( true );
+      }
+    );
+  }
+);

--- a/src/utils/getSketchOptions.ts
+++ b/src/utils/getSketchOptions.ts
@@ -96,11 +96,23 @@ export async function getSketchMeta(
       interactionFormValues, interactionFormConfiguration
     } = await import( "@/p5/utils/interaction/defaults.js" );
 
+    // The canonical defaults ship "live" (enabled + orbit on) for the sketches
+    // that import them deliberately, but a seeded sketch has no bindings yet —
+    // an active block would boot the interaction handler and run the orbit
+    // virtual pointer on every non-interactive sketch. Seed it INERT instead;
+    // picking an input source on a binding flips `enabled` (and the source's
+    // own flag) back on — see interactionEnablePaths / enableSourceInputs in
+    // the BindingAffordance.
+    const seededInteraction = structuredClone( interactionFormValues );
+
+    seededInteraction.enabled = false;
+    seededInteraction.orbit.enabled = false;
+
     return {
       formValues: needValues
         ? {
           ...loaded.formValues,
-          interaction: structuredClone( interactionFormValues )
+          interaction: seededInteraction
         }
         : loaded.formValues,
       formConfiguration: needConfig

--- a/src/utils/getSketchOptions.ts
+++ b/src/utils/getSketchOptions.ts
@@ -73,46 +73,48 @@ export async function getSketchMeta(
       return loaded;
     }
 
-    const needValues = !!loaded.formValues && !loaded.formValues.interaction;
     const needConfig = !!loaded.formConfiguration && !loaded.formConfiguration.interaction;
+
+    // Only seed the actual VALUES when this sketch already ships bindings
+    // that need them (e.g. a demo sketch with default `bindings` pointing at
+    // a live input) — most sketches have none at load time, and get the block
+    // seeded lazily client-side the first time a binding picks a live input
+    // source (see BindingAffordance.enableSourceInputs). The schema
+    // (formConfiguration) is still added unconditionally: it's a static, cheap
+    // field descriptor with no runtime cost, and the client needs it available
+    // to render the panel once a binding actually requires it. `bindings.js` is
+    // a small pure module (no MediaPipe/DOM), but still dynamic-imported here
+    // — like defaults.js below — so a plugin-off build never pulls either in.
+    const {
+      needsInteractionBlock
+    } = await import( "@/p5/utils/interaction/bindings.js" );
+    const needValues = !!loaded.formValues &&
+      !loaded.formValues.interaction &&
+      needsInteractionBlock( loaded.formValues.bindings );
 
     if ( !needValues && !needConfig ) {
       return loaded;
     }
 
-    // Surface the shared Interaction block on every sketch that doesn't declare
-    // its own: seed `sketch.interaction` (so the channel sampler can read
-    // hands / audio / orbit / … live) AND add the classic Interaction settings
-    // panel to the form. Loaded lazily so a plugin-off build never pulls it in.
-    // Each sketch gets its own clone of the values so runtime edits never leak
-    // across sketches; the config is static and shared. Sketches that declare
-    // their own `interaction` (e.g. interaction-test) are left untouched.
+    // Loaded lazily so a plugin-off build never pulls the panel/defaults
+    // module in. Each sketch gets its own clone of the values so runtime
+    // edits never leak across sketches; the config is static and shared.
+    // Sketches that declare their own `interaction` (e.g. interaction-test)
+    // are left untouched.
     //
     // `loaded` is the dynamic-import module namespace — its exports are
     // read-only getters, so we build a fresh meta object rather than assigning
     // onto it (assigning throws, which the catch below would turn into a sketch
     // with no form at all).
     const {
-      interactionFormValues, interactionFormConfiguration
+      inertInteractionFormValues, interactionFormConfiguration
     } = await import( "@/p5/utils/interaction/defaults.js" );
-
-    // The canonical defaults ship "live" (enabled + orbit on) for the sketches
-    // that import them deliberately, but a seeded sketch has no bindings yet —
-    // an active block would boot the interaction handler and run the orbit
-    // virtual pointer on every non-interactive sketch. Seed it INERT instead;
-    // picking an input source on a binding flips `enabled` (and the source's
-    // own flag) back on — see interactionEnablePaths / enableSourceInputs in
-    // the BindingAffordance.
-    const seededInteraction = structuredClone( interactionFormValues );
-
-    seededInteraction.enabled = false;
-    seededInteraction.orbit.enabled = false;
 
     return {
       formValues: needValues
         ? {
           ...loaded.formValues,
-          interaction: seededInteraction
+          interaction: inertInteractionFormValues()
         }
         : loaded.formValues,
       formConfiguration: needConfig

--- a/src/utils/getSketchOptions.ts
+++ b/src/utils/getSketchOptions.ts
@@ -73,58 +73,45 @@ export async function getSketchMeta(
       return loaded;
     }
 
+    // Only the CONFIG (the panel schema) is injected — never values. Values
+    // for the plugin-managed block live in the top-level `interactive`
+    // namespace, seeded lazily client-side the first time a binding picks a
+    // live input source (see BindingAffordance.enableSourceInputs); legacy
+    // `sketch.bindings` are relocated there on load by initOptions. Sketches
+    // that declare their own `interaction` config (hand-tracking, audio, …)
+    // are left untouched — theirs is a real sketch parameter, edited at the
+    // sketch scope and read by their own sketch code.
     const needConfig = !!loaded.formConfiguration && !loaded.formConfiguration.interaction;
 
-    // Only seed the actual VALUES when this sketch already ships bindings
-    // that need them (e.g. a demo sketch with default `bindings` pointing at
-    // a live input) — most sketches have none at load time, and get the block
-    // seeded lazily client-side the first time a binding picks a live input
-    // source (see BindingAffordance.enableSourceInputs). The schema
-    // (formConfiguration) is still added unconditionally: it's a static, cheap
-    // field descriptor with no runtime cost, and the client needs it available
-    // to render the panel once a binding actually requires it. `bindings.js` is
-    // a small pure module (no MediaPipe/DOM), but still dynamic-imported here
-    // — like defaults.js below — so a plugin-off build never pulls either in.
-    const {
-      needsInteractionBlock
-    } = await import( "@/p5/utils/interaction/bindings.js" );
-    const needValues = !!loaded.formValues &&
-      !loaded.formValues.interaction &&
-      needsInteractionBlock( loaded.formValues.bindings );
-
-    if ( !needValues && !needConfig ) {
+    if ( !needConfig ) {
       return loaded;
     }
 
     // Loaded lazily so a plugin-off build never pulls the panel/defaults
-    // module in. Each sketch gets its own clone of the values so runtime
-    // edits never leak across sketches; the config is static and shared.
-    // Sketches that declare their own `interaction` (e.g. interaction-test)
-    // are left untouched.
+    // module in.
     //
     // `loaded` is the dynamic-import module namespace — its exports are
     // read-only getters, so we build a fresh meta object rather than assigning
     // onto it (assigning throws, which the catch below would turn into a sketch
     // with no form at all).
     const {
-      inertInteractionFormValues, interactionFormConfiguration
+      interactionFormConfiguration
     } = await import( "@/p5/utils/interaction/defaults.js" );
 
     return {
-      formValues: needValues
-        ? {
-          ...loaded.formValues,
-          interaction: inertInteractionFormValues()
-        }
-        : loaded.formValues,
-      formConfiguration: needConfig
-        ? {
-          ...loaded.formConfiguration,
-          // `defaults.js` is untyped (component fields widen to `string`); the
-          // config is the canonical interaction panel, so assert the shape.
-          interaction: interactionFormConfiguration as unknown as FieldConfig
-        }
-        : loaded.formConfiguration
+      formValues: loaded.formValues,
+      formConfiguration: {
+        ...loaded.formConfiguration,
+        // `managed: true` marks this as the plugin-injected panel (vs a
+        // sketch-declared one): the form renders it against the `interactive`
+        // namespace and only while a binding needs it. `defaults.js` is
+        // untyped (component fields widen to `string`); the config is the
+        // canonical interaction panel, so assert the shape.
+        interaction: {
+          ...( interactionFormConfiguration as unknown as Record<string, unknown> ),
+          managed: true
+        } as unknown as FieldConfig
+      }
     };
   } catch {
     return {};

--- a/src/utils/initOptions.ts
+++ b/src/utils/initOptions.ts
@@ -1,9 +1,10 @@
 import {
   OptionsSchema, SketchOption
 } from "@/types/sketch.types";
+import migrateInteractiveOptions from "@/utils/migrateInteractiveOptions";
 
 const OptionsSchemaWithCatch = OptionsSchema.catch( OptionsSchema.parse( {} ) );
 
 export default function initOptions( initialOptions: unknown ): SketchOption {
-  return OptionsSchemaWithCatch.parse( initialOptions ?? {} );
+  return migrateInteractiveOptions( OptionsSchemaWithCatch.parse( initialOptions ?? {} ) );
 }

--- a/src/utils/migrateInteractiveOptions.ts
+++ b/src/utils/migrateInteractiveOptions.ts
@@ -1,0 +1,81 @@
+/**
+ * Legacy-shape migration for the interaction-bindings plugin.
+ *
+ * Bindings used to be stored INSIDE the sketch's own parameter object
+ * (`sketch.bindings`, `slides[i].sketch.bindings`), which leaked binding
+ * infrastructure into exports, save-defaults, randomize and sketch code. They
+ * now live in a sibling namespace — `interactive.bindings` at the root and
+ * per-slide — so this moves any legacy array over the first time an old save /
+ * import / options.ts default passes through initOptions.
+ *
+ * NON-MUTATING at the input's expense: `OptionsSchema.parse` passes `sketch`
+ * (a `z.any()` key) through BY REFERENCE, so the parsed tree can share objects
+ * with the caller's input (page props, the live store). Deleting in place here
+ * would strip `bindings` out of those shared objects too — every later parse
+ * of the same input would then see no bindings and produce no `interactive`
+ * namespace. The touched holder/sketch levels are shallow-copied instead.
+ *
+ * `sketch.interaction` is deliberately NOT moved: sketches that declare an
+ * interaction block in their own options.ts (hand-tracking, audio, …) read it
+ * from `options.sketch.interaction` in their sketch code, so it is a real
+ * sketch parameter for them. The engine reads interaction as
+ * `sketch.interaction ?? interactive.interaction`, which covers both declared
+ * blocks and the plugin-managed one.
+ */
+
+type AnyRecord = Record<string, any>;
+
+function migrateScope<T extends AnyRecord>( holder: T ): T {
+  const sketch = holder?.sketch;
+
+  if ( !sketch || typeof sketch !== "object" || !Array.isArray( sketch.bindings ) ) {
+    return holder;
+  }
+
+  const {
+    bindings, ...sketchRest
+  } = sketch;
+
+  return {
+    ...holder,
+    sketch: sketchRest,
+    interactive: {
+      ...holder.interactive,
+      // An existing interactive.bindings wins — the sketch-scope copy is
+      // stale legacy data at that point, and is dropped either way so it
+      // stops leaking into sketch-scope consumers.
+      bindings: holder.interactive?.bindings ?? bindings
+    }
+  };
+}
+
+export default function migrateInteractiveOptions<T extends AnyRecord>( options: T ): T {
+  let migrated = migrateScope( options );
+
+  if ( Array.isArray( migrated?.slides ) ) {
+    let slidesChanged = false;
+    const slides = migrated.slides.map( ( slide: AnyRecord ) => {
+      const next = migrateScope( slide );
+
+      slidesChanged ||= next !== slide;
+
+      return next;
+    } );
+
+    if ( slidesChanged ) {
+      migrated = migrated === options
+        ? {
+          ...migrated,
+          slides
+        }
+        : Object.assign(
+          migrated,
+          {
+            slides
+          }
+        );
+    }
+  }
+
+  return migrated;
+}


### PR DESCRIPTION
## Problem

With `INTERACTION_BINDINGS` on, every sketch got the shared `interaction` block injected into its own options — with **live** defaults (`enabled: true`, `orbit.enabled: true`). Every sketch booted the interaction handler and ran the orbit virtual pointer with zero bindings, and ~180 lines of interaction config polluted every form, saved template, and export. Binding data (`bindings` arrays) also lived inside `sketch.*`, leaking into save-defaults, randomize, and sketch code.

## Changes (four steps)

### 1 — Inert seed + stricter boot guard
- The injected clone ships `enabled: false`, `orbit.enabled: false`; picking a binding source flips flags back on via `interactionEnablePaths`.
- `initInteractionForOptions` requires at least one enabled source group before booting the handler.
- `_collectMouse` / `_collectTouch` arm `ensurePointerTracking()` lazily (gyro-collector pattern), so runtime-enabled sources work without the setup boot.

### 2 — Seed on demand, prune when unused
- `BindingAffordance.enableSourceInputs` seeds an inert block the first time a binding picks a live input source (lazy dynamic import of the defaults module).
- `BindingAffordance` / `InteractivePanel` prune the block when no binding needs it (remove / reset / switch-to-generator).
- The injected settings panel appears and disappears in sync with the block it edits.

### 3 — Relocation out of `sketch.*`
- **New shape**: `options.interactive = { bindings, interaction }`, per-slide `slides[i].interactive` (key-level override). Binding targets stay sketch-relative. `OptionsSchema`/`SlideSchema` gain an untyped `interactive` key.
- **Migration**: `initOptions` relocates legacy `sketch.bindings` (global + per-slide) via a **non-mutating** `migrateInteractiveOptions` — zod passes `sketch` through by reference, so an in-place delete would strip bindings out of the caller's shared props/store tree and make every later parse come up empty (regression-tested). Sketch-**declared** `sketch.interaction` blocks are real parameters and are not moved.
- **Engine**: `effectiveInteractive()` resolves `slide.interactive ?? root.interactive` (with a legacy `base.bindings` fallback for unmigrated capture snapshots); interaction precedence is `sketch.interaction ?? interactive.interaction` so declared blocks win. The resolver shim grafts the effective interaction onto the resolved clone so `options.sketch.interaction` reads stay correct everywhere.
- **UI**: binding reads/writes, the on-demand seed, and pruning all target the `interactive` scope (`interactiveScopeFor` maps `slides.N.sketch` → `slides.N.interactive`); source-enable flags still land in a sketch-declared block when one exists.
- **Managed vs declared panels**: `getSketchMeta` injects only the panel *config*, marked `managed: true`. `GenericObjectForm` renders a managed panel against the `interactive` namespace only while the managed block exists — and a sketch-declared panel unconditionally at the sketch scope. This also **fixes a regression from step 2**, which hid declared Interaction panels (hand-tracking, audio, …) whenever a sketch had no bindings.
- `SketchPage`'s touch-gesture handoff mirrors the engine precedence.

### 4 — A new binding defaults to the oscillator
Clicking a parameter's pastille used to create a *mouse* binding, which seeded the interaction block and made the sketch "interactive" before the user chose anything. A generator is the better default — it computes from the sketch's own progression, so it needs no interaction block, no camera/mic permission, and stays deterministic under recording; the parameter simply starts animating. Picking a live input is one explicit step away in the source selector, which seeds the block at that point.
- `makeDefaultBinding` builds an oscillator binding for continuous targets (and resolves the vector2d fallback source itself, so its `source` argument is gone). vector2d still starts on an input — `mapVector` reads a channel, so there is no generator family for it.
- `enableSourceInputs` returns early for a source with no enable paths; it previously seeded the block *before* consulting them, so an oscillator default would have seeded a block nothing reads.
- Pastille tooltip is now "Modulate this parameter".

**Known limitation**: the dev-only "save defaults" tool diffs sketch-scope values, so a sketch shipping default bindings in `options.ts` (the demo) won't round-trip them through save-defaults — they migrate out of the sketch scope on load.

## Verification

- `npm run check` — lint 0 errors, typecheck clean, **1821 tests** (9 new migration tests, incl. non-mutation regressions)
- `npm run build` — succeeds with the plugin flag off and on
- Headless-browser E2E against the running dev app (`INTERACTION_BINDINGS=true`):
  - **Plain sketch** (noise-grid): zero interaction footprint at load; a first click on a slider stores an **oscillator** binding at `interactive.bindings` with **no** interaction block seeded and no Interaction panel — and its published signal sweeps (0.89 → 0.69 → 0.50 → 0.24), proving the sine resolves live. Switching that binding's category to an input seeds the block, enables mouse and reveals the panel; removing the binding prunes both. Sketch scope untouched throughout.
  - **Fresh vector2d binding**: still defaults to mouse and seeds the block, as intended.
  - **interactive-binding-demo**: legacy `options.ts` bindings migrate on load, all 5 bindings resolve live (mouse + oscillators in the HUD), mixer shows 5 layers, and exported options carry `interactive.bindings` with a clean `sketch` block.
  - **interaction-test** (declared interaction): its Interaction panel is visible with zero bindings, values intact at the sketch scope.