### PR TITLE
Add photo-trail-effect v2-echo and v3-growth on a shared category base

### DIFF
--- a/src/generated/sketchModuleRegistry.ts
+++ b/src/generated/sketchModuleRegistry.ts
@@ -163,6 +163,7 @@ export const sketchModuleLoaders: Record<string, SketchModuleLoader> = {
   "p5:photo-segmentation/photo-segmentation-v1-mask": () => import( "@/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/index.js" ),
   "p5:photo-segmentation/photo-segmentation-v2-noise-reveal": () => import( "@/p5/sketches/photo-segmentation/photo-segmentation-v2-noise-reveal/index.js" ),
   "p5:photo-trail-effect/photo-trail-effect-v1": () => import( "@/p5/sketches/photo-trail-effect/photo-trail-effect-v1/index.js" ),
+  "p5:photo-trail-effect/photo-trail-effect-v2-echo": () => import( "@/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/index.js" ),
   "p5:photo/dominant-colors-block-switch": () => import( "@/p5/sketches/photo/dominant-colors-block-switch/index.js" ),
   "p5:photo/photo-3d-cylinder": () => import( "@/p5/sketches/photo/photo-3d-cylinder/index.js" ),
   "p5:photo/photo-3d-sphere": () => import( "@/p5/sketches/photo/photo-3d-sphere/index.js" ),

--- a/src/generated/sketchOptionsRegistry.ts
+++ b/src/generated/sketchOptionsRegistry.ts
@@ -181,6 +181,7 @@ export const sketchFormLoaders: Record<string, SketchModuleLoader> = {
   "p5:photo-segmentation/photo-segmentation-v1-mask": () => import( "@/p5/sketches/photo-segmentation/photo-segmentation-v1-mask/options" ),
   "p5:photo-segmentation/photo-segmentation-v2-noise-reveal": () => import( "@/p5/sketches/photo-segmentation/photo-segmentation-v2-noise-reveal/options" ),
   "p5:photo-trail-effect/photo-trail-effect-v1": () => import( "@/p5/sketches/photo-trail-effect/photo-trail-effect-v1/options" ),
+  "p5:photo-trail-effect/photo-trail-effect-v2-echo": () => import( "@/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/options" ),
   "p5:photo/dominant-colors-block-switch": () => import( "@/p5/sketches/photo/dominant-colors-block-switch/options" ),
   "p5:photo/photo-3d-cylinder": () => import( "@/p5/sketches/photo/photo-3d-cylinder/options" ),
   "p5:photo/photo-3d-sphere": () => import( "@/p5/sketches/photo/photo-3d-sphere/options" ),

--- a/src/sketches/metadata.json
+++ b/src/sketches/metadata.json
@@ -3730,5 +3730,17 @@
     "hiddenFromGallery": false,
     "mtime": "2026-08-08T11:51:07.033Z",
     "ctime": "2026-08-08T11:50:37.437Z"
+  },
+  {
+    "name": "photo-trail-effect-v2-echo",
+    "engine": "p5",
+    "category": "photo-trail-effect",
+    "hasSketchForm": true,
+    "hasThumbnail": false,
+    "hasPreview": false,
+    "hiddenFromHome": false,
+    "hiddenFromGallery": false,
+    "mtime": "2026-08-09T21:04:41.741Z",
+    "ctime": "2026-08-09T21:03:57.429Z"
   }
 ]

