### PR TITLE
Include export dimensions in downloaded filenames

### DIFF
--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/CaptureActions/hooks/useBrowserRecorder.ts
@@ -454,7 +454,10 @@ export function useBrowserRecorder( {
           }
 
           const safeName = sketchNameRef.current || "sketch";
-          const fileName = `${ safeName }.${ result.fileExtension }`;
+          const {
+            width, height
+          } = host.getCaptureSource();
+          const fileName = `${ safeName }-${ width }x${ height }.${ result.fileExtension }`;
 
           triggerDownload(
             result.blob,

--- a/src/components/ClientProcessingSketch/components/SketchOptions/components/CaptureActions/hooks/useFrameExporter.ts
+++ b/src/components/ClientProcessingSketch/components/SketchOptions/components/CaptureActions/hooks/useFrameExporter.ts
@@ -342,7 +342,7 @@ export function useFrameExporter( {
 
         triggerDownload(
           zip,
-          `${ safeName }-frames-${ suffix }.zip`
+          `${ safeName }-${ width }x${ height }-frames-${ suffix }.zip`
         );
 
         finish();

--- a/src/lib/recordSketch.ts
+++ b/src/lib/recordSketch.ts
@@ -310,9 +310,12 @@ async function recordSingleSketch(
   // ─── Capture frames and encode video ──────────────────────────────────────
   const totalFrames = calculateTotalFrames( options.animation );
   const framerate = resolveAnimation( options.animation ).framerate;
+  const {
+    size
+  } = getEffectiveSlideSettings( options );
   const outputVideoPath = path.join(
     temporaryDirectoryPath,
-    `${ path.basename( sketch ) }-${ jobId }.mp4`
+    `${ path.basename( sketch ) }-${ size.width }x${ size.height }-${ jobId }.mp4`
   );
   const thumbnailPath = path.join(
     temporaryDirectoryPath,
@@ -472,16 +475,18 @@ async function recordMultipleSlides(
     // over the global) the same way the engines do, so a partial override
     // (e.g. framerate-only) keeps the global duration instead of dropping it —
     // and the frame count matches what the in-page clock loops over.
-    const slideAnimation = getEffectiveSlideSettings(
+    const {
+      size: slideSize, animation: slideAnimation
+    } = getEffectiveSlideSettings(
       options,
       slideIndex
-    ).animation;
+    );
     const totalFrames = calculateTotalFrames( slideAnimation );
     const framerate = resolveAnimation( slideAnimation ).framerate;
 
     const slideVideoPath = path.join(
       temporaryDirectoryPath,
-      `${ path.basename( sketch ) }_${ slideIndex }.mp4`
+      `${ path.basename( sketch ) }-${ slideSize.width }x${ slideSize.height }_${ slideIndex }.mp4`
     );
     const slideThumbnailPath = path.join(
       temporaryDirectoryPath,


### PR DESCRIPTION
## Summary
- Browser (in-tab) recording downloads now include the export canvas size, e.g. `rings-v9-flick-reveal-1080x1350.mp4` instead of `rings-v9-flick-reveal.mp4`.
- Frame-sequence zip exports include the size too, e.g. `rings-v9-flick-reveal-1080x1350-frames-all.zip`.
- Backend (headless Playwright) recordings — both single-sketch and per-slide — now bake the effective `size` (global or per-slide override, via `getEffectiveSlideSettings`) into the output video filename, which is also what ends up as the downloaded filename (derived from the S3 object key basename).

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01P13h1EhQugNQn2Epb7z7Vf)_