### PR TITLE
Fix broken pointer image path in 36days-of-type-2023 sketches 4, 5, 7, 8

### DIFF
--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-4/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-4/index.js
@@ -30,7 +30,7 @@ events.register(
   () => {
     const p = getP5();
 
-    sketchState.interactive.image = p.loadImage( "/assets/images/handpointing.png" );
+    sketchState.interactive.image = p.loadImage( "/assets/images/cursors/handpointing.png" );
   }
 );
 

--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-5/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-5/index.js
@@ -29,7 +29,7 @@ events.register(
   () => {
     const p = getP5();
 
-    sketchState.interactive.image = p.loadImage( "/assets/images/handpointing.png" );
+    sketchState.interactive.image = p.loadImage( "/assets/images/cursors/handpointing.png" );
   }
 );
 

--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-7/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-7/index.js
@@ -29,7 +29,7 @@ events.register(
   () => {
     const p = getP5();
 
-    sketchState.interactive.image = p.loadImage( "/assets/images/handpointing.png" );
+    sketchState.interactive.image = p.loadImage( "/assets/images/cursors/handpointing.png" );
   }
 );
 

--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-8/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-8/index.js
@@ -26,7 +26,7 @@ events.register(
   () => {
     const p = getP5();
 
-    interactive.image = p.loadImage( "/assets/images/handpointing.png" );
+    interactive.image = p.loadImage( "/assets/images/cursors/handpointing.png" );
   }
 );
 


### PR DESCRIPTION
## Problem

`36days-of-type-2023-4` (and `-5`, `-7`, `-8`) never load. The page renders the options form and sits forever on `→ loading 36days-of-type-2023-4 (p5)` — no `<canvas>` is ever mounted.

All four register an `engine-window-preload` handler that does:

```js
p.loadImage( "/assets/images/handpointing.png" );
```

That file was a duplicate of the canonical `/assets/images/cursors/handpointing.png` and was deleted in d04d3d7 ("Delete handpointing.png", 2026-08-09). The remaining `cursors/` copy is what the `rings-v7/v8/v9` sketches already use.

With the duplicate gone the preload 404s, the engine's preload phase never resolves, and the sketch never reaches setup/draw. p5 surfaces this only as a console notice plus a bare `[error] Event`, which is why it reads as a silent hang rather than a failure.

## Fix

Repoint the four `loadImage` calls at the canonical `cursors/handpointing.png`. No asset is re-added — the deletion stays.

## Verification

Built the app and drove each page headlessly (Chromium + SwiftShader), capturing canvas pixels directly:

| sketch | canvas | unique colours sampled | 404s / page errors |
|---|---|---|---|
| `-4` | 1080×1350 | 1704 | none |
| `-5` | 1080×1350 | 2172 | none |
| `-7` | 1080×1350 | 1408 | none |
| `-8` | 1080×1350 | 1710 | none |

Each mounts its canvas, renders, and advances between frames. Before the change, the same probe reported no canvas at all and a 404 on `handpointing.png`.

Also run: `npm run build` (compiles every sketch route) and `npm run check` — 0 lint errors, typecheck clean, 1829/1829 tests passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_019z55SR3XwryNNWe7vBGYZa)_