--- a/src/sketches/p5/sketches/photo-trail-effect/_shared.js
+++ b/src/sketches/p5/sketches/photo-trail-effect/_shared.js
@@ -1,0 +1,959 @@
+import options from "@/p5/utils/options.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
+import imageUtils from "@/p5/utils/imageUtils.js";
+import animation from "@/p5/utils/animation.js";
+import easing from "@/p5/utils/easing.js";
+import {
+  drawSegmentationMask
+} from "@/p5/utils/segmentation.js";
+import {
+  drawFocusMarkers,
+  hitFocusMarker
+} from "@/p5/utils/multiSegmentation.js";
+import {
+  setSketchOptions
+} from "@/p5/shared/syncSketchOptions.js";
+
+/* ------------------------------------------------------------------ */
+/*  Shared plumbing for the `photo-trail-effect` category.             */
+/*                                                                     */
+/*  Every variant layers the same photo stack — full photo (original / */
+/*  blur / dim / color backdrop), a trail layer, then the MediaPipe-   */
+/*  segmented subject drawn back on top so the trails pass BEHIND it — */
+/*  and shares the click-to-pick / click-a-marker-to-unpick focus-     */
+/*  point interaction. What differs per variant is the trail layer     */
+/*  itself (pixel ribbons in v1, ghost copies of the subject in v2),   */
+/*  so this module holds everything BUT that layer:                    */
+/*                                                                     */
+/*    - small numeric / point helpers,                                 */
+/*    - spine geometry (Chaikin, resampling, the angle / spline        */
+/*      builders, the sideways wave),                                  */
+/*    - the photo layer + backdrop + subject + marker drawing,         */
+/*    - the focus-point store (sync / persist / click routing) and the */
+/*      subject builder (union mask → feathered cut-out).              */
+/* ------------------------------------------------------------------ */
+
+// The wave offset eases in over this fraction of the spine so the root
+// stays glued to its start.
+const WAVE_RAMP = 0.18;
+
+/* ------------------------------------------------------------------ */
+/*  Small helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+export function clamp(
+  value, min, max
+) {
+  return value < min ? min : value > max ? max : value;
+}
+
+export function clamp01( value ) {
+  return clamp(
+    value,
+    0,
+    1
+  );
+}
+
+export function smoothstep( t ) {
+  const c = clamp01( t );
+
+  return c * c * ( 3 - 2 * c );
+}
+
+// Shortest signed angular difference, in [-PI, PI].
+export function wrapAngle( delta ) {
+  return ( ( delta + Math.PI ) % ( Math.PI * 2 ) + Math.PI * 2 ) % ( Math.PI * 2 ) - Math.PI;
+}
+
+export function isPoint( value ) {
+  return !!value && typeof value.x === "number" && typeof value.y === "number";
+}
+
+export function sanitizePoint(
+  value, fallback
+) {
+  if ( !isPoint( value ) ) {
+    return {
+      ...fallback
+    };
+  }
+
+  return {
+    x: clamp01( value.x ),
+    y: clamp01( value.y )
+  };
+}
+
+// The `image` option is a plain path, but the asset picker may persist it as
+// a single-element array — accept either.
+export function resolveImagePath( value ) {
+  if ( Array.isArray( value ) ) {
+    return value.find( Boolean ) ?? null;
+  }
+
+  return value || null;
+}
+
+export function toPx(
+  point, p
+) {
+  return {
+    x: point.x * p.width,
+    y: point.y * p.height
+  };
+}
+
+export function mirrorPoint(
+  point, center
+) {
+  return {
+    x: 2 * center.x - point.x,
+    y: 2 * center.y - point.y
+  };
+}
+
+export function photoSettings() {
+  const photo = options.sketch?.photo ?? {};
+
+  return {
+    margin: photo.margin ?? 0,
+    scale: photo.scale ?? 1,
+    center: photo.center ?? true,
+    clip: photo.clip ?? false,
+    fill: photo.fill ?? false
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Graphics buffers                                                   */
+/* ------------------------------------------------------------------ */
+
+// Lazily create / resize the sketch's full-canvas layers on `store` (the
+// sketch state object). `density1` names buffers that are read back pixel by
+// pixel and must stay 1:1; `onResize` fires once when any buffer resized.
+export function ensureLayerGraphics(
+  store, keys, {
+    density1 = [],
+    onResize
+  } = {}
+) {
+  const p = getP5();
+  let resized = false;
+
+  for ( const key of keys ) {
+    let g = store[ key ];
+
+    if ( !g ) {
+      g = p.createGraphics(
+        p.width,
+        p.height
+      );
+      store[ key ] = g;
+
+      if ( density1.includes( key ) ) {
+        g.pixelDensity( 1 );
+      }
+    } else if ( g.width !== p.width || g.height !== p.height ) {
+      g.resizeCanvas(
+        p.width,
+        p.height
+      );
+
+      if ( density1.includes( key ) ) {
+        g.pixelDensity( 1 );
+      }
+
+      resized = true;
+    }
+  }
+
+  if ( resized ) {
+    onResize?.();
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Click → image-point mapping                                        */
+/* ------------------------------------------------------------------ */
+
+export function getInternalCanvasPoint( event ) {
+  const p = getP5();
+  const canvasElement = sketch.engine?.getCanvasElement?.();
+
+  if ( !canvasElement ) {
+    return null;
+  }
+
+  const rect = canvasElement.getBoundingClientRect();
+  const clientX =
+    event.touches?.[ 0 ]?.clientX ??
+    event.changedTouches?.[ 0 ]?.clientX ??
+    event.clientX;
+  const clientY =
+    event.touches?.[ 0 ]?.clientY ??
+    event.changedTouches?.[ 0 ]?.clientY ??
+    event.clientY;
+
+  if ( typeof clientX !== "number" || typeof clientY !== "number" ) {
+    return null;
+  }
+
+  if ( rect.width === 0 || rect.height === 0 ) {
+    return null;
+  }
+
+  return {
+    x: ( ( clientX - rect.left ) / rect.width ) * p.width,
+    y: ( ( clientY - rect.top ) / rect.height ) * p.height
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Focus points (segmentation zones)                                  */
+/* ------------------------------------------------------------------ */
+
+function sanitizeFocusPoint( value ) {
+  if ( !isPoint( value ) ) {
+    // A fresh, not-yet-edited form item — park it in the middle.
+    return {
+      x: 0.5,
+      y: 0.5
+    };
+  }
+
+  return {
+    x: clamp01( value.x ),
+    y: clamp01( value.y )
+  };
+}
+
+// The stored focus points. Templates saved before multi-mask kept a single
+// `roi` point — adopt it as the first (and only) point. An explicit empty
+// `points` array means "no subject picked" and is respected.
+function storedFocusPoints() {
+  const seg = options.sketch?.segmentation ?? {};
+
+  if ( Array.isArray( seg.points ) ) {
+    return seg.points.map( sanitizeFocusPoint );
+  }
+
+  if ( isPoint( seg.roi ) ) {
+    return [
+      sanitizeFocusPoint( seg.roi )
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * Working copy of the focus points, kept in sync with the stored options
+ * and with the segmenter's point list. One instance per sketch, wired to
+ * that sketch's `createMultiMaskSegmenter()`.
+ */
+export function createFocusPointStore( segmenter ) {
+  const store = {
+    // Normalized (0-1) image space. One mask per point; the subject is
+    // their union.
+    points: [],
+    syncHash: null,
+
+    reset() {
+      store.points = [];
+      store.syncHash = null;
+    },
+
+    // Reconcile with the stored options (form edit, reload, preset): adopt
+    // whenever the stored list differs from what we last synced.
+    sync() {
+      const seg = options.sketch?.segmentation ?? {};
+      const raw = Array.isArray( seg.points ) ? seg.points : null;
+      const rawHash = JSON.stringify( raw );
+
+      if ( rawHash === store.syncHash ) {
+        return;
+      }
+
+      store.syncHash = rawHash;
+      store.points = storedFocusPoints();
+      segmenter.setPoints( store.points );
+    },
+
+    // Persist the picked zones so they survive reloads and are exported
+    // with the template. Origin "p5" so the options module skips its own
+    // change handler while React still picks the new values up.
+    persist() {
+      const points = store.points.map( ( pt ) => ( {
+        x: pt.x,
+        y: pt.y
+      } ) );
+
+      store.syncHash = JSON.stringify( points );
+
+      setSketchOptions(
+        {
+          sketch: {
+            segmentation: {
+              points
+            }
+          }
+        },
+        "p5"
+      );
+    },
+
+    // Route a photo click: a focus marker (the circle with the minus)
+    // unpicks its zone, anywhere else on the photo picks a new one.
+    // Returns "removed" / "added" (already persisted), or null when the
+    // click landed outside the photo.
+    handleClick(
+      point, photoRect, markerOptions
+    ) {
+      if ( markerOptions?.show ) {
+        const hit = hitFocusMarker(
+          store.points,
+          photoRect,
+          point,
+          markerOptions.radius ?? 16
+        );
+
+        if ( hit !== -1 ) {
+          store.points.splice(
+            hit,
+            1
+          );
+          segmenter.setPoints( store.points );
+          store.persist();
+
+          return "removed";
+        }
+      }
+
+      const {
+        x, y, w, h
+      } = photoRect;
+
+      if ( w <= 0 || h <= 0 ) {
+        return null;
+      }
+
+      if ( point.x < x || point.x > x + w || point.y < y || point.y > y + h ) {
+        return null;
+      }
+
+      store.points.push( {
+        x: clamp01( ( point.x - x ) / w ),
+        y: clamp01( ( point.y - y ) / h )
+      } );
+      segmenter.setPoints( store.points );
+      store.persist();
+
+      return "added";
+    }
+  };
+
+  return store;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Subject builder (union mask → feathered cut-out)                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Owns the two mask buffers and builds the cut-out from the union of every
+ * picked mask using the current edge settings: blur the binary union, then
+ * remap its alpha through a smoothstep whose centre shifts the edge
+ * (expand) and whose width sets the softness.
+ */
+export function createSubjectBuilder() {
+  const buffers = {
+    binary: null,
+    soft: null
+  };
+
+  function ensureMaskGraphics(
+    key, width, height
+  ) {
+    const p = getP5();
+    let g = buffers[ key ];
+
+    if ( !g ) {
+      g = p.createGraphics(
+        width,
+        height
+      );
+      buffers[ key ] = g;
+    } else if ( g.width !== width || g.height !== height ) {
+      g.resizeCanvas(
+        width,
+        height
+      );
+    }
+
+    g.pixelDensity( 1 );
+
+    return g;
+  }
+
+  return {
+    // The buffers belong to the previous p5 instance after a sketch reset —
+    // drop them so they are recreated lazily against the fresh one.
+    reset() {
+      buffers.binary = null;
+      buffers.soft = null;
+    },
+
+    // Returns { image, builtWith } (the settings the cut-out was built
+    // from, for cheap change detection), or null while the photo or the
+    // combined mask is still missing.
+    build(
+      photo, segmenter, seg = {}
+    ) {
+      const inverse = seg.inverse ?? true;
+      const combined = segmenter.combined( inverse );
+
+      if ( !photo?.img?.width || !combined ) {
+        return null;
+      }
+
+      const {
+        data, width, height
+      } = combined;
+      const softness = clamp01( seg.edgeSoftness ?? 0 );
+      const expand = clamp(
+        seg.edgeExpand ?? 0,
+        -1,
+        1
+      );
+
+      const binary = ensureMaskGraphics(
+        "binary",
+        width,
+        height
+      );
+
+      // The union already applied `inverse` per raw mask, so it is passed
+      // as false here.
+      drawSegmentationMask(
+        binary,
+        data,
+        [
+          255,
+          255,
+          255,
+          255
+        ],
+        false
+      );
+
+      let mask = binary;
+      const minDimension = Math.min(
+        width,
+        height
+      );
+      const radius = Math.round( 0.05 * minDimension * Math.max(
+        softness,
+        Math.abs( expand )
+      ) );
+
+      if ( radius > 0 ) {
+        const soft = ensureMaskGraphics(
+          "soft",
+          width,
+          height
+        );
+
+        soft.clear();
+        soft.drawingContext.filter = `blur(${ radius }px)`;
+        soft.image(
+          binary,
+          0,
+          0
+        );
+        soft.drawingContext.filter = "none";
+
+        const centre = clamp(
+          0.5 - expand * 0.5,
+          0.02,
+          0.98
+        );
+        const half = Math.max(
+          softness * 0.5,
+          0.03
+        );
+        const lo = clamp01( centre - half );
+        const hi = clamp01( centre + half );
+        const span = Math.max(
+          hi - lo,
+          1e-4
+        );
+
+        soft.loadPixels();
+        const pixels = soft.pixels;
+
+        for ( let i = 3; i < pixels.length; i += 4 ) {
+          pixels[ i ] = smoothstep( ( pixels[ i ] / 255 - lo ) / span ) * 255;
+        }
+
+        soft.updatePixels();
+        mask = soft;
+      }
+
+      const image = photo.img.get();
+
+      image.mask( mask );
+
+      return {
+        image,
+        builtWith: {
+          inverse,
+          softness,
+          expand
+        }
+      };
+    }
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Photo layers                                                       */
+/* ------------------------------------------------------------------ */
+
+// Draw the full photo into the offscreen buffer and return where it landed
+// on the canvas ({x, y, w, h}), or null when the layout callback did not
+// fire. The caller diffs the rect against the previous frame to invalidate
+// whatever it derived from the photo layout.
+export function drawPhotoLayer(
+  g, photo
+) {
+  const p = getP5();
+  const {
+    margin, scale, center, clip, fill
+  } = photoSettings();
+  let rect = null;
+
+  g.clear();
+  imageUtils.marginImage( {
+    img: photo.img,
+    graphics: g,
+    position: p.createVector(
+      p.width / 2,
+      p.height / 2
+    ),
+    margin: p.width * margin,
+    scale,
+    center,
+    clip,
+    fill,
+    callback: (
+      cx, cy, w, h
+    ) => {
+      rect = {
+        x: center ? cx - w / 2 : cx,
+        y: center ? cy - h / 2 : cy,
+        w,
+        h
+      };
+    }
+  } );
+
+  return rect;
+}
+
+// The backdrop behind the trails: nothing (transparent), the photo layer
+// as-is (original), a solid color, or a full-bleed blurred / dimmed copy.
+export function drawBackdrop(
+  p, photo, {
+    photoG, bgG
+  }
+) {
+  const bg = options.sketch?.background ?? {};
+  const mode = bg.mode ?? "transparent";
+
+  if ( mode === "transparent" ) {
+    return;
+  }
+
+  if ( mode === "color" ) {
+    p.push();
+    p.noStroke();
+    p.fill( ...( bg.color ?? [
+      0,
+      0,
+      0
+    ] ) );
+    p.rect(
+      0,
+      0,
+      p.width,
+      p.height
+    );
+    p.pop();
+
+    return;
+  }
+
+  if ( mode === "original" ) {
+    p.image(
+      photoG,
+      0,
+      0
+    );
+
+    return;
+  }
+
+  // blur / dim: a full-bleed copy of the photo behind everything.
+  bgG.clear();
+
+  if ( mode === "blur" ) {
+    bgG.drawingContext.filter = `blur(${ bg.blur ?? 0 }px)`;
+  }
+
+  imageUtils.marginImage( {
+    img: photo.img,
+    graphics: bgG,
+    position: p.createVector(
+      p.width / 2,
+      p.height / 2
+    ),
+    margin: 0,
+    scale: 1,
+    center: true,
+    fill: true
+  } );
+
+  bgG.drawingContext.filter = "none";
+
+  p.image(
+    bgG,
+    0,
+    0,
+    p.width,
+    p.height
+  );
+
+  if ( mode === "dim" ) {
+    p.push();
+    p.noStroke();
+    p.fill(
+      0,
+      0,
+      0,
+      clamp01( bg.dim ?? 0 ) * 255
+    );
+    p.rect(
+      0,
+      0,
+      p.width,
+      p.height
+    );
+    p.pop();
+  }
+}
+
+// The segmented subject on top, so the trails pass behind it.
+export function drawSubjectLayer(
+  p, subject
+) {
+  if ( !subject ) {
+    return;
+  }
+
+  const {
+    margin, scale, center, fill
+  } = photoSettings();
+  const subjectScale = options.sketch?.subject?.scale ?? 1;
+  const shadow = options.sketch?.subject?.shadow ?? {};
+
+  p.push();
+
+  if ( shadow.enabled ) {
+    const [
+      r = 0,
+      g = 0,
+      b = 0,
+      a = 255
+    ] = shadow.color ?? [];
+
+    p.drawingContext.shadowColor = `rgba(${ r }, ${ g }, ${ b }, ${ a / 255 })`;
+    p.drawingContext.shadowBlur = shadow.blur ?? 0;
+    p.drawingContext.shadowOffsetX = shadow.offsetX ?? 0;
+    p.drawingContext.shadowOffsetY = shadow.offsetY ?? 0;
+  }
+
+  imageUtils.marginImage( {
+    img: subject,
+    position: p.createVector(
+      p.width / 2,
+      p.height / 2
+    ),
+    margin: p.width * margin,
+    scale: scale * subjectScale,
+    center,
+    clip: false,
+    fill
+  } );
+
+  p.pop();
+}
+
+export function drawMarkersLayer(
+  p, points, photoRect
+) {
+  const marker = options.sketch?.marker ?? {};
+
+  if ( !marker.show ) {
+    return;
+  }
+
+  drawFocusMarkers(
+    p,
+    points,
+    photoRect,
+    marker
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Spine geometry                                                     */
+/* ------------------------------------------------------------------ */
+
+// Chaikin corner-cutting on an open polyline of plain {x, y} points (same
+// algorithm as the splines category, without the p5.Vector churn).
+export function chaikinOpen(
+  points, iterations
+) {
+  let result = points;
+
+  for ( let i = 0; i < iterations; i++ ) {
+    const count = result.length;
+    const out = [
+      {
+        ...result[ 0 ]
+      }
+    ];
+
+    for ( let j = 0; j < count - 1; j++ ) {
+      const a = result[ j ];
+      const b = result[ j + 1 ];
+
+      out.push( {
+        x: 0.75 * a.x + 0.25 * b.x,
+        y: 0.75 * a.y + 0.25 * b.y
+      } );
+      out.push( {
+        x: 0.25 * a.x + 0.75 * b.x,
+        y: 0.25 * a.y + 0.75 * b.y
+      } );
+    }
+
+    out.push( {
+      ...result[ count - 1 ]
+    } );
+    result = out;
+  }
+
+  return result;
+}
+
+// Resample a polyline at a fixed step so every point along the spine is
+// evenly spaced (even spacing = no visible density changes on curves).
+export function resamplePolyline(
+  points, step
+) {
+  if ( points.length < 2 ) {
+    return points;
+  }
+
+  const out = [
+    {
+      ...points[ 0 ]
+    }
+  ];
+  let prev = points[ 0 ];
+  let need = step;
+
+  for ( let i = 1; i < points.length; i++ ) {
+    const curr = points[ i ];
+    let segLen = Math.hypot(
+      curr.x - prev.x,
+      curr.y - prev.y
+    );
+
+    while ( segLen >= need ) {
+      const t = need / segLen;
+      const next = {
+        x: prev.x + ( curr.x - prev.x ) * t,
+        y: prev.y + ( curr.y - prev.y ) * t
+      };
+
+      out.push( next );
+      prev = next;
+      segLen -= need;
+      need = step;
+    }
+
+    need -= segLen;
+    prev = curr;
+  }
+
+  const last = points[ points.length - 1 ];
+  const tail = out[ out.length - 1 ];
+
+  if ( Math.hypot(
+    last.x - tail.x,
+    last.y - tail.y
+  ) > step * 0.25 ) {
+    out.push( {
+      ...last
+    } );
+  }
+
+  return out;
+}
+
+// "Angles" spine: integrate a heading that eases from `launch` to
+// launch + bend over `length` pixels — a clean swoosh with no control
+// points at all. Returns an even polyline starting at `start`.
+export function buildAngleSpine( {
+  start,
+  launch,
+  bend,
+  easingName,
+  length,
+  step
+} ) {
+  const easeFn = easing[ easingName ] ?? easing.linear;
+  const steps = Math.max(
+    2,
+    Math.ceil( length / step )
+  );
+  const ds = length / steps;
+  const spine = [
+    {
+      ...start
+    }
+  ];
+  let x = start.x;
+  let y = start.y;
+
+  for ( let i = 1; i <= steps; i++ ) {
+    const heading = launch + bend * easeFn( i / steps );
+
+    x += Math.cos( heading ) * ds;
+    y += Math.sin( heading ) * ds;
+    spine.push( {
+      x,
+      y
+    } );
+  }
+
+  return spine;
+}
+
+// "Spline" spine: round start → guide 1 → guide 2 → exit with Chaikin, so
+// two draggable guide handles literally steer the path. The exit point
+// extends the guides' direction so the spine leaves the canvas.
+export function buildSplineSpine( {
+  start,
+  g1,
+  g2,
+  length,
+  iterations,
+  step
+} ) {
+  const exitAngle = Math.atan2(
+    g2.y - g1.y,
+    g2.x - g1.x
+  );
+  const exit = {
+    x: g2.x + Math.cos( exitAngle ) * length * 0.6,
+    y: g2.y + Math.sin( exitAngle ) * length * 0.6
+  };
+  const dense = chaikinOpen(
+    [
+      start,
+      g1,
+      g2,
+      exit
+    ],
+    clamp(
+      Math.round( iterations ?? 4 ),
+      0,
+      6
+    )
+  );
+
+  return resamplePolyline(
+    dense,
+    step
+  );
+}
+
+// Push the spine sideways on a sine wave: `twists` full oscillations along
+// the path, `warp` bunches them toward the start (>1) or the end (<1),
+// `speed` (whole loops per animation cycle) keeps exports seamless.
+// `phase` (0..1) offsets the wave so parallel spines don't oscillate in
+// sync.
+export function applyWave(
+  spine, wave, phase, p
+) {
+  const amplitude = ( wave.amplitude ?? 0 ) * Math.min(
+    p.width,
+    p.height
+  );
+
+  if ( amplitude === 0 || spine.length < 3 ) {
+    return spine;
+  }
+
+  const twists = wave.twists ?? 1;
+  const warp = Math.max(
+    0.1,
+    wave.warp ?? 1
+  );
+  const speed = Math.round( wave.speed ?? 0 );
+  const animPhase = animation.angle * speed;
+  const basePhase = phase * Math.PI * 2;
+  const total = spine.length - 1;
+
+  return spine.map( (
+    point, index
+  ) => {
+    const t = index / total;
+    const prev = spine[ Math.max(
+      0,
+      index - 1
+    ) ];
+    const next = spine[ Math.min(
+      total,
+      index + 1
+    ) ];
+    const tx = next.x - prev.x;
+    const ty = next.y - prev.y;
+    const len = Math.hypot(
+      tx,
+      ty
+    ) || 1;
+    const ramp = smoothstep( Math.min(
+      1,
+      t / WAVE_RAMP
+    ) );
+    const offset =
+      Math.sin( Math.PI * 2 * twists * Math.pow(
+        t,
+        warp
+      ) + basePhase + animPhase ) *
+      amplitude *
+      ramp;
+
+    return {
+      x: point.x - ( ty / len ) * offset,
+      y: point.y + ( tx / len ) * offset
+    };
+  } );
+}

--- a/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/index.js
+++ b/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v1/index.js
@@ -4,20 +4,13 @@ import sketch, {
   getP5
 } from "@/p5/utils/sketch.js";
 import string from "@/p5/utils/string.js";
-import imageUtils from "@/p5/utils/imageUtils.js";
 import * as common from "@/p5/utils/common.js";
-import animation from "@/p5/utils/animation.js";
 import easing from "@/p5/utils/easing.js";
 import {
   init as mediapipeInit
 } from "@/p5/utils/mediapipe/mediapipe.js";
 import {
-  drawSegmentationMask
-} from "@/p5/utils/segmentation.js";
-import {
-  createMultiMaskSegmenter,
-  drawFocusMarkers,
-  hitFocusMarker
+  createMultiMaskSegmenter
 } from "@/p5/utils/multiSegmentation.js";
 import {
   setSketchOptions,
@@ -27,6 +20,27 @@ import {
   createDraggable,
   nearestTargetIndex
 } from "@/p5/utils/interaction/draggable.js";
+import {
+  clamp,
+  clamp01,
+  wrapAngle,
+  isPoint,
+  sanitizePoint,
+  resolveImagePath,
+  toPx,
+  mirrorPoint,
+  ensureLayerGraphics,
+  getInternalCanvasPoint,
+  createFocusPointStore,
+  createSubjectBuilder,
+  drawPhotoLayer,
+  drawBackdrop,
+  drawSubjectLayer,
+  drawMarkersLayer,
+  buildAngleSpine,
+  buildSplineSpine,
+  applyWave
+} from "../_shared.js";
 
 /* ------------------------------------------------------------------ */
 /*  photo-trail-effect-v1                                              */
@@ -53,13 +67,15 @@ import {
 /*    - guide 1/2 (spline direction mode): control points that steer   */
 /*      the ribbon toward the canvas edge, rounded with the same       */
 /*      Chaikin corner-cutting as the splines category.                */
+/*                                                                     */
+/*  The photo stack, segmentation pipeline and spine geometry live in  */
+/*  ../_shared.js — this file owns what makes v1 v1: the pixel strips  */
+/*  sampled across the band and the ribbon slicing that stretches them */
+/*  along the spine.                                                   */
 /* ------------------------------------------------------------------ */
 
 // Slices overlap a hair so the ribbon has no seams on tight curves.
 const SLICE_OVERLAP = 1.5;
-// The wave offset eases in over this fraction of the ribbon so the root
-// stays glued to the band.
-const WAVE_RAMP = 0.18;
 const MAX_TRAILS = 12;
 
 /* ------------------------------------------------------------------ */
@@ -69,11 +85,6 @@ const MAX_TRAILS = 12;
 const state = {
   // Path of the photo currently driving the segmenter.
   imagePath: null,
-
-  // Working copy of the focus points, normalized (0-1) image space. One
-  // mask per point; the subject is their union.
-  focusPoints: [],
-  focusSyncHash: null,
 
   // Finished cut-out (photo with the feathered union mask applied).
   subject: null,
@@ -121,8 +132,6 @@ const state = {
   sampleG: null, // density-1 copy of the photo layer for pixel sampling
   trailsG: null, // the composited trail layer
   scratchG: null, // one trail at a time, composited with its opacity
-  binaryMaskG: null,
-  softMaskG: null,
 
   unregisterClick: null,
   unsubscribe: null
@@ -133,243 +142,16 @@ const draggable = createDraggable();
 // One inference per focus point, run sequentially; masks cached per point.
 const segmenter = createMultiMaskSegmenter();
 
-/* ------------------------------------------------------------------ */
-/*  Small helpers                                                      */
-/* ------------------------------------------------------------------ */
-
-function clamp(
-  value, min, max
-) {
-  return value < min ? min : value > max ? max : value;
-}
-
-function clamp01( value ) {
-  return clamp(
-    value,
-    0,
-    1
-  );
-}
-
-function smoothstep( t ) {
-  const c = clamp01( t );
-
-  return c * c * ( 3 - 2 * c );
-}
-
-// Shortest signed angular difference, in [-PI, PI].
-function wrapAngle( delta ) {
-  return ( ( delta + Math.PI ) % ( Math.PI * 2 ) + Math.PI * 2 ) % ( Math.PI * 2 ) - Math.PI;
-}
-
-// The `image` option is a plain path, but the asset picker may persist it as
-// a single-element array — accept either.
-function resolveImagePath( value ) {
-  if ( Array.isArray( value ) ) {
-    return value.find( Boolean ) ?? null;
-  }
-
-  return value || null;
-}
-
-function sanitizeFocusPoint( value ) {
-  if ( !isPoint( value ) ) {
-    // A fresh, not-yet-edited form item — park it in the middle.
-    return {
-      x: 0.5,
-      y: 0.5
-    };
-  }
-
-  return {
-    x: clamp01( value.x ),
-    y: clamp01( value.y )
-  };
-}
-
-// The stored focus points. Templates saved before multi-mask kept a single
-// `roi` point — adopt it as the first (and only) point. An explicit empty
-// `points` array means "no subject picked" and is respected.
-function storedFocusPoints() {
-  const seg = options.sketch?.segmentation ?? {};
-
-  if ( Array.isArray( seg.points ) ) {
-    return seg.points.map( sanitizeFocusPoint );
-  }
-
-  if ( isPoint( seg.roi ) ) {
-    return [
-      sanitizeFocusPoint( seg.roi )
-    ];
-  }
-
-  return [];
-}
-
-// Reconcile the working copy with the stored options (form edit, reload,
-// preset): adopt whenever the stored list differs from what we last synced.
-function syncFocusPoints() {
-  const seg = options.sketch?.segmentation ?? {};
-  const raw = Array.isArray( seg.points ) ? seg.points : null;
-  const rawHash = JSON.stringify( raw );
-
-  if ( rawHash === state.focusSyncHash ) {
-    return;
-  }
-
-  state.focusSyncHash = rawHash;
-  state.focusPoints = storedFocusPoints();
-  segmenter.setPoints( state.focusPoints );
-}
-
-// Persist the picked zones so they survive reloads and are exported with
-// the template. Origin "p5" so the options module skips its own change
-// handler while React still picks the new values up.
-function persistFocusPoints() {
-  const points = state.focusPoints.map( ( pt ) => ( {
-    x: pt.x,
-    y: pt.y
-  } ) );
-
-  state.focusSyncHash = JSON.stringify( points );
-
-  setSketchOptions(
-    {
-      sketch: {
-        segmentation: {
-          points
-        }
-      }
-    },
-    "p5"
-  );
-}
-
-function photoSettings() {
-  const photo = options.sketch?.photo ?? {};
-
-  return {
-    margin: photo.margin ?? 0,
-    scale: photo.scale ?? 1,
-    center: photo.center ?? true,
-    clip: photo.clip ?? false,
-    fill: photo.fill ?? false
-  };
-}
-
-function toPx(
-  point, p
-) {
-  return {
-    x: point.x * p.width,
-    y: point.y * p.height
-  };
-}
+// Click-to-pick focus points + the feathered cut-out, shared with v2.
+const focus = createFocusPointStore( segmenter );
+const subjectBuilder = createSubjectBuilder();
 
 /* ------------------------------------------------------------------ */
-/*  Graphics buffers                                                   */
+/*  Clicks & subject                                                   */
 /* ------------------------------------------------------------------ */
-
-function ensureCanvasGraphics( p ) {
-  for ( const key of [
-    "photoG",
-    "bgG",
-    "trailsG",
-    "scratchG",
-    "sampleG"
-  ] ) {
-    let g = state[ key ];
-
-    if ( !g ) {
-      g = p.createGraphics(
-        p.width,
-        p.height
-      );
-      state[ key ] = g;
-
-      if ( key === "sampleG" ) {
-        // The sampling buffer is read back pixel by pixel — keep it 1:1.
-        g.pixelDensity( 1 );
-      }
-    } else if ( g.width !== p.width || g.height !== p.height ) {
-      g.resizeCanvas(
-        p.width,
-        p.height
-      );
-
-      if ( key === "sampleG" ) {
-        g.pixelDensity( 1 );
-      }
-
-      state.sampleDirty = true;
-      state.trailsDirty = true;
-    }
-  }
-}
-
-function ensureMaskGraphics(
-  key, width, height
-) {
-  const p = getP5();
-  let g = state[ key ];
-
-  if ( !g ) {
-    g = p.createGraphics(
-      width,
-      height
-    );
-    state[ key ] = g;
-  } else if ( g.width !== width || g.height !== height ) {
-    g.resizeCanvas(
-      width,
-      height
-    );
-  }
-
-  g.pixelDensity( 1 );
-
-  return g;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Click → image-point mapping                                        */
-/* ------------------------------------------------------------------ */
-
-function getInternalCanvasPoint( event ) {
-  const p = getP5();
-  const canvasElement = sketch.engine?.getCanvasElement?.();
-
-  if ( !canvasElement ) {
-    return null;
-  }
-
-  const rect = canvasElement.getBoundingClientRect();
-  const clientX =
-    event.touches?.[ 0 ]?.clientX ??
-    event.changedTouches?.[ 0 ]?.clientX ??
-    event.clientX;
-  const clientY =
-    event.touches?.[ 0 ]?.clientY ??
-    event.changedTouches?.[ 0 ]?.clientY ??
-    event.clientY;
-
-  if ( typeof clientX !== "number" || typeof clientY !== "number" ) {
-    return null;
-  }
-
-  if ( rect.width === 0 || rect.height === 0 ) {
-    return null;
-  }
-
-  return {
-    x: ( ( clientX - rect.left ) / rect.width ) * p.width,
-    y: ( ( clientY - rect.top ) / rect.height ) * p.height
-  };
-}
 
 // Route a canvas click: a trail handle wins (the drag layer owns it), then
-// a focus marker (the circle with the minus) unpicks its zone, and anywhere
-// else on the photo picks a new one.
+// the focus store picks / unpicks a zone.
 function handleCanvasClick( event ) {
   const point = getInternalCanvasPoint( event );
 
@@ -389,372 +171,64 @@ function handleCanvasClick( event ) {
     return;
   }
 
-  const marker = options.sketch?.marker ?? {};
+  const result = focus.handleClick(
+    point,
+    state.photoRect,
+    options.sketch?.marker ?? {}
+  );
 
-  if ( marker.show ) {
-    const hit = hitFocusMarker(
-      state.focusPoints,
-      state.photoRect,
-      point,
-      marker.radius ?? 16
-    );
-
-    if ( hit !== -1 ) {
-      state.focusPoints.splice(
-        hit,
-        1
-      );
-      segmenter.setPoints( state.focusPoints );
-      persistFocusPoints();
-      state.maskDirty = true;
-
-      return;
-    }
+  if ( result === "removed" ) {
+    state.maskDirty = true;
   }
-
-  const {
-    x, y, w, h
-  } = state.photoRect;
-
-  if ( w <= 0 || h <= 0 ) {
-    return;
-  }
-
-  if ( point.x < x || point.x > x + w || point.y < y || point.y > y + h ) {
-    return;
-  }
-
-  state.focusPoints.push( {
-    x: clamp01( ( point.x - x ) / w ),
-    y: clamp01( ( point.y - y ) / h )
-  } );
-  segmenter.setPoints( state.focusPoints );
-  persistFocusPoints();
 }
 
-/* ------------------------------------------------------------------ */
-/*  Segmentation (same pipeline as photo-segmentation-v1-mask)         */
-/* ------------------------------------------------------------------ */
-
-// Build the cut-out from the union of every picked mask using the current
-// edge settings: blur the binary union, then remap its alpha through a
-// smoothstep whose centre shifts the edge (expand) and whose width sets the
-// softness.
 function rebuildSubject() {
   const photo = common.getAsset( state.imagePath );
   const seg = options.sketch?.segmentation ?? {};
-  const inverse = seg.inverse ?? true;
-  const combined = segmenter.combined( inverse );
+  const built = subjectBuilder.build(
+    photo,
+    segmenter,
+    seg
+  );
 
-  if ( !photo?.img?.width || !combined ) {
-    state.subject = null;
+  state.subject = built?.image ?? null;
 
-    return;
+  if ( built ) {
+    state.builtWith = built.builtWith;
   }
-
-  const {
-    data, width, height
-  } = combined;
-  const softness = clamp01( seg.edgeSoftness ?? 0 );
-  const expand = clamp(
-    seg.edgeExpand ?? 0,
-    -1,
-    1
-  );
-
-  const binary = ensureMaskGraphics(
-    "binaryMaskG",
-    width,
-    height
-  );
-
-  // The union already applied `inverse` per raw mask, so it is passed as
-  // false here.
-  drawSegmentationMask(
-    binary,
-    data,
-    [
-      255,
-      255,
-      255,
-      255
-    ],
-    false
-  );
-
-  let mask = binary;
-  const minDimension = Math.min(
-    width,
-    height
-  );
-  const radius = Math.round( 0.05 * minDimension * Math.max(
-    softness,
-    Math.abs( expand )
-  ) );
-
-  if ( radius > 0 ) {
-    const soft = ensureMaskGraphics(
-      "softMaskG",
-      width,
-      height
-    );
-
-    soft.clear();
-    soft.drawingContext.filter = `blur(${ radius }px)`;
-    soft.image(
-      binary,
-      0,
-      0
-    );
-    soft.drawingContext.filter = "none";
-
-    const centre = clamp(
-      0.5 - expand * 0.5,
-      0.02,
-      0.98
-    );
-    const half = Math.max(
-      softness * 0.5,
-      0.03
-    );
-    const lo = clamp01( centre - half );
-    const hi = clamp01( centre + half );
-    const span = Math.max(
-      hi - lo,
-      1e-4
-    );
-
-    soft.loadPixels();
-    const pixels = soft.pixels;
-
-    for ( let i = 3; i < pixels.length; i += 4 ) {
-      pixels[ i ] = smoothstep( ( pixels[ i ] / 255 - lo ) / span ) * 255;
-    }
-
-    soft.updatePixels();
-    mask = soft;
-  }
-
-  const subject = photo.img.get();
-
-  subject.mask( mask );
-
-  state.subject = subject;
-  state.builtWith = {
-    inverse,
-    softness,
-    expand
-  };
 }
-
-/* ------------------------------------------------------------------ */
-/*  Photo layers                                                       */
-/* ------------------------------------------------------------------ */
 
 // Draw the full photo into the offscreen buffer, record where it landed and
 // invalidate the pixel samples when the layout moved.
-function drawPhotoLayer( photo ) {
-  const p = getP5();
-  const {
-    margin, scale, center, clip, fill
-  } = photoSettings();
-  const g = state.photoG;
-
-  g.clear();
-  imageUtils.marginImage( {
-    img: photo.img,
-    graphics: g,
-    position: p.createVector(
-      p.width / 2,
-      p.height / 2
-    ),
-    margin: p.width * margin,
-    scale,
-    center,
-    clip,
-    fill,
-    callback: (
-      cx, cy, w, h
-    ) => {
-      const rect = {
-        x: center ? cx - w / 2 : cx,
-        y: center ? cy - h / 2 : cy,
-        w,
-        h
-      };
-      const previous = state.photoRect;
-
-      if (
-        rect.x !== previous.x ||
-        rect.y !== previous.y ||
-        rect.w !== previous.w ||
-        rect.h !== previous.h
-      ) {
-        state.sampleDirty = true;
-        state.stripsDirty = true;
-        state.trailsDirty = true;
-      }
-
-      state.photoRect = rect;
-    }
-  } );
-}
-
-function drawBackground(
-  p, photo
-) {
-  const bg = options.sketch?.background ?? {};
-  const mode = bg.mode ?? "transparent";
-
-  if ( mode === "transparent" ) {
-    return;
-  }
-
-  if ( mode === "color" ) {
-    p.push();
-    p.noStroke();
-    p.fill( ...( bg.color ?? [
-      0,
-      0,
-      0
-    ] ) );
-    p.rect(
-      0,
-      0,
-      p.width,
-      p.height
-    );
-    p.pop();
-
-    return;
-  }
-
-  if ( mode === "original" ) {
-    p.image(
-      state.photoG,
-      0,
-      0
-    );
-
-    return;
-  }
-
-  // blur / dim: a full-bleed copy of the photo behind everything.
-  const g = state.bgG;
-
-  g.clear();
-
-  if ( mode === "blur" ) {
-    g.drawingContext.filter = `blur(${ bg.blur ?? 0 }px)`;
-  }
-
-  imageUtils.marginImage( {
-    img: photo.img,
-    graphics: g,
-    position: p.createVector(
-      p.width / 2,
-      p.height / 2
-    ),
-    margin: 0,
-    scale: 1,
-    center: true,
-    fill: true
-  } );
-
-  g.drawingContext.filter = "none";
-
-  p.image(
-    g,
-    0,
-    0,
-    p.width,
-    p.height
+function updatePhotoLayer( photo ) {
+  const rect = drawPhotoLayer(
+    state.photoG,
+    photo
   );
 
-  if ( mode === "dim" ) {
-    p.push();
-    p.noStroke();
-    p.fill(
-      0,
-      0,
-      0,
-      clamp01( bg.dim ?? 0 ) * 255
-    );
-    p.rect(
-      0,
-      0,
-      p.width,
-      p.height
-    );
-    p.pop();
-  }
-}
-
-function drawSubject( p ) {
-  if ( !state.subject ) {
+  if ( !rect ) {
     return;
   }
 
-  const {
-    margin, scale, center, fill
-  } = photoSettings();
-  const subjectScale = options.sketch?.subject?.scale ?? 1;
-  const shadow = options.sketch?.subject?.shadow ?? {};
+  const previous = state.photoRect;
 
-  p.push();
-
-  if ( shadow.enabled ) {
-    const [
-      r = 0,
-      g = 0,
-      b = 0,
-      a = 255
-    ] = shadow.color ?? [];
-
-    p.drawingContext.shadowColor = `rgba(${ r }, ${ g }, ${ b }, ${ a / 255 })`;
-    p.drawingContext.shadowBlur = shadow.blur ?? 0;
-    p.drawingContext.shadowOffsetX = shadow.offsetX ?? 0;
-    p.drawingContext.shadowOffsetY = shadow.offsetY ?? 0;
+  if (
+    rect.x !== previous.x ||
+    rect.y !== previous.y ||
+    rect.w !== previous.w ||
+    rect.h !== previous.h
+  ) {
+    state.sampleDirty = true;
+    state.stripsDirty = true;
+    state.trailsDirty = true;
   }
 
-  imageUtils.marginImage( {
-    img: state.subject,
-    position: p.createVector(
-      p.width / 2,
-      p.height / 2
-    ),
-    margin: p.width * margin,
-    scale: scale * subjectScale,
-    center,
-    clip: false,
-    fill
-  } );
-
-  p.pop();
-}
-
-function drawMarkers( p ) {
-  const marker = options.sketch?.marker ?? {};
-
-  if ( !marker.show ) {
-    return;
-  }
-
-  drawFocusMarkers(
-    p,
-    state.focusPoints,
-    state.photoRect,
-    marker
-  );
+  state.photoRect = rect;
 }
 
 /* ------------------------------------------------------------------ */
 /*  Trail list sync (count-driven, handles persisted like splines-v2)  */
 /* ------------------------------------------------------------------ */
-
-function isPoint( value ) {
-  return !!value && typeof value.x === "number" && typeof value.y === "number";
-}
 
 // A pleasant default for trail `index`: a vertical band around the canvas
 // centre, launched toward alternating sides.
@@ -785,21 +259,6 @@ function defaultTrail( index ) {
     },
     flip: side < 0,
     phase: ( index * 0.27 ) % 1
-  };
-}
-
-function sanitizePoint(
-  value, fallback
-) {
-  if ( !isPoint( value ) ) {
-    return {
-      ...fallback
-    };
-  }
-
-  return {
-    x: clamp01( value.x ),
-    y: clamp01( value.y )
   };
 }
 
@@ -920,100 +379,6 @@ function syncTrails( cfg ) {
 /*  Spine geometry                                                     */
 /* ------------------------------------------------------------------ */
 
-// Chaikin corner-cutting on an open polyline of plain {x, y} points (same
-// algorithm as the splines category, without the p5.Vector churn).
-function chaikinOpen(
-  points, iterations
-) {
-  let result = points;
-
-  for ( let i = 0; i < iterations; i++ ) {
-    const count = result.length;
-    const out = [
-      {
-        ...result[ 0 ]
-      }
-    ];
-
-    for ( let j = 0; j < count - 1; j++ ) {
-      const a = result[ j ];
-      const b = result[ j + 1 ];
-
-      out.push( {
-        x: 0.75 * a.x + 0.25 * b.x,
-        y: 0.75 * a.y + 0.25 * b.y
-      } );
-      out.push( {
-        x: 0.25 * a.x + 0.75 * b.x,
-        y: 0.25 * a.y + 0.75 * b.y
-      } );
-    }
-
-    out.push( {
-      ...result[ count - 1 ]
-    } );
-    result = out;
-  }
-
-  return result;
-}
-
-// Resample a polyline at a fixed step so every ribbon slice has the same
-// length (even slice spacing = no visible density changes on curves).
-function resamplePolyline(
-  points, step
-) {
-  if ( points.length < 2 ) {
-    return points;
-  }
-
-  const out = [
-    {
-      ...points[ 0 ]
-    }
-  ];
-  let prev = points[ 0 ];
-  let need = step;
-
-  for ( let i = 1; i < points.length; i++ ) {
-    const curr = points[ i ];
-    let segLen = Math.hypot(
-      curr.x - prev.x,
-      curr.y - prev.y
-    );
-
-    while ( segLen >= need ) {
-      const t = need / segLen;
-      const next = {
-        x: prev.x + ( curr.x - prev.x ) * t,
-        y: prev.y + ( curr.y - prev.y ) * t
-      };
-
-      out.push( next );
-      prev = next;
-      segLen -= need;
-      need = step;
-    }
-
-    need -= segLen;
-    prev = curr;
-  }
-
-  const last = points[ points.length - 1 ];
-  const tail = out[ out.length - 1 ];
-
-  if ( Math.hypot(
-    last.x - tail.x,
-    last.y - tail.y
-  ) > step * 0.25 ) {
-    out.push( {
-      ...last
-    } );
-  }
-
-  return out;
-}
-
 // Build one trail's spine: an even polyline starting at the band centre and
 // running off the canvas. `reverse` mirrors it for the bidirectional mode.
 //
@@ -1057,42 +422,24 @@ function buildSpine(
     );
 
     if ( reverse ) {
-      g1 = {
-        x: 2 * mid.x - g1.x,
-        y: 2 * mid.y - g1.y
-      };
-      g2 = {
-        x: 2 * mid.x - g2.x,
-        y: 2 * mid.y - g2.y
-      };
+      g1 = mirrorPoint(
+        g1,
+        mid
+      );
+      g2 = mirrorPoint(
+        g2,
+        mid
+      );
     }
 
-    const exitAngle = Math.atan2(
-      g2.y - g1.y,
-      g2.x - g1.x
-    );
-    const exit = {
-      x: g2.x + Math.cos( exitAngle ) * length * 0.6,
-      y: g2.y + Math.sin( exitAngle ) * length * 0.6
-    };
-    const dense = chaikinOpen(
-      [
-        mid,
-        g1,
-        g2,
-        exit
-      ],
-      clamp(
-        Math.round( direction.iterations ?? 4 ),
-        0,
-        6
-      )
-    );
-
-    return resamplePolyline(
-      dense,
+    return buildSplineSpine( {
+      start: mid,
+      g1,
+      g2,
+      length,
+      iterations: direction.iterations,
       step
-    );
+    } );
   }
 
   const bandAngle = Math.atan2(
@@ -1109,93 +456,14 @@ function buildSpine(
     ( reverse ? Math.PI : 0 ) +
     ( ( direction.startAngle ?? 0 ) * Math.PI / 180 ) * sign;
   const bend = ( ( direction.bend ?? 0 ) * Math.PI / 180 ) * sign;
-  const easeFn = easing[ direction.easing ] ?? easing.linear;
-  const steps = Math.max(
-    2,
-    Math.ceil( length / step )
-  );
-  const ds = length / steps;
-  const spine = [
-    {
-      ...mid
-    }
-  ];
-  let x = mid.x;
-  let y = mid.y;
 
-  for ( let i = 1; i <= steps; i++ ) {
-    const heading = launch + bend * easeFn( i / steps );
-
-    x += Math.cos( heading ) * ds;
-    y += Math.sin( heading ) * ds;
-    spine.push( {
-      x,
-      y
-    } );
-  }
-
-  return spine;
-}
-
-// Push the spine sideways on a sine wave: `twists` full oscillations along
-// the ribbon, `warp` bunches them toward the start (>1) or the end (<1),
-// `speed` (whole loops per animation cycle) keeps exports seamless.
-function applyWave(
-  spine, wave, trail, p
-) {
-  const amplitude = ( wave.amplitude ?? 0 ) * Math.min(
-    p.width,
-    p.height
-  );
-
-  if ( amplitude === 0 || spine.length < 3 ) {
-    return spine;
-  }
-
-  const twists = wave.twists ?? 1;
-  const warp = Math.max(
-    0.1,
-    wave.warp ?? 1
-  );
-  const speed = Math.round( wave.speed ?? 0 );
-  const animPhase = animation.angle * speed;
-  const basePhase = trail.phase * Math.PI * 2;
-  const total = spine.length - 1;
-
-  return spine.map( (
-    point, index
-  ) => {
-    const t = index / total;
-    const prev = spine[ Math.max(
-      0,
-      index - 1
-    ) ];
-    const next = spine[ Math.min(
-      total,
-      index + 1
-    ) ];
-    const tx = next.x - prev.x;
-    const ty = next.y - prev.y;
-    const len = Math.hypot(
-      tx,
-      ty
-    ) || 1;
-    const ramp = smoothstep( Math.min(
-      1,
-      t / WAVE_RAMP
-    ) );
-    const offset =
-      Math.sin( Math.PI * 2 * twists * Math.pow(
-        t,
-        warp
-      ) + basePhase + animPhase ) *
-      amplitude *
-      ramp;
-
-    return {
-      x: point.x - ( ty / len ) * offset,
-      y: point.y + ( tx / len ) * offset
-    };
+  return buildAngleSpine( {
+    start: mid,
+    launch,
+    bend,
+    easingName: direction.easing,
+    length,
+    step
   } );
 }
 
@@ -1206,27 +474,11 @@ function applyWave(
 // Redraw the photo into the density-1 sampling buffer and read its pixels
 // back once. Only runs when the photo or its layout actually changed.
 function rebuildSample( photo ) {
-  const p = getP5();
-  const {
-    margin, scale, center, clip, fill
-  } = photoSettings();
-  const g = state.sampleG;
-
-  g.clear();
-  imageUtils.marginImage( {
-    img: photo.img,
-    graphics: g,
-    position: p.createVector(
-      p.width / 2,
-      p.height / 2
-    ),
-    margin: p.width * margin,
-    scale,
-    center,
-    clip,
-    fill
-  } );
-  g.loadPixels();
+  drawPhotoLayer(
+    state.sampleG,
+    photo
+  );
+  state.sampleG.loadPixels();
   state.samplePixelsReady = true;
 }
 
@@ -1502,7 +754,7 @@ function renderTrails(
       applyWave(
         spine,
         wave,
-        trail,
+        trail.phase,
         p
       ),
       strip,
@@ -1783,8 +1035,6 @@ sketch.setup( () => {
   state.sampleG = null;
   state.trailsG = null;
   state.scratchG = null;
-  state.binaryMaskG = null;
-  state.softMaskG = null;
   state.strips = [];
   state.trails = [];
   state.trailsSyncHash = null;
@@ -1795,14 +1045,14 @@ sketch.setup( () => {
   state.handleTargets = [];
   state.handleMeta = [];
   state.subject = null;
-  state.focusPoints = [];
-  state.focusSyncHash = null;
   state.builtVersion = -1;
   state.maskDirty = false;
 
+  subjectBuilder.reset();
   segmenter.reset();
   segmenter.setImage( state.imagePath );
-  syncFocusPoints();
+  focus.reset();
+  focus.sync();
 
   // Re-arm the listeners (the engine's registries are cleared on reset).
   draggable.attach();
@@ -1838,7 +1088,7 @@ sketch.setup( () => {
       return;
     }
 
-    // Point-list edits are adopted from the draw loop via syncFocusPoints().
+    // Point-list edits are adopted from the draw loop via focus.sync().
 
     const seg = sk.segmentation ?? {};
 
@@ -1902,11 +1152,29 @@ sketch.draw( () => {
   }
 
   p.frameRate( options.animation.framerate );
-  ensureCanvasGraphics( p );
+  ensureLayerGraphics(
+    state,
+    [
+      "photoG",
+      "bgG",
+      "trailsG",
+      "scratchG",
+      "sampleG"
+    ],
+    {
+      density1: [
+        "sampleG"
+      ],
+      onResize: () => {
+        state.sampleDirty = true;
+        state.trailsDirty = true;
+      }
+    }
+  );
 
   // Adopt external point edits, then let the segmenter pump one inference
   // per focus point that is still missing its mask.
-  syncFocusPoints();
+  focus.sync();
   segmenter.update( photo );
 
   if ( state.maskDirty || state.builtVersion !== segmenter.version ) {
@@ -1915,10 +1183,14 @@ sketch.draw( () => {
     rebuildSubject();
   }
 
-  drawPhotoLayer( photo );
-  drawBackground(
+  updatePhotoLayer( photo );
+  drawBackdrop(
     p,
-    photo
+    photo,
+    {
+      photoG: state.photoG,
+      bgG: state.bgG
+    }
   );
 
   // Re-sync the trail list from the store only when nothing is being
@@ -2000,7 +1272,10 @@ sketch.draw( () => {
   );
 
   // Layer 3: the segmented subject on top, so the ribbons pass behind it.
-  drawSubject( p );
+  drawSubjectLayer(
+    p,
+    state.subject
+  );
 
   if ( showHandles ) {
     drawHandles(
@@ -2011,5 +1286,9 @@ sketch.draw( () => {
     );
   }
 
-  drawMarkers( p );
+  drawMarkersLayer(
+    p,
+    focus.points,
+    state.photoRect
+  );
 } );

--- a/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/index.js
+++ b/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/index.js
@@ -1,0 +1,1101 @@
+import options from "@/p5/utils/options.js";
+import events from "@/p5/utils/events.js";
+import sketch, {
+  getP5
+} from "@/p5/utils/sketch.js";
+import string from "@/p5/utils/string.js";
+import * as common from "@/p5/utils/common.js";
+import animation from "@/p5/utils/animation.js";
+import easing from "@/p5/utils/easing.js";
+import {
+  init as mediapipeInit
+} from "@/p5/utils/mediapipe/mediapipe.js";
+import {
+  createMultiMaskSegmenter
+} from "@/p5/utils/multiSegmentation.js";
+import {
+  setSketchOptions,
+  subscribeSketchOptions
+} from "@/p5/shared/syncSketchOptions.js";
+import {
+  createDraggable,
+  nearestTargetIndex
+} from "@/p5/utils/interaction/draggable.js";
+import {
+  clamp,
+  clamp01,
+  smoothstep,
+  wrapAngle,
+  sanitizePoint,
+  resolveImagePath,
+  toPx,
+  mirrorPoint,
+  ensureLayerGraphics,
+  getInternalCanvasPoint,
+  createFocusPointStore,
+  createSubjectBuilder,
+  drawPhotoLayer,
+  drawBackdrop,
+  drawSubjectLayer,
+  drawMarkersLayer,
+  buildAngleSpine,
+  buildSplineSpine,
+  applyWave
+} from "../_shared.js";
+
+/* ------------------------------------------------------------------ */
+/*  photo-trail-effect-v2-echo                                         */
+/*                                                                     */
+/*  The "echo" trail: instead of v1's pixel ribbons, the segmented     */
+/*  subject ITSELF is stamped repeatedly along a curve — fading,       */
+/*  shrinking, optionally rotating and tinted ghost copies trailing    */
+/*  behind the cut-out. Layer stack, bottom to top:                    */
+/*                                                                     */
+/*    1. the full photo (original / blur / dim / color backdrop),      */
+/*    2. the ghost copies, far → near,                                 */
+/*    3. the subject cut out with MediaPipe's interactive segmenter    */
+/*       (same click-to-pick / click-a-marker-to-unpick interaction    */
+/*       as v1).                                                       */
+/*                                                                     */
+/*  The path is defined by draggable, persisted handles (normalized    */
+/*  0..1 so they survive resizes and exports):                         */
+/*                                                                     */
+/*    - anchor: where the ghost trail leaves the subject — drop it on  */
+/*      the subject's centre.                                          */
+/*    - guide 1/2 (spline direction mode): control points that steer   */
+/*      the trail, rounded with the same Chaikin corner-cutting as v1. */
+/*                                                                     */
+/*  Two loop-safe animations: the shared sideways wave, and `travel`   */
+/*  (whole cycles per loop) that marches the ghosts along the path,    */
+/*  fading them in at the subject and out at the tail.                 */
+/* ------------------------------------------------------------------ */
+
+// Spine sampling step (px) — ghosts only need positions and tangents, not
+// v1's slice-dense geometry.
+const SPINE_STEP = 6;
+const MAX_COPIES = 24;
+// While `travel` animates, ghosts fade in/out over this fraction of the
+// path so a copy wrapping from the tail back to the subject never pops.
+const TRAVEL_RAMP = 0.12;
+
+/* ------------------------------------------------------------------ */
+/*  Sketch state                                                       */
+/* ------------------------------------------------------------------ */
+
+const state = {
+  // Path of the photo currently driving the segmenter.
+  imagePath: null,
+
+  // Finished cut-out (photo with the feathered union mask applied).
+  subject: null,
+  builtWith: {
+    inverse: null,
+    softness: null,
+    expand: null
+  },
+  // Segmenter mask-set version the cached subject was built from.
+  builtVersion: -1,
+  maskDirty: false,
+
+  // Where the photo sits on the canvas — used both to map clicks onto the
+  // image and to size the ghost stamps like the subject layer.
+  photoRect: {
+    x: 0,
+    y: 0,
+    w: 0,
+    h: 0
+  },
+
+  // Working copy of the path handles (normalized), synced with
+  // options.sketch.trail like v1 does with its trail list.
+  trail: null,
+  trailSyncHash: null,
+
+  // The ghost layer is cached and only re-rendered when something actually
+  // changed (or the wave / travel is animated).
+  echoDirty: true,
+
+  // Last frame's handle targets, kept for the click-vs-drag arbitration.
+  handleTargets: [],
+  handleMeta: [],
+  handleRadius: 44,
+
+  // Reused graphics buffers.
+  photoG: null, // full photo, measures photoRect / "original" backdrop
+  bgG: null, // full-bleed backdrop for the blur / dim modes
+  echoG: null, // the composited ghost layer
+  scratchG: null, // one tinted ghost at a time
+
+  unregisterClick: null,
+  unsubscribe: null
+};
+
+const draggable = createDraggable();
+
+// One inference per focus point, run sequentially; masks cached per point.
+const segmenter = createMultiMaskSegmenter();
+
+// Click-to-pick focus points + the feathered cut-out, shared with v1.
+const focus = createFocusPointStore( segmenter );
+const subjectBuilder = createSubjectBuilder();
+
+/* ------------------------------------------------------------------ */
+/*  Clicks & subject                                                   */
+/* ------------------------------------------------------------------ */
+
+// Route a canvas click: a path handle wins (the drag layer owns it), then
+// the focus store picks / unpicks a zone.
+function handleCanvasClick( event ) {
+  const point = getInternalCanvasPoint( event );
+
+  if ( !point || draggable.dragging ) {
+    return;
+  }
+
+  if (
+    state.handleTargets.length > 0 &&
+    nearestTargetIndex(
+      state.handleTargets,
+      point.x,
+      point.y,
+      state.handleRadius
+    ) !== -1
+  ) {
+    return;
+  }
+
+  const result = focus.handleClick(
+    point,
+    state.photoRect,
+    options.sketch?.marker ?? {}
+  );
+
+  if ( result === "removed" ) {
+    state.maskDirty = true;
+  }
+}
+
+function rebuildSubject() {
+  const photo = common.getAsset( state.imagePath );
+  const seg = options.sketch?.segmentation ?? {};
+  const built = subjectBuilder.build(
+    photo,
+    segmenter,
+    seg
+  );
+
+  state.subject = built?.image ?? null;
+
+  if ( built ) {
+    state.builtWith = built.builtWith;
+  }
+}
+
+// Draw the full photo into the offscreen buffer, record where it landed and
+// invalidate the ghost layer when the layout moved.
+function updatePhotoLayer( photo ) {
+  const rect = drawPhotoLayer(
+    state.photoG,
+    photo
+  );
+
+  if ( !rect ) {
+    return;
+  }
+
+  const previous = state.photoRect;
+
+  if (
+    rect.x !== previous.x ||
+    rect.y !== previous.y ||
+    rect.w !== previous.w ||
+    rect.h !== previous.h
+  ) {
+    state.echoDirty = true;
+  }
+
+  state.photoRect = rect;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Path handle sync (persisted like v1's trail list)                  */
+/* ------------------------------------------------------------------ */
+
+function defaultTrailHandles() {
+  return {
+    anchor: {
+      x: 0.47,
+      y: 0.35
+    },
+    guides: {
+      a: {
+        x: 0.3,
+        y: 0.3
+      },
+      b: {
+        x: 0.12,
+        y: 0.5
+      }
+    }
+  };
+}
+
+function sanitizeTrailHandles( raw ) {
+  const fallback = defaultTrailHandles();
+
+  return {
+    anchor: sanitizePoint(
+      raw?.anchor,
+      fallback.anchor
+    ),
+    guides: {
+      a: sanitizePoint(
+        raw?.guides?.a,
+        fallback.guides.a
+      ),
+      b: sanitizePoint(
+        raw?.guides?.b,
+        fallback.guides.b
+      )
+    }
+  };
+}
+
+// Persist the working copy so the handles survive reloads and are exported
+// with the template. Origin "p5" so the options module skips its own change
+// handler while React still picks the new values up.
+function persistTrail() {
+  const trail = {
+    anchor: {
+      ...state.trail.anchor
+    },
+    guides: {
+      a: {
+        ...state.trail.guides.a
+      },
+      b: {
+        ...state.trail.guides.b
+      }
+    }
+  };
+
+  state.trailSyncHash = JSON.stringify( trail );
+
+  setSketchOptions(
+    {
+      sketch: {
+        trail
+      }
+    },
+    "p5"
+  );
+}
+
+// Reconcile the working copy with the stored options each frame (skipped
+// while a drag is in flight).
+function syncTrail( cfg ) {
+  const rawHash = JSON.stringify( cfg ?? null );
+
+  if ( rawHash === state.trailSyncHash ) {
+    return;
+  }
+
+  state.trailSyncHash = rawHash;
+  state.trail = sanitizeTrailHandles( cfg );
+  state.echoDirty = true;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Spine geometry                                                     */
+/* ------------------------------------------------------------------ */
+
+// Build the ghost path: an even polyline starting at the anchor. `reverse`
+// mirrors it through the anchor for the bidirectional mode.
+//
+//   - "angles" mode integrates a heading that eases from the launch angle
+//     (0° = up, clockwise) to launch + bend: a clean swoosh with no
+//     control points at all.
+//   - "spline" mode rounds anchor → guide 1 → guide 2 → exit with Chaikin,
+//     so the two guide handles literally steer the trail.
+function buildEchoSpine(
+  direction, p, reverse
+) {
+  const anchor = toPx(
+    state.trail.anchor,
+    p
+  );
+  const diagonal = Math.hypot(
+    p.width,
+    p.height
+  );
+  const length = Math.max(
+    0.05,
+    direction.length ?? 0.45
+  ) * diagonal;
+
+  if ( ( direction.mode ?? "angles" ) === "spline" ) {
+    let g1 = toPx(
+      state.trail.guides.a,
+      p
+    );
+    let g2 = toPx(
+      state.trail.guides.b,
+      p
+    );
+
+    if ( reverse ) {
+      g1 = mirrorPoint(
+        g1,
+        anchor
+      );
+      g2 = mirrorPoint(
+        g2,
+        anchor
+      );
+    }
+
+    return buildSplineSpine( {
+      start: anchor,
+      g1,
+      g2,
+      length,
+      iterations: direction.iterations,
+      step: SPINE_STEP
+    } );
+  }
+
+  const launch =
+    ( ( direction.startAngle ?? 0 ) * Math.PI / 180 ) -
+    Math.PI / 2 +
+    ( reverse ? Math.PI : 0 );
+  const bend = ( ( direction.bend ?? 0 ) * Math.PI / 180 ) * ( reverse ? -1 : 1 );
+
+  return buildAngleSpine( {
+    start: anchor,
+    launch,
+    bend,
+    easingName: direction.easing,
+    length,
+    step: SPINE_STEP
+  } );
+}
+
+// Local path direction at a spine index, from the neighbouring points.
+function spineTangent(
+  spine, index
+) {
+  const prev = spine[ Math.max(
+    0,
+    index - 1
+  ) ];
+  const next = spine[ Math.min(
+    spine.length - 1,
+    index + 1
+  ) ];
+
+  return Math.atan2(
+    next.y - prev.y,
+    next.x - prev.x
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Ghost rendering                                                    */
+/* ------------------------------------------------------------------ */
+
+// One ghost: the subject image at a spine position, scaled / rotated /
+// faded, optionally pushed toward the tint colour (composited in the
+// scratch buffer with source-atop so only the subject's pixels are tinted).
+function stampGhost(
+  layer, stamp, size, tintColor
+) {
+  const alpha = clamp01( stamp.opacity );
+  const w = size.w * stamp.scale;
+  const h = size.h * stamp.scale;
+
+  if ( alpha <= 0 || w <= 0 || h <= 0 ) {
+    return;
+  }
+
+  if ( stamp.tintAmount <= 0 ) {
+    layer.push();
+    layer.translate(
+      stamp.x,
+      stamp.y
+    );
+    layer.rotate( stamp.rotation );
+    layer.drawingContext.globalAlpha = alpha;
+    layer.image(
+      state.subject,
+      -w / 2,
+      -h / 2,
+      w,
+      h
+    );
+    layer.drawingContext.globalAlpha = 1;
+    layer.pop();
+
+    return;
+  }
+
+  const scratch = state.scratchG;
+
+  scratch.clear();
+  scratch.push();
+  scratch.translate(
+    stamp.x,
+    stamp.y
+  );
+  scratch.rotate( stamp.rotation );
+  scratch.image(
+    state.subject,
+    -w / 2,
+    -h / 2,
+    w,
+    h
+  );
+  scratch.pop();
+
+  const [
+    r = 255,
+    g = 255,
+    b = 255
+  ] = tintColor;
+  const ctx = scratch.drawingContext;
+
+  ctx.save();
+  ctx.globalCompositeOperation = "source-atop";
+  ctx.globalAlpha = stamp.tintAmount;
+  ctx.fillStyle = `rgb(${ r }, ${ g }, ${ b })`;
+  ctx.fillRect(
+    0,
+    0,
+    scratch.width,
+    scratch.height
+  );
+  ctx.restore();
+
+  layer.drawingContext.globalAlpha = alpha;
+  layer.image(
+    scratch,
+    0,
+    0
+  );
+  layer.drawingContext.globalAlpha = 1;
+}
+
+// Re-render the cached ghost layer when something changed (or every frame
+// while the wave / travel is animated).
+function renderEchoes(
+  p, o
+) {
+  const echo = o.echo ?? {};
+  const wave = o.wave ?? {};
+  const direction = o.direction ?? {};
+  const travel = Math.round( echo.travel ?? 0 );
+  const animated =
+    travel > 0 || ( ( wave.speed ?? 0 ) > 0 && ( wave.amplitude ?? 0 ) > 0 );
+
+  if ( !state.echoDirty && !animated ) {
+    return;
+  }
+
+  const layer = state.echoG;
+
+  layer.clear();
+  state.echoDirty = false;
+
+  if ( !state.subject || state.photoRect.w <= 0 || state.photoRect.h <= 0 ) {
+    return;
+  }
+
+  const copies = clamp(
+    Math.round( echo.copies ?? 6 ),
+    1,
+    MAX_COPIES
+  );
+  const easeFn = easing[ echo.easing ] ?? easing.linear;
+  const opacityStart = clamp01( echo.opacityStart ?? 0.55 );
+  const opacityEnd = clamp01( echo.opacityEnd ?? 0.1 );
+  const scaleStart = echo.scaleStart ?? 0.95;
+  const scaleEnd = echo.scaleEnd ?? 0.7;
+  const rotate = ( echo.rotate ?? 0 ) * Math.PI / 180;
+  const alignToPath = echo.alignToPath ?? false;
+  const tint = echo.tint ?? {};
+  const tintBase = clamp01( tint.amount ?? 0 );
+  const tintColor = tint.color ?? [
+    255,
+    255,
+    255
+  ];
+  const subjectScale = o.subject?.scale ?? 1;
+  const size = {
+    w: state.photoRect.w * subjectScale,
+    h: state.photoRect.h * subjectScale
+  };
+  // `travel` whole cycles per animation loop keeps the exported video
+  // seamless, exactly like the wave speed.
+  const progress = travel > 0 ? animation.angle / ( Math.PI * 2 ) * travel : 0;
+
+  const spines = [
+    applyWave(
+      buildEchoSpine(
+        direction,
+        p,
+        false
+      ),
+      wave,
+      0,
+      p
+    )
+  ];
+
+  if ( direction.bidirectional ) {
+    spines.push( applyWave(
+      buildEchoSpine(
+        direction,
+        p,
+        true
+      ),
+      wave,
+      0,
+      p
+    ) );
+  }
+
+  const stamps = [];
+
+  spines.forEach( ( spine ) => {
+    if ( spine.length < 2 ) {
+      return;
+    }
+
+    const tangent0 = spineTangent(
+      spine,
+      0
+    );
+
+    for ( let i = 1; i <= copies; i++ ) {
+      let t = i / copies;
+
+      if ( travel > 0 ) {
+        t = ( t + progress ) % 1;
+      }
+
+      const eased = easeFn( t );
+      let opacity = opacityStart + ( opacityEnd - opacityStart ) * eased;
+
+      // While travelling, ghosts fade in at the subject and out at the
+      // tail so the wrap from t=1 back to t=0 never pops.
+      if ( travel > 0 ) {
+        opacity *=
+          smoothstep( Math.min(
+            1,
+            t / TRAVEL_RAMP
+          ) ) *
+          smoothstep( Math.min(
+            1,
+            ( 1 - t ) / TRAVEL_RAMP
+          ) );
+      }
+
+      const index = Math.round( t * ( spine.length - 1 ) );
+      const point = spine[ index ];
+      let rotation = rotate * eased;
+
+      if ( alignToPath ) {
+        rotation += wrapAngle( spineTangent(
+          spine,
+          index
+        ) - tangent0 );
+      }
+
+      stamps.push( {
+        t,
+        x: point.x,
+        y: point.y,
+        scale: scaleStart + ( scaleEnd - scaleStart ) * eased,
+        rotation,
+        opacity,
+        tintAmount: tintBase * eased
+      } );
+    }
+  } );
+
+  // Farthest ghosts first so nearer copies stack on top of them.
+  stamps.sort( (
+    a, b
+  ) => b.t - a.t );
+  stamps.forEach( ( stamp ) => stampGhost(
+    layer,
+    stamp,
+    size,
+    tintColor
+  ) );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Handles overlay                                                    */
+/* ------------------------------------------------------------------ */
+
+// Flatten every visible handle into the draggable layer's target list.
+// meta[i] tells onMove which point target i belongs to.
+function collectHandles(
+  p, o
+) {
+  const targets = [];
+  const meta = [];
+
+  if ( !state.trail ) {
+    return {
+      targets,
+      meta
+    };
+  }
+
+  targets.push( toPx(
+    state.trail.anchor,
+    p
+  ) );
+  meta.push( {
+    group: "anchor",
+    key: null
+  } );
+
+  if ( ( o.direction?.mode ?? "angles" ) === "spline" ) {
+    targets.push( toPx(
+      state.trail.guides.a,
+      p
+    ) );
+    meta.push( {
+      group: "guides",
+      key: "a"
+    } );
+    targets.push( toPx(
+      state.trail.guides.b,
+      p
+    ) );
+    meta.push( {
+      group: "guides",
+      key: "b"
+    } );
+  }
+
+  return {
+    targets,
+    meta
+  };
+}
+
+function drawHandles(
+  p, o, hovers, grabbed
+) {
+  if ( !state.trail ) {
+    return;
+  }
+
+  const handles = o.handles ?? {};
+  const size = handles.size ?? 16;
+  const splineMode = ( o.direction?.mode ?? "angles" ) === "spline";
+  const anchor = toPx(
+    state.trail.anchor,
+    p
+  );
+
+  p.push();
+
+  if ( splineMode ) {
+    const g1 = toPx(
+      state.trail.guides.a,
+      p
+    );
+    const g2 = toPx(
+      state.trail.guides.b,
+      p
+    );
+
+    p.stroke(
+      120,
+      200,
+      255,
+      120
+    );
+    p.strokeWeight( 1.5 );
+    p.line(
+      anchor.x,
+      anchor.y,
+      g1.x,
+      g1.y
+    );
+    p.line(
+      g1.x,
+      g1.y,
+      g2.x,
+      g2.y
+    );
+
+    p.noStroke();
+
+    for ( const guide of [
+      g1,
+      g2
+    ] ) {
+      p.push();
+      p.translate(
+        guide.x,
+        guide.y
+      );
+      p.rotate( Math.PI / 4 );
+      p.fill(
+        120,
+        200,
+        255,
+        230
+      );
+      p.rectMode( p.CENTER );
+      p.rect(
+        0,
+        0,
+        size * 0.8,
+        size * 0.8
+      );
+      p.pop();
+    }
+  }
+
+  // The anchor: where the ghost trail leaves the subject.
+  p.noStroke();
+  p.fill(
+    255,
+    255,
+    255,
+    255
+  );
+  p.circle(
+    anchor.x,
+    anchor.y,
+    size
+  );
+  p.fill(
+    10,
+    10,
+    14,
+    255
+  );
+  p.circle(
+    anchor.x,
+    anchor.y,
+    size * 0.4
+  );
+
+  // Hover / grab rings, same affordance as v1.
+  p.noFill();
+
+  hovers.forEach( ( index ) => {
+    const target = state.handleTargets[ index ];
+
+    if ( !target || grabbed.has( index ) ) {
+      return;
+    }
+
+    p.stroke(
+      255,
+      255,
+      255,
+      170
+    );
+    p.strokeWeight( 2 );
+    p.circle(
+      target.x,
+      target.y,
+      size * 1.8 + 10
+    );
+  } );
+
+  grabbed.forEach( ( index ) => {
+    const target = state.handleTargets[ index ];
+
+    if ( !target ) {
+      return;
+    }
+
+    p.stroke(
+      120,
+      200,
+      255,
+      230
+    );
+    p.strokeWeight( 3 );
+    p.circle(
+      target.x,
+      target.y,
+      size * 2.1 + 12
+    );
+  } );
+
+  p.pop();
+}
+
+/* ------------------------------------------------------------------ */
+/*  Lifecycle                                                          */
+/* ------------------------------------------------------------------ */
+
+sketch.setup( () => {
+  const p = getP5();
+
+  p.background( ...options.sketch.backgroundColor );
+
+  state.imagePath = resolveImagePath( options.sketch?.photo?.image );
+
+  // Every buffer belongs to the previous p5 instance after a sketch reset —
+  // drop them so they are recreated lazily against the fresh one.
+  state.photoG = null;
+  state.bgG = null;
+  state.echoG = null;
+  state.scratchG = null;
+  state.trail = null;
+  state.trailSyncHash = null;
+  state.echoDirty = true;
+  state.handleTargets = [];
+  state.handleMeta = [];
+  state.subject = null;
+  state.builtVersion = -1;
+  state.maskDirty = false;
+
+  subjectBuilder.reset();
+  segmenter.reset();
+  segmenter.setImage( state.imagePath );
+  focus.reset();
+  focus.sync();
+
+  // Re-arm the listeners (the engine's registries are cleared on reset).
+  draggable.attach();
+  state.unregisterClick?.();
+  state.unregisterClick = events.register(
+    "engine-canvas-mouse-clicked",
+    handleCanvasClick
+  );
+
+  state.unsubscribe?.();
+  state.unsubscribe = subscribeSketchOptions( (
+    newOptions, origin
+  ) => {
+    // Only react to user edits from the form; sketch-origin writes (drag
+    // persistence, the click handler) are already applied locally.
+    if ( origin !== "react" ) {
+      return;
+    }
+
+    // Any form edit may restyle the ghosts — cheap to just re-render.
+    state.echoDirty = true;
+
+    const sk = newOptions.sketch ?? {};
+    const nextImage = resolveImagePath( sk.photo?.image );
+
+    if ( nextImage !== state.imagePath ) {
+      state.imagePath = nextImage;
+      state.subject = null;
+      segmenter.setImage( nextImage );
+
+      return;
+    }
+
+    // Point-list edits are adopted from the draw loop via focus.sync().
+
+    const seg = sk.segmentation ?? {};
+
+    if (
+      ( seg.inverse ?? true ) !== state.builtWith.inverse ||
+      ( seg.edgeSoftness ?? 0 ) !== state.builtWith.softness ||
+      ( seg.edgeExpand ?? 0 ) !== state.builtWith.expand
+    ) {
+      state.maskDirty = true;
+    }
+  } );
+
+  // Fire-and-forget: awaiting init would block the first draw on the ~4s
+  // model load, so the photo renders right away and the draw loop segments
+  // each focus point as soon as the processor is ready.
+  mediapipeInit( {
+    enableIdle: false,
+    worker: false,
+    enableCapture: false, // image-based interactive segmentation: no camera
+    tasks: [
+      "interactive"
+    ]
+  } ).catch( ( error ) => {
+    console.error(
+      "[photo-trail-effect-v2-echo] mediapipe init failed",
+      error
+    );
+  } );
+} );
+
+sketch.draw( () => {
+  const p = getP5();
+  const o = options.sketch ?? {};
+
+  p.background( ...( o.backgroundColor ?? [
+    0
+  ] ) );
+
+  const photo = common.getAsset( state.imagePath );
+
+  if ( !photo?.img?.width ) {
+    p.frameRate( 1 );
+    string.write(
+      "photo-trail-effect-v2:\n\nadd a photo :)",
+      0,
+      0,
+      {
+        size: 72,
+        stroke: p.color( 255 ),
+        fill: p.color( 0 ),
+        textHeight: p.height,
+        font: string.fonts.martian,
+        textAlign: [
+          p.CENTER,
+          p.CENTER
+        ]
+      }
+    );
+
+    return;
+  }
+
+  p.frameRate( options.animation.framerate );
+  ensureLayerGraphics(
+    state,
+    [
+      "photoG",
+      "bgG",
+      "echoG",
+      "scratchG"
+    ],
+    {
+      onResize: () => {
+        state.echoDirty = true;
+      }
+    }
+  );
+
+  // Adopt external point edits, then let the segmenter pump one inference
+  // per focus point that is still missing its mask.
+  focus.sync();
+  segmenter.update( photo );
+
+  if ( state.maskDirty || state.builtVersion !== segmenter.version ) {
+    state.maskDirty = false;
+    state.builtVersion = segmenter.version;
+    rebuildSubject();
+    state.echoDirty = true;
+  }
+
+  updatePhotoLayer( photo );
+  drawBackdrop(
+    p,
+    photo,
+    {
+      photoG: state.photoG,
+      bgG: state.bgG
+    }
+  );
+
+  // Re-sync the handles from the store only when nothing is being dragged,
+  // so a live drag is never snapped back to a stale value.
+  if ( !draggable.dragging ) {
+    syncTrail( o.trail );
+  }
+
+  const showHandles = o.handles?.show ?? true;
+  let hovers = new Set();
+  let grabbed = new Set();
+
+  if ( showHandles ) {
+    const {
+      targets, meta
+    } = collectHandles(
+      p,
+      o
+    );
+
+    state.handleTargets = targets;
+    state.handleMeta = meta;
+    state.handleRadius = o.handles?.radius ?? 44;
+
+    const dragResult = draggable.update( {
+      targets,
+      radius: state.handleRadius,
+      onMove: (
+        index, pointer
+      ) => {
+        const info = meta[ index ];
+
+        if ( !info || !state.trail ) {
+          return;
+        }
+
+        const moved = {
+          x: clamp01( pointer.x / p.width ),
+          y: clamp01( pointer.y / p.height )
+        };
+
+        if ( info.group === "anchor" ) {
+          state.trail.anchor = moved;
+        } else {
+          state.trail.guides[ info.key ] = moved;
+        }
+
+        targets[ index ] = {
+          x: moved.x * p.width,
+          y: moved.y * p.height
+        };
+
+        state.echoDirty = true;
+      }
+    } );
+
+    hovers = dragResult.hovers;
+    grabbed = dragResult.grabbed;
+
+    if ( dragResult.released ) {
+      persistTrail();
+    }
+  } else {
+    state.handleTargets = [];
+    state.handleMeta = [];
+    draggable.idle();
+  }
+
+  // Layer 2: the ghost copies, behind the cut-out subject.
+  renderEchoes(
+    p,
+    o
+  );
+  p.image(
+    state.echoG,
+    0,
+    0
+  );
+
+  // Layer 3: the segmented subject on top, so the ghosts pass behind it.
+  drawSubjectLayer(
+    p,
+    state.subject
+  );
+
+  if ( showHandles ) {
+    drawHandles(
+      p,
+      o,
+      hovers,
+      grabbed
+    );
+  }
+
+  drawMarkersLayer(
+    p,
+    focus.points,
+    state.photoRect
+  );
+} );

--- a/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/options.ts
+++ b/src/sketches/p5/sketches/photo-trail-effect/photo-trail-effect-v2-echo/options.ts
@@ -1,0 +1,608 @@
+// photo-trail-effect-v2-echo — the "echo" trail: fading, shrinking,
+// optionally tinted ghost copies of the MediaPipe-segmented subject stamped
+// along a draggable curve, with the cut-out drawn back on top.
+
+import getTestImagePaths from "@/utils/getTestImagePaths";
+
+const testImagePaths = await getTestImagePaths();
+
+type TrailPoint = {x: number;
+  y: number };
+
+// The ghost path handles: `anchor` is where the trail leaves the subject
+// (drop it on the subject's centre), `guides` are the spline-mode control
+// points steering the trail.
+type TrailHandles = {anchor: TrailPoint;
+  guides: {a: TrailPoint;
+    b: TrailPoint } };
+
+export const formValues = {
+  photo: {
+    // A repo-shipped test photo so the sketch renders out of the box (no
+    // S3/MinIO dependency); pick any image from the asset picker.
+    image: testImagePaths[ 0 ] ?? "/assets/images/test/DSC02023%20Medium.jpeg",
+    margin: 0.1,
+    scale: 1.1,
+    center: true,
+    clip: false,
+    fill: false
+  },
+  segmentation: {
+    // Normalized (0-1) focus points fed to the interactive segmenter — one
+    // mask per point, the subject is their union. Click the photo to add a
+    // point, click a marker (the circle with the minus) to unpick its zone.
+    points: [
+      {
+        x: 0.4720334741274328,
+        y: 0.2927933578609266
+      }
+    ],
+    inverse: true,
+    edgeSoftness: 0.25,
+    edgeExpand: 0
+  },
+  background: {
+    // transparent · original · color · blur · dim
+    mode: "original",
+    color: [
+      246,
+      235,
+      225
+    ],
+    blur: 12,
+    dim: 0.45
+  },
+  trail: {
+    // Normalized handles. Drag them on the canvas or edit them here.
+    anchor: {
+      x: 0.47,
+      y: 0.35
+    },
+    guides: {
+      a: {
+        x: 0.3,
+        y: 0.3
+      },
+      b: {
+        x: 0.12,
+        y: 0.5
+      }
+    }
+  } as TrailHandles,
+  direction: {
+    // angles → launch angle + bend, no control points; spline → the two
+    // draggable guide handles steer the trail (Chaikin corner-cutting).
+    mode: "angles" as "angles" | "spline",
+    // Launch heading in degrees: 0 = up, positive = clockwise.
+    startAngle: -135,
+    // Total heading change from launch to exit (degrees) — the swoosh.
+    bend: 70,
+    // Where the bending happens along the trail.
+    easing: "easeInOutSine",
+    // Trail length as a fraction of the canvas diagonal.
+    length: 0.45,
+    // Also stamp ghosts the other way, mirrored through the anchor.
+    bidirectional: false,
+    // Chaikin iterations for the spline mode.
+    iterations: 4
+  },
+  echo: {
+    // Number of ghost copies along the path.
+    copies: 6,
+    // Opacity of the nearest / farthest ghost.
+    opacityStart: 0.55,
+    opacityEnd: 0.1,
+    // Size multipliers of the nearest / farthest ghost (× subject size).
+    scaleStart: 0.95,
+    scaleEnd: 0.7,
+    // Extra rotation of the farthest ghost (degrees), eased along the path.
+    rotate: 0,
+    // Also rotate each ghost with the local path direction.
+    alignToPath: false,
+    // How opacity / scale / rotation / tint progress along the path.
+    easing: "linear",
+    // Whole march-along-the-path cycles per animation loop — 0 keeps the
+    // ghosts still, integers keep the exported video seamless.
+    travel: 0,
+    tint: {
+      // Push the ghosts toward this colour, stronger toward the tail.
+      // Amount 0 leaves the photo colours untouched.
+      color: [
+        64,
+        120,
+        255
+      ],
+      amount: 0
+    }
+  },
+  wave: {
+    // Sideways sine offset of the path, as a fraction of the smaller
+    // canvas dimension.
+    amplitude: 0,
+    // Number of full oscillations along the path.
+    twists: 1.5,
+    // Bunches the oscillations toward the start (>1) or the end (<1).
+    warp: 1,
+    // Whole wave cycles per animation loop — 0 keeps the path still,
+    // integers keep the exported video seamless.
+    speed: 0
+  },
+  subject: {
+    scale: 1,
+    shadow: {
+      enabled: true,
+      blur: 28,
+      color: [
+        0,
+        0,
+        0,
+        90
+      ],
+      offsetX: 0,
+      offsetY: 18
+    }
+  },
+  handles: {
+    // Master switch for the on-canvas drag handles (anchor + guides).
+    // Turn off for the final render / export.
+    show: true,
+    radius: 44,
+    size: 16
+  },
+  marker: {
+    // Focus markers double as the unpick control (click the circle with
+    // the minus to remove that zone), so they show by default.
+    show: true,
+    color: [
+      255,
+      255,
+      255
+    ],
+    radius: 61,
+    weight: 3
+  },
+  backgroundColor: [
+    246,
+    235,
+    225
+  ]
+};
+
+export const formConfiguration: Record<string, any> = {
+  photo: {
+    label: "Photo",
+    component: "nested-object",
+    initialExpanded: true,
+    fields: {
+      image: {
+        component: "image",
+        label: "Image"
+      },
+      margin: {
+        label: "Image margin",
+        component: "slider",
+        min: 0,
+        max: 0.45,
+        step: 0.005
+      },
+      scale: {
+        label: "Scale",
+        component: "slider",
+        min: 0.1,
+        max: 4,
+        step: 0.1
+      },
+      center: {
+        label: "Center",
+        component: "checkbox"
+      },
+      clip: {
+        label: "Clip",
+        component: "checkbox"
+      },
+      fill: {
+        label: "Fill",
+        component: "checkbox"
+      }
+    }
+  },
+  segmentation: {
+    label: "Segmentation",
+    component: "nested-object",
+    fields: {
+      points: {
+        label: "Focus points (click photo to add, click a marker to remove)",
+        component: "item-list",
+        itemConfig: {
+          component: "vector2d",
+          label: "Focus point",
+          allowNegative: false,
+          min: 0,
+          max: 1,
+          step: 0.01,
+          yDown: true
+        }
+      },
+      inverse: {
+        label: "Inverse mask",
+        component: "checkbox"
+      },
+      edgeSoftness: {
+        label: "Edge softness",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      edgeExpand: {
+        label: "Edge expand",
+        component: "slider",
+        min: -1,
+        max: 1,
+        step: 0.01
+      }
+    }
+  },
+  background: {
+    label: "Background",
+    component: "nested-object",
+    fields: {
+      mode: {
+        label: "Mode",
+        component: "select",
+        options: [
+          {
+            value: "transparent",
+            label: "Transparent"
+          },
+          {
+            value: "original",
+            label: "Original photo"
+          },
+          {
+            value: "color",
+            label: "Solid color"
+          },
+          {
+            value: "blur",
+            label: "Blurred photo"
+          },
+          {
+            value: "dim",
+            label: "Dimmed photo"
+          }
+        ]
+      },
+      color: {
+        label: "Color",
+        component: "color"
+      },
+      blur: {
+        label: "Blur amount",
+        component: "slider",
+        min: 0,
+        max: 40,
+        step: 1
+      },
+      dim: {
+        label: "Dim amount",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      }
+    }
+  },
+  trail: {
+    label: "Trail handles (normalized 0..1)",
+    component: "nested-object",
+    fields: {
+      anchor: {
+        label: "Anchor (drop on the subject)",
+        component: "vector2d",
+        min: 0,
+        max: 1,
+        step: 0.001,
+        yDown: true
+      },
+      guides: {
+        label: "Direction guides (spline mode)",
+        component: "nested-object",
+        fields: {
+          a: {
+            label: "Guide 1",
+            component: "vector2d",
+            min: 0,
+            max: 1,
+            step: 0.001,
+            yDown: true
+          },
+          b: {
+            label: "Guide 2",
+            component: "vector2d",
+            min: 0,
+            max: 1,
+            step: 0.001,
+            yDown: true
+          }
+        }
+      }
+    }
+  },
+  direction: {
+    label: "Direction",
+    component: "nested-object",
+    initialExpanded: true,
+    fields: {
+      mode: {
+        label: "Strategy",
+        component: "select",
+        options: [
+          {
+            value: "angles",
+            label: "Angles (launch + bend)"
+          },
+          {
+            value: "spline",
+            label: "Spline (drag the guides)"
+          }
+        ]
+      },
+      startAngle: {
+        label: "Launch angle (°, 0 = up)",
+        component: "slider",
+        min: -180,
+        max: 180,
+        step: 1
+      },
+      bend: {
+        label: "End angle / bend (°)",
+        component: "slider",
+        min: -360,
+        max: 360,
+        step: 1
+      },
+      easing: {
+        label: "Bend easing",
+        component: "easing"
+      },
+      length: {
+        label: "Length (× canvas diagonal)",
+        component: "slider",
+        min: 0.05,
+        max: 1.5,
+        step: 0.05
+      },
+      bidirectional: {
+        label: "Echo both ways",
+        component: "checkbox"
+      },
+      iterations: {
+        label: "Spline smoothing (Chaikin iterations)",
+        component: "slider",
+        min: 0,
+        max: 6,
+        step: 1
+      }
+    }
+  },
+  echo: {
+    label: "Echo",
+    component: "nested-object",
+    initialExpanded: true,
+    fields: {
+      copies: {
+        label: "Ghost copies",
+        component: "slider",
+        min: 1,
+        max: 24,
+        step: 1
+      },
+      opacityStart: {
+        label: "Opacity at the subject",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      opacityEnd: {
+        label: "Opacity at the tail",
+        component: "slider",
+        min: 0,
+        max: 1,
+        step: 0.01
+      },
+      scaleStart: {
+        label: "Scale × at the subject",
+        component: "slider",
+        min: 0.1,
+        max: 2,
+        step: 0.05
+      },
+      scaleEnd: {
+        label: "Scale × at the tail",
+        component: "slider",
+        min: 0,
+        max: 2,
+        step: 0.05
+      },
+      rotate: {
+        label: "Rotation at the tail (°)",
+        component: "slider",
+        min: -360,
+        max: 360,
+        step: 1
+      },
+      alignToPath: {
+        label: "Rotate with the path",
+        component: "checkbox"
+      },
+      easing: {
+        label: "Falloff easing",
+        component: "easing"
+      },
+      travel: {
+        label: "Travel (cycles per loop)",
+        component: "slider",
+        min: 0,
+        max: 6,
+        step: 1
+      },
+      tint: {
+        label: "Tint",
+        component: "nested-object",
+        fields: {
+          color: {
+            label: "Color",
+            component: "color"
+          },
+          amount: {
+            label: "Amount at the tail",
+            component: "slider",
+            min: 0,
+            max: 1,
+            step: 0.01
+          }
+        }
+      }
+    }
+  },
+  wave: {
+    label: "Wave",
+    component: "nested-object",
+    fields: {
+      amplitude: {
+        label: "Amplitude",
+        component: "slider",
+        min: 0,
+        max: 0.4,
+        step: 0.005
+      },
+      twists: {
+        label: "Twists (oscillations)",
+        component: "slider",
+        min: 0,
+        max: 8,
+        step: 0.25
+      },
+      warp: {
+        label: "Warp (twist distribution)",
+        component: "slider",
+        min: 0.3,
+        max: 3,
+        step: 0.05
+      },
+      speed: {
+        label: "Animation (cycles per loop)",
+        component: "slider",
+        min: 0,
+        max: 6,
+        step: 1
+      }
+    }
+  },
+  subject: {
+    label: "Subject",
+    component: "nested-object",
+    fields: {
+      scale: {
+        label: "Scale",
+        component: "slider",
+        min: 0.5,
+        max: 2,
+        step: 0.01
+      },
+      shadow: {
+        label: "Drop shadow",
+        component: "nested-object",
+        fields: {
+          enabled: {
+            label: "Enabled",
+            component: "checkbox"
+          },
+          blur: {
+            label: "Blur",
+            component: "slider",
+            min: 0,
+            max: 80,
+            step: 1
+          },
+          color: {
+            label: "Color",
+            component: "color"
+          },
+          offsetX: {
+            label: "Offset X",
+            component: "slider",
+            min: -80,
+            max: 80,
+            step: 1
+          },
+          offsetY: {
+            label: "Offset Y",
+            component: "slider",
+            min: -80,
+            max: 80,
+            step: 1
+          }
+        }
+      }
+    }
+  },
+  handles: {
+    label: "Drag handles",
+    component: "nested-object",
+    fields: {
+      show: {
+        label: "Show handles",
+        component: "checkbox"
+      },
+      radius: {
+        label: "Pick-up radius (px)",
+        component: "slider",
+        min: 10,
+        max: 120,
+        step: 1
+      },
+      size: {
+        label: "Handle size (px)",
+        component: "slider",
+        min: 6,
+        max: 40,
+        step: 1
+      }
+    }
+  },
+  marker: {
+    label: "Focus markers",
+    component: "nested-object",
+    fields: {
+      show: {
+        label: "Show markers (click one to unpick its zone)",
+        component: "checkbox"
+      },
+      color: {
+        label: "Color",
+        component: "color"
+      },
+      radius: {
+        label: "Radius",
+        component: "slider",
+        min: 0,
+        max: 100,
+        step: 1
+      },
+      weight: {
+        label: "Stroke weight",
+        component: "slider",
+        min: 0,
+        max: 10,
+        step: 0.1
+      }
+    }
+  },
+  backgroundColor: {
+    component: "color",
+    label: "Canvas color"
+  }
+};

--- a/src/sketches/p5/utils/multiSegmentation.js
+++ b/src/sketches/p5/utils/multiSegmentation.js
@@ -7,8 +7,8 @@ import mediapipe, {
 // segmenter. The segmenter answers one point at a time (a single result
 // slot), so the manager runs one inference per point sequentially, caches
 // each point's raw category mask, and exposes the union of every mask as
-// the combined subject. Used by photo-segmentation-v1-mask and
-// photo-trail-effect-v1, which share the click-to-pick /
+// the combined subject. Used by photo-segmentation-v1-mask and the
+// photo-trail-effect sketches, which share the click-to-pick /
 // click-a-marker-to-unpick interaction.
 
 // An in-flight request that never lands (dropped message, worker restart)


### PR DESCRIPTION
## What

Two new `photo-trail-effect` variants, plus the shared base they and v1 sit on.

### v2-echo — subject ghost trail

Instead of v1's pixel ribbons, the MediaPipe-segmented subject itself is stamped repeatedly along a draggable curve — fading, shrinking, optionally rotating and tinted ghost copies trailing behind the cut-out, which is drawn back on top so the ghosts pass behind it.

- **Path**: a draggable `anchor` handle (drop it on the subject) plus the same two direction strategies as v1 — `angles` (launch + bend, absolute, 0° = up) and `spline` (two draggable Chaikin guides). `bidirectional` mirrors the trail through the anchor.
- **Echo controls**: copy count, opacity / scale falloffs with a shared easing, rotation at the tail, rotate-with-the-path, and a tint (composited `source-atop`, so only subject pixels are tinted) that strengthens toward the tail.
- **Loop-safe animation**: the shared sideways `wave`, plus `travel` — ghosts march along the path with fade ramps at both ends so the wrap from tail back to subject never pops.

### v3-growth — ribbons revealed along their own length

v1's ribbons, drawn over time rather than standing there fully formed. Three reveal modes, all driven by the canonical loop phase (`animation.progression`) so the live preview and a deterministic frame capture agree exactly:

- `grow` — extrudes out of the band and holds at full length (`hold` parks it there before the loop wraps; the one mode that restarts empty, which the options document).
- `pulse` — grows out, then the tail swallows it. Seamless loop, and the default.
- `comet` — a fixed-length span travels the ribbon and exits at the tip. Also seamless.

`stagger` offsets each trail's cycle so a fan of ribbons fires in sequence, and the travelling tip / tail can be softened. Two details worth flagging for review: the softness **erases the finished ribbon through a linear gradient** rather than fading slices as they are stamped, because per-slice alpha would double-darken every slice overlap; and spine slicing **interpolates both ends exactly** instead of snapping to the nearest sample, so a growing tip doesn't stair-step by the sampling step.

## Shared base

- `_shared.js` — photo layer / backdrop / subject / marker drawing, the focus-point store (sync, persist, click-to-pick / click-a-marker-to-unpick routing), the subject builder (union mask → feathered cut-out), spine geometry (Chaikin, resampling, angle / spline builders, wave, slicing), layer-buffer management, canvas click routing, subject rebuild, photo-rect tracking and the handle hover/grab rings.
- `_ribbon.js` — the band → strip → ribbon pipeline v1 and v3 share: trail list, band spine builder, photo sampler and colour strips, ribbon slicing, band handle overlay. `paintRibbon` takes the painted span's place in the full ribbon (`tRange`) so a partial span keeps the width profile it would have had as part of the whole.

v1 keeps only its own behavior — paint every ribbon whole, once — and is unchanged visually. `metadata.json` and the generated registries are regenerated; `multiSegmentation.js` gets a comment touch-up only.

## Verification

- `npm run check` (lint + typecheck + 1816 tests) and `npm run build` pass.
- All three sketches driven headlessly (Playwright + SwiftShader) against the production build. v1 and v2 render identical to their pre-refactor captures — no regression from either extraction. v3 sampled at five points across the loop produces five distinct frames, with the lit span visibly travelling along the curve and its soft ends rendering as intended. No sketch console errors.
- Not covered: thumbnails for the new sketches aren't generated yet (the editor logs a 404 for them), and the reveal was verified in the live preview, not through a backend recording export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zbZddyg2m79BvBx3Wk27y