### PR TITLE
fix(36days-4/5/7): align the interactive field with the cursor

### DIFF
--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-4/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-4/index.js
@@ -104,6 +104,47 @@ const getBackgroundColor = () =>
     225
   ];
 
+// Where the interactive "cursor" is this frame, in canvas pixels: the mouse,
+// or a scripted lissajous sweep. Null in the non-interactive wave modes.
+function updateInteractivePosition( p ) {
+  const waveConfig = options.sketch?.animation?.wave ?? {
+    mode: "linear"
+  };
+
+  if ( waveConfig.mode !== "interactive" ) {
+    sketchState.interactive.position = null;
+    return;
+  }
+
+  if ( waveConfig.useMouse ) {
+    sketchState.interactive.position = p.createVector(
+      p.mouseX,
+      p.mouseY
+    );
+    return;
+  }
+
+  const sinMult = waveConfig.sinMultiplier ?? 3;
+  const cosMult = waveConfig.cosMultiplier ?? 1;
+
+  sketchState.interactive.position = p.createVector(
+    p.map(
+      Math.sin( animation.angle * sinMult ),
+      -1,
+      1,
+      0,
+      p.width
+    ),
+    p.map(
+      Math.cos( animation.angle * cosMult ),
+      -1,
+      1,
+      0,
+      p.height
+    )
+  );
+}
+
 sketch.draw( async() => {
   const p = getP5();
 
@@ -186,6 +227,11 @@ sketch.draw( async() => {
     cacheKey
   );
 
+  // Resolved before the boxes are drawn so the field they react to and the
+  // cursor drawn on top belong to the same frame (they used to be one frame
+  // apart, which showed as lag during capture).
+  updateInteractivePosition( p );
+
   alphaPoints.forEach( (
     {
       layers, position
@@ -243,16 +289,20 @@ sketch.draw( async() => {
     if ( waveConfig.mode === "interactive" ) {
       // Interactive mode: distance from cursor/animated point
       if ( sketchState.interactive.position ) {
+        // screenPosition returns WEBGL-centered coordinates while the
+        // interactive position is in canvas pixels, so bring the projected
+        // point into pixel space before measuring — otherwise the field's hot
+        // spot sits half a canvas away from the cursor drawn on top.
         const screenPos = sketchState.shape.graphics.screenPosition(
           0,
           0,
           0
         );
-        const distance = sketchState.shape.graphics.dist(
+        const distance = p.dist(
           sketchState.interactive.position.x,
           sketchState.interactive.position.y,
-          screenPos.x,
-          screenPos.y
+          screenPos.x + p.width / 2,
+          screenPos.y + p.height / 2
         );
         const sensitivity = waveConfig.sensitivity ?? 0.3;
 
@@ -461,39 +511,13 @@ sketch.draw( async() => {
   );
   sketchState.shape.graphics.clear();
 
-  // Update interactive position if in interactive mode
+  // The cursor overlay: drawn on the 2D canvas, after the 3D buffer has been
+  // flattened onto it, so it never joins the scene's depth buffer.
   const waveConfig = options.sketch?.animation?.wave ?? {
     mode: "linear"
   };
 
-  if ( waveConfig.mode === "interactive" ) {
-    if ( waveConfig.useMouse ) {
-      sketchState.interactive.position = p.createVector(
-        p.mouseX,
-        p.mouseY
-      );
-    } else {
-      const sinMult = waveConfig.sinMultiplier ?? 3;
-      const cosMult = waveConfig.cosMultiplier ?? 1;
-
-      sketchState.interactive.position = p.createVector(
-        p.map(
-          Math.sin( animation.angle * sinMult ),
-          -1,
-          1,
-          0,
-          p.width
-        ),
-        p.map(
-          Math.cos( animation.angle * cosMult ),
-          -1,
-          1,
-          0,
-          p.height
-        )
-      );
-    }
-
+  if ( waveConfig.mode === "interactive" && sketchState.interactive.position ) {
     // Draw crosshair
     p.stroke(
       128,

--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-5/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-5/index.js
@@ -104,6 +104,47 @@ const getBackgroundColor = () =>
     225
   ];
 
+// Where the interactive "cursor" is this frame, in canvas pixels: the mouse,
+// or a scripted lissajous sweep. Null in the non-interactive wave modes.
+function updateInteractivePosition( p ) {
+  const waveConfig = options.sketch?.animation?.wave ?? {
+    mode: "linear"
+  };
+
+  if ( waveConfig.mode !== "interactive" ) {
+    sketchState.interactive.position = null;
+    return;
+  }
+
+  if ( waveConfig.useMouse ) {
+    sketchState.interactive.position = p.createVector(
+      p.mouseX,
+      p.mouseY
+    );
+    return;
+  }
+
+  const sinMult = waveConfig.sinMultiplier ?? 3;
+  const cosMult = waveConfig.cosMultiplier ?? 1;
+
+  sketchState.interactive.position = p.createVector(
+    p.map(
+      Math.sin( animation.angle * sinMult ),
+      -1,
+      1,
+      0,
+      p.width
+    ),
+    p.map(
+      Math.cos( animation.angle * cosMult ),
+      -1,
+      1,
+      0,
+      p.height
+    )
+  );
+}
+
 sketch.draw( async() => {
   const p = getP5();
 
@@ -185,6 +226,11 @@ sketch.draw( async() => {
     textPointsMatrix,
     cacheKey
   );
+
+  // Resolved before the boxes are drawn so the field they react to and the
+  // cursor drawn on top belong to the same frame (they used to be one frame
+  // apart, which showed as lag during capture).
+  updateInteractivePosition( p );
 
   alphaPoints.forEach( (
     {
@@ -288,16 +334,20 @@ sketch.draw( async() => {
     if ( waveConfig.mode === "interactive" ) {
       // Interactive mode: distance from cursor/animated point
       if ( sketchState.interactive.position ) {
+        // screenPosition returns WEBGL-centered coordinates while the
+        // interactive position is in canvas pixels, so bring the projected
+        // point into pixel space before measuring — otherwise the field's hot
+        // spot sits half a canvas away from the cursor drawn on top.
         const screenPos = sketchState.shape.graphics.screenPosition(
           0,
           0,
           0
         );
-        const distance = sketchState.shape.graphics.dist(
+        const distance = p.dist(
           sketchState.interactive.position.x,
           sketchState.interactive.position.y,
-          screenPos.x,
-          screenPos.y
+          screenPos.x + p.width / 2,
+          screenPos.y + p.height / 2
         );
         const sensitivity = waveConfig.sensitivity ?? 0.3;
 
@@ -471,39 +521,13 @@ sketch.draw( async() => {
   );
   sketchState.shape.graphics.clear();
 
-  // Update interactive position if in interactive mode
+  // The cursor overlay: drawn on the 2D canvas, after the 3D buffer has been
+  // flattened onto it, so it never joins the scene's depth buffer.
   const waveConfig = options.sketch?.animation?.wave ?? {
     mode: "linear"
   };
 
-  if ( waveConfig.mode === "interactive" ) {
-    if ( waveConfig.useMouse ) {
-      sketchState.interactive.position = p.createVector(
-        p.mouseX,
-        p.mouseY
-      );
-    } else {
-      const sinMult = waveConfig.sinMultiplier ?? 3;
-      const cosMult = waveConfig.cosMultiplier ?? 1;
-
-      sketchState.interactive.position = p.createVector(
-        p.map(
-          Math.sin( animation.angle * sinMult ),
-          -1,
-          1,
-          0,
-          p.width
-        ),
-        p.map(
-          Math.cos( animation.angle * cosMult ),
-          -1,
-          1,
-          0,
-          p.height
-        )
-      );
-    }
-
+  if ( waveConfig.mode === "interactive" && sketchState.interactive.position ) {
     // Draw crosshair
     p.stroke(
       128,

--- a/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-7/index.js
+++ b/src/sketches/p5/sketches/36days-of-type-2023/36days-of-type-2023-7/index.js
@@ -110,6 +110,47 @@ const getBackgroundColor = () =>
     225
   ];
 
+// Where the interactive "cursor" is this frame, in canvas pixels: the mouse,
+// or a scripted lissajous sweep. Null in the non-interactive wave modes.
+function updateInteractivePosition( p ) {
+  const waveConfig = options.sketch?.animation?.wave ?? {
+    mode: "linear"
+  };
+
+  if ( waveConfig.mode !== "interactive" ) {
+    sketchState.interactive.position = null;
+    return;
+  }
+
+  if ( waveConfig.useMouse ) {
+    sketchState.interactive.position = p.createVector(
+      p.mouseX,
+      p.mouseY
+    );
+    return;
+  }
+
+  const sinMult = waveConfig.sinMultiplier ?? 3;
+  const cosMult = waveConfig.cosMultiplier ?? 1;
+
+  sketchState.interactive.position = p.createVector(
+    p.map(
+      Math.sin( animation.angle * sinMult ),
+      -1,
+      1,
+      0,
+      p.width
+    ),
+    p.map(
+      Math.cos( animation.angle * cosMult ),
+      -1,
+      1,
+      0,
+      p.height
+    )
+  );
+}
+
 sketch.draw( async() => {
   const p = getP5();
 
@@ -191,6 +232,11 @@ sketch.draw( async() => {
       options.sketch?.mask?.distance
     )
   );
+
+  // Resolved before the boxes are drawn so the field they react to and the
+  // cursor drawn on top belong to the same frame (they used to be one frame
+  // apart, which showed as lag during capture).
+  updateInteractivePosition( p );
 
   alphaPoints.forEach( (
     {
@@ -292,16 +338,20 @@ sketch.draw( async() => {
     if ( waveConfig.mode === "interactive" ) {
       // Interactive mode: distance from cursor/animated point
       if ( sketchState.interactive.position ) {
+        // screenPosition returns WEBGL-centered coordinates while the
+        // interactive position is in canvas pixels, so bring the projected
+        // point into pixel space before measuring — otherwise the field's hot
+        // spot sits half a canvas away from the cursor drawn on top.
         const screenPos = sketchState.shape.graphics.screenPosition(
           0,
           0,
           0
         );
-        const distance = sketchState.shape.graphics.dist(
+        const distance = p.dist(
           sketchState.interactive.position.x,
           sketchState.interactive.position.y,
-          screenPos.x,
-          screenPos.y
+          screenPos.x + p.width / 2,
+          screenPos.y + p.height / 2
         );
         const sensitivity = waveConfig.sensitivity ?? 0.3;
 
@@ -489,39 +539,13 @@ sketch.draw( async() => {
   );
   sketchState.shape.graphics.clear();
 
-  // Update interactive position if in interactive mode
+  // The cursor overlay: drawn on the 2D canvas, after the 3D buffer has been
+  // flattened onto it, so it never joins the scene's depth buffer.
   const waveConfig = options.sketch?.animation?.wave ?? {
     mode: "linear"
   };
 
-  if ( waveConfig.mode === "interactive" ) {
-    if ( waveConfig.useMouse ) {
-      sketchState.interactive.position = p.createVector(
-        p.mouseX,
-        p.mouseY
-      );
-    } else {
-      const sinMult = waveConfig.sinMultiplier ?? 3;
-      const cosMult = waveConfig.cosMultiplier ?? 1;
-
-      sketchState.interactive.position = p.createVector(
-        p.map(
-          Math.sin( animation.angle * sinMult ),
-          -1,
-          1,
-          0,
-          p.width
-        ),
-        p.map(
-          Math.cos( animation.angle * cosMult ),
-          -1,
-          1,
-          0,
-          p.height
-        )
-      );
-    }
-
+  if ( waveConfig.mode === "interactive" && sketchState.interactive.position ) {
     // Draw crosshair
     p.stroke(
       128,


### PR DESCRIPTION
Follow-up to #304: sweep of the rest of the sketches for the same defect class.

## Audit result

**No other sketch draws a flat overlay inside a WEBGL main canvas.** I checked every sketch that creates its canvas with `type: "webgl"` (40 files) for `image` / `text` overlay draws — the only hit is `photo/photo-3d-sphere`, and there the graphics buffer is a `texture()`, not an overlay. Every sketch that calls `drawInteractionOverlay` / `drawInteractionCameraPreview` runs on a 2D main canvas. So the bug fixed in #304 was unique to `36days-8`.

## What I did fix

`36days-4`, `36days-5` and `36days-7` are the same family and already use the correct split (boxes into an offscreen WEBGL buffer, flattened onto a 2D canvas, cursor drawn last). But their interactive mode carries the **two secondary bugs** that #304 also fixed:

- **Coordinate-space mismatch.** The distance field compared `graphics.screenPosition()` — which returns WEBGL-centered coordinates, `[-w/2, w/2]` — against an interactive position expressed in canvas pixels, `[0, w]`. The field's hot spot therefore sat half a canvas away from the crosshair and cursor drawn on top. Now the projected point is brought into pixel space before measuring.
- **One-frame lag.** The position was resolved *after* the boxes were drawn, so the field reacted to the previous frame's cursor. Hoisted into an `updateInteractivePosition( p )` helper called before the loop; the crosshair and pointer artwork still draw last, over the flattened buffer.

Only reachable when the wave mode is switched to `interactive` (all three default to `linear`), which is why it went unnoticed.

## Verification

- `npm run check` — lint (0 errors), typecheck, 1829 tests pass.
- `npm run build` — full build including every sketch route.
- Headless check on sketch 7 with a temporarily tightened, mouse-driven field (`sensitivity: 3`, `waveSpread: 8`, probe reverted before commit): before the fix the disturbance was offset from the crosshair by half the canvas; after it centres on the cursor, at both a top-left and a bottom-right mouse position.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Tk88pkzi2fhWffNpd4LpP)